### PR TITLE
Add “global event handlers” link to attribute index page

### DIFF
--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -17,6 +17,10 @@ tags:
 
 <p>Elements in HTML have <strong>attributes</strong>; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.</p>
 
+<h2 id="global_event_handlers">Global event handlers</h2>
+
+<p>In addition to the attributes listed in the table below, the <a href="/en-US/docs/Web/API/GlobalEventHandlers"><code>GlobalEventHandlers</code></a> article lists global event handlers — such as <a href="/en-US/docs/Web/API/GlobalEventHandlers/onclick"><code>onclick</code></a> — than can also be specified as <a href="#content_versus_idl_attributes">content attributes</a> on all elements.</a></p>
+
 <h2 id="Attribute_list">Attribute list</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/4551