### PR TITLE
Drop tabindex for <object> attribute list

### DIFF
--- a/files/en-us/web/html/element/object/index.html
+++ b/files/en-us/web/html/element/object/index.html
@@ -75,8 +75,6 @@ browser-compat: html.elements.object
  <dd>The name of valid browsing context (HTML5), or the name of the control (HTML 4).</dd>
  <dt>{{HTMLAttrDef("standby")}} {{deprecated_inline}}</dt>
  <dd>A message that the browser can show while loading the object's implementation and data.</dd>
- <dt>{{HTMLAttrDef("tabindex")}} {{deprecated_inline}}</dt>
- <dd>The position of the element in the tabbing navigation order for the current document.</dd>
  <dt>{{HTMLAttrDef("type")}}</dt>
  <dd>The <a href="/en-US/docs/Glossary/MIME_type">content type</a> of the resource specified by <strong>data</strong>. At least one of <strong>data</strong> and <strong>type</strong> must be defined.</dd>
  <dt>{{HTMLAttrDef("usemap")}}</dt>


### PR DESCRIPTION
The `tabindex` attribute is a global attribute; it should not be (re)included in the `<object>` article’s list of attribute that are specific to `<object>.`

Fixes https://github.com/mdn/content/issues/5644