### PR TITLE
Remove style attributes in api/idb* (first half)

### DIFF
--- a/files/en-us/web/api/idbcursor/advance/index.html
+++ b/files/en-us/web/api/idbcursor/advance/index.html
@@ -15,8 +15,8 @@ browser-compat: api.IDBCursor.advance
 <div>{{APIRef("IndexedDB")}}</div>
 
 <p>The <strong><code>advance()</code></strong> method of the {{domxref("IDBCursor")}}
-  interface sets the num<span style="line-height: 1.5;">ber of times a cursor should move
-    its position forward.</span></p>
+  interface sets the number of times a cursor should move
+    its position forward.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -33,8 +33,8 @@ browser-compat: api.IDBCursor.advance
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<p><span style="line-height: 1.5;">This method may raise a {{domxref("DOMException")}} of
-    one of the following types:</span></p>
+<p>This method may raise a {{domxref("DOMException")}} of
+    one of the following types:</p>
 
 <table class="standard-table">
   <thead>
@@ -70,17 +70,13 @@ browser-compat: api.IDBCursor.advance
   {{domxref("IDBCursor.continue")}}, except that it allows you to jump multiple records at
   a time, not just always go onto the next record.</p>
 
-<p><span style="line-height: 1.5;">Note that in each iteration of the loop, you can grab
-    data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
+<p>Note that in each iteration of the loop, you can grab
+    data from the current record under the cursor object using <code
+    >cursor.value.foo</code>. For a complete working example, see our <a
       href="https://github.com/mdn/indexeddb-examples/tree/master/idbcursor">IDBCursor
-      example</a></span><span style="line-height: 1.5;"> (</span><a
-    href="https://mdn.github.io/indexeddb-examples/idbcursor/"
-    style="line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+      example</a> (<a href="https://mdn.github.io/indexeddb-examples/idbcursor/">view example live</a>.)></p>
 
-<pre class="brush: js"><span class="brush: js" style="line-height: 1.5;">function advanceResult() {</span>
+<pre class="brush: js">function advanceResult() {
   list.textContent = '';
   const transaction = db.transaction(['rushAlbumList'], "readonly");
   const objectStore = transaction.objectStore('rushAlbumList');

--- a/files/en-us/web/api/idbcursor/direction/index.html
+++ b/files/en-us/web/api/idbcursor/direction/index.html
@@ -26,8 +26,7 @@ browser-compat: api.IDBCursor.direction
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"
-  style="font-size: 14px;">var <em>direction = cursor</em>.direction;</pre>
+<pre class="brush: js" >var <em>direction = cursor</em>.direction;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -76,12 +75,10 @@ browser-compat: api.IDBCursor.direction
   cursor to iterate through all the records in the object store. Within each iteration we
   log the direction of the cursor, something like this:</p>
 
-<pre class="language-html"
-  style="padding: 1em 0px 1em 30px; font-size: 14px; color: rgb(77, 78, 83);"><code class="language-html" style="font-family: Consolas, Monaco, 'Andale Mono', monospace; direction: ltr;">prev</code></pre>
+<pre>
+  prev
+</pre>
 
-<div class="line-number"
-  style="margin-top: 1em; position: absolute; left: 0px; right: 0px; line-height: inherit; top: 0px; background: 0px 0px;">
-</div>
 
 <div class="note">
   <p><strong>Note</strong>: we can't change the direction of travel of the cursor using

--- a/files/en-us/web/api/idbcursor/key/index.html
+++ b/files/en-us/web/api/idbcursor/key/index.html
@@ -38,18 +38,14 @@ browser-compat: api.IDBCursor.key
   log the key of the cursor to the console, something like this (its the album title in
   each case, which is our key).</p>
 
-<p>T<span style="line-height: 1.5;">he cursor does not require us to select the data based
+<p>The cursor does not require us to select the data based
     on a key; we can just grab all of it. Also note that in each iteration of the loop,
-    you can grab data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
+    you can grab data from the current record under the cursor object using <code
+    >cursor.value.foo</code>. For a complete working example, see our <a
       href="https://github.com/mdn/indexeddb-examples/tree/master/idbcursor">IDBCursor
-      example</a></span><span style="line-height: 1.5;"> (</span><a
-    href="https://mdn.github.io/indexeddb-examples/idbcursor/"
-    style="line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+      example</a> (<a href="https://mdn.github.io/indexeddb-examples/idbcursor/">view example live</a>.)</p>
 
-<pre style="font-size: 14px;"><span style="line-height: 1.5;">function displayData() {</span>
+<pre class="brush:js">function displayData() {
   var transaction = db.transaction(['rushAlbumList'], "readonly");
   var objectStore = transaction.objectStore('rushAlbumList');
 

--- a/files/en-us/web/api/idbcursor/primarykey/index.html
+++ b/files/en-us/web/api/idbcursor/primarykey/index.html
@@ -38,21 +38,17 @@ browser-compat: api.IDBCursor.primaryKey
   log the primary key of the cursor to the console, something like this (its the album
   title in each case, which is our primarykey):</p>
 
-<pre style="font-size: 14px;">Hemispheres
-</pre>
+<pre>Hemispheres</pre>
 
-<p>T<span style="line-height: 1.5;">he cursor does not require us to select the data based
+<p>The cursor does not require us to select the data based
     on a key; we can just grab all of it. Also note that in each iteration of the loop,
-    you can grab data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
+    you can grab data from the current record under the cursor object using <code
+    >cursor.value.foo</code>. For a complete working example, see our <a
       href="https://github.com/mdn/indexeddb-examples/tree/master/idbcursor">IDBCursor
-      example</a></span><span style="line-height: 1.5;"> (</span><a
-    href="https://mdn.github.io/indexeddb-examples/idbcursor/"
-    style="line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+      example</a> (><a
+    href="https://mdn.github.io/indexeddb-examples/idbcursor/">view example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;"><span style="line-height: 1.5;">function displayData() {</span>
+<pre class="brush: js">function displayData() {
   var transaction = db.transaction(['rushAlbumList'], "readonly");
   var objectStore = transaction.objectStore('rushAlbumList');
 

--- a/files/en-us/web/api/idbcursor/source/index.html
+++ b/files/en-us/web/api/idbcursor/source/index.html
@@ -43,18 +43,13 @@ browser-compat: api.IDBCursor.source
 <pre
   class="brush: json">IDBObjectStore {autoIncrement: false, transaction: IDBTransaction, indexNames: DOMStringList, keyPath: "albumTitle", name: "rushAlbumList"…}</pre>
 
-<p>T<span style="line-height: 1.5;">he cursor does not require us to select the data based
+<p>The cursor does not require us to select the data based
     on a key; we can just grab all of it. Also note that in each iteration of the loop,
-    you can grab data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
+    you can grab data from the current record under the cursor object using <code>cursor.value.foo</code>. For a complete working example, see our <a
       href="https://github.com/mdn/indexeddb-examples/blob/master/idbcursor">IDBCursor
-      example</a></span><span style="line-height: 1.5;"> (</span><a
-    href="https://mdn.github.io/indexeddb-examples/idbcursor/"
-    style="line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+      example</a> (<a href="https://mdn.github.io/indexeddb-examples/idbcursor/">view example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;"><span style="line-height: 1.5;">function displayData() {</span>
+<pre class="brush: js">function displayData() {
   var transaction = db.transaction(['rushAlbumList'], "readonly");
   var objectStore = transaction.objectStore('rushAlbumList');
 

--- a/files/en-us/web/api/idbcursor/update/index.html
+++ b/files/en-us/web/api/idbcursor/update/index.html
@@ -98,18 +98,13 @@ browser-compat: api.IDBCursor.update
   <code>cursor.value</code> into an update call, hence the below example using an
   intermediary <code>updateData</code> variable.</p>
 
-<p>T<span style="line-height: 1.5;">he cursor does not require us to select the data based
+<p>The cursor does not require us to select the data based
     on a key; we can just grab all of it. Also note that in each iteration of the loop,
-    you can grab data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
+    you can grab data from the current record under the cursor object using <code>cursor.value.foo</code>. For a complete working example, see our <a
       class="external external-icon"
       href="https://github.com/mdn/indexeddb-examples/tree/master/idbcursor"
-      style="white-space: pre-line;">IDBCursor example</a></span><span
-    style="line-height: 1.5;"> (</span><a class="external external-icon"
-    href="https://mdn.github.io/indexeddb-examples/idbcursor/"
-    style="white-space: pre-line; line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+      >IDBCursor example</a> (<a class="external external-icon"
+    href="https://mdn.github.io/indexeddb-examples/idbcursor/">view example live</a>.)</p>
 
 <pre class="brush: js">function updateResult() {
   list.textContent = '';

--- a/files/en-us/web/api/idbcursorwithvalue/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/index.html
@@ -39,9 +39,9 @@ browser-compat: api.IDBCursorWithValue
 
 <h2 id="Example">Example</h2>
 
-<p>In this example we create a transaction, retrieve an object store, then use a cursor to iterate through all the records in the object store. T<span style="line-height: 1.5;">he cursor does not require us to select the data based on a key; we can just grab all of it. Also note that in each iteration of the loop, you can grab data from the current record under the cursor object using </span><code style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span style="line-height: 1.5;">. For a complete working example, see our <a href="https://github.com/mdn/IDBcursor-example/">IDBCursor example</a></span><span style="line-height: 1.5;"> (</span><a href="https://mdn.github.io/IDBcursor-example/" style="line-height: 1.5;">view example live</a><span style="line-height: 1.5;">.)</span></p>
+<p>In this example we create a transaction, retrieve an object store, then use a cursor to iterate through all the records in the object store. The cursor does not require us to select the data based on a key; we can just grab all of it. Also note that in each iteration of the loop, you can grab data from the current record under the cursor object using <code>cursor.value.foo</code>. For a complete working example, see our <a href="https://github.com/mdn/IDBcursor-example/">IDBCursor example</a> (<a href="https://mdn.github.io/IDBcursor-example/">view example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;"><span style="line-height: 1.5;">function displayData() {</span>
+<pre class="brush: js">function displayData() {
   var transaction = db.transaction(['rushAlbumList'], "readonly");
   var objectStore = transaction.objectStore('rushAlbumList');
 

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.html
@@ -36,17 +36,13 @@ browser-compat: api.IDBCursorWithValue.value
   iterate through all the records in the object store. Within each iteration we log the
   value of the cursor with <code>cursor.value</code>.</p>
 
-<p>T<span style="line-height: 1.5;">he cursor does not require us to select the data based
+<p>The cursor does not require us to select the data based
     on a key; we can just grab all of it. Also note that in each iteration of the loop,
-    you can grab data from the current record under the cursor object using </span><code
-    style="font-style: normal; line-height: 1.5;">cursor.value.foo</code><span
-    style="line-height: 1.5;">. For a complete working example, see our <a
-      href="https://github.com/mdn/IDBcursor-example/">IDBCursor example</a></span><span
-    style="line-height: 1.5;"> (</span><a href="https://mdn.github.io/IDBcursor-example/"
-    style="line-height: 1.5;">view example live</a><span
-    style="line-height: 1.5;">.)</span></p>
+    you can grab data from the current record under the cursor object using <code>cursor.value.foo</code>.
+     For a complete working example, see our <a href="https://github.com/mdn/IDBcursor-example/">IDBCursor example</a> 
+     (<a href="https://mdn.github.io/IDBcursor-example/">view example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;"><span style="line-height: 1.5;">function displayData() {</span>
+<pre class="brush: js">function displayData() {
   var transaction = db.transaction(['rushAlbumList'], "readonly");
   var objectStore = transaction.objectStore('rushAlbumList');
 

--- a/files/en-us/web/api/idbdatabase/name/index.html
+++ b/files/en-us/web/api/idbdatabase/name/index.html
@@ -35,12 +35,9 @@ browser-compat: api.IDBDatabase.name
 
 <p>This example shows a database connection being opened, the resulting
   {{domxref("IDBDatabase")}} object being stored in a db variable, and the name property
-  then being logged. For a full example, see our <a
-    href="https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages"
-    style="line-height: 1.5;">To-do Notifications</a><span style="line-height: 1.5;"> app
-    (</span><a href="https://chrisdavidmills.github.io/to-do-notifications/"
-    style="line-height: 1.5;">view example live</a>)<span
-    style="line-height: 1.5;">.</span></p>
+  then being logged. For a full example, see our 
+  <a href="https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages">To-do Notifications</a>
+   app (<a href="https://chrisdavidmills.github.io/to-do-notifications/">view example live</a>).</p>
 
 <pre class="brush: js;highlight:[16]">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.html
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.html
@@ -30,12 +30,12 @@ browser-compat: api.IDBDatabase.objectStoreNames
 
 <h3 id="Value">Value</h3>
 
-<p><span style="line-height: 1.5;">A {{ domxref("DOMStringList") }} containing a list of
-    the names of the </span><a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store"
-    style="line-height: 1.5;">object stores</a><span style="line-height: 1.5;"> currently
-    in the connected database.</span></p>
+<p>A {{ domxref("DOMStringList") }} containing a list of
+    the names of the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store"
+   >object stores</a>currently
+    in the connected database.</p>
 
-<h2 id="Example"><span style="line-height: 1.5;">Example</span></h2>
+<h2 id="Example">Example</h2>
 
 <pre class="brush: js;highlight:[17]">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);

--- a/files/en-us/web/api/idbdatabase/onerror/index.html
+++ b/files/en-us/web/api/idbdatabase/onerror/index.html
@@ -33,9 +33,7 @@ browser-compat: api.IDBDatabase.onerror
 <h2 id="Example">Example</h2>
 
 <p>This example shows an {{domxref("IDBOpenDBRequest.onupgradeneeded")}} block that
-  creates a new object store; it also includes <code
-    style="font-style: normal;">onerror</code> and <code
-    style="font-style: normal;">onabort</code> functions to handle non-success cases.</p>
+  creates a new object store; it also includes <code>onerror</code> and <code>onabort</code> functions to handle non-success cases.</p>
 
 <pre class="brush: js;highlight:[4,5,6]">DBOpenRequest.onupgradeneeded = function(event) {
   var db = this.result;

--- a/files/en-us/web/api/idbdatabase/onversionchange/index.html
+++ b/files/en-us/web/api/idbdatabase/onversionchange/index.html
@@ -35,9 +35,7 @@ browser-compat: api.IDBDatabase.onversionchange
 <h2 id="Example">Example</h2>
 
 <p>This example shows an {{domxref("IDBOpenDBRequest.onupgradeneeded")}} block that
-  creates a new object store; it also includes <code
-    style="font-style: normal;">onerror</code> and <code
-    style="font-style: normal;">onabort</code> functions to handle non-success cases, and
+  creates a new object store; it also includes <code>onerror</code> and <code>onabort</code> functions to handle non-success cases, and
   an onversionchange function to notify when a database structure change has occurred.</p>
 
 <pre class="brush: js;highlight:[28,29,30,31,32]">request.onupgradeneeded = function(event) {

--- a/files/en-us/web/api/idbdatabase/transaction/index.html
+++ b/files/en-us/web/api/idbdatabase/transaction/index.html
@@ -143,9 +143,9 @@ var transaction = db.transaction('my-store-name');</pre>
 
 <p>In this example we open a database connection, then use transaction() to open a
   transaction on the database. For a complete example, see our <a
-    href="https://github.com/mdn/to-do-notifications/" style="line-height: 1.5;">To-do
+    href="https://github.com/mdn/to-do-notifications/">To-do
     Notifications</a> app (<a
-    href="https://mdn.github.io/to-do-notifications/" style="line-height: 1.5;">view
+    href="https://mdn.github.io/to-do-notifications/">view
     example live</a>.)</p>
 
 <pre class="brush: js">var db;

--- a/files/en-us/web/api/idbfactory/cmp/index.html
+++ b/files/en-us/web/api/idbfactory/cmp/index.html
@@ -50,7 +50,7 @@ browser-compat: api.IDBFactory.cmp
 <p>An integer that indicates the result of the comparison; the table below lists the
   possible values and their meanings:</p>
 
-<table class="standard-table" style="width: 434px;">
+<table class="standard-table">
   <tbody>
     <tr>
       <th scope="col">Returned value</th>

--- a/files/en-us/web/api/idbfactory/databases/index.html
+++ b/files/en-us/web/api/idbfactory/databases/index.html
@@ -32,17 +32,16 @@ browser-compat: api.IDBFactory.databases
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A promise that resolves either to an error or a list of dictionaries, each with two elements, <code>name</code> and <code>version</code>.</p>
+<p>A promise that resolves either to an error or a list of dictionaries, each with two elements, <code>name</code> and <code>version</code>:
 
-<h4 id="name"><code>name</code></h4>
-
-<p>The database name.</p>
-
-<h4 id="version"><code>version</code></h4>
-
-<p>The database version.</p>
-
-<p><span style='background-color: #333333; color: #ffffff; font-family: x-locale-heading-primary,zillaslab,Palatino,"Palatino Linotype",x-locale-heading-secondary,serif; font-size: 1.44444rem; letter-spacing: -0.00278rem;'>Exceptions</span></p>
+<dl>
+  <dt><code>name</code></dt>
+  <dd>The database name.</dd>
+  <dt><code>version</code></dt>
+  <dd>The database version.</dd>
+</dl>
+</p>
+<h3>Exceptions</h3>
 
 <p>This method may raise a {{domxref("DOMException")}} of the following types:</p>
 

--- a/files/en-us/web/api/idbfactory/open/index.html
+++ b/files/en-us/web/api/idbfactory/open/index.html
@@ -100,8 +100,7 @@ var <em>IDBOpenDBRequest</em> = <em>indexedDB</em>.open(<em>name</em>, <em>versi
 <p>Example of calling <code>open</code> with the current specification's
   <code>version</code> parameter:</p>
 
-<pre class="brush: js"
-  style="font-size: 14px;">var request = window.indexedDB.open("toDoList", 4);</pre>
+<pre class="brush: js">var request = window.indexedDB.open("toDoList", 4);</pre>
 
 <p>In the following code snippet, we make a request to open a database, and include
   handlers for the success and error cases. For a full working example, see our <a

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -45,7 +45,7 @@ browser-compat: api.IDBIndex.get
 <p>An {{domxref("IDBRequest")}} object on which subsequent events related to this
   operation are fired.</p>
 
-<h3 id="Exceptions"><span style="line-height: 1.5;">Exceptions</span></h3>
+<h3 id="Exceptions">Exceptions</h3>
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -44,7 +44,7 @@ browser-compat: api.IDBIndex.getKey
 <p>An {{domxref("IDBRequest")}} object on which subsequent events related to this
   operation are fired.</p>
 
-<h3 id="Exceptions"><span style="line-height: 1.5;">Exceptions</span></h3>
+<h3 id="Exceptions">Exceptions</h3>
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
@@ -98,7 +98,7 @@ browser-compat: api.IDBIndex.getKey
   var objectStore = transaction.objectStore('contactsList');
 
   var myIndex = objectStore.index('lName');
-  <span style="font-size: 1rem;">var getKeyRequest = myIndex.getKey('Bungle');</span>
+  var getKeyRequest = myIndex.getKey('Bungle');
   getKeyRequest.onsuccess = function() {
     console.log(getKeyRequest.result);
   }

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -19,7 +19,7 @@ browser-compat: api.IDBIndex
 
 <p>The index is a persistent key-value storage where the value part of its records is the key part of a record in the referenced object store. The records in an index are automatically populated whenever records in the referenced object store are inserted, updated, or deleted. Each record in an index can point to only one record in its referenced object store, but several indexes can reference the same object store. When the object store changes, all indexes that refers to the object store are automatically updated.</p>
 
-<p><span style="line-height: 1.5;">You can grab a set of keys within a range. To learn more, see {{domxref("IDBKeyRange")}}.</span></p>
+<p>You can grab a set of keys within a range. To learn more, see {{domxref("IDBKeyRange")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -69,7 +69,7 @@ browser-compat: api.IDBIndex
 
 <p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -32,8 +32,7 @@ browser-compat: api.IDBIndex.keyPath
 
 <h3 id="Value">Value</h3>
 
-<p><span style="line-height: 1.5;">Any data type that can be used as a key path.</span>
-</p>
+<p>Any data type that can be used as a key path.</p>
 
 <h2 id="Example">Example</h2>
 
@@ -53,7 +52,7 @@ browser-compat: api.IDBIndex.keyPath
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>.)</p>
 
-<pre style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush:js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbindex/multientry/index.html
+++ b/files/en-us/web/api/idbindex/multientry/index.html
@@ -21,10 +21,7 @@ browser-compat: api.IDBIndex.multiEntry
 
   <p>This is decided when the index is created, using the
     {{domxref("IDBObjectStore.createIndex")}} method. This method takes an optional
-    <code>options</code> parameter whose <code
-      style="font-style: normal;">multiEntry</code> property is set to <code
-      style="font-style: normal;">true</code>/<code
-      style="font-style: normal;">false</code>.</p>
+    <code>options</code> parameter whose <code>multiEntry</code> property is set to <code>true</code>/<code>false</code>.</p>
 
   <p>{{AvailableInWorkers}}</p>
 </div>
@@ -73,7 +70,7 @@ browser-compat: api.IDBIndex.multiEntry
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>.)</p>
 
-<pre style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush:js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbindex/name/index.html
+++ b/files/en-us/web/api/idbindex/name/index.html
@@ -64,7 +64,7 @@ browser-compat: api.IDBIndex.name
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>).</p>
 
-<pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbindex/objectstore/index.html
+++ b/files/en-us/web/api/idbindex/objectstore/index.html
@@ -51,7 +51,7 @@ browser-compat: api.IDBIndex.objectStore
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>.)</p>
 
-<pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbindex/unique/index.html
+++ b/files/en-us/web/api/idbindex/unique/index.html
@@ -72,7 +72,7 @@ browser-compat: api.IDBIndex.unique
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>.)</p>
 
-<pre style="font-size: 14px;">function displayDataByIndex() {
+<pre class="brush:js">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');


### PR DESCRIPTION
This is part of #5438.

It removes the style attributes in api/idb*. There are a lot of them, so I'm doing two PRs for them.

It was all useless styles, doing nothing. I also added a few brush:js that were missing.