### PR TITLE
Remove style attributes in api/[efh]*

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.html
+++ b/files/en-us/web/api/element/getboundingclientrect/index.html
@@ -45,8 +45,7 @@ browser-compat: api.Element.getBoundingClientRect
   <code>width</code> and <code>height</code> are relative to the top-left of the viewport.
 </p>
 
-<p style="display: block;"><img alt=""
-    src="element-box-diagram.png"></p>
+<p><img alt="" src="element-box-diagram.png"></p>
 
 <p>The <code>width</code> and <code>height</code> properties of the {{domxref("DOMRect")}}
   object returned by the method include the <code>padding</code> and
@@ -152,7 +151,7 @@ p { margin: 0; }</pre>
   const container = document.getElementById("controls");
   const elem = document.querySelector('div');
   const rect = elem.getBoundingClientRect();
-  
+
   container.innerHTML = '';
   for (let key in rect) {
     if(typeof rect[key] !== 'function') {

--- a/files/en-us/web/api/element/insertadjacentelement/index.html
+++ b/files/en-us/web/api/element/insertadjacentelement/index.html
@@ -30,13 +30,13 @@ browser-compat: api.Element.insertAdjacentElement
     <code>targetElement</code>; must match (case-insensitively) one of the following
     strings:
     <ul>
-      <li><code style="color: red;">'beforebegin'</code>: Before the
+      <li><code>'beforebegin'</code>: Before the
         <code>targetElement</code> itself.</li>
-      <li><code style="color: green;">'afterbegin'</code>: Just inside the
+      <li><code>'afterbegin'</code>: Just inside the
         <code>targetElement</code>, before its first child.</li>
-      <li><code style="color: blue;">'beforeend'</code>: Just inside the
+      <li><code>'beforeend'</code>: Just inside the
         <code>targetElement</code>, after its last child.</li>
-      <li><code style="color: magenta;">'afterend'</code>: After the
+      <li><code>'afterend'</code>: After the
         <code>targetElement</code> itself.</li>
     </ul>
   </dd>
@@ -71,13 +71,13 @@ browser-compat: api.Element.insertAdjacentElement
 
 <h3 id="Visualization_of_position_names">Visualization of position names</h3>
 
-<pre>&lt;!-- <strong><code style="color: red;">beforebegin</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;p&gt;</code>
-  &lt;!-- <strong><code style="color: green;">afterbegin</code></strong> --&gt;
+<pre>&lt;!-- <strong><code>beforebegin</code></strong> --&gt;
+<code>&lt;p&gt;</code>
+  &lt;!-- <strong><code>afterbegin</code></strong> --&gt;
   foo
-  &lt;!-- <strong><code style="color: blue;">beforeend</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;/p&gt;</code>
-&lt;!-- <strong><code style="color: magenta;">afterend</code></strong> --&gt;</pre>
+  &lt;!-- <strong><code>beforeend</code></strong> --&gt;
+<code>&lt;/p&gt;</code>
+&lt;!-- <strong><code>afterend</code></strong> --&gt;</pre>
 
 <div class="note"><strong>Note:</strong> The <code>beforebegin</code> and
   <code>afterend</code> positions work only if the node is in a tree and has an element

--- a/files/en-us/web/api/element/insertadjacenthtml/index.html
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.html
@@ -36,13 +36,13 @@ browser-compat: api.Element.insertAdjacentHTML
   <dd>A {{domxref("DOMString")}} representing the position relative to the
     <code>element</code>; must be one of the following strings:
     <ul>
-      <li><code style="color: red;">'beforebegin'</code>: Before the <code>element</code>
+      <li><code>'beforebegin'</code>: Before the <code>element</code>
         itself.</li>
-      <li><code style="color: green;">'afterbegin'</code>: Just inside the
+      <li><code>'afterbegin'</code>: Just inside the
         <code>element</code>, before its first child.</li>
-      <li><code style="color: blue;">'beforeend'</code>: Just inside the
+      <li><code>'beforeend'</code>: Just inside the
         <code>element</code>, after its last child.</li>
-      <li><code style="color: magenta;">'afterend'</code>: After the <code>element</code>
+      <li><code>'afterend'</code>: After the <code>element</code>
         itself.</li>
     </ul>
   </dd>
@@ -52,13 +52,13 @@ browser-compat: api.Element.insertAdjacentHTML
 
 <h3 id="Visualization_of_position_names">Visualization of position names</h3>
 
-<pre>&lt;!-- <strong><code style="color: red;">beforebegin</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;p&gt;</code>
-  &lt;!-- <strong><code style="color: green;">afterbegin</code></strong> --&gt;
+<pre>&lt;!-- <strong><code>beforebegin</code></strong> --&gt;
+<code>&lt;p&gt;</code>
+  &lt;!-- <strong><code>afterbegin</code></strong> --&gt;
   foo
-  &lt;!-- <strong><code style="color: blue;">beforeend</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;/p&gt;</code>
-&lt;!-- <strong><code style="color: magenta;">afterend</code></strong> --&gt;</pre>
+  &lt;!-- <strong><code>beforeend</code></strong> --&gt;
+<code>&lt;/p&gt;</code>
+&lt;!-- <strong><code>afterend</code></strong> --&gt;</pre>
 
 <div class="note"><strong>Note:</strong> The <code>beforebegin</code> and
   <code>afterend</code> positions work only if the node is in the DOM tree and has a

--- a/files/en-us/web/api/element/insertadjacenttext/index.html
+++ b/files/en-us/web/api/element/insertadjacenttext/index.html
@@ -29,13 +29,13 @@ browser-compat: api.Element.insertAdjacentText
   <dd>A {{domxref("DOMString")}} representing the position relative to the
     <code>element</code>; must be one of the following strings:
     <ul>
-      <li><code style="color: red;">'beforebegin'</code>: Before the <code>element</code>
+      <li><code>'beforebegin'</code>: Before the <code>element</code>
         itself.</li>
-      <li><code style="color: green;">'afterbegin'</code>: Just inside the
+      <li><code>'afterbegin'</code>: Just inside the
         <code>element</code>, before its first child.</li>
-      <li><code style="color: blue;">'beforeend'</code>: Just inside the
+      <li><code>'beforeend'</code>: Just inside the
         <code>element</code>, after its last child.</li>
-      <li><code style="color: magenta;">'afterend'</code>: After the <code>element</code>
+      <li><code>'afterend'</code>: After the <code>element</code>
         itself.</li>
     </ul>
   </dd>
@@ -66,13 +66,13 @@ browser-compat: api.Element.insertAdjacentText
 
 <h3 id="Visualization_of_position_names">Visualization of position names</h3>
 
-<pre>&lt;!-- <strong><code style="color: red;">beforebegin</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;p&gt;</code>
-  &lt;!-- <strong><code style="color: green;">afterbegin</code></strong> --&gt;
+<pre>&lt;!-- <strong><code>beforebegin</code></strong> --&gt;
+<code>&lt;p&gt;</code>
+  &lt;!-- <strong><code>afterbegin</code></strong> --&gt;
   foo
-  &lt;!-- <strong><code style="color: blue;">beforeend</code></strong> --&gt;
-<code style="font-weight: bold;">&lt;/p&gt;</code>
-&lt;!-- <strong><code style="color: magenta;">afterend</code></strong> --&gt;</pre>
+  &lt;!-- <strong><code>beforeend</code></strong> --&gt;
+<code>&lt;/p&gt;</code>
+&lt;!-- <strong><code>afterend</code></strong> --&gt;</pre>
 
 <div class="note"><strong>Note:</strong> The <code>beforebegin</code> and
   <code>afterend</code> positions work only if the node is in a tree and has an element

--- a/files/en-us/web/api/element/mouseenter_event/index.html
+++ b/files/en-us/web/api/element/mouseenter_event/index.html
@@ -44,11 +44,14 @@ browser-compat: api.Element.mouseenter_event
 
 <p>Though similar to {{domxref("Element/mouseover_event", "mouseover")}}, <code>mouseenter</code> differs in that it doesn't <a href="/en-US/docs/Web/API/Event/bubbles">bubble</a> and it isn't sent to any descendants when the pointer is moved from one of its descendants' physical space to its own physical space.</p>
 
-<div style="column-width: 455px; border: 1px solid; padding: 5px; margin-bottom: 10px;">
-<div style="text-align: center;"><img class="default internal" src="mouseenter.png"></div>
+<h4>Behavior of <code>mouseenter</code> events:</h4>
+
+<img class="default internal" src="mouseenter.png">
 One <code>mouseenter</code> event is sent to each element of the hierarchy when entering them. Here 4 events are sent to the four elements of the hierarchy when the pointer reaches the text.
 
-<div style="text-align: center;"><img class="default internal" src="mouseover.png"></div>
+<h4>Behavior of <code>mouseover</code> events:</h4>
+
+<img class="default internal" src="mouseover.png">
 A single <code>mouseover</code> event is sent to the deepest element of the DOM tree, then it bubbles up the hierarchy until it is canceled by a handler or reaches the root.</div>
 
 <p>With deep hierarchies, the number of <code>mouseenter</code> events sent can be quite huge and cause significant performance problems. In such cases, it is better to listen for <code>mouseover</code> events.</p>

--- a/files/en-us/web/api/element/mouseleave_event/index.html
+++ b/files/en-us/web/api/element/mouseleave_event/index.html
@@ -40,15 +40,18 @@ browser-compat: api.Element.mouseleave_event
 
 <p><code>mouseleave</code> and {{event('mouseout')}} are similar but differ in that <code>mouseleave</code> does not bubble and <code>mouseout</code> does. This means that <code>mouseleave</code> is fired when the pointer has exited the element <em>and</em> all of its descendants, whereas <code>mouseout</code> is fired when the pointer leaves the element <em>or</em> leaves one of the element's descendants (even if the pointer is still within the element).</p>
 
-<div style="column-width: 455px; border: 1px solid; padding: 5px; margin-bottom: 10px;">
-<div style="text-align: center;"><img class="default internal" src="mouseleave.png"></div>
+<h4>Behavior of <code>mouseleave</code> events:</h4>
+
+<img class="default internal" src="mouseleave.png">
 
 <p>One <code>mouseleave</code> event is sent to each element of the hierarchy when leaving them. Here four events are sent to the four elements of the hierarchy when the pointer moves from the text to an area outside of the most outer div represented here.</p>
 
-<div style="text-align: center;"><img class="default internal" src="mouseout.png"></div>
+<h4>Behavior of <code>mouseover</code> events:</h4>
+
+<img class="default internal" src="mouseout.png"><
 
 <p>One single <code>mouseout</code> event is sent to the deepest element of the DOM tree, then it bubbles up the hierarchy until it is canceled by a handler or reaches the root.</p>
-</div>
+
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/fetchevent/respondwith/index.html
+++ b/files/en-us/web/api/fetchevent/respondwith/index.html
@@ -93,28 +93,16 @@ browser-compat: api.FetchEvent.respondWith
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table" style="height: 140px; width: 1236px;">
-	<thead>
-		<tr>
-			<th scope="col">Exception</th>
-			<th scope="col">Notes</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><code>NetworkError</code></td>
-			<td>A network error is triggered on certain combinations of
-				{{domxref("Request.mode","FetchEvent.request.mode")}} and
-				{{domxref("Response.type")}}  values, as hinted at in the "global rules"
-				listed above.</td>
-		</tr>
-		<tr>
-			<td><code>InvalidStateError</code></td>
-			<td>The event has not been dispatched or <code>respondWith()</code> has
-				already been invoked.</td>
-		</tr>
-	</tbody>
-</table>
+<dl>
+  <dt><code>NetworkError</code></dt>
+  <dd>A network error is triggered on certain combinations of
+    {{domxref("Request.mode","FetchEvent.request.mode")}} and
+    {{domxref("Response.type")}}  values, as hinted at in the "global rules"
+    listed above.</dd>
+  <dt><code>InvalidStateError</code></dt>
+  <dd>The event has not been dispatched or <code>respondWith()</code> has
+    already been invoked.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/file_handle_api/index.html
+++ b/files/en-us/web/api/file_handle_api/index.html
@@ -29,7 +29,6 @@ tags:
 
 <p>Because the intent is to allow the storage of files through IndexedDB, creating a {{domxref("IDBMutableFile")}} instance requires an <a href="/en-US/docs/Web/API/IDBFactory#open">IndexedDB Database</a>.</p>
 
-<div style="overflow: hidden;">
 <pre class="brush: js">var IDBReq = indexedDB.open("myFileStorageDataBase");
 
 IDBReq.onsuccess = function(){
@@ -42,7 +41,6 @@ IDBReq.onsuccess = function(){
   };
 };
 </pre>
-</div>
 
 <p>{{domxref("IDBDatabase.createMutableFile","createMutableFile()")}} takes two arguments: a name and an optional type. Both of these are just descriptive and are not used by the database. However, they are important for the {{domxref("FileHandle")}} object as it can generate {{domxref("File")}} objects which inherit their own {{domxref("File.name","name")}} and {{domxref("File.type","type")}} from those values. That said, as the name does not match any real filename it can be an empty string, for example, and it doesn't even have to be unique.</p>
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -34,7 +34,7 @@ browser-compat: api.FileReaderSync.readAsArrayBuffer
  <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
  <dt><code>SecurityError</code></dt>
  <dd>is raised when one of the following problematic situation is detected:
- <ul style="margin-left: 40px;">
+ <ul>
   <li>the resource has been modified by a third party;</li>
   <li>too many read are performed simultaneously;</li>
   <li>the file pointed by the resource is unsafe for a use from the Web (like it is a system file).</li>

--- a/files/en-us/web/api/filesystemflags/index.html
+++ b/files/en-us/web/api/filesystemflags/index.html
@@ -43,7 +43,7 @@ browser-compat: api.FileSystemFlags
 <table class="standard-table">
  <thead>
   <tr>
-   <th colspan="2" scope="col" style="text-align: center;">Option values</th>
+   <th colspan="2" scope="col">Option values</th>
    <th rowspan="2" scope="col">File/directory condition</th>
    <th rowspan="2" scope="col">Result</th>
   </tr>

--- a/files/en-us/web/api/history_api/example/index.html
+++ b/files/en-us/web/api/history_api/example/index.html
@@ -8,7 +8,6 @@ slug: Web/API/History_API/Example
 
 <p><strong>first_page.php</strong>:</p>
 
-<div style="height: 400px; margin-bottom: 12px; overflow: auto;">
 <pre class="brush: php">&lt;?php
     $page_title = "First page";
 
@@ -53,11 +52,9 @@ slug: Web/API/History_API/Example
     }
 ?&gt;
 </pre>
-</div>
 
 <p><strong>second_page.php</strong>:</p>
 
-<div style="height: 400px; margin-bottom: 12px; overflow: auto;">
 <pre class="brush: php">&lt;?php
     $page_title = "Second page";
 
@@ -102,11 +99,9 @@ slug: Web/API/History_API/Example
     }
 ?&gt;
 </pre>
-</div>
 
 <p><strong>third_page.php</strong>:</p>
 
-<div style="height: 400px; margin-bottom: 12px; overflow: auto;">
 <pre class="brush: php">&lt;?php
     $page_title = "Third page";
     $page_content = "&lt;p&gt;This is the content of &lt;strong&gt;third_page.php&lt;/strong&gt;. This content is stored into a php variable.&lt;/p&gt;";
@@ -142,7 +137,6 @@ slug: Web/API/History_API/Example
     }
 ?&gt;
 </pre>
-</div>
 
 <p><strong>css/style.css</strong>:</p>
 
@@ -191,7 +185,6 @@ slug: Web/API/History_API/Example
 
 <p><strong>js/ajax_nav.js</strong>:</p>
 
-<div style="height: 400px; margin-bottom: 12px; overflow: auto;">
 <pre class="brush: js">"use strict";
 
 const ajaxRequest = new (function () {
@@ -399,7 +392,6 @@ const ajaxRequest = new (function () {
 
 })();
 </pre>
-</div>
 
 <p><br>
  For more information, please see: <a href="/en-US/docs/Web/API/History_API/Working_with_the_History_API">Working with the History API</a>.</p>

--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.html
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.html
@@ -100,7 +100,7 @@ history.pushState(stateObj, "page 2", "bar.html")
 
 <h3 id="Reading_the_current_state">Reading the current state</h3>
 
-<p>When your page loads, it might have a non-null state object.  This can happen, for example, if the page sets a state object (using {{DOMxRef("History.pushState","pushState()")}} or {{DOMxRef("History.replaceState","replaceState()")}}) and then the user restarts their browser. When the page reloads, the page will receive an <code>onload</code><span style="font-family: helvetica;"> event, but no </span><code>popstate</code> <span style="font-family: helvetica;">event.</span> However, if you read the {{DOMxRef("History.state","history.state")}} property, you'll get back the state object you would have gotten if a <code>popstate</code> had fired.</p>
+<p>When your page loads, it might have a non-null state object.  This can happen, for example, if the page sets a state object (using {{DOMxRef("History.pushState","pushState()")}} or {{DOMxRef("History.replaceState","replaceState()")}}) and then the user restarts their browser. When the page reloads, the page will receive an <code>onload</code> event, but no <code>popstate</code> event. However, if you read the {{DOMxRef("History.state","history.state")}} property, you'll get back the state object you would have gotten if a <code>popstate</code> had fired.</p>
 
 <p>You can read the state of the current history entry without waiting for a <code>popstate</code> event using the {{DOMxRef("History.state","history.state")}} property like this:</p>
 

--- a/files/en-us/web/api/html_dom_api/index.html
+++ b/files/en-us/web/api/html_dom_api/index.html
@@ -45,7 +45,7 @@ tags:
 
 <p>For example, consider a document with two elements, one of which has two more elements nested inside it:</p>
 
-<p><img alt="Structure of a document with elements inside a document in a window" src="dom-structure.svg" style="display: block; margin: 0 auto;"></p>
+<p><img alt="Structure of a document with elements inside a document in a window" src="dom-structure.svg"></p>
 
 <p>While the {{domxref("Document")}} interface is defined as part of the {{DOMxRef("Document_Object_Model", "DOM", "", "1")}} specification, the HTML specification significantly enhances it to add information specific to using the DOM in the context of a web browser, as well as to using it to represent HTML documents specifically.</p>
 
@@ -71,7 +71,7 @@ tags:
 
 <p>The overall inheritance for HTML element classes looks like this:</p>
 
-<p><img alt="Hierarchy of interfaces for HTML elements" src="html-dom-hierarchy.svg" style="display: block; margin: 0 auto;"></p>
+<p><img alt="Hierarchy of interfaces for HTML elements" src="html-dom-hierarchy.svg"></p>
 
 <p>As such, an element inherits the properties and methods of all of its ancestors. For example, consider a {{HTMLElement("a")}} element, which is represented in the DOM by an object of type {{domxref("HTMLAnchorElement")}}. The element, then, includes the anchor-specific properties and methods described in that class's documentation, but also those defined by {{domxref("HTMLElement")}} and {{domxref("Element")}}, as well as from {{domxref("Node")}} and, finally, {{domxref("EventTarget")}}.</p>
 
@@ -486,7 +486,7 @@ nameField.addEventListener("input", event =&gt; {
  <dd>
  <ul>
   <li>
-   <p><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents" style="font-size: 1rem; letter-spacing: -0.00278rem;">Manipulating documents</a><span style="font-size: 1rem; letter-spacing: -0.00278rem;">: A beginner's guide to manipulating the DOM.</span></p>
+   <p><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents">Manipulating documents</a>: A beginner's guide to manipulating the DOM.</p>
   </li>
  </ul>
  </dd>

--- a/files/en-us/web/api/htmlaudioelement/msaudiocategory/index.html
+++ b/files/en-us/web/api/htmlaudioelement/msaudiocategory/index.html
@@ -122,6 +122,6 @@ slug: Web/API/HTMLAudioElement/msAudioCategory
 
 <h2 id="Example">Example</h2>
 
-<pre><span style="color: blue;">&lt;<span style="color: #a31515;">audio</span> <span style="color: red;">msAudioCategory</span><span style="color: blue;">=</span><span style="color: blue;">"BackgroundCapableMedia"</span> <span style="color: red;">controls</span><span style="color: blue;">=</span><span style="color: blue;">"controls"</span><span style="color: blue;">&gt;</span>
-<span style="color: blue;">&lt;</span><span style="color: #a31515;">source</span> <span style="color: red;">src</span><span style="color: blue;">=</span><span style="color: blue;">"song.mp3"</span><span style="color: blue;">/&gt;</span>
-<span style="color: blue;">&lt;/</span><span style="color: #a31515;">audio</span><span style="color: blue;">&gt;</span></span></pre>
+<pre class="brush: html">&lt;audio msAudioCategory="BackgroundCapableMedia" controls="controls"&gt;
+  &lt;source src="song.mp3"/&gt;
+&lt;/audio&gt;</pre>

--- a/files/en-us/web/api/htmlelement/offsetleft/index.html
+++ b/files/en-us/web/api/htmlelement/offsetleft/index.html
@@ -53,8 +53,8 @@ if (tOLeft &gt; 5) {
   box.style.left = longspan.offsetLeft + document.body.scrollLeft + "px";
   box.style.top = longspan.offsetTop + document.body.scrollTop + "px";
   box.style.width = longspan.offsetWidth + "px";
-  box.style.height = longspan.offsetHeight<span style="line-height: normal;"> + "px"</span><span style="line-height: normal;">;
-</span><span style="line-height: normal;">&lt;/script&gt; </span></pre>
+  box.style.height = longspan.offsetHeight + "px";
+&lt;/script&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlimageelement/image/index.html
+++ b/files/en-us/web/api/htmlimageelement/image/index.html
@@ -52,7 +52,7 @@ browser-compat: api.HTMLImageElement.Image
   {{DOMxRef("HTMLImageElement.naturalHeight")}}. If no size is specified in the
   constructor both pairs of properties have the same values.</p>
 
-<h2 id="Examples"><span style="line-height: 1.572;">Examples</span></h2>
+<h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">var myImage = new Image(100, 200);
 myImage.src = 'picture.jpg';


### PR DESCRIPTION
This is part of #5438.

It removes the style in api/[efh]* except for 4 files (Element.clientLeft, clientTop, scollHeight, scrollLeft) that need their own PR (as it wasn't cosmetic).

They were all used to center some images, so I just removed them.