### PR TITLE
Get MathML specs from BCD spec_urls

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.html
+++ b/files/en-us/web/mathml/element/maction/index.html
@@ -79,32 +79,7 @@ browser-compat: mathml.elements.maction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("MathMLCore", "#dfn-maction", "maction")}}</td>
-			<td>{{Spec2("MathMLCore")}}</td>
-			<td>Draft specification</td>
-		</tr>
-		<tr>
-			<td>{{ SpecName('MathML3', 'chapter3.html#presm.maction', 'maction') }}</td>
-			<td>{{ Spec2('MathML3') }}</td>
-			<td>Current specification</td>
-		</tr>
-		<tr>
-			<td>{{ SpecName('MathML2', 'chapter3.html#presm.maction', 'maction') }}</td>
-			<td>{{ Spec2('MathML2') }}</td>
-			<td>Initial specification</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/math/index.html
+++ b/files/en-us/web/mathml/element/math/index.html
@@ -116,27 +116,7 @@ browser-compat: mathml.elements.math
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('MathML3', 'chapter2.html#interf.toplevel', 'The Top-Level math Element') }}</td>
-			<td>{{ Spec2('MathML3') }}</td>
-			<td>Current specification</td>
-		</tr>
-		<tr>
-			<td>{{ SpecName('MathML2', 'chapter7.html#interf.toplevel', 'The Top-Level math Element') }}</td>
-			<td>{{ Spec2('MathML2') }}</td>
-			<td>Initial specification</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/menclose/index.html
+++ b/files/en-us/web/mathml/element/menclose/index.html
@@ -157,27 +157,7 @@ browser-compat: mathml.elements.menclose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.menclose', 'menclose') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.menclose', 'menclose') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/merror/index.html
+++ b/files/en-us/web/mathml/element/merror/index.html
@@ -46,32 +46,7 @@ browser-compat: mathml.elements.merror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#error-message-merror", "merror")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.merror', 'merror') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.merror', 'merror') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mfrac/index.html
+++ b/files/en-us/web/mathml/element/mfrac/index.html
@@ -65,32 +65,7 @@ browser-compat: mathml.elements.mfrac
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#fractions-mfrac", "mfrac")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mfrac', 'mfrac') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mfrac', 'mfrac') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mi/index.html
+++ b/files/en-us/web/mathml/element/mi/index.html
@@ -81,32 +81,7 @@ browser-compat: mathml.elements.mi
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#identifier-mi", "mi")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mi', 'mi') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mi', 'mi') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.html
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.html
@@ -107,32 +107,7 @@ browser-compat: mathml.elements.mmultiscripts
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#prescripts-and-tensor-indices-mmultiscripts", "mmultiscripts")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mmultiscripts', 'mmultiscripts') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mmultiscripts', 'mmultiscripts') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mn/index.html
+++ b/files/en-us/web/mathml/element/mn/index.html
@@ -83,32 +83,7 @@ browser-compat: mathml.elements.mn
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#number-mn", "mn")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mn', 'mn') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mn', 'mn') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mo/index.html
+++ b/files/en-us/web/mathml/element/mo/index.html
@@ -125,32 +125,7 @@ browser-compat: mathml.elements.mo
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#operator-fence-separator-or-accent-mo", "mo")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mo', 'mo') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mo', 'mo') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mover/index.html
+++ b/files/en-us/web/mathml/element/mover/index.html
@@ -57,32 +57,7 @@ browser-compat: mathml.elements.mover
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#underscripts-and-overscripts-munder-mover-munderover", "mover")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mover', 'mover') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mover', 'mover') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mpadded/index.html
+++ b/files/en-us/web/mathml/element/mpadded/index.html
@@ -57,32 +57,7 @@ browser-compat: mathml.elements.mpadded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#adjust-space-around-content-mpadded", "mpadded")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mpadded', 'mpadded') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mpadded', 'mpadded') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mphantom/index.html
+++ b/files/en-us/web/mathml/element/mphantom/index.html
@@ -46,32 +46,7 @@ browser-compat: mathml.elements.mphantom
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#making-sub-expressions-invisible-mphantom", "mphantom")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mphantom', 'mphantom') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mphantom', 'mphantom') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mroot/index.html
+++ b/files/en-us/web/mathml/element/mroot/index.html
@@ -45,32 +45,7 @@ browser-compat: mathml.elements.mroot
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#radicals-msqrt-mroot", "mroot")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mroot', 'mroot') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mroot', 'mroot') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mrow/index.html
+++ b/files/en-us/web/mathml/element/mrow/index.html
@@ -62,32 +62,7 @@ browser-compat: mathml.elements.mrow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#horizontally-group-sub-expressions-mrow", "mrow")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mrow', 'mrow') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mrow', 'mrow') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/ms/index.html
+++ b/files/en-us/web/mathml/element/ms/index.html
@@ -79,32 +79,7 @@ browser-compat: mathml.elements.ms
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#string-literal-ms", "ms")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.ms', 'ms') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.ms', 'ms') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mspace/index.html
+++ b/files/en-us/web/mathml/element/mspace/index.html
@@ -44,32 +44,7 @@ browser-compat: mathml.elements.mspace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#space-mspace", "mspace")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mspace', 'mspace') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mspace', 'mspace') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/msqrt/index.html
+++ b/files/en-us/web/mathml/element/msqrt/index.html
@@ -44,32 +44,7 @@ browser-compat: mathml.elements.msqrt
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#radicals-msqrt-mroot", "msqrt")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mroot', 'msqrt') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.msqrt', 'msqrt') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mstyle/index.html
+++ b/files/en-us/web/mathml/element/mstyle/index.html
@@ -74,32 +74,7 @@ browser-compat: mathml.elements.mstyle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#style-change-mstyle", "mstyle")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mstyle', 'mstyle') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mstyle', 'mstyle') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/msub/index.html
+++ b/files/en-us/web/mathml/element/msub/index.html
@@ -50,32 +50,7 @@ browser-compat: mathml.elements.msub
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#subscripts-and-superscripts-msub-msup-msubsup", "msub")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.msub', 'msub') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.msub', 'msub') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/msubsup/index.html
+++ b/files/en-us/web/mathml/element/msubsup/index.html
@@ -54,32 +54,7 @@ browser-compat: mathml.elements.msubsup
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#subscripts-and-superscripts-msub-msup-msubsup", "msubsup")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.msubsup', 'msubsup') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.msubsup', 'msubsup') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/msup/index.html
+++ b/files/en-us/web/mathml/element/msup/index.html
@@ -50,32 +50,7 @@ browser-compat: mathml.elements.msup
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#subscripts-and-superscripts-msub-msup-msubsup", "msup")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.msup', 'msup') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.msup', 'msup') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mtable/index.html
+++ b/files/en-us/web/mathml/element/mtable/index.html
@@ -90,32 +90,7 @@ browser-compat: mathml.elements.mtable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#table-or-matrix-mtable", "mtable")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mtable', 'mtable') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mtable', 'mtable') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mtd/index.html
+++ b/files/en-us/web/mathml/element/mtd/index.html
@@ -39,32 +39,7 @@ browser-compat: mathml.elements.mtd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#entry-in-table-or-matrix-mtd", "mtd")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mtd', 'mtd') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mtd', 'mtd') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mtext/index.html
+++ b/files/en-us/web/mathml/element/mtext/index.html
@@ -80,32 +80,7 @@ browser-compat: mathml.elements.mtext
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#text-mtext", "mtext")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mtext', 'mtext') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mtext', 'mtext') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/mtr/index.html
+++ b/files/en-us/web/mathml/element/mtr/index.html
@@ -35,32 +35,7 @@ browser-compat: mathml.elements.mtr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#row-in-table-or-matrix-mtr", "mtr")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.mtr', 'mtr') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.mtr', 'mtr') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/munder/index.html
+++ b/files/en-us/web/mathml/element/munder/index.html
@@ -57,32 +57,7 @@ browser-compat: mathml.elements.munder
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#underscripts-and-overscripts-munder-mover-munderover", "munder")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.munder', 'munder') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.munder', 'munder') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/munderover/index.html
+++ b/files/en-us/web/mathml/element/munderover/index.html
@@ -57,32 +57,7 @@ browser-compat: mathml.elements.munderover
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#underscripts-and-overscripts-munder-mover-munderover", "munderover")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter3.html#presm.munderover', 'munderover') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter3.html#presm.munderover', 'munderover') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/mathml/element/semantics/index.html
+++ b/files/en-us/web/mathml/element/semantics/index.html
@@ -91,32 +91,7 @@ browser-compat: mathml.elements.semantics
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("MathMLCore", "#semantics-and-presentation", "semantics")}}</td>
-   <td>{{Spec2("MathMLCore")}}</td>
-   <td>Draft specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML3', 'chapter5.html', 'Mixing Markup Languages for Mathematical Expressions') }}</td>
-   <td>{{ Spec2('MathML3') }}</td>
-   <td>Current specification</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('MathML2', 'chapter5.html', 'Combining Presentation and Content Markup ') }}</td>
-   <td>{{ Spec2('MathML2') }}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Only show current/relevant MathML specs and have less manual tables in the source :)