### PR TITLE
Retitle IndexedDB “Basic concepts” article

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -4114,7 +4114,7 @@
 /en-US/docs/Inbox/Writing_a_WebSocket_server_in_Java	/en-US/docs/Web/API/WebSockets_API/Writing_a_WebSocket_server_in_Java
 /en-US/docs/Incorrect_MIME_Type_for_CSS_Files	/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 /en-US/docs/IndexedDB	/en-US/docs/Web/API/IndexedDB_API
-/en-US/docs/IndexedDB/Basic_Concepts_Behind_IndexedDB	/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB
+/en-US/docs/IndexedDB/Basic_Concepts_Behind_IndexedDB	/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology
 /en-US/docs/IndexedDB/Cursor	/en-US/docs/Web/API/IDBCursor
 /en-US/docs/IndexedDB/CursorSync/IDBCursorSync	/en-US/docs/Web/API/IDBCursorSync
 /en-US/docs/IndexedDB/DatabaseException	/en-US/docs/Web/API/IDBDatabaseException
@@ -7879,6 +7879,7 @@
 /en-US/docs/Web/API/ImageData.width	/en-US/docs/Web/API/ImageData/width
 /en-US/docs/Web/API/IndexSync	/en-US/docs/Web/API/IDBIndexSync
 /en-US/docs/Web/API/IndexedDB	/en-US/docs/Web/API/IndexedDB_API
+/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB	/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology
 /en-US/docs/Web/API/IndexedDB_API/Cursor	/en-US/docs/Web/API/IDBCursor
 /en-US/docs/Web/API/IndexedDB_API/DatabaseException	/en-US/docs/Web/API/IDBDatabaseException
 /en-US/docs/Web/API/IndexedDB_API/DatabaseSync	/en-US/docs/Web/API/IDBDatabaseSync

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -58524,7 +58524,7 @@
       "flodby"
     ]
   },
-  "Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB": {
+  "Web/API/IndexedDB_API/Basic_Terminology": {
     "modified": "2019-10-31T11:49:41.183Z",
     "contributors": [
       "leela52452",

--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -44,7 +44,7 @@ tags:
 
 <h3 id="The_File_and_Directory_Entries_API_and_other_storage_APIs">The File and Directory Entries API and other storage APIs</h3>
 
-<p>The File and Directory Entries API is an alternative to other storage APIs like <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB">IndexedDB</a>, WebSQL (which has been deprecated since November18, 2010), and AppCache. The API is a better choice for apps that deal with blobs for the following reasons:</p>
+<p>The File and Directory Entries API is an alternative to other storage APIs such as <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB</a>. The API is a better choice for apps that deal with blobs for the following reasons:</p>
 
 <ul>
  <li>The File and Directory Entries API offers client-side storage for use cases that are not addressed by databases. If you want to have large mutable chunks of data, the File and Directory Entries API is a much more efficient storage solution than a database.</li>

--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -16,7 +16,7 @@ browser-compat: api.IDBCursor
 <p><strong>Note:</strong> Not to be confused with {{domxref("IDBCursorWithValue")}} which is just an <strong><code>IDBCursor</code></strong> interface with an additional <strong><code>value</code></strong> property.</p>
 </div>
 
-<p>The <strong><code>IDBCursor</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database.</p>
+<p>The <strong><code>IDBCursor</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database.</p>
 
 <p>The cursor has a source that indicates which index or object store it is iterating over. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. The cursor enables an application to asynchronously process all the records in the cursor's range.</p>
 

--- a/files/en-us/web/api/idbcursorwithvalue/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.IDBCursorWithValue
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
-<p>The <strong><code>IDBCursorWithValue</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database. It is the same as the {{domxref("IDBCursor")}}, except that it includes the <code>value</code> property.</p>
+<p>The <strong><code>IDBCursorWithValue</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database. It is the same as the {{domxref("IDBCursor")}}, except that it includes the <code>value</code> property.</p>
 
 <p>The cursor has a source that indicates which index or object store it is iterating over. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. The cursor enables an application to asynchronously process all the records in the cursor's range.</p>
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.html
@@ -58,16 +58,16 @@ browser-compat: api.IDBDatabase.createObjectStore
         <tr>
           <td><code>keyPath</code></td>
           <td>The <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keypath">key
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
               path</a> to be used by the new object store. If empty or not specified, the
             object store is created without a key path and uses <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_outofline_key">out-of-line
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_outofline_key">out-of-line
               keys</a>. You can also pass in an array as a <code>keyPath</code>.</td>
         </tr>
         <tr>
           <td><code>autoIncrement</code></td>
           <td>If <code>true</code>, the object store has a <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keygenerator">key
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keygenerator">key
               generator</a>. Defaults to <code>false</code>.</td>
         </tr>
       </tbody>

--- a/files/en-us/web/api/idbdatabase/index.html
+++ b/files/en-us/web/api/idbdatabase/index.html
@@ -21,7 +21,7 @@ browser-compat: api.IDBDatabase
 <p>{{AvailableInWorkers}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
+<p><strong>Note</strong>: Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
 </div>
 
 <p>{{InheritanceDiagram}}</p>

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.IDBIndex
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
-<p><span class="seoSummary"><code>IDBIndex</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides asynchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_index">index</a> in a database. An index is a kind of object store for looking up records in another object store, called the referenced object store. You use this interface to retrieve data.</span></p>
+<p><span class="seoSummary"><code>IDBIndex</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides asynchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_index">index</a> in a database. An index is a kind of object store for looking up records in another object store, called the referenced object store. You use this interface to retrieve data.</span></p>
 
 <p>You can retrieve records in an object store through the primary key or by using an index. An index lets you look up records in an object store using properties of the values in the object stores records other than the primary key</p>
 

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBIndex.keyPath
 <div>
   <p>The <strong><code>keyPath</code></strong> property of the {{domxref("IDBIndex")}}
     interface returns the <a
-      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keypath">key
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
       path</a> of the current index. If null, this index is not <a
       href="/en-US/docs/Web/API/IDBIndex#gloss_auto-populated">auto-populated</a>.
   </p>

--- a/files/en-us/web/api/idbobjectstore/keypath/index.html
+++ b/files/en-us/web/api/idbobjectstore/keypath/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBObjectStore.keyPath
 <div>
   <p>The <strong><code>keyPath</code></strong> read-only property of the
     {{domxref("IDBObjectStore")}} interface returns the <a
-      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keypath">key
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
       path</a> of this object store.</p>
 </div>
 

--- a/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
@@ -1,42 +1,32 @@
 ---
-title: Basic concepts
-slug: Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB
+title: IndexedDB key characteristics and basic terminology
+slug: Web/API/IndexedDB_API/Basic_Terminology
 tags:
   - Advanced
   - IndexedDB
-  - concepts
+  - terminology
 ---
 <p>{{DefaultAPISidebar("IndexedDB")}}</p>
 
 <div class="summary">
-<p><strong>IndexedDB</strong> is a way for you to persistently store data inside a user's browser. Because it lets you create web applications with rich query abilities regardless of network availability, these applications can work both online and offline. IndexedDB is useful for applications that store a large amount of data (for example, a catalog of DVDs in a lending library) and applications that don't need persistent internet connectivity to work (for example, mail clients, to-do lists, and notepads).</p>
+<p>This article describes the key characteristics of IndexedDB, and introduces some essential terminology relevant to understanding the IndexedDB API.</p>
 </div>
 
-<h2 id="About_this_document">About this document</h2>
-
-<p>This introduction discusses essential concepts and terminology in IndexedDB. It gives you the big picture and explains key concepts.</p>
-
-<p>You'll find the following useful:</p>
+<p>You'll also find the following articles useful:</p>
 
 <ul>
- <li>For an overview of the design and structure of IndexedDB, see <a href="#concepts">Big Concepts</a>.</li>
- <li>To learn more about IndexedDB terms, see the <a href="#definitions">Definitions</a> section.</li>
  <li>For a detailed tutorial on how to use the API, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a>.</li>
  <li>For the reference documentation on the IndexedDB API, refer back to the main <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> article and its subpages, which document the types of objects used by IndexedDB.</li>
  <li>For more information on how the browser handles storing your data in the background, read <a href="/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria">Browser storage limits and eviction criteria</a>.</li>
 </ul>
 
-<h2 id="Overview_of_IndexedDB">Overview of IndexedDB</h2>
+<h2 id="key_characteristics">Key characteristics</h2>
+
+<p>IndexedDB is a way for you to persistently store data inside a user's browser. Because it lets you create web applications with rich query abilities regardless of network availability, these applications can work both online and offline. IndexedDB is useful for applications that store a large amount of data (for example, a catalog of DVDs in a lending library) and applications that don't need persistent internet connectivity to work (for example, mail clients, to-do lists, and notepads).</p>
 
 <p>IndexedDB lets you store and retrieve objects that are indexed with a "key." All changes that you make to the database happen within transactions. Like most web storage solutions, IndexedDB follows a <a href="https://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>. So while you can access stored data within a domain, you cannot access data across different domains.</p>
 
-<p>IndexedDB is an <a href="/en-US/docs/Web/API/IndexedDB_API#asynchronous_api">asynchronous</a> API that can be used in most contexts, including <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>. It used to include a <a href="/en-US/docs/Web/API/IndexedDB_API#synchronous_api">synchronous</a> version also, for use in web workers, but this was removed from the spec due to lack of interest by the web community.</p>
-
-<p>IndexedDB used to have a competing spec, WebSQL Database, but the W3C deprecated it on November 18, 2010. While both IndexedDB and WebSQL are solutions for storage, they do not offer the same functionalities. WebSQL Database is a relational database access system, whereas IndexedDB is an indexed table system.</p>
-
-<h2 id="concepts">Big concepts</h2>
-
-<p>If you have assumptions from working with other types of databases, you might get thrown off when working with IndexedDB. So keep the following important concepts in mind:</p>
+<p>If you have assumptions from working with other types of databases, you might get thrown off when working with IndexedDB. So the following key characteristics of IndexedDB are important to keep in mind:</p>
 
 <ul>
  <li>
@@ -67,15 +57,37 @@ tags:
  <li>
   <p><a name="origin"><strong>IndexedDB adheres to a same-origin policy</strong></a>. An origin is the domain, application layer protocol, and port of a URL of the document where the script is being executed. Each origin has its own associated set of databases. Every database has a name that identifies it within an origin.</p>
 
-  <p>The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in <a href="http://www.example.com/app/">http://www.example.com/app/</a> can retrieve data from <a href="http://www.example.com/dir/">http://www.example.com/dir/</a>, because they have the same origin, it cannot retrieve data from <a href="http://www.example.com:8080/dir/">http://www.example.com:8080/dir/</a> (different port) or <a class="link-https" href="https://www.example.com/dir/">https://www.example.com/dir/</a> (different protocol), because they have different origins.</p>
+  <p>The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in <a href="https://www.example.com/app/">http://www.example.com/app/</a> can retrieve data from <a href="https://www.example.com/dir/">http://www.example.com/dir/</a>, because they have the same origin, it cannot retrieve data from <a href="https://www.example.com:8080/dir/">http://www.example.com:8080/dir/</a> (different port) or <a class="link-https" href="https://www.example.com/dir/">https://www.example.com/dir/</a> (different protocol), because they have different origins.</p>
 
   <div class="note"><strong>Note</strong>: Third party window content (e.g. {{htmlelement("iframe")}} content) can access the IndexedDB store for the origin it is embedded into, unless the browser is set to <a href="https://support.mozilla.org/en-US/kb/disable-third-party-cookies">never accept third party cookies</a> (see {{bug("1147821")}}.)</div>
  </li>
 </ul>
 
-<h2 id="definitions">Definitions</h2>
+<h3 id="limitations">Limitations</h3>
 
-<p>This section defines and explains terms used in the IndexedDB API.</p>
+<p>IndexedDB is designed to cover most cases that need client-side storage. However, it is not designed for a few cases like the following:</p>
+
+<ul>
+ <li>Internationalized sorting. Not all languages sort strings in the same way, so internationalized sorting is not supported. While the database can't store data in a specific internationalized order, you can sort the data that you've read out of the database yourself. Note, however, that <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#locale-aware_sorting">locale-aware sorting</a> has been allowed with an experimental flag enabled (currently for Firefox only) since Firefox 43.</li>
+ <li>Synchronizing. The API is not designed to take care of synchronizing with a server-side database. You have to write code that synchronizes a client-side indexedDB database with a server-side database.</li>
+ <li>Full text searching. The API<span style="direction: ltr;"> does not have an</span><span style="direction: ltr;"> equivalent of the <code>LIKE</code> operator in SQL. </span></li>
+</ul>
+
+<p>In addition, be aware that browsers can wipe out the database, such as in the following conditions:</p>
+
+<ul>
+ <li>The user requests a wipe out. Many browsers have settings that let users wipe all data stored for a given website, including cookies, bookmarks, stored passwords, and IndexedDB data.</li>
+ <li>The browser is in private browsing mode. Some browsers, have "private browsing" (Firefox) or "incognito" (Chrome) modes. At the end of the session, the browser wipes out the database.</li>
+ <li>The disk or quota limit has been reached.</li>
+ <li>The data is corrupt.</li>
+ <li>An incompatible change is made to the feature.</li>
+</ul>
+
+<p>The exact circumstances and browser capabilities change over time, but the general philosophy of the browser vendors is to make the best effort to keep the data when possible.</p>
+
+<h2 id="core_terminology">Core terminology</h2>
+
+<p>This section defines and explains core terminology relevant to understanding the IndexedDB API.</p>
 
 <h3 id="database">Database</h3>
 
@@ -108,8 +120,7 @@ tags:
  <p>For the reference documentation on object store, see {{domxref("IDBObjectStore")}}.</p>
  </dd>
  <dt><a name="gloss_version">version</a></dt>
- <dd>When a database is first created, its version is the integer 1. Each database has one version at a time; a database can't exist in multiple versions at once. The only way to change the version is by opening it with a greater version than the current one. This will start a <a href="/en-US/docs/Web/API/IDBVersionChangeRequest"><code>versionchange</code></a> <em>transaction</em> and fire an <a href="/en-US/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event"><code>upgradeneeded</code></a> event. The only place where the schema of the database can be updated is inside the handler of that event.</dd>
- <dd>Note: This definition describes the <a href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">most recent specification</a>, which is only implemented in up-to-date browsers. Old browsers implemented the now deprecated and removed <a href="/en-US/docs/Web/API/IDBDatabase#setversion()"><code>IDBDatabase.setVersion()</code></a> method.</dd>
+ <dd>When a database is first created, its version is the integer 1. Each database has one version at a time; a database can't exist in multiple versions at once. The only way to change the version is by opening it with a greater version than the current one.</dd>
  <dt><a name="gloss_database_connection">database connection</a></dt>
  <dd>An operation created by opening a <em><a href="#gloss_database">database</a></em>. A given database can have multiple connections at the same time.</dd>
  <dt><a name="gloss_transaction">transaction</a></dt>
@@ -161,7 +172,7 @@ tags:
 
  <p>When an object or array is stored, the properties and values in that object or array can also be anything that is a valid value.</p>
 
- <p><a href="/en-US/docs/Web/API/Blob">Blobs</a> and files can be stored, cf. <a href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a>.</p>
+ <p><a href="/en-US/docs/Web/API/Blob">Blobs</a> and files can be stored, cf. <a href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a>.</p>
  </dd>
 </dl>
 
@@ -204,7 +215,7 @@ tags:
 
 <h2 id="next">Next steps</h2>
 
-<p>With these big concepts under our belts, we can get to more concrete stuff. For a tutorial on how to use the API, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a>.</p>
+<p>With an understanding of IndexedDB’s key characteristics and core terminology under our belts, we can get to more concrete stuff. For a tutorial on how to use the API, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a>.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/indexeddb_api/index.html
+++ b/files/en-us/web/api/indexeddb_api/index.html
@@ -25,7 +25,7 @@ tags:
 <p>IndexedDB is a transactional database system, like an SQL-based RDBMS. However, unlike SQL-based RDBMSes, which use fixed-column tables, IndexedDB is a JavaScript-based object-oriented database. IndexedDB lets you store and retrieve objects that are indexed with a <strong>key</strong>; any objects supported by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone algorithm</a> can be stored. You need to specify the database schema, open a connection to your database, and then retrieve and update data within a series of <strong>transactions</strong>.</p>
 
 <ul>
- <li>Read more about the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB">Concepts behind IndexedDB</a>.</li>
+ <li>Read more about <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a>.</li>
  <li>Learn to use IndexedDB asynchronously from first principles with our <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a> guide.</li>
  <li>Combine IndexedDB for storing data offline with Service Workers for storing assets offline, as outlined in <a href="/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers">Making PWAs work offline with Service workers</a>.</li>
 </ul>

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="About_this_document">About this document</h2>
 
-<p>This tutorial walks you through using the asynchronous API of IndexedDB. If you are not familiar with IndexedDB, you should first read the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB">Basic Concepts</a> article.</p>
+<p>This tutorial walks you through using the asynchronous API of IndexedDB. If you are not familiar with IndexedDB, you should first read the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</p>
 
 <p>For the reference documentation on the IndexedDB API, see the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> article and its subpages. This article documents the types of objects used by IndexedDB, as well as the methods of the asynchronous API (the synchronous API was removed from spec).  </p>
 
@@ -144,7 +144,7 @@ request.onupgradeneeded = function(event) {
 
 <h3 id="Structuring_the_database">Structuring the database</h3>
 
-<p>Now to structure the database. IndexedDB uses object stores rather than tables, and a single database can contain any number of object stores. Whenever a value is stored in an object store, it is associated with a key. There are several different ways that a key can be supplied depending on whether the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keypath">key path</a> or a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_keygenerator">key generator</a>.</p>
+<p>Now to structure the database. IndexedDB uses object stores rather than tables, and a single database can contain any number of object stores. Whenever a value is stored in an object store, it is associated with a key. There are several different ways that a key can be supplied depending on whether the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key path</a> or a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keygenerator">key generator</a>.</p>
 
 <p>The following table shows the different ways the keys are supplied:</p>
 
@@ -285,7 +285,7 @@ request.onupgradeneeded = function (event) {
 
 <ul>
  <li>When defining the scope, specify only the object stores you need. This way, you can run multiple transactions with non-overlapping scopes concurrently.</li>
- <li>Only specify a <code>readwrite</code> transaction mode when necessary. You can concurrently run multiple <code>readonly</code> transactions with overlapping scopes, but you can have only one <code>readwrite</code> transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB">Basic Concepts</a> article.</li>
+ <li>Only specify a <code>readwrite</code> transaction mode when necessary. You can concurrently run multiple <code>readonly</code> transactions with overlapping scopes, but you can have only one <code>readwrite</code> transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
 </ul>
 
 <h3 id="Adding_data_to_the_database">Adding data to the database</h3>
@@ -362,7 +362,7 @@ request.onsuccess = function(event) {
 
 <ul>
  <li>When defining the <a href="#scope">scope</a>, specify only the object stores you need. This way, you can run multiple transactions with non-overlapping scopes concurrently.</li>
- <li>Only specify a readwrite transaction mode when necessary. You can concurrently run multiple readonly transactions with overlapping scopes, but you can have only one readwrite transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB">Basic Concepts</a> article.</li>
+ <li>Only specify a readwrite transaction mode when necessary. You can concurrently run multiple readonly transactions with overlapping scopes, but you can have only one readwrite transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
 </ul>
 
 <h3 id="Updating_an_entry_in_the_database">Updating an entry in the database</h3>


### PR DESCRIPTION
The change retitles the IndexedDB “Basic concepts” article to “IndexedDB key characteristics and basic terminology” — in order to make more clear what the actual purpose of the article is, and what information the article actually provides.

This change also does some streamlining of the article content — to better align, and more clearly align, the article content with the actual purpose of the article.

The scope of this article intentionally doesn’t include presenting an example and walking the reader through it — that’s what the “Using IndexedDB” tutorial is for. But in order for the reader to be able to really understand the tutorial and find it useful, the reader first needs to understand something about the key characteristics of IndexedDB, along with some core terminology.

So this change repositions the article to more clearly align it with that purpose.

Fixes https://github.com/mdn/content/issues/5340