### PR TITLE
Fix HTML table markup in KeyboardEvent “Key Values” doc

### DIFF
--- a/files/en-us/web/api/keyboardevent/key/key_values/index.html
+++ b/files/en-us/web/api/keyboardevent/key/key_values/index.html
@@ -1502,6 +1502,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"F1"</code></td>
    <td>The first general-purpose function key, <kbd>F1</kbd>.</td>
@@ -1718,7 +1720,7 @@ tags:
    <td><code>Qt::Key_Context4</code> (0x01100003)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <h2 id="Phone_keys">Phone keys</h2>
@@ -1738,6 +1740,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"AppSwitch"</code></td>
    <td>Presents a list of recently-used applications which lets the user change apps quickly.</td>
@@ -1834,7 +1838,7 @@ tags:
    <td><code>Qt::Key_VoiceDial</code> (0x01100008)</td>
    <td><code>KEYCODE_VOICE_ASSIST</code> (231)</td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Prior to Firefox 37, the Home button generated a key code of <code>"Exit"</code>. Starting in Firefox 37, the button generates the key code <code>"MozHomeScreen"</code>.</p>
@@ -1856,6 +1860,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"ChannelDown"</code></td>
    <td>Switches to the previous channel.</td>
@@ -1961,7 +1967,7 @@ tags:
     <code>Qt::Key_MediaPrevious</code> (0x01000082)</td>
    <td><code>KEYCODE_MEDIA_PREVIOUS</code> (88)</td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Internet Explorer, Edge, and Firefox (36 and earlier) use <code>"MediaNextTrack"</code> and <code>"MediaPreviousTrack"</code> instead of <code>"MediaTrackNext"</code> and <code>"MediaTrackPrevious"</code>.</p>
@@ -1985,6 +1991,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"AudioBalanceLeft"</code></td>
    <td>Adjusts audio balance toward the left.</td>
@@ -2144,7 +2152,7 @@ tags:
    <td><code>Qt::Key_MicVolumeUp</code> (0x0100011D)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Internet Explorer, Edge, and Firefox (48 and earlier) use <code>"VolumeUp"</code>, <code>"VolumeDown"</code>, and <code>"VolumeMute"</code> instead of <code>"AudioVolumeUp"</code>, <code>"AudioVolumeDown"</code>, and <code>"AudioVolumeMute"</code>. In Firefox 49 they were updated to match the latest specification. The old names are still used on <a href="/en-US/docs/Mozilla/B2G_OS">Boot to Gecko</a>.</p>
@@ -2166,6 +2174,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"TV"</code> [1]</td>
    <td>Switches into TV viewing mode.</td>
@@ -2406,7 +2416,7 @@ tags:
    <td></td>
    <td><code>KEYCODE_TV_TIMER_PROGRAMMING</code> (258)</td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Firefox added proper support for the <code>"TV"</code> key in Firefox 37; before that, this key generated the key code <code>"Live"</code>.</p>
@@ -2443,6 +2453,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"AVRInput"</code> [3]</td>
    <td>Changes the input mode on an external audio/video receiver (AVR) unit.</td>
@@ -3021,7 +3033,7 @@ tags:
    <td><code>Qt::Key_Zoom</code> (0x01020006)</td>
    <td><code>KEYCODE_TV_ZOOM_MODE</code> (255)</td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Don't confuse the media controller <code>VK_APPS</code> key with the Windows <code>VK_APPS</code> key, which is also known as <code>VK_CONTEXT_MENU</code>. That key is encoded as <code>"ContextMenu"</code>.</p>
@@ -3047,6 +3059,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"SpeechCorrectionList"</code> [1]</td>
    <td>Presents a list of possible corrections for a word which was incorrectly identified.</td>
@@ -3063,7 +3077,7 @@ tags:
    <td></td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] The <code>APPCOMMAND_CORRECTION_LIST</code> command on Windows generates <code>"Unidentified"</code> on Firefox.</p>
@@ -3168,7 +3182,7 @@ tags:
     <code>Qt::Key_Send</code> (0x010000EB)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Prior to Firefox 37, this key generated the key value <code>"Unidentified"</code>.</p>
@@ -3190,6 +3204,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"LaunchCalculator"</code> [5]</td>
    <td>The <kbd>Calculator</kbd> key, often labeled with an icon. This is often used as a generic application launcher key (<code>APPCOMMAND_LAUNCH_APP2</code>).</td>
@@ -3456,7 +3472,7 @@ tags:
     <code>Qt::Key_LaunchF</code> (0x010000B1)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Internet Explorer, Edge, and Firefox (36 and earlier) use <code>"SelectMedia"</code> instead of <code>"LaunchMediaPlayer"</code>. Firefox 37 through Firefox 48 use <code>"MediaSelect"</code>. Firefox 49 has been updated to match the latest specification, and to return <code>"LaunchMediaPlayer"</code>.</p>
@@ -3486,6 +3502,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"BrowserBack"</code></td>
    <td>Navigates to the previous content or page in the current Web view's history.</td>
@@ -3557,7 +3575,7 @@ tags:
     <code>Qt::Key_Search</code> (0x01000063)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Prior to Firefox 37, this key's value was reported as <code>"Unidentified"</code>.</p>
@@ -3583,6 +3601,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"Decimal"</code> [1] {{deprecated_inline}}</td>
    <td>
@@ -3676,7 +3696,7 @@ tags:
    <td><code>GDK_KEY_KP_0</code> (0xFFB0) - <code>GDK_KEY_KP_9</code> (0xFFB9)</td>
    <td><code>KEYCODE_NUMPAD_0</code> (144) - <code>KEYCODE_NUMPAD_9</code> (153)</td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] While older browsers used words like <code>"Add"</code>, <code>"Decimal"</code>, <code>"Multiply"</code>, and so forth modern browsers identify these using the actual character (<code>"+"</code>, <code>"."</code>, <code>"*"</code>, and so forth).</p>

--- a/files/en-us/web/api/keyboardevent/key/key_values/index.html
+++ b/files/en-us/web/api/keyboardevent/key/key_values/index.html
@@ -79,6 +79,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"Alt"</code> [5]</td>
    <td>The <kbd>Alt</kbd> (Alternative) key.</td>
@@ -231,7 +233,7 @@ tags:
    <td></td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] In Internet Explorer (tested on release 9 and 11), as well as in all versions of Firefox, the <kbd>Windows</kbd> key is reported as <code>"OS"</code> instead of as <code>"Meta"</code>. This will be changed in Firefox per {{bug(1232918)}}. Until that's fixed, these keys are returned as <code>"OS"</code> by Firefox: <code>VK_LWIN</code> (0x5B) and <code>VK_RWIN</code> (0x5C) on Windows, and <code>GDK_KEY_Super_L</code> (0xFFEB), <code>GDK_KEY_Super_R</code> (0xFFEC), <code>GDK_KEY_Hyper_L</code> (0xFFED), and <code>GDK_KEY_Hyper_R</code> (0xFFEE) on Linux.</p>
@@ -1045,6 +1047,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"HangulMode"</code></td>
    <td>The <kbd>Hangul</kbd> (Korean character set) mode key, which toggles between Hangul and English entry modes.</td>
@@ -1072,7 +1076,7 @@ tags:
     <code>Qt::Key_Hangul_Jeonja</code> (0x01001138)</td>
    <td></td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] <code>VK_HANGUL</code> and <code>VK_KANA</code> share the same numeric key value on Windows, as do <code>VK_HANJA</code> and <code>VK_KANJI</code>.</p>
@@ -1094,6 +1098,8 @@ tags:
    <th scope="col" style="text-align: left;">Linux</th>
    <th scope="col" style="text-align: left;">Android</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>"Eisu"</code> [1]</td>
    <td>The <kbd>Eisu</kbd> key. This key's purpose is defined by the IME, but may be used to close the IME.</td>
@@ -1189,7 +1195,7 @@ tags:
     <p><code>KEYCODE_ZENKAKU_HANKAKU</code> (211)</p>
    </td>
   </tr>
- </thead>
+ </tbody>
 </table>
 
 <p>[1] Prior to Firefox 37, the <kbd>Eisu</kbd> key was mapped to <code>"RomanCharacters"</code> by mistake.</p>


### PR DESCRIPTION
I have fixed the Key Values page HTML tables to move body rows from `<thead>` to `<tbody>` like in other tables in the same file.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values