### PR TITLE
Remove a duplicated sentence in Web/HTML/Attributes/rel

### DIFF
--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -211,8 +211,6 @@ tags:
 
 <p>The <code>rel</code> attribute has no default value. If the attribute is omitted or if none of the values in the attribute are supported, then the document has no particular relationship with the destination resource other than there being a hyperlink between the two. In this case, on {{htmlelement('link')}} and {{htmlelement('form')}}, if the <code>rel</code> attribute is absent, has no keywords, or if not one or more of the space-separated keywords above, then the element does not create any links. {{htmlelement('a')}} and {{htmlelement('area')}} will still created links, but without a defined relationship.</p>
 
-<p>Like all HTML keyword attribute values, these values are case-insensitive.</p>
-
 <h2 id="Values">Values</h2>
 
 <p>If there are multiple <code>&lt;link rel="icon"&gt;</code>s, the browser uses their <a href="media"><code>media</code></a> attribute, <a href="type"><code>type</code></a> and <a href="sizes"><code>sizes</code></a> attributes to select the most appropriate icon. If several icons are equally appropriate, the last one is used. If the most appropriate icon is later found to be inappropriate, for example, because it uses an unsupported format, the browser proceeds to the next-most appropriate, and so on.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This sentence is a duplicate of the two previous sentence.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel
