### PR TITLE
Update Web/HTML/Link_types

### DIFF
--- a/files/en-us/web/html/link_types/index.html
+++ b/files/en-us/web/html/link_types/index.html
@@ -28,7 +28,7 @@ browser-compat: html.elements.link.rel
    <td><code>alternate</code></td>
    <td>
     <ul>
-     <li>If the element is {{HTMLElement("link")}} and the {{HTMLAttrxRef("rel", "link")}} attribute also contains the <code>stylesheet</code> type, the link defines an <a href="/en-US/docs/Alternative_style_sheets">alternative style sheet</a>; in that case the {{HTMLAttrxRef("title", "link")}} attribute must be present and not be the empty string.</li>
+     <li>If the element is {{HTMLElement("link")}} and the {{HTMLAttrxRef("rel", "link")}} attribute also contains the <code>stylesheet</code> type, the link defines an <a href="/en-US/docs/Web/CSS/Alternative_style_sheets">alternative style sheet</a>; in that case the {{HTMLAttrxRef("title", "link")}} attribute must be present and not be the empty string.</li>
      <li>If the {{HTMLAttrxRef("type","link")}} is set to <code>application/rss+xml</code> or <code>application/atom+xml</code>, the link defines a <a href="/en-US/docs/Archive/RSS/Getting_Started/Syndicating">syndication feed</a>. The first one defined on the page is the default.</li>
      <li>Otherwise, the link defines an alternative page, of one of these types:
       <ul>
@@ -63,7 +63,7 @@ browser-compat: html.elements.link.rel
   </tr>
   <tr>
    <td><code>bookmark</code></td>
-   <td>Indicates that the hyperlink is a <a href="/en-US/docs/Permalink">permalink</a> for the nearest ancestor {{HTMLElement("article")}} element. If none, it is a permalink for the <a href="/en-US/docs/Sections_and_Outlines_of_an_HTML5_document">section</a> that the element is most closely associated to.<br>
+   <td>Indicates that the hyperlink is a <a href="/en-US/docs/Permalink">permalink</a> for the nearest ancestor {{HTMLElement("article")}} element. If none, it is a permalink for the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">section</a> that the element is most closely associated to.<br>
     <br>
     This allows for bookmarking a single article in a page containing multiple articles, such as on a monthly summary blog page, or a blog aggregator.</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}</td>
@@ -192,7 +192,7 @@ browser-compat: html.elements.link.rel
    <td>{{HTMLElement("link")}}</td>
   </tr>
   <tr>
-   <td><code>noreferrer</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Link_types/noreferrer">noreferrer</a></code></td>
    <td>
     <p>Prevents the browser, when navigating to another page, to send this page address, or any other value, as referrer via the <code>Referer:</code> HTTP header.<br>
      (In Firefox, before Firefox 37, this worked only in links found in pages. Links clicked in the UI, like "Open in a new tab" via the contextual menu, ignored this).</p>
@@ -210,7 +210,7 @@ browser-compat: html.elements.link.rel
   </tr>
   <tr>
    <td><code>pingback</code></td>
-   <td>Defines an external resource URI to call if one wishes to make a comment or a citation about the webpage. The protocol used to make such a call is defined in the <a href="http://www.hixie.ch/specs/pingback/pingback">Pingback 1.0</a> specification.<br>
+   <td>Defines an external resource URI to call if one wishes to make a comment or a citation about the webpage. The protocol used to make such a call is defined in the <a href="https://www.hixie.ch/specs/pingback/pingback">Pingback 1.0</a> specification.<br>
     <br>
     <strong>Note:</strong> if the <code>X-Pingback:</code> HTTP header is also present, it supersedes the {{HTMLElement("link")}} element with this link type.</td>
    <td>{{HTMLElement("link")}}</td>
@@ -226,13 +226,13 @@ browser-compat: html.elements.link.rel
    <td><code><a href="/en-US/docs/Web/HTML/Link_types/prefetch">prefetch</a></code></td>
    <td>Suggests that the browser fetch the linked resource in advance, as it is likely to be requested by the user. Starting with Firefox 44, the value of the {{HTMLAttrxRef("crossorigin", "link")}} attribute is taken into consideration, making it possible to make anonymous prefetches.<br>
     <br>
-    <strong>Note:</strong> The <a href="/en-US/docs/Link_prefetching_FAQ">Link Prefetch FAQ</a> has details on which links can be prefetched and on alternative methods.</td>
+    <strong>Note:</strong> The <a href="/en-US/docs/Web/HTTP/Link_prefetching_FAQ">Link Prefetch FAQ</a> has details on which links can be prefetched and on alternative methods.</td>
    <td>{{HTMLElement("link")}}</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}</td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Link_types/preload">preload</a></code></td>
-   <td>Tells the browser to download a resource because this resource will be needed later during the current navigation. See <a href="/en-US/docs/Web/HTML/Preloading_content">Preloading content with rel="preload"</a> for more details.</td>
+   <td>Tells the browser to download a resource because this resource will be needed later during the current navigation. See <a href="/en-US/docs/Web/HTML/Link_types/preload">Preloading content with rel="preload"</a> for more details.</td>
    <td>{{HTMLElement("link")}}</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}</td>
   </tr>
@@ -256,7 +256,7 @@ browser-compat: html.elements.link.rel
    <td><code>search</code></td>
    <td>Indicates that the hyperlink references a document whose interface is specially designed for searching in this document, or site, and its resources.<br>
     <br>
-    If the {{HTMLAttrxRef("type","link")}} attribute is set to <code>application/opensearchdescription+xml </code>the resource is an <a href="/en-US/docs/Creating_OpenSearch_plugins_for_Firefox">OpenSearch plugin</a> that can be easily added to the interface of some browsers like Firefox or Internet Explorer.</td>
+    If the {{HTMLAttrxRef("type","link")}} attribute is set to <code>application/opensearchdescription+xml </code>the resource is an <a href="/en-US/docs/Web/OpenSearch">OpenSearch plugin</a> that can be easily added to the interface of some browsers like Firefox or Internet Explorer.</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("link")}}, {{HTMLElement("form")}}</td>
    <td><em>None.</em></td>
   </tr>
@@ -280,7 +280,7 @@ browser-compat: html.elements.link.rel
    <td><code>stylesheet</code></td>
    <td>Defines an external resource to be used as a stylesheet. If the <code>type</code> is not set, the browser should assume it is a <code>text/css</code> stylesheet until further inspection.<br>
     <br>
-    If used in combination with the <code>alternate</code> keyword, it defines an <a href="/en-US/docs/Alternative_style_sheets">alternative style sheet</a>; in that case the {{HTMLAttrxRef("title", "link")}} attribute must be present and not be the empty string.</td>
+    If used in combination with the <code>alternate</code> keyword, it defines an <a href="/en-US/docs/Web/CSS/Alternative_style_sheets">alternative style sheet</a>; in that case the {{HTMLAttrxRef("title", "link")}} attribute must be present and not be the empty string.</td>
    <td>{{HTMLElement("link")}}</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}</td>
   </tr>

--- a/files/en-us/web/html/link_types/noopener/index.html
+++ b/files/en-us/web/html/link_types/noopener/index.html
@@ -16,7 +16,7 @@ browser-compat: html.elements.a.rel.noopener
 
 <div class="notecard note">
  <h4>Note</h4>
- <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements now implicitly provides the same <code>rel</code> behavior as setting <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> which does not set <code>window.opener</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility">browser compatibility</a> for support status.</p>
+ <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements now implicitly provides the same <code>rel</code> behavior as setting <code>rel="noopener"</code> which does not set <code>window.opener</code>. See <a href="/en-US/docs/Web/HTML/Element/a#browser_compatibility">browser compatibility</a> for support status.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

- Update links
- Add a link to the noreferrer reference

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
