### PR TITLE
add detail about qualified attribute names to Element.getAttributeNames documentation

### DIFF
--- a/files/en-us/web/api/element/getattributenames/index.html
+++ b/files/en-us/web/api/element/getattributenames/index.html
@@ -21,10 +21,7 @@ browser-compat: api.Element.getAttributeNames
   {{domxref("Element.getAttribute","getAttribute()")}}, is a memory-efficient and
   performant alternative to accessing {{domxref("Element.attributes")}}.</p>
 
-<p>The attribute names returned by <strong><code>getAttributeNames()</code></strong> are
-  <em>qualified</em> attribute names, meaning that any non-namespaced attributes have their
-  names returned as-is (f.e. <strong><code>some-attribute</code></strong>), while namespaced attributes have their
-  names returned prefixed by the namespace and a colon (f.e. <strong><code>namespace:other-attribute</code></strong>).</p>
+<p>The names returned by <strong><code>getAttributeNames()</code></strong> are <em>qualified</em> attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (<em>not</em> the actual namespace URI), followed by a colon, followed by the attribute name (for example, <strong><code>xlink:href</code></strong>), while any attributes which have no namespace prefix have their names returned as-is (for example, <strong><code>href</code></strong>).</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -33,10 +30,30 @@ browser-compat: api.Element.getAttributeNames
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush:js">const element = document.createElement('div')
+<p>The following example shows how:</p>
 
-element.setAttribute('foo', 'bar')
-element.setAttributeNS('http://example.com/lorem', 'foo', 'bar')
+<ul>
+  <li>For an attribute which has a namespace prefix, <code>getAttributeNames()</code> returns that namespace prefix along with the attribute name.</li>
+  <li>For an attribute which has no namespace prefix, <code>getAttributeNames()</code> returns just the attribute name, as-is.</li>
+</ul>
+
+<p>It’s important to understand that:
+<ol>
+  <li>An attribute can be present in the DOM with a namespace but lacking a namespace prefix.</li>
+  <li>For an attribute in the DOM that has a namespace but lacks a namespace prefix, <code>getAttributeNames()</code> will return just the attribute name, with no indication that the attribute is in a namespace.</li>
+</ol>
+
+<p>The example below includes such a “namespaced but without a namespace prefix” case.</p>
+
+<pre class="brush:js">
+const element = document.createElement('a')
+
+// set "href" attribute with no namespace and no namespace prefix
+element.setAttribute('href', 'https://example.com')
+// set "href" attribute with namespace and also "xlink" namespace prefix
+element.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'https://example.com')
+// set "show" attribute with namespace but no namespace prefix
+element.setAttributeNS('http://www.w3.org/1999/xlink', 'show', 'new')
 
 // Iterate over element's attributes
 for (let name of element.getAttributeNames()) {
@@ -45,8 +62,9 @@ for (let name of element.getAttributeNames()) {
 }
 
 // logs:
-// foo bar
-// http://example.com/lorem:foo bar
+// href https://example.com
+// xlink:href https://example.com
+// show new
 </pre>
 
 <h2 id="Polyfill">Polyfill</h2>

--- a/files/en-us/web/api/element/getattributenames/index.html
+++ b/files/en-us/web/api/element/getattributenames/index.html
@@ -21,6 +21,11 @@ browser-compat: api.Element.getAttributeNames
   {{domxref("Element.getAttribute","getAttribute()")}}, is a memory-efficient and
   performant alternative to accessing {{domxref("Element.attributes")}}.</p>
 
+<p>The attribute names returned by <strong><code>getAttributeNames()</code></strong> are
+  <em>qualified</em> attribute names, meaning that any non-namespaced attributes have their
+  names returned as-is (f.e. <strong><code>some-attribute</code></strong>), while namespaced attributes have their
+  names returned prefixed by the namespace and a colon (f.e. <strong><code>namespace:other-attribute</code></strong>).</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js"><em>let attributeNames</em> = element.getAttributeNames();
@@ -28,11 +33,20 @@ browser-compat: api.Element.getAttributeNames
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush:js">// Iterate over element's attributes
+<pre class="brush:js">const element = document.createElement('div')
+
+element.setAttribute('foo', 'bar')
+element.setAttributeNS('http://example.com/lorem', 'foo', 'bar')
+
+// Iterate over element's attributes
 for (let name of element.getAttributeNames()) {
   let value = element.getAttribute(name);
   console.log(name, value);
 }
+
+// logs:
+// foo bar
+// http://example.com/lorem:foo bar
 </pre>
 
 <h2 id="Polyfill">Polyfill</h2>


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

[The spec](https://dom.spec.whatwg.org/#dom-element-getattributenames) says the names should be [qualified](https://dom.spec.whatwg.org/#concept-attribute-qualified-name) which it describes as being prefixed by `namespace:`.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames

> Issue number (if there is an associated issue)

> Anything else that could help us review it

https://bugs.chromium.org/p/chromium/issues/detail?id=1216840
