### PR TITLE
adds info about -webkit-image-set

### DIFF
--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -25,6 +25,10 @@ tags:
 
 <h3 id="CSS">CSS</h3>
 
+<ul>
+  <li><code>-webkit-image-set()</code> has been implemented as an alias of the standard {{cssxref("image-set()")}} function ({{bug(1709415)}}).</li>
+</ul>
+
 <h4 id="removals_css">Removals</h4>
 
 <h3 id="JavaScript">JavaScript</h3>

--- a/files/en-us/web/css/image-set()/index.html
+++ b/files/en-us/web/css/image-set()/index.html
@@ -48,7 +48,7 @@ where &lt;image-set-option&gt; = [ &lt;image&gt; | &lt;string&gt; ] &lt;resoluti
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>In the above example the <code>-webkit</code> prefixed version is also used to support Chrome and Safari. In Firefox 90 support was added for <code>-webkit-image-set()</code> as an alias to <code>image-set()</code> in order to provide compat where developers had not added the standard property.</p>
+  <p>In the above example, the <code>-webkit</code> prefixed version is also used to support Chrome and Safari. In Firefox 90, support was added for <code>-webkit-image-set()</code> as an alias to <code>image-set()</code> (in order to provide compat where developers had not added the standard property).</p>
 </div>
 
 <h3 id="Using_image-set_to_provide_alternative_formats">Using image-set() to provide alternative image formats</h3>

--- a/files/en-us/web/css/image-set()/index.html
+++ b/files/en-us/web/css/image-set()/index.html
@@ -46,6 +46,11 @@ where &lt;image-set-option&gt; = [ &lt;image&gt; | &lt;string&gt; ] &lt;resoluti
 
 <p>{{EmbedGHLiveSample("css-examples/images/image-set.html", '100%', 600)}}</p>
 
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>In the above example the <code>-webkit</code> prefixed version is also used to support Chrome and Safari. In Firefox 90 support was added for <code>-webkit-image-set()</code> as an alias to <code>image-set()</code> in order to provide compat where developers had not added the standard property.</p>
+</div>
+
 <h3 id="Using_image-set_to_provide_alternative_formats">Using image-set() to provide alternative image formats</h3>
 
 <p>In the next example the <code>type()</code> function is used to serve the image in AVIF and JPEG formats. If the browser supports avif, it will choose that version. Otherwise it will use the jpeg version.</p>


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/5379 

Adds a note to the image-set() page and also mentions this in the release notes.