### PR TITLE
Improve the tone of SyntaxError: missing variable name's content

### DIFF
--- a/files/en-us/web/javascript/reference/errors/no_variable_name/index.html
+++ b/files/en-us/web/javascript/reference/errors/no_variable_name/index.html
@@ -9,8 +9,7 @@ tags:
 ---
 <div>{{jsSidebar("Errors")}}</div>
 
-<p>The JavaScript exception "missing variable name" occurs way too often as naming things
-  is so hard. Or maybe a comma is wrong. Check for typos!</p>
+<p>The JavaScript exception "missing variable name" is a common error experienced by developers. It mostly occurs due to a typo or a forgotten variable name.</p>
 
 <h2 id="Message">Message</h2>
 
@@ -23,14 +22,11 @@ SyntaxError: Unexpected token = (Chrome)</pre>
 
 <h2 id="What_went_wrong">What went wrong?</h2>
 
-<p>A variable is missing a name. This is likely due to a syntax error in your code.
-  Probably a comma is wrong somewhere or you struggled with coming up with a name. Totally
-  understandable! Naming things is so hard.</p>
+<p>A variable is missing a name. The cause is most likely a typo or a forgotten variable name.
+  Make sure that you've provided the name of the variable before the <code>=</code> sign.</p>
 
-<ul>
-  <li>Check to ensure the previous lines / declaration does not end with a comma instead
-    of a semi-colon.</li>
-</ul>
+<p>When declaring multiple variables at the same time, make sure that the previous lines/declaration does not end with a comma instead
+  of a semi-colon.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -39,9 +35,9 @@ SyntaxError: Unexpected token = (Chrome)</pre>
 <pre class="brush: js example-bad">var = "foo";
 </pre>
 
-<p>It's tough coming up with good variable names. We all have been there.</p>
+<p>Coming up with a descriptive variable name is challenging for most developers. It gets easier over time.</p>
 
-<pre class="brush: js example-good">var ohGodWhy = "foo";</pre>
+<pre class="brush: js example-good">var description = "foo";</pre>
 
 <h3 id="Reserved_keywords_cant_be_variable_names">Reserved keywords can't be variable
   names</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Improved the tone to be more consistent with MDN docs.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_variable_name

> Issue number (if there is an associated issue)

Closes #5251 

> Anything else that could help us review it
