### PR TITLE
Remove style attributes in api/console/*

### DIFF
--- a/files/en-us/web/api/console/index.html
+++ b/files/en-us/web/api/console/index.html
@@ -153,7 +153,7 @@ console.info("My first car was a", car, ". The object is:", someObject);</pre>
 
 <p>The text before the directive will not be affected, but the text after the directive will be styled using the CSS declarations in the parameter.</p>
 
-<p><img alt="" src="css-styling.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="" src="css-styling.png"></p>
 
 <p>You may use <code>%c</code> multiple times:</p>
 
@@ -223,7 +223,7 @@ console.timeEnd("answer time");
 
 <p>Will log the time needed by the user to dismiss the alert box, log the time to the console, wait for the user to dismiss the second alert, and then log the ending time to the console:</p>
 
-<p><img class="default internal" src="console-timelog.png" style="border: 1px solid black; margin: 0 auto;"></p>
+<p><img class="default internal" src="console-timelog.png"></p>
 
 <p>Notice that the timer's name is displayed both when the timer is started and when it's stopped.</p>
 
@@ -245,7 +245,7 @@ foo();
 
 <p>The output in the console looks something like this:</p>
 
-<p><img alt="" src="api-trace2.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="api-trace2.png"></p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/console/timeend/index.html
+++ b/files/en-us/web/api/console/timeend/index.html
@@ -46,10 +46,7 @@ console.timeEnd("answer time");
 <p>The output from the example above shows the time taken by the user to dismiss the first
 	alert box, followed by the time it took for the user to dismiss the second alert:</p>
 
-<p><img class="default internal"
-		src="timer_output.png"
-		style="border: 1px solid black; display: block; margin: 0px auto;">
-</p>
+<p><img class="default internal" src="timer_output.png"></p>
 
 <p>Notice that the timer's name is displayed when the timer value is logged using
 	<code>timeLog()</code> and again when it's stopped. In addition, the call to timeEnd()

--- a/files/en-us/web/api/console/timelog/index.html
+++ b/files/en-us/web/api/console/timelog/index.html
@@ -64,9 +64,7 @@ console.timeEnd("answer time");
 <p>The output from the example above shows the time taken by the user to dismiss the first
   alert box, followed by the time it took for the user to dismiss the second alert:</p>
 
-<p><img class="default internal"
-    src="timer_output.png"
-    style="border: 1px solid black; margin: 0px auto;"></p>
+<p><img class="default internal" src="timer_output.png"></p>
 
 <p>Notice that the timer's name is displayed when the timer value is logged using
   <code>timeLog()</code> and again when it's stopped. In addition, the call to timeEnd()


### PR DESCRIPTION
This is part of #5438.

It removes the only styles in the three files of Console that had some.

They were all used to center some images, so I just removed them.