### PR TITLE
Remove div IDs from Grid guides

### DIFF
--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
@@ -8,9 +8,12 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>In addition to the ability to place items accurately onto a created grid, the CSS Grid Layout specification contains rules that control what happens when you create a grid and do not place some or all of the child items. You can see auto-placement in action in the simplest of ways by creating a grid on a set of items. If you give the items no placement information they will position themselves on the grid, one in each grid cell.</p>
+<p>In addition to the ability to place items accurately onto a created grid, the CSS Grid Layout specification contains rules that control what happens when you create a grid and do not place some or all of the child items. You can see auto-placement in action in the simplest of ways by creating a grid on a set of items.</p>
 
-<div id="placement_1">
+<h2 id="default_placement">Default placement</h2>
+
+<p>If you give the items no placement information they will position themselves on the grid, one in each grid cell.</p>
+
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -46,7 +49,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('placement_1', '500', '230') }}</p>
+<p>{{ EmbedLiveSample('default_placement', '500', '230') }}</p>
 </div>
 
 <h2 id="Default_rules_for_auto-placement">Default rules for auto-placement</h2>
@@ -59,7 +62,6 @@ tags:
 
 <p>You can however control the size of these rows with the property <code>grid-auto-rows</code>. To cause all created rows to be 100 pixels tall for example you would use:</p>
 
-<div id="placement_2">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -96,12 +98,12 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_2', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Sizing_rows_in_the_implicit_grid', '500', '330') }}</p>
+
+<h3 id="Sizing_rows_using_minmax">Sizing rows using minmax()</h3>
 
 <p>You can use {{cssxref("minmax()","minmax()")}} in your value for {{cssxref("grid-auto-rows")}} enabling the creation of rows that are a minimum size but then grow to fit content if it is taller.</p>
 
-<div id="placement_3">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -144,12 +146,12 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_3', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Sizing_rows_using_minmax', '500', '330') }}</p>
+
+<h3 id="Sizing_rows_using_a_track_listing">Sizing rows using a track listing</h3>
 
 <p>You can also pass in a track listing, this will repeat. The following track listing will create an initial implicit row track as 100 pixels and a second as <code>200px</code>. This will continue for as long as content is added to the implicit grid. </p>
 
-<div id="placement_4">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -189,8 +191,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_4', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Sizing_rows_using_a_track_listing', '500', '450') }}</p>
 
 <h3 id="Auto-placement_by_column">Auto-placement by column</h3>
 
@@ -198,7 +199,6 @@ tags:
 
 <p>In this next example I have created a grid with three row tracks of 200 pixels height. I am auto-placing by column and the columns created will be a column width of 300 pixels, then a column width of 100 pixels until there are enough column tracks to hold all of the items.</p>
 
-<div id="placement_5">
 <pre class="brush: css">.wrapper {
     display: grid;
     grid-template-rows: repeat(3, 200px);
@@ -239,8 +239,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('placement_5', '500', '640') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Auto-placement_by_column', '500', '700') }}</p>
 
 <h2 id="The_order_of_auto_placed_items">The order of auto placed items</h2>
 
@@ -254,7 +253,6 @@ tags:
 
 <p>The first thing grid will do is place any items that have a position. In the example below I have 12 grid items. Item 2 and item 5 have been placed using line based placement on the grid. You can see how those items are placed and the other items then auto-place in the spaces. The auto-placed items will place themselves before the placed items in DOM order, they don’t start after the position of a placed item that comes before them.</p>
 
-<div id="placement_6">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -306,8 +304,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_6', '500', '450') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Items_with_placement_properties', '500', '500') }}</p>
 
 <h3 id="Deal_with_items_that_span_tracks">Deal with items that span tracks</h3>
 
@@ -315,7 +312,6 @@ tags:
 
 <p>You can see how this then leaves gaps in the grid, as for the auto-placed items if grid comes across an item that doesn’t fit into a track, it will move to the next row until it finds a space the item can fit in.</p>
 
-<div id="placement_7">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 .wrapper {
@@ -371,8 +367,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_7', '500', '770') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Deal_with_items_that_span_tracks', '500', '800') }}</p>
 
 <h3 id="Filling_in_the_gaps">Filling in the gaps</h3>
 
@@ -382,7 +377,6 @@ tags:
 
 <p>Having done this, grid will now backfill the gaps, as it moves through the grid it leaves gaps as before, but then if it finds an item that will fit in a previous gap it will pick it up and take it out of DOM order to place it in the gap. As with any other reordering in grid this does not change the logical order. Tab order for example, will still follow the document order. We will take a look at the potential accessibility issues of Grid Layout in a later guide, but you should take care when creating this disconnect between the visual order and display order.</p>
 
-<div id="placement_8">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 .wrapper {
@@ -439,8 +433,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_8', '500', '730') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Filling_in_the_gaps', '500', '730') }}</p>
 
 <h3 id="Anonymous_grid_items">Anonymous grid items</h3>
 
@@ -461,13 +454,10 @@ tags:
 
 <p>Try removing the line <code>grid-auto-flow: dense</code> to see the content reflow to leave gaps in the layout.</p>
 
-<div id="placement_9">
 <p>{{EmbedGHLiveSample("css-examples/grid/docs/autoplacement.html", '100%', 1200)}}</p>
-</div>
 
 <p>Auto-placement can also help you lay out interface items which do have logical order. An example is the definition list in this next example. Definition lists are an interesting challenge to style as they are flat, there is nothing wrapping the groups of <code>dt</code> and <code>dd</code> items. In my example I am allowing auto-placement to place the items, however I have classes that start a <code>dt</code> in column 1, and <code>dd</code> in column 2, this ensure that terms go on one side and definitions on the other - no matter how many of each we have.</p>
 
-<div id="placement_10">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -510,8 +500,7 @@ dd {
  }
 </pre>
 
-<p>{{ EmbedLiveSample('placement_10', '500', '230') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Use_cases_for_auto-placement', '500', '230') }}</p>
 
 <h2 id="What_can’t_we_do_with_auto-placement_yet">What can’t we do with auto-placement (yet)?</h2>
 

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -88,17 +88,18 @@ tags:
 
 <p>If we want to start making this more grid-like we need to add column tracks.</p>
 
-<h2 id="Grid_Tracks">Grid Tracks</h2>
+<h2 id="grid_tracks">Grid tracks</h2>
 
 <p>We define rows and columns on our grid with the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties. These define grid tracks. A <em>grid track</em> is the space between any two lines on the grid. In the below image you can see a track highlighted – this is the first row track in our grid.</p>
 
 <p><img alt="" src="1_grid_track.png"></p>
 
+<h3 id="basic_example">Basic example</h3>
+
 <p>I can add to our earlier example by adding the <code>grid-template-columns</code> property, then defining the size of the column tracks.</p>
 
 <p>I have now created a grid with three 200-pixel-wide column tracks. The child items will be laid out on this grid one in each grid cell.</p>
 
-<div id="grid_first">
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
@@ -133,14 +134,12 @@ tags:
 </pre>
 </div>
 
-<p>{{ EmbedLiveSample('grid_first', '610', '140') }}</p>
-</div>
+<p>{{ EmbedLiveSample('basic_example', '610', '140') }}</p>
 
-<h3 id="The_fr_Unit">The fr Unit</h3>
+<h3 id="the_fr_unit">The fr unit</h3>
 
 <p>Tracks can be defined using any length unit. Grid also introduces an additional length unit to help us create flexible grid tracks. The new <code>fr</code> unit represents a fraction of the available space in the grid container. The next grid definition would create three equal width tracks that grow and shrink according to the available space.</p>
 
-<div id="fr_unit_ls">
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
@@ -176,10 +175,20 @@ tags:
 </pre>
 </div>
 
-<p>{{ EmbedLiveSample('fr_unit_ls', '220', '140') }}</p>
-</div>
+<p>{{ EmbedLiveSample('the_fr_unit', '220', '140') }}</p>
+
+<h3 id="unequal_fractions">Unequal fractions</h3>
 
 <p>In this next example, we create a definition with a <code>2fr</code> track then two <code>1fr</code> tracks. The available space is split into four. Two parts are given to the first track and one part each to the next two tracks.</p>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+  &lt;div&gt;One&lt;/div&gt;
+  &lt;div&gt;Two&lt;/div&gt;
+  &lt;div&gt;Three&lt;/div&gt;
+  &lt;div&gt;Four&lt;/div&gt;
+  &lt;div&gt;Five&lt;/div&gt;
+&lt;/div&gt;
+</pre>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -187,13 +196,68 @@ tags:
 }
 </pre>
 
+<div class="hidden">
+<pre class="brush: css">* {box-sizing: border-box;}
+
+.wrapper {
+  border: 2px solid #f76707;
+  border-radius: 5px;
+  background-color: #fff4e6;
+}
+
+.wrapper &gt; div {
+  border: 2px solid #ffa94d;
+  border-radius: 5px;
+  background-color: #ffd8a8;
+  padding: 1em;
+  color: #d9480f;
+}
+
+</pre>
+</div>
+
+<p>{{ EmbedLiveSample('unequal_fractions', '220', '140') }}</p>
+
+<h3 id="mixing_fractions_and_absolute_sizes">Mixing fractions and absolute sizes</h3>
+
 <p>In this final example, we mix absolute sized tracks with fraction units. The first track is 500 pixels, so the fixed width is taken away from the available space. The remaining space is divided into three and assigned in proportion to the two flexible tracks.</p>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+  &lt;div&gt;One&lt;/div&gt;
+  &lt;div&gt;Two&lt;/div&gt;
+  &lt;div&gt;Three&lt;/div&gt;
+  &lt;div&gt;Four&lt;/div&gt;
+  &lt;div&gt;Five&lt;/div&gt;
+&lt;/div&gt;
+</pre>
 
 <pre class="brush: css">.wrapper {
   display: grid;
   grid-template-columns: 500px 1fr 2fr;
 }
 </pre>
+
+<div class="hidden">
+<pre class="brush: css">* {box-sizing: border-box;}
+
+.wrapper {
+  border: 2px solid #f76707;
+  border-radius: 5px;
+  background-color: #fff4e6;
+}
+
+.wrapper &gt; div {
+  border: 2px solid #ffa94d;
+  border-radius: 5px;
+  background-color: #ffd8a8;
+  padding: 1em;
+  color: #d9480f;
+}
+
+</pre>
+</div>
+
+<p>{{ EmbedLiveSample('mixing_fractions_and_absolute_sizes', '220', '140') }}</p>
 
 <h3 id="Track_listings_with_repeat_notation">Track listings with repeat() notation</h3>
 
@@ -458,21 +522,9 @@ tags:
 
 <p>A grid item can become a grid container. In the following example, I have the three-column grid that I created earlier, with our two positioned items. In this case the first item has some sub-items. As these items are not direct children of the grid they do not participate in grid layout and so display in a normal document flow.</p>
 
-<div id="nesting">
-<pre class="brush: html">&lt;div class="wrapper"&gt;
-  &lt;div class="box box1"&gt;
-    &lt;div class="nested"&gt;a&lt;/div&gt;
-    &lt;div class="nested"&gt;b&lt;/div&gt;
-    &lt;div class="nested"&gt;c&lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div class="box box2"&gt;Two&lt;/div&gt;
-  &lt;div class="box box3"&gt;Three&lt;/div&gt;
-  &lt;div class="box box4"&gt;Four&lt;/div&gt;
-  &lt;div class="box box5"&gt;Five&lt;/div&gt;
-&lt;/div&gt;
-</pre>
-
 <p><img alt="Nested grid in flow" src="1_nested_grids_in_flow.png"></p>
+
+<h3 id="nesting_without_subgrid">Nesting without subgrid</h3>
 
 <p>If I set <code>box1</code> to <code>display: grid</code> I can give it a track definition and it too will become a grid. The items then lay out on this new grid.</p>
 
@@ -487,6 +539,19 @@ tags:
 </pre>
 
 <div class="hidden">
+  <pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box box1"&gt;
+      &lt;div class="nested"&gt;a&lt;/div&gt;
+      &lt;div class="nested"&gt;b&lt;/div&gt;
+      &lt;div class="nested"&gt;c&lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="box box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box box3"&gt;Three&lt;/div&gt;
+    &lt;div class="box box4"&gt;Four&lt;/div&gt;
+    &lt;div class="box box5"&gt;Five&lt;/div&gt;
+  &lt;/div&gt;
+  </pre>
+
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .wrapper {
@@ -517,9 +582,8 @@ tags:
 }
 </pre>
 </div>
-</div>
 
-<p>{{ EmbedLiveSample('nesting', '600', '340') }}</p>
+<p>{{ EmbedLiveSample('nesting_without_subgrid', '600', '340') }}</p>
 
 <p>In this case the nested grid has no relationship to the parent. As you can see in the example it has not inherited the {{cssxref("gap")}} of the parent and the lines in the nested grid do not align to the lines in the parent grid.</p>
 
@@ -545,9 +609,12 @@ tags:
 
 <h2 id="Layering_items_with_z-index">Layering items with <code>z-index</code></h2>
 
-<p>Grid items can occupy the same cell. If we return to our example with items positioned by line number, we can change this to make two items overlap.</p>
+<p>Grid items can occupy the same cell, and in this case we can use the {{cssxref("z-index")}} property to control the order in which overlapping items stack.</p>
 
-<div id="l_ex">
+<h3 id="overlapping_without_z-index">Overlapping without z-index</h3>
+
+<p>If we return to our example with items positioned by line number, we can change this to make two items overlap.</p>
+
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box box1"&gt;One&lt;/div&gt;
   &lt;div class="box box2"&gt;Two&lt;/div&gt;
@@ -595,9 +662,8 @@ tags:
 }
 </pre>
 </div>
-</div>
 
-<p>{{ EmbedLiveSample('l_ex', '230', '420') }}</p>
+<p>{{ EmbedLiveSample('overlapping_without_z-index', '230', '460') }}</p>
 
 <p>The item <code>box2</code> is now overlapping <code>box1</code>, it displays on top as it comes later in the source order.</p>
 
@@ -655,7 +721,7 @@ tags:
 </pre>
 </div>
 
-<p>{{ EmbedLiveSample('Controlling_the_order', '230', '420') }}</p>
+<p>{{ EmbedLiveSample('Controlling_the_order', '230', '460') }}</p>
 
 <h2 id="Next_Steps">Next Steps</h2>
 

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
@@ -33,6 +33,8 @@ tags:
 
 <p>The {{cssxref("align-self")}} and {{cssxref("align-items")}} properties control alignment on the block axis. When we use these properties, we are changing the alignment of the item within the grid area you have placed it.</p>
 
+<h3 id="using_align-items">Using align-items</h3>
+
 <p>In the following example, I have four grid areas within my grid. I can use the {{cssxref("align-items")}} property on the grid container, to align the items using one of the following values:</p>
 
 <ul>
@@ -47,7 +49,6 @@ tags:
  <li><code>last baseline</code></li>
 </ul>
 
-<div id="alignment_1">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -101,16 +102,16 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_1', '500', '500') }}</p>
-</div>
+<p>{{ EmbedLiveSample('using_align-items', '500', '500') }}</p>
 
 <p>Keep in mind that once you set <code>align-items: start</code>, the height of each child <code>&lt;div&gt;</code> will be determined by the contents of the <code>&lt;div&gt;</code>.  This is in contrast to omitting <code><a href="/en-US/docs/Web/CSS/align-items">align-items</a></code> completely, in which case the height of each <code>&lt;div&gt;</code> stretches to fill its grid area.</p>
 
 <p>The {{cssxref("align-items")}} property sets the {{cssxref("align-self")}} property for all of the child grid items. This means that you can set the property individually, by using <code>align-self</code> on a grid item.</p>
 
+<h3 id="using_align-self">Using align-self</h3>
+
 <p>In this next example, I am using the <code>align-self</code> property, to demonstrate the different alignment values. The first area, is showing the default behavior of <code>align-self</code>, which is to stretch. The second item, has an <code>align-self</code> value of <code>start</code>, the third <code>end</code> and the fourth <code>center</code>.</p>
 
-<div id="alignment_2">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -166,8 +167,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_2', '500', '500') }}</p>
-</div>
+<p>{{ EmbedLiveSample('using_align-self', '500', '500') }}</p>
 
 <h3 id="Items_with_an_intrinsic_aspect_ratio">Items with an intrinsic aspect ratio</h3>
 
@@ -195,7 +195,6 @@ tags:
 
 <p>Once again the default is <code>stretch</code>, other than for items with an intrinsic aspect ratio. This means that by default, grid items will cover their grid area, unless you change that by setting alignment. The first item in the example demonstrates this default alignment:</p>
 
-<div id="alignment_3">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -251,8 +250,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_3', '500', '500') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Justifying_Items_on_the_Inline_Axis', '500', '500') }}</p>
 
 <p>As with {{cssxref("align-self")}} and {{cssxref("align-items")}}, you can apply {{cssxref("justify-items")}} to the grid container, to set the {{cssxref("justify-self")}} value for all items.</p>
 
@@ -268,7 +266,6 @@ tags:
 
 <p>By combining the align and justify properties we can easily center an item inside a grid area.</p>
 
-<div id="alignment_4">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -309,8 +306,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_4', '500', '500') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Center_an_item_in_the_area', '500', '500') }}</p>
 
 <h2 id="Aligning_the_grid_tracks_on_the_block_axis">Aligning the grid tracks on the block axis</h2>
 
@@ -332,9 +328,12 @@ tags:
 
 <p>In the below example I have a grid container of 500 pixels by 500 pixels. I have defined 3 row and column tracks each of 100 pixels with a 10 pixel gutter. This means that there is space inside the grid container both in the block and inline directions.</p>
 
-<p>The <code>align-content</code> property is applied to the grid container as it works on the entire grid. The default behavior in grid layout is <code>start</code>, which is why our grid tracks are in the top left corner of the grid, aligned against the start grid lines:</p>
+<p>The <code>align-content</code> property is applied to the grid container as it works on the entire grid.</p>
 
-<div id="alignment_5">
+<h3 id="default_alignment">Default alignment</h3>
+
+<p>The default behavior in grid layout is <code>start</code>, which is why our grid tracks are in the top left corner of the grid, aligned against the start grid lines:</p>
+
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -388,12 +387,12 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_5', '500', '550') }}</p>
+<p>{{ EmbedLiveSample('default_alignment', '500', '550') }}</p>
+
+<h3 id="align-content_end">Setting align-content: end</h3>
 
 <p>If I add <code>align-content</code> to my container, with a value of <code>end</code>, the tracks all move to the end line of the grid container in the block dimension:</p>
-</div>
 
-<div id="alignment_6">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -448,12 +447,12 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_6', '500', '550') }}</p>
-</div>
+<p>{{ EmbedLiveSample('align-content_end', '500', '550') }}</p>
+
+<h3 id="align-content_end_space-between">Setting align-content: space-between</h3>
 
 <p>We can also use values for this property that you may be familiar with from flexbox; the space distribution values of <code>space-between</code>, <code>space-around</code> and <code>space-evenly</code>. If we update {{cssxref("align-content")}} to <code>space-between</code>, you can see how the elements on our grid space out:</p>
 
-<div id="alignment_7">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -508,8 +507,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_7', '500', '600') }}</p>
-</div>
+<p>{{ EmbedLiveSample('align-content_end_space-between', '500', '600') }}</p>
 
 <p>It is worth noting, that using these space distribution values may cause items on your grid to become larger. If an item spans more than one grid track, as further space is added between the tracks, that item needs to become large to absorb the space. We’re always working in a strict grid. Therefore, if you decide to use these values, ensure that the content of your tracks can cope with the extra space, or that you have used alignment properties on the items, to cause them to move to the start rather than stretch.</p>
 
@@ -523,7 +521,6 @@ tags:
 
 <p>Using the same example, I am setting {{cssxref("justify-content")}} to <code>space-around</code>. This once again causes tracks which span more than one column track to gain extra space:</p>
 
-<div id="alignment_8">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -579,8 +576,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_8', '500', '550') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Justifying_the_grid_tracks_on_the_inline_axis', '500', '550') }}</p>
 
 <h2 id="Alignment_and_auto_margins">Alignment and auto margins</h2>
 
@@ -588,7 +584,6 @@ tags:
 
 <p>In this next example, I have given item 1 a left margin of <code>auto</code>. You can see how the content is now pushed over to the right side of the area, as the auto margin takes up remaining space, after room for the content of that item has been assigned:</p>
 
-<div id="alignment_9">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -643,8 +638,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('alignment_9', '500', '550') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Alignment_and_auto_margins', '500', '550') }}</p>
 
 <p>You can see how the item is aligned by using the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts">Firefox Grid Highlighter</a>:</p>
 

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
@@ -54,7 +54,6 @@ tags:
 
 <p>The {{cssxref("float")}} no longer applies, and I can use the CSS Box Alignment property {{cssxref("align-self")}} to align my content to the end of the container:</p>
 
-<div id="enhancement_1">
 <pre class="brush: css">* {box-sizing: border-box;}
 img {
     max-width: 100%;
@@ -92,8 +91,7 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('enhancement_1', '500', '180') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Floats', '500', '200') }}</p>
 
 <p>The image below shows the media object in a non-supporting browser on the left, and a supporting one on the right:</p>
 
@@ -103,9 +101,10 @@ img {
 
 <p>The above example is very simple, and we can get away without needing to write code that would be a problem to browsers that do not support grid, and legacy code is not an issue to our grid supporting browsers. However, things are not always so simple.</p>
 
+<h4 id="a_more_complex_example">A more complex example</h4>
+
 <p>In this next example, I have a set of floated cards. I have given the cards a {{cssxref("width")}}, in order to {{cssxref("float")}} them. To create gaps between the cards, I use a {{cssxref("margin")}} on the items, and then a negative margin on the container:</p>
 
-<div id="enhancement_2">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -163,8 +162,7 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('enhancement_2', '550', '400') }}</p>
-</div>
+<p>{{ EmbedLiveSample('a_more_complex_example', '550', '450') }}</p>
 
 <p>The example demonstrates the typical problem that we have with floated layouts: if additional content is added to any one card, the layout breaks.</p>
 
@@ -177,6 +175,8 @@ img {
 <p><img alt="After applying grid to our container, the width of the items is now incorrect as they display at one third of the item width." src="10-float-width-problem.png"></p>
 
 <p>If I reset the width to <code>auto</code>, then this will stop the float behavior happening for older browsers. I need to be able to define the width for older browsers, and remove the width for grid supporting browsers. Thanks to <a href="/en-US/docs/Web/CSS/@supports">CSS Feature Queries</a> I can do this, right in my CSS.</p>
+
+<h4 id="a_solution_using_feature_queries">A solution using feature queries</h4>
 
 <p><em>Feature queries</em> will look very familiar if you have ever used a <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a> to create a responsive layout. Rather than checking a {{glossary("viewport")}} width, or some feature of the browser or device, we check for support of a CSS property and value pair using an {{cssxref("@supports")}} rule. Inside the feature query, we can then write any CSS we need to apply our modern layout, and remove anything required for the older layout.</p>
 
@@ -191,7 +191,6 @@ img {
 
 <p>I use an <code>@supports</code> rule to check for support of <code>display: grid</code>. I then do my grid code on the {{HTMLElement("ul")}}, set my width and {{cssxref("min-height")}} on the {{HTMLElement("li")}} to <code>auto</code>. I also remove the margins and negative margins, and replace the spacing with the {{cssxref("gap")}} property. This means I don’t get a final margin on the last row of boxes. The layout now works, even if there is more content in one of the cards, than the others:</p>
 
-<div id="enhancement_3">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -263,8 +262,7 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('enhancement_3', '550', '480') }}</p>
-</div>
+<p>{{ EmbedLiveSample('a_solution_using_feature_queries', '550', '480') }}</p>
 
 <h2 id="Overwriting_other_values_of_display">Overwriting other values of <code>display</code></h2>
 
@@ -272,7 +270,6 @@ img {
 
 <p>Once again I can use feature queries to overwrite a layout that uses <code>display: inline-block</code>, and again I don’t need to overwrite everything. An item that is set to <code>inline-block</code> becomes a grid item, and so the behavior of <code>inline-block</code> no longer applies. I have used the {{cssxref("vertical-align")}} property on my item when in the <code>inline-block</code> display mode, but this property does not apply to grid items and, therefore, is ignored once the item becomes a grid item:</p>
 
-<div id="enhancement_4">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -351,8 +348,7 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('enhancement_4', '500', '480') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Overwriting_other_values_of_display', '500', '480') }}</p>
 
 <p>Once again it is the width on the item we need to address, and then any other properties we want to enhance. In this example I have again used <code>gap</code>, rather than margins and negative margins to create my gutters.</p>
 

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
@@ -41,7 +41,6 @@ tags:
 
 <p>In this example I have used grid to lay out a set of boxes that contain links. I have used the line-based placement properties to position box 1 on the second row of the grid. Visually it now appears as the fourth item in the list. However, if I tab from link to link the tab order still begins with box 1, as it comes first in the source.</p>
 
-<div id="accessibility_1">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -82,8 +81,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('accessibility_1', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Visual_not_logical_re-ordering', '500', '330') }}</p>
 
 <p>The specification says that in this scenario, if box 1 really makes sense logically in that position, we should go back to our source and make the change there rather than reordering using grid layout. This is what is meant by visual versus logical reordering, logical ordering is important for the meaning and structure of our document, and we should make sure that we preserve that structure.</p>
 

--- a/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
@@ -67,7 +67,6 @@ tags:
 
 <p>The value <code>horizontal-tb</code> is the default for text on the web. It is the direction in which you are reading this guide. The other properties will change the way that text flows in our document, matching the different writing modes found around the world. Again, for full details of these see <a href="https://24ways.org/2016/css-writing-modes/">Jen’s article</a>. As a simple example, I have two paragraphs below. The first uses the default <code>horizontal-tb</code>, and the second uses <code>vertical-rl</code>. In the mode text still runs left to right, however the direction of the text is vertical - inline text now runs down the page, from top to bottom.</p>
 
-<div id="writing_1">
 <div class="hidden">
 <pre class="brush: css">.wrapper &gt; p {
     border: 2px solid #ffa94d;
@@ -87,16 +86,16 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_1', '500', '420') }}</p>
-</div>
+<p>{{ EmbedLiveSample('writing-mode', '500', '500') }}</p>
 
 <h2 id="Writing_modes_in_grid_layouts">Writing modes in grid layouts</h2>
 
 <p>If we now take a look at a grid layout example, we can see how changing the writing mode means changing our idea of where the Block and Inline Axis are.</p>
 
-<p>The grid in my next example has three columns and two row tracks. This means there are three tracks running down the block axis. In default writing mode, grid auto-places items starting at the top left, moving along to the right, filling up the three cells on the inline axis. It then moves onto the next line, creating a new Row track, and fills in more items:</p>
+<h3 id="default_writing_mode">Default writing mode</h3>
 
-<div id="writing_2">
+<p>The grid in this example has three columns and two row tracks. This means there are three tracks running down the block axis. In default writing mode, grid auto-places items starting at the top left, moving along to the right, filling up the three cells on the inline axis. It then moves onto the next line, creating a new Row track, and fills in more items:</p>
+
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -133,12 +132,12 @@ gap: 10px;
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_2', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('default_writing_mode', '500', '330') }}</p>
+
+<h3 id="setting_writing_mode">Setting writing mode</h3>
 
 <p>If we add <code>writing-mode: vertical-lr</code> to the grid container, we can see that the block and inline Axis are now running in a different direction. The block or <em>column</em> axis now runs across the page from left to right, Inline runs down the page, creating rows from top to bottom.</p>
 
-<div id="writing_3">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -176,8 +175,7 @@ gap: 10px;
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_3', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('setting_writing_mode', '500', '330') }}</p>
 
 <p><img alt="A image showing the direction of Block and Inline when writing-mode is vertical-lr" src="8-vertical-lr.png"></p>
 
@@ -187,7 +185,6 @@ gap: 10px;
 
 <p>In this next example, I am using alignment to align items inside a grid that is set to <code>writing-mode: vertical-lr</code>. The <code>start</code> and <code>end</code> properties work in exactly the same way that they do in the default writing mode, and remain logical in a way that using left and right, top and bottom to align items would not do. This occurs once we've flipped the grid onto the side, like this:</p>
 
-<div id="writing_4">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -241,8 +238,7 @@ gap: 10px;
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_4', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Logical_values_for_alignment', '500', '330') }}</p>
 
 <p>If you want to see how these work, with a right to left as well as top to bottom writing mode, switch <code>vertical-lr</code> to <code>vertical-rl</code>, which is a vertical writing mode running from right to left.</p>
 
@@ -254,6 +250,8 @@ gap: 10px;
 
 <p>The key thing to remember when placing items by line number, is that line 1 is the start line, no matter which writing mode you are in. Line -1 is the end line, no matter which writing mode you are in.</p>
 
+<h3 id="line-based_placement_with_left_to_right_text">Line-based placement with left to right text</h3>
+
 <p>In this next example, I have a grid which is in the default <code>ltr</code> direction. I have positioned three items using line-based placement.</p>
 
 <ul>
@@ -262,7 +260,6 @@ gap: 10px;
  <li>Item 3 starts at column line 1, spanning to column line 3.</li>
 </ul>
 
-<div id="writing_5">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -307,12 +304,12 @@ gap: 10px;
     &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_5', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('line-based_placement_with_left_to_right_text', '500', '330') }}</p>
+
+<h3 id="line-based_placement_with_right_to_left_text">Line-based placement with right to left text</h3>
 
 <p>If I now add the {{cssxref("direction")}} property with a value of <code>rtl</code> to the grid container, line 1 becomes the right hand side of the grid, and line -1 on the left.</p>
 
-<div id="writing_6">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -358,8 +355,7 @@ gap: 10px;
     &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_6', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('line-based_placement_with_right_to_left_text', '500', '330') }}</p>
 
 <p>What this demonstrates, is that if you are switching the direction of your text, either for entire pages or for parts of pages, and are using lines: you may want to name your lines, if you do not want the layout to completely switch direction. For some things, for example, where a grid contains text content, this switching may be exactly what you want. For other usage it may not.</p>
 
@@ -391,7 +387,6 @@ gap: 10px;
 
 <p>In addition to displaying documents, using the correct writing mode for the language, writing modes can be used creatively within documents that are otherwise <code>ltr</code>. In this next example I have a grid layout with a set of links down one side. I’ve used writing modes to turn these on their side in the column track:</p>
 
-<div id="writing_7">
 <pre class="brush: css">.wrapper {
     display: grid;
     grid-gap: 20px;
@@ -428,8 +423,7 @@ gap: 10px;
     &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('writing_7', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Mixed_writing_modes_and_grid_layout', '500', '330') }}</p>
 
 <h2 id="Physical_values_and_grid_layout">Physical values and grid layout</h2>
 

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
@@ -36,7 +36,6 @@ tags:
 
 <p>With the {{cssxref("grid-area")}} property I can assign each of these areas a name. This will not yet create any layout, but we now have named areas to use in a layout.</p>
 
-<div id="Grid_Area_1">
 <pre class="brush: css">.header {
     grid-area: hd;
 }
@@ -92,8 +91,7 @@ tags:
     &lt;div class="footer"&gt;Footer&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('Grid_Area_1', '300', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Naming_a_grid_area', '300', '330') }}</p>
 
 <p>Using this method we do not need to specify anything at all on the individual grid items, everything happens on our grid container. We can see the layout described as the value of the {{cssxref("grid-template-areas")}} property.</p>
 
@@ -312,6 +310,8 @@ tags:
 
 <p>Many of the grid examples you will find online make the assumption that you will use grid for main page layout, however grid can be just as useful for small elements as those larger ones. Using {{cssxref("grid-template-areas")}} can be especially nice as it is easy to see in the code what your element looks like.</p>
 
+<h3 id="media_object_example">Media object example</h3>
+
 <p>As a very simple example we can create a “media object”. This is a component with space for an image or other media on one side and content on the other. The image might be displayed on the right or left of the box.</p>
 
 <p><img alt="Images showing an example media object design" src="4_media_objects.png"></p>
@@ -320,7 +320,6 @@ tags:
 
 <p>We give the image area a grid area name of <code>img</code> and the text area <code>content</code>, then we can lay those out using the <code>grid-template-areas</code> property.</p>
 
-<div id="Media_1">
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .media {
@@ -355,14 +354,12 @@ tags:
     &lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('Media_1', '300', '200') }}</p>
-</div>
+<p>{{ EmbedLiveSample('media_object_example', '300', '200') }}</p>
 
 <h3 id="Displaying_the_image_on_the_other_side_of_the_box">Displaying the image on the other side of the box</h3>
 
 <p>We might want to be able to display our box with the image the other way around. To do this, we redefine the grid to put the <code>1fr</code> track last, and flip the values in {{cssxref("grid-template-areas")}}.</p>
 
-<div id="Media_2">
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .media {
@@ -402,8 +399,7 @@ tags:
     &lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('Media_2', '300', '200') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Displaying_the_image_on_the_other_side_of_the_box', '300', '200') }}</p>
 
 <h2 id="Grid_definition_shorthands">Grid definition shorthands</h2>
 

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
@@ -14,7 +14,6 @@ tags:
 
 <p>You can assign some or all of the lines in your grid a name when you define your grid with the <code>grid-template-rows</code> and <code>grid-template-columns</code> properties. To demonstrate I’ll use the simple layout created in the guide on line-based placement. This time I’ll create the grid using named lines.</p>
 
-<div id="example_named_lines">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -77,8 +76,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('example_named_lines', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Naming_lines_when_defining_a_grid', '500', '330') }}</p>
 
 <p>Everything else about line-based placement still works in the same way and you can mix named lines and line numbers. Naming lines is useful when creating a responsive design where you redefine the grid, rather than then needing to redefine the content position by changing the line number in your media queries, you can ensure that the line is always named the same in your definitions.</p>
 
@@ -92,7 +90,6 @@ tags:
 
 <p>While you can choose any name, if you append <code>-start</code> and <code>-end</code> to the lines around an area, as I have in the example above, grid will create you a named area of the main name used. Taking the above example, I have <code>content-start</code> and <code>content-end</code> both for rows and for columns. This means I get a grid area named <code>content</code>, and could place something in that area should I wish to.</p>
 
-<div id="implicit_areas_from_lines">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -129,8 +126,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('implicit_areas_from_lines', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Implicit_grid_areas_from_named_lines', '500', '330') }}</p>
 
 <p>We don’t need to define where our areas are with <code>grid-template-areas</code> as our named lines have created an area for us.</p>
 
@@ -166,7 +162,6 @@ tags:
 
 <p>To position <code>overlay</code> using these implicit named lines is the same as positioning an item using lines that we have named.</p>
 
-<div id="implicit_lines_from_area">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -232,8 +227,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('implicit_lines_from_area', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Implicit_Grid_lines_from_named_areas', '500', '330') }}</p>
 
 <p>Given that we have this ability to position create lines from named areas and areas from named lines it is worth taking a little bit of time to plan your naming strategy when starting out creating your grid layout. By selecting names that will make sense to you and your team you will help everyone to use the layouts you create more easily.</p>
 
@@ -241,9 +235,10 @@ tags:
 
 <p>If you want to give all of the lines in your grid a unique name then you will need to write out the track definition long-hand rather than using the repeat syntax, as you need to add the name in square brackets while defining the tracks. If you do use the repeat syntax you will end up with multiple lines that have the same name, however this can be very useful too.</p>
 
+<h3 id="twelve_column_grid_using_repeat">12-column grid using repeat()</h3>
+
 <p>In this next example I am creating a grid with twelve equal width columns. Before defining the 1fr size of the column track I am also defining a line name of <code>[col-start]</code>. This means that we will end up with a grid that has 12 column lines all named <code>col-start</code> before a <code>1fr</code> width column.</p>
 
-<div id="multiple_lines_same_name">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -289,12 +284,13 @@ tags:
   &lt;div class="item2"&gt;I am placed from col-start line 7 spanning 3 lines&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('multiple_lines_same_name', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('twelve_column_grid_using_repeat', '500', '330') }}</p>
 
 <p>If you take a look at this layout in the Firefox Grid Highlighter you can see how the column lines are shown, and how our items are placed against these lines.</p>
 
 <p><img alt="The 12 column grid with items placed. The Grid Highlighter shows the position of the lines." src="5_named_lines1.png"></p>
+
+<h3 id="defining_named_lines_with_a_track_list">Defining named lines with a track list</h3>
 
 <p>The repeat syntax can also take a track list, it doesn’t just need to be a single track size that is being repeated. The code below would create an eight track grid, with a narrower <code>1fr</code> width column named <code>col1-start</code> followed by a wider <code>3fr</code> column named <code>col2-start</code>.</p>
 
@@ -319,7 +315,6 @@ tags:
 
 <p>If you have used a track list then you can use the <code>span</code> keyword not just to span a number of lines but also to span a number of lines of a certain name.</p>
 
-<div id="span_line_number">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -360,14 +355,14 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('span_line_number', '500', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('defining_named_lines_with_a_track_list', '500', '330') }}</p>
+
+<h3 id="twelve_column_grid_framework">12-column grid framework</h3>
 
 <p>Over the last three guides you have discovered that there are a lot of different ways to place items using grid. This can seem a little bit overcomplicated at first, but remember you don’t need to use all of them. In practice I find that for straightforward layouts, using named template areas works well, it gives that nice visual representation of what your layout looks like, and it is then easy to move things around on the grid.</p>
 
 <p>If working with a strict multiple column layout for example the named lines demonstration in the last part of this guide works very well. If you consider grid systems such as those found in frameworks like Foundation or Bootstrap, these are based on a 12 column grid. The framework then imports the code to do all of the calculations to make sure that the columns add up to 100%. With grid layout the only code we need for our grid “framework” is:</p>
 
-<div id="three_column">
 <pre class="brush: css">.wrapper {
   display: grid;
   gap: 10px;
@@ -428,11 +423,10 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('three_column', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('twelve_column_grid_framework', '500', '330') }}</p>
 
 <p>Once again, the grid highlighter is helpful to show us how the grid we have placed our items on works.</p>
 
 <p><img alt="The layout with the grid highlighted." src="5_named_lines2.png"></p>
-</div>
 
 <p>That’s all I need. I don’t need to do any calculations, grid automatically removed my 10 pixel gutter track before assigning the space to the <code>1fr</code> column tracks. As you start to build out your own layouts, you will find that the syntax becomes more familiar and you choose the ways that work best for you and the type of projects you like to build. Try building some common patterns with these various methods, and you will soon find your most productive way to work. Then, in the next guide we will look at how grid can position items for us - without us needing to use placement properties at all!</p>

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
@@ -58,7 +58,6 @@ tags:
 
 <p>We can use line-based placement to control where these items sit on the grid. I would like the first item to start on the far left of the grid and span a single column track. It should also start on the first row line, at the top of the grid and span to the fourth row line.</p>
 
-<div id="Line_Number">
 <pre class="brush: css">.box1 {
    grid-column-start: 1;
    grid-column-end: 2;
@@ -127,10 +126,8 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Line_Number', '300', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Positioning_items_by_line_number', '300', '330') }}</p>
 
-<div id="Grid_Shorthands">
 <h2 id="The_grid-column_and_grid-row_shorthands">The <code>grid-column</code> and <code>grid-row</code> shorthands</h2>
 
 <p>We have quite a lot of code here to position each item. It should come as no surprise to know there is a {{glossary("shorthand properties", "shorthand")}}. The {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties can be combined into {{cssxref("grid-column")}}, {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} into {{cssxref("grid-row")}}.</p>
@@ -183,14 +180,17 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Grid_Shorthands', '300', '330') }}</p>
+<p>{{ EmbedLiveSample('The_grid-column_and_grid-row_shorthands', '300', '330') }}</p>
 </div>
 
-<h3 id="Default_spans">Default spans</h3>
+<h2 id="Default_spans">Default spans</h2>
 
-<p>In the above examples I specified every end row and column line, in order to demonstrate the properties, however in practice if an item only spans one track you can omit the <code>grid-column-end</code> or <code>grid-row-end</code> value. Grid defaults to spanning one track. This means that our initial, long-hand, example would look like this:</p>
+<p>In the above examples I specified every end row and column line, in order to demonstrate the properties, however in practice if an item only spans one track you can omit the <code>grid-column-end</code> or <code>grid-row-end</code> value. Grid defaults to spanning one track.</p>
 
-<div id="End_Lines">
+<h3 id="Default_spans_with_longhand_placement">Default spans with longhand placement</h3>
+
+<p>This means that our initial, long-hand, example would look like this:</p>
+
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -242,12 +242,12 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('End_Lines', '300', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Default_spans_with_longhand_placement', '300', '330') }}</p>
+
+<h3 id="Default_spans_with_shorthand_placement">Default spans with shorthand placement</h3>
 
 <p>Our shorthand would look like the following code, with no forward slash and second value for the items spanning one track only.</p>
 
-<div id="New_Shorthand">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -296,8 +296,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('New_Shorthand', '300', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Default_spans_with_shorthand_placement', '300', '330') }}</p>
 
 <h2 id="The_grid-area_property">The <code>grid-area</code> property</h2>
 

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -20,7 +20,6 @@ tags:
 
 <p>My mark-up is a container with elements inside for a header, footer, main content, navigation, sidebar, and a block into which I am intending to place advertising.</p>
 
-<div id="layout_1">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -142,8 +141,7 @@ tags:
 
 <p>In this layout I am displaying the <code>nav</code> in the left column, alongside the <code>content</code>. In the right column we have the <code>sidebar</code> and underneath it the advertisements (<code>ad</code>). The <code>footer</code> now spans right across the bottom of the layout. I then use a flexbox to display the navigation as a column.</p>
 
-<p>{{ EmbedLiveSample('layout_1', '800', '500') }}</p>
-</div>
+<p>{{ EmbedLiveSample('A_responsive_layout_with_1_to_3_fluid_columns_using_grid-template-areas', '800', '500') }}</p>
 
 <p>This is a simple example but demonstrates how we can use a grid layout to rearrange our layout for different breakpoints. In particular I am changing the location of that <code>ad</code> block, as appropriate in my different column setups. I find this named areas method very helpful at a prototyping stage, it is easy to play around with the location of elements. You could always begin to use grid in this way for prototyping, even if you can’t rely on it fully in production due to the browsers that visit your site.</p>
 
@@ -151,7 +149,6 @@ tags:
 
 <p>If you have been working with one of the many frameworks or grid systems you may be accustomed to laying out your site on a 12- or 16-column flexible grid. We can create this type of system using CSS Grid Layout. As a simple example, I am creating a 12-column flexible grid that has 12 <code>1fr</code>-unit column tracks, they all have a start line named <code>col-start</code>. This means that we will have twelve grid lines named <code>col-start</code>.</p>
 
-<div id="layout_2">
 <div class="hidden">
 <pre class="brush: css">.wrapper {
   max-width: 1024px;
@@ -203,8 +200,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('layout_2', '800', '400') }}</p>
-</div>
+<p>{{ EmbedLiveSample('A_flexible_12-column_layout', '800', '400') }}</p>
 
 <p>As described in the <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">guide to named lines</a>, we are using the named line to place our item. As we have 12 lines all with the same name we use the name, and then the index of the line. You could also use the line index itself if you prefer and avoid using named lines at all.</p>
 
@@ -214,11 +210,10 @@ tags:
 
 <p>There are some key differences with how a grid layout works over the grid systems you may have used previously. As you can see, we do not need to add any markup to create a row, grid systems need to do this to stop elements popping up into the row above. With CSS Grid Layout, we can place things into rows, with no danger of them rising up into the row above if it is left empty. Due to this <em>strict</em> column and row placement we can also easily leave white space in our layout. We also don’t need special classes to pull or push things, to indent them into the grid. All we need to do is specify the start and end line for the item.</p>
 
-<h3 id="Building_a_layout_using_the_12-column_system">Building a layout using the 12-column system</h3>
+<h2 id="Building_a_layout_using_the_12-column_system">Building a layout using the 12-column system</h2>
 
 <p>To see how this layout method works in practice, we can create the same layout that we created with {{cssxref("grid-template-areas")}}, this time using the 12-column grid system. I am starting with the same markup as used for the grid template areas example.</p>
 
-<div id="layout_3">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -330,8 +325,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('layout_3', '800', '450') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Building_a_layout_using_the_12-column_system', '800', '450') }}</p>
 
 <p>Once again the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts">Grid Inspector</a> is useful to help us see how our layout has taken shape.</p>
 
@@ -345,7 +339,6 @@ tags:
 
 <p>The markup for my listing is an unordered list of items. Each item contains a heading, some text of varying height, and a call to action link.</p>
 
-<div id="layout_4">
 <pre class="brush: html">&lt;ul class="listing"&gt;
   &lt;li&gt;
     &lt;h2&gt;Item One&lt;/h2&gt;
@@ -433,8 +426,9 @@ tags:
 
 <p>This is really one of the key reasons I would use flexbox rather than grid, if I am just aligning or distributing something in a single dimension, that’s a flexbox use case. </p>
 
-<p>{{ EmbedLiveSample('layout_4', '800', '900') }}</p>
-</div>
+<p>{{ EmbedLiveSample('A_product_listing_with_auto-placement', '800', '900') }}</p>
+
+<h2 id="preventing_gaps_with_the_dense_keyword">Preventing gaps with the dense keyword</h2>
 
 <p>This is all looking fairly complete now, however we sometimes have these cards which contain far more content than the others. It might be nice to cause those to span two tracks, and then they won’t be so tall. I have a class of <code>wide</code> on my larger item, and I add a rule {{cssxref("grid-column-end")}} with a value of <code>span 2</code>. Now when grid encounters this item, it will assign it two tracks. At some breakpoints, this means that we'll get a gap in the grid – where there isn’t space to lay out a two-track item.</p>
 
@@ -442,7 +436,6 @@ tags:
 
 <p>I can cause a grid to backfill those gaps by setting {{cssxref("grid-auto-flow")}}<code>: dense </code> on the grid container. Take care when doing this however as it does take items away from their logical source order. You should only do this if your items do not have a set order – and be aware of the <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility#visual_not_logical_re-ordering">issues</a> of the tab order following the source and not your reordered display.</p>
 
-<div id="layout_5">
 <div class="hidden">
 <pre class="brush: html">&lt;ul class="listing"&gt;
   &lt;li&gt;
@@ -525,10 +518,9 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('layout_5', '800', '900') }}</p>
+<p>{{ EmbedLiveSample('preventing_gaps_with_the_dense_keyword', '800', '900') }}</p>
 
 <p>This technique of using auto-placement with some rules applied to certain items is very useful, and can help you to deal with content that is being output by a CMS for example, where you have repeated items and can perhaps add a class to certain ones as they are rendered into the HTML.</p>
-</div>
 
 <h2 id="Further_exploration">Further exploration</h2>
 

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The basic difference between CSS Grid Layout and <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">CSS Flexbox Layout</a> is that flexbox was designed for layout in one dimension - either a row <em>or</em> a column. Grid was designed for two-dimensional layout - rows, and columns at the same time. The two specifications share some common features, however, and if you have already learned how to use flexbox, the similarities should help you get to grips with Grid.</p>
 
-<h3 id="One-dimensional_vs._two-dimensional_layout">One-dimensional vs. two-dimensional layout</h3>
+<h3 id="One-dimensional_versus_two-dimensional_layout">One-dimensional versus two-dimensional layout</h3>
 
 <p>A simple example can demonstrate the difference between one- and two-dimensional layouts.</p>
 
@@ -22,7 +22,6 @@ tags:
 
 <p>I have also set the {{cssxref("flex-wrap")}} property to <code>wrap</code>, so that if the space in the container becomes too narrow to maintain the flex basis, items will wrap onto a new row.</p>
 
-<div id="onedtwod">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -60,9 +59,8 @@ tags:
   flex: 1 1 150px;
 }
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('onedtwod', '500', '230') }}</p>
+<p>{{ EmbedLiveSample('One-dimensional_versus_two-dimensional_layout', '500', '230') }}</p>
 
 <p>In the image, you can see that two items have wrapped onto a new line. These items are sharing the available space and not lining up underneath the items above. This is because when you wrap flex items, each new row (or column when working by column) is an independent flex line in the flex container. Space distribution happens across the flex line.</p>
 
@@ -72,7 +70,6 @@ tags:
 
 <p>In this next example, I create the same layout using Grid. This time we have three <code>1fr</code> column tracks. We do not need to set anything on the items themselves; they will lay themselves out one into each cell of the created grid. As you can see they stay in a strict grid, lining up in rows and columns. With five items, we get a gap on the end of row two.</p>
 
-<div id="Two_Dimensional_With_Grid">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -107,8 +104,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Two_Dimensional_With_Grid', '300', '170') }}</p>
-</div>
+<p>{{ EmbedLiveSample('The_same_layout_with_CSS_grids', '300', '170') }}</p>
 
 <p>A simple question to ask yourself when deciding between grid or flexbox is:</p>
 
@@ -442,7 +438,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('With_a_grid_area_as_the_parent', '500', '420') }}</p>
+<p>{{ EmbedLiveSample('With_a_grid_area_as_the_parent', '500', '460') }}</p>
 
 <h2 id="Grid_and_display_contents">Grid and <code>display: contents</code></h2>
 
@@ -452,9 +448,12 @@ tags:
 <p>“The element itself does not generate any boxes, but its children and pseudo-elements still generate boxes as normal. For the purposes of box generation and layout, the element must be treated as if it had been replaced with its children and pseudo-elements in the document tree.”</p>
 </blockquote>
 
-<p>If you set an item to <code>display:</code> <code>contents</code> the box it would normally create disappears, and the boxes of the child elements appear as if they have risen up a level. This means that children of a grid item can become grid items. Sound odd? Here is a simple example. In the following markup, I have a grid and the first item on the grid is set to span all three column tracks. It contains three nested items. As these items are not direct children, they don’t become part of the grid layout and so display using regular block layout.</p>
+<p>If you set an item to <code>display:</code> <code>contents</code> the box it would normally create disappears, and the boxes of the child elements appear as if they have risen up a level. This means that children of a grid item can become grid items. Sound odd? Here is a simple example.</p>
 
-<div id="Display_Contents_Before">
+<h3 id="grid_layout_with_nested_child_elements">Grid layout with nested child elements</h3>
+
+<p>In the following markup, I have a grid and the first item on the grid is set to span all three column tracks. It contains three nested items. As these items are not direct children, they don’t become part of the grid layout and so display using regular block layout.</p>
+
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -505,12 +504,12 @@ tags:
 
 </pre>
 
-<p>{{ EmbedLiveSample('Display_Contents_Before', '400', '420') }}</p>
-</div>
+<p>{{ EmbedLiveSample('grid_layout_with_nested_child_elements', '400', '440') }}</p>
+
+<h3 id="using_display_contents">Using display_contents</h3>
 
 <p>If I now add <code>display:</code> <code>contents</code> to the rules for <code>box1</code>, the box for that item vanishes and the sub-items now become grid items and lay themselves out using the auto-placement rules.</p>
 
-<div id="Display_Contents_After">
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -561,8 +560,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Display_Contents_After', '400', '330') }}</p>
-</div>
+<p>{{ EmbedLiveSample('using_display_contents', '400', '350') }}</p>
 
 <p>This can be a way to get items nested into the grid to act as if they are part of the grid, and is a way around some of the issues that would be solved by subgrids once they are implemented. You can also use <code>display:</code> <code>contents</code> in a similar way with flexbox to enable nested items to become flex items.</p>
 


### PR DESCRIPTION
@rachelandrew , this is the next part of https://github.com/mdn/content/issues/5601, and tries to rework places in the Grid documentation where we use `div` IDs to refer to code blocks for live samples.

Generally this involves making sure that each live sample lives under its own heading. I've tried not to mangle the flow of these tutorials too badly, but I'd very much appreciate any improvement suggestions you had especially for some heading titles.