### PR TITLE
Improve css mask-image

### DIFF
--- a/files/en-us/web/css/mask-image/index.html
+++ b/files/en-us/web/css/mask-image/index.html
@@ -12,7 +12,8 @@ browser-compat: css.properties.mask-image
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>mask-image</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the image that is used as mask layer for an element.</p>
+<p>The <strong><code>mask-image</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the image that is used as mask layer for an element.
+By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the {{cssxref("mask-mode")}} property.</p>
 
 <pre class="brush:css no-line-numbers">/* Keyword value */
 mask-image: none;

--- a/files/en-us/web/css/mask-image/index.html
+++ b/files/en-us/web/css/mask-image/index.html
@@ -40,7 +40,7 @@ mask-image: unset;
 
 <dl>
  <dt><code>none</code></dt>
- <dd>This keyword is interpreted as a transparent black image layer.</dd>
+ <dd>This keyword is interpreted as an opaque white image layer.</dd>
  <dt><code>&lt;mask-source&gt;</code></dt>
  <dd>A {{cssxref("url()","url()")}} reference to a {{SVGElement("mask")}} or to a CSS image.</dd>
  <dt>{{cssxref("&lt;image&gt;")}}</dt>


### PR DESCRIPTION
- Added a reference to the `mask-mode` property. IMO this should make it more clear what is used as a mask.
- `mask-image: none` means the alpha channel of the element remains unchanged. This is equivalent to a white (luminance mode) and fully opaque (alpha mode) mask image, not a transparent black one. In the later case `mask-image: none` would have the same effect as `opacity: 0`. Note this also seems to be wrong in the spec draft.
