### PR TITLE
Remove useless style attribute in web audio api pages

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/index.html
@@ -24,7 +24,7 @@ browser-compat: api.AudioBufferSourceNode
 <p>Multiple calls to {{domxref("AudioScheduledSourceNode/stop", "stop()")}} are allowed. The most recent call replaces the previous one, if the <code>AudioBufferSourceNode</code> has not already reached the end of the buffer.</p>
 
 <p><br>
- <img alt="The AudioBufferSourceNode takes the content of an AudioBuffer and m" src="webaudioaudiobuffersourcenode.png" style="display: block; margin: 0px auto;"></p>
+ <img alt="The AudioBufferSourceNode takes the content of an AudioBuffer and m" src="webaudioaudiobuffersourcenode.png"></p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/index.html
@@ -97,7 +97,7 @@ var finish = audioCtx.destination;
 
 <h2 id="See_also">See also</h2>
 
-<ul style="margin-left: 40px;">
+<ul>
  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
  <li>{{domxref("OfflineAudioContext")}}</li>
 </ul>

--- a/files/en-us/web/api/audiolistener/index.html
+++ b/files/en-us/web/api/audiolistener/index.html
@@ -15,7 +15,7 @@ browser-compat: api.AudioListener
 
 <p>It is important to note that there is only one listener per context and that it isn't an {{domxref("AudioNode")}}.</p>
 
-<p><img alt="We see the position, up and front vectors of an AudioListener, with the up and front vectors at 90° from the other." src="webaudiolistenerreduced.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="We see the position, up and front vectors of an AudioListener, with the up and front vectors at 90° from the other." src="webaudiolistenerreduced.png"></p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/audionode/connect/index.html
+++ b/files/en-us/web/api/audionode/connect/index.html
@@ -96,7 +96,7 @@ browser-compat: api.AudioNode.connect
 <p>This example creates an oscillator, then links it to a gain node, so that the gain node
   controls the volume of the oscillator node.</p>
 
-<pre class="brush: js" style="font-size: 14px;">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js">var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audionode/index.html
+++ b/files/en-us/web/api/audionode/index.html
@@ -30,7 +30,7 @@ browser-compat: api.AudioNode
 
 <h3 id="The_audio_routing_graph">The audio routing graph</h3>
 
-<p><img alt="AudioNodes participating in an AudioContext create a audio routing graph." src="webaudiobasics.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="AudioNodes participating in an AudioContext create a audio routing graph." src="webaudiobasics.png"></p>
 
 <p>Each <code>AudioNode</code> has inputs and outputs, and multiple audio nodes are connected to build a <em>processing graph</em>. This graph is contained in an {{domxref("AudioContext")}}, and each audio node can only belong to one audio context.</p>
 

--- a/files/en-us/web/api/audioparam/settargetattime/index.html
+++ b/files/en-us/web/api/audioparam/settargetattime/index.html
@@ -92,41 +92,41 @@ browser-compat: api.AudioParam.setTargetAtTime
 <p>For more details, check the following table on how the value changes from 0% to 100% as
   the time progresses.</p>
 
-<table style="width: auto;">
+<table>
   <thead>
     <tr>
-      <th style="white-space: nowrap;">Time since <code>startTime</code></th>
+      <th>Time since <code>startTime</code></th>
       <th>Value</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td><code>0 * timeConstant</code></td>
-      <td style="text-align: right;">0%</td>
+      <td>0%</td>
     </tr>
     <tr>
       <td><code>0.5 * timeConstant</code></td>
-      <td style="text-align: right;">39.3%</td>
+      <td>39.3%</td>
     </tr>
     <tr>
       <td><code>1 * timeConstant</code></td>
-      <td style="text-align: right;">63.2%</td>
+      <td>63.2%</td>
     </tr>
     <tr>
       <td><code>2 * timeConstant</code></td>
-      <td style="text-align: right;">86.5%</td>
+      <td>86.5%</td>
     </tr>
     <tr>
       <td><code>3 * timeConstant</code></td>
-      <td style="text-align: right;">95.0%</td>
+      <td>95.0%</td>
     </tr>
     <tr>
       <td><code>4 * timeConstant</code></td>
-      <td style="text-align: right;">98.2%</td>
+      <td>98.2%</td>
     </tr>
     <tr>
       <td><code>5 * timeConstant</code></td>
-      <td style="text-align: right;">99.3%</td>
+      <td>99.3%</td>
     </tr>
     <tr>
       <td><code>n * timeConstant</code></td>

--- a/files/en-us/web/api/baseaudiocontext/index.html
+++ b/files/en-us/web/api/baseaudiocontext/index.html
@@ -128,7 +128,7 @@ const finish = audioContext.destination;
 
 <h2 id="See_also">See also</h2>
 
-<ul style="margin-left: 40px;">
+<ul>
  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
  <li>{{domxref("AudioContext")}}</li>
  <li>{{domxref("OfflineAudioContext")}}</li>

--- a/files/en-us/web/api/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ChannelMergerNode
 
 <p>The <code>ChannelMergerNode</code> interface, often used in conjunction with its opposite, {{domxref("ChannelSplitterNode")}}, reunites different mono inputs into a single output. Each input is used to fill a channel of the output. This is useful for accessing each channels separately, e.g. for performing channel mixing where gain must be separately controlled on each channel.</p>
 
-<p><img alt="" src="webaudiomerger.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="" src="webaudiomerger.png"></p>
 
 <p>If <code>ChannelMergerNode</code> has one single output, but as many inputs as there are channels to merge; the number of inputs is defined as a parameter of its constructor and the call to {{domxref("BaseAudioContext/createChannelMerger", "AudioContext.createChannelMerger()")}}. In the case that no value is given, it will default to <code>6</code>.</p>
 

--- a/files/en-us/web/api/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/index.html
@@ -16,7 +16,7 @@ browser-compat: api.ChannelSplitterNode
 
 <p>The <code>ChannelSplitterNode</code> interface, often used in conjunction with its opposite, {{domxref("ChannelMergerNode")}}, separates the different channels of an audio source into a set of mono outputs. This is useful for accessing each channel separately, e.g. for performing channel mixing where gain must be separately controlled on each channel.</p>
 
-<p><img alt="" src="webaudiosplitter.png" style="display: block;"></p>
+<p><img alt="" src="webaudiosplitter.png"></p>
 
 <p>If your <code>ChannelSplitterNode</code> always has one single input, the amount of outputs is defined by a parameter on its constructor and the call to {{domxref("BaseAudioContext/createChannelSplitter", "AudioContext.createChannelSplitter()")}}. In the case that no value is given, it will default to <code>6</code>. If there are fewer channels in the input than there are outputs, supernumerary outputs are silent.</p>
 

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -55,9 +55,9 @@ browser-compat: api.OscillatorNode
 
 <dl>
  <dt>{{domxref("OscillatorNode.frequency")}}</dt>
- <dd>An <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} representing the frequency of oscillation in hertz (though the <code style="font-size: 14px;">AudioParam</code> returned is read-only, the value it represents is not). The default value is 440 Hz (a standard middle-A note).</dd>
+ <dd>An <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} representing the frequency of oscillation in hertz (though the <code>AudioParam</code> returned is read-only, the value it represents is not). The default value is 440 Hz (a standard middle-A note).</dd>
  <dt>{{domxref("OscillatorNode.detune")}}</dt>
- <dd>An <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} representing detuning of oscillation in cents (though the <code style="font-size: 14px;">AudioParam</code> returned is read-only, the value it represents is not). The default value is 0.</dd>
+ <dd>An <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} representing detuning of oscillation in cents (though the <code>AudioParam</code> returned is read-only, the value it represents is not). The default value is 0.</dd>
  <dt>{{domxref("OscillatorNode.type")}}</dt>
  <dd>A string which specifies the shape of waveform to play; this can be one of a number of standard values, or <code>custom</code> to use a {{domxref("PeriodicWave")}} to describe a custom waveform. Different waves will produce different tones. Standard values are <code>"sine"</code>, <code>"square"</code>, <code>"sawtooth"</code>, <code>"triangle"</code> and <code>"custom"</code>. The default is <code>"sine"</code>.</dd>
 </dl>

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -17,7 +17,7 @@ browser-compat: api.PannerNode
 
 <p>A <code>PannerNode</code> always has exactly one input and one output: the input can be <em>mono</em> or <em>stereo</em> but the output is always <em>stereo</em> (2 channels); you can't have panning effects without at least two audio channels!</p>
 
-<p><img alt="The PannerNode brings a spatial position and velocity and a directionality for a given signal." src="webaudiopannernode.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="The PannerNode brings a spatial position and velocity and a directionality for a given signal." src="webaudiopannernode.png"></p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/scriptprocessornode/index.html
+++ b/files/en-us/web/api/scriptprocessornode/index.html
@@ -20,7 +20,7 @@ browser-compat: api.ScriptProcessorNode
 
 <p>The <code>ScriptProcessorNode</code> interface is an {{domxref("AudioNode")}} audio-processing module that is linked to two buffers, one containing the input audio data, one containing the processed output audio data. An event, implementing the {{domxref("AudioProcessingEvent")}} interface, is sent to the object each time the input buffer contains new data, and the event handler terminates when it has filled the output buffer with data.</p>
 
-<p><img alt="The ScriptProcessorNode stores the input in a buffer, send the audioprocess event. The EventHandler takes the input buffer and fill the output buffer which is sent to the output by the ScriptProcessorNode." src="webaudioscriptprocessingnode.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="The ScriptProcessorNode stores the input in a buffer, send the audioprocess event. The EventHandler takes the input buffer and fill the output buffer which is sent to the output by the ScriptProcessorNode." src="webaudioscriptprocessingnode.png"></p>
 
 <p>The size of the input and output buffer are defined at the creation time, when the {{domxref("BaseAudioContext.createScriptProcessor")}} method is called (both are defined by {{domxref("BaseAudioContext.createScriptProcessor")}}'s <code>bufferSize</code> parameter). The buffer size must be a power of 2 between <code>256</code> and <code>16384</code>, that is <code>256</code>, <code>512</code>, <code>1024</code>, <code>2048</code>, <code>4096</code>, <code>8192</code> or <code>16384</code>. Small numbers lower the <em>latency</em>, but large number may be necessary to avoid audio breakup and glitches.</p>
 

--- a/files/en-us/web/api/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/index.html
@@ -18,7 +18,7 @@ browser-compat: api.StereoPannerNode
 
 <p>The {{domxref("StereoPannerNode.pan", "pan")}} property takes a unitless value between <code>-1</code> (full left pan) and <code>1</code> (full right pan). This interface was introduced as a much simpler way to apply a simple panning effect than having to use a full {{domxref("PannerNode")}}.</p>
 
-<p><img alt="" src="stereopannernode.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="" src="stereopannernode.png"></p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
@@ -36,11 +36,11 @@ tags:
 <p>The number of audio channels available on a signal is frequently presented in a numeric format, such as 2.0 or 5.1. This is called {{interwiki("wikipedia", "Surround_sound#Channel_notation", "channel notation")}}. The first number is the number of full frequency range audio channels that the signal includes. The number after the period indicates the number of those channels which are reserved for low-frequency effect (LFE) outputs; these are often referred to as <strong>subwoofers</strong>.</p>
 </div>
 
-<p><img alt="A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information." src="webaudioapi_en.svg" style="display: block; margin: 0px auto;"></p>
+<p><img alt="A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information." src="webaudioapi_en.svg"></p>
 
 <p>Each input or output is composed of one or more audio <strong>channels,</strong> which together represent a specific audio layout. Any discrete channel structure is supported, including <em>mono</em>, <em>stereo</em>, <em>quad</em>, <em>5.1</em>, and so on.</p>
 
-<p><img alt="Show the ability of AudioNodes to connect via their inputs and outputs and the channels inside these inputs/outputs." src="mdn.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="Show the ability of AudioNodes to connect via their inputs and outputs and the channels inside these inputs/outputs." src="mdn.png"></p>
 
 <p>Audio sources can be obtained in a number of ways:</p>
 
@@ -338,7 +338,7 @@ var buffer = context.createBuffer(1, 22050, 22050);</pre>
 <p>The listener's position is described using right-hand Cartesian coordinates; its movement using a velocity vector and the direction the listener's head is pointing using two direction vectors: up and front. These respectively define the direction of the top of the listener's head, and the direction the listener's nose is pointing, and are at right angles to one another.</p>
 </div>
 
-<p><img alt="We see the position, up and front vectors of an AudioListener, with the up and front vectors at 90° from the other." src="webaudiolistenerreduced.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="We see the position, up and front vectors of an AudioListener, with the up and front vectors at 90° from the other." src="webaudiolistenerreduced.png"></p>
 
 <div class="note">
 <p><strong>Note</strong>: For more information, see our <a href="/en-US/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics">Web audio spatialization basics</a> article.</p>

--- a/files/en-us/web/api/web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/index.html
@@ -93,7 +93,7 @@ tags:
 	<dt>{{domxref("AudioScheduledSourceNode")}}</dt>
 	<dd>The <strong><code>AudioScheduledSourceNode</code></strong> is a parent interface for several types of audio source node interfaces. It is an {{domxref("AudioNode")}}.</dd>
 	<dt>{{domxref("OscillatorNode")}}</dt>
-	<dd>The <strong><code style="font-size: 14px;">OscillatorNode</code> </strong>interface represents a periodic waveform, such as a sine or triangle wave. It is an {{domxref("AudioNode")}} audio-processing module that causes a given <em>frequency</em> of wave to be created.</dd>
+	<dd>The <strong><code>OscillatorNode</code> </strong>interface represents a periodic waveform, such as a sine or triangle wave. It is an {{domxref("AudioNode")}} audio-processing module that causes a given <em>frequency</em> of wave to be created.</dd>
 	<dt>{{domxref("AudioBuffer")}}</dt>
 	<dd>The <strong><code>AudioBuffer</code></strong> interface represents a short audio asset residing in memory, created from an audio file using the {{ domxref("BaseAudioContext.decodeAudioData") }} method, or created with raw data using {{ domxref("BaseAudioContext.createBuffer") }}. Once decoded into this form, the audio can then be put into an {{ domxref("AudioBufferSourceNode") }}.</dd>
 	<dt>{{domxref("AudioBufferSourceNode")}}</dt>
@@ -114,7 +114,7 @@ tags:
 	<dt>{{domxref("BiquadFilterNode")}}</dt>
 	<dd>The <strong><code>BiquadFilterNode</code></strong> interface represents a simple low-order filter. It is an {{domxref("AudioNode")}} that can represent different kinds of filters, tone control devices, or graphic equalizers. A <code>BiquadFilterNode</code> always has exactly one input and one output.</dd>
 	<dt>{{domxref("ConvolverNode")}}</dt>
-	<dd>The <code><strong>Convolver</strong></code><strong><code>Node</code></strong> interface is an <span style="line-height: 1.5;">{{domxref("AudioNode")}} that</span><span style="line-height: 1.5;"> performs a Linear Convolution on a given {{domxref("AudioBuffer")}}, and is often used to achieve a reverb effect</span><span style="line-height: 1.5;">.</span></dd>
+	<dd>The <code><strong>Convolver</strong></code><strong><code>Node</code></strong> interface is an {{domxref("AudioNode")}} that performs a Linear Convolution on a given {{domxref("AudioBuffer")}}, and is often used to achieve a reverb effect.</dd>
 	<dt>{{domxref("DelayNode")}}</dt>
 	<dd>The <strong><code>DelayNode</code></strong> interface represents a <a href="https://en.wikipedia.org/wiki/Digital_delay_line">delay-line</a>; an {{domxref("AudioNode")}} audio-processing module that causes a delay between the arrival of an input data and its propagation to the output.</dd>
 	<dt>{{domxref("DynamicsCompressorNode")}}</dt>

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.html
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.html
@@ -376,7 +376,7 @@ let cosineTerms = null;
   </tr>
   <tr>
    <th scope="row">2</th>
-   <td colspan="12" style="text-align: center;">. . .</td>
+   <td colspan="12">. . .</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Our simple example for this guide provides a play/pause button that starts and pauses audio play, and a toggle that turns an IIR filter on and off, altering the tone of the sound. It also provides a canvas on which is drawn the frequency response of the audio, so you can see what effect the IIR filter has.</p>
 
-<p><img alt="A demo featuring a play button, and toggle to turn a filter on and off, and a line graph showing the filter frequencies returned after the filter has been applied." src="iir-filter-demo.png" style="border-style: solid; border-width: 1px; display: block; margin: 0 auto;"></p>
+<p><img alt="A demo featuring a play button, and toggle to turn a filter on and off, and a line graph showing the filter frequencies returned after the filter has been applied." src="iir-filter-demo.png"></p>
 
 <p>You can check out the <a href="https://codepen.io/Rumyra/pen/oPxvYB/">full demo here on Codepen</a>. Also see the <a href="https://github.com/mdn/webaudio-examples/tree/master/iirfilter-node">source code on GitHub</a>. It includes some different coefficient values for different lowpass frequencies — you can change the value of the <code>filterNumber</code> constant to a value between 0 and 3 to check out the different available effects.</p>
 

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>Our boombox looks like this:</p>
 
-<p><img alt="A boombox with play, pan, and volume controls" src="boombox.png" style="border-style: solid; border-width: 1px;"></p>
+<p><img alt="A boombox with play, pan, and volume controls" src="boombox.png"></p>
 
 <p>Note the retro cassette deck with a play button, and vol and pan sliders to allow you to alter the volume and stereo panning. We could make this a lot more complex, but this is ideal for simple learning at this stage.</p>
 
@@ -107,7 +107,7 @@ const track = audioContext.createMediaElementSource(audioElement);
 
 <p>A good way to visualise these nodes is by drawing an audio graph so you can visualize it. This is what our current audio graph looks like:</p>
 
-<p><img alt="an audio graph with an audio element source connected to the default destination" src="graph1.jpg" style="border-style: solid; border-width: 1px;"></p>
+<p><img alt="an audio graph with an audio element source connected to the default destination" src="graph1.jpg"></p>
 
 <p>Now we can add the play and pause functionality.</p>
 
@@ -156,7 +156,7 @@ playButton.addEventListener('click', function() {
 
 <p>This will make our audio graph look like this:</p>
 
-<p><img alt="an audio graph with an audio element source, connected to a gain node that modifies the audio source, and then going to the default destination" src="graph2.jpg" style="border-style: solid; border-width: 1px;"></p>
+<p><img alt="an audio graph with an audio element source, connected to a gain node that modifies the audio source, and then going to the default destination" src="graph2.jpg"></p>
 
 <p>The default value for gain is 1; this keeps the current volume the same. Gain can be set to a minimum of about -3.4 and a max of about 3.4. Here we'll allow the boombox to move the gain up to 2 (double the original volume) and down to 0 (this will effectively mute our sound).</p>
 
@@ -194,7 +194,7 @@ volumeControl.addEventListener('input', function() {
 
 <p>To visualise it, we will be making our audio graph look like this:</p>
 
-<p><img alt="An image showing the audio graph showing an input node, two modification nodes (a gain node and a stereo panner node) and a destination node." src="graphpan.jpg" style="border-style: solid; border-width: 1px;"></p>
+<p><img alt="An image showing the audio graph showing an input node, two modification nodes (a gain node and a stereo panner node) and a destination node." src="graphpan.jpg"></p>
 
 <p>Let's use the constructor method of creating a node this time. When we do it this way, we have to pass in the context and any options that the particular node may take:</p>
 
@@ -239,10 +239,10 @@ pannerControl.addEventListener('input', function() {
 
 <p>The <a href="https://github.com/mdn/voice-change-o-matic">Voice-change-O-matic</a> is a fun voice manipulator and sound visualization web app that allows you to choose different effects and visualizations. The application is fairly rudimentary, but it demonstrates the simultaneous use of multiple Web Audio API features. (<a href="https://mdn.github.io/voice-change-o-matic/">run the Voice-change-O-matic live</a>).</p>
 
-<p><img alt="A UI with a sound wave being shown, and options for choosing voice effects and visualizations." src="voice-change-o-matic.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="A UI with a sound wave being shown, and options for choosing voice effects and visualizations." src="voice-change-o-matic.png"></p>
 
 <p>Another application developed specifically to demonstrate the Web Audio API is the <a href="https://mdn.github.io/violent-theremin/">Violent Theremin</a>, a simple web application that allows you to change pitch and volume by moving your mouse pointer. It also provides a psychedelic lightshow (<a href="https://github.com/mdn/violent-theremin">see Violent Theremin source code</a>).</p>
 
-<p><img alt="A page full of rainbow colors, with two buttons labeled Clear screen and mute." src="violent-theremin.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="A page full of rainbow colors, with two buttons labeled Clear screen and mute." src="violent-theremin.png"></p>
 
 <p>Also see our <a href="https://github.com/mdn/webaudio-examples">webaudio-examples repo</a> for more examples.</p>

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
@@ -129,7 +129,7 @@ var x = 0;</pre>
 
 <p>This gives us a nice waveform display that updates several times a second:</p>
 
-<p><img alt="a black oscilloscope line, showing the waveform of an audio signal" src="wave.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="a black oscilloscope line, showing the waveform of an audio signal" src="wave.png"></p>
 
 <h2 id="Creating_a_frequency_bar_graph">Creating a frequency bar graph</h2>
 

--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.html
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>To demonstrate 3D spatialization we've created a modified version of the boombox demo we created in our basic <a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a> guide. see the <a href="https://mdn.github.io/webaudio-examples/spacialization/">3D spatialization demo live</a> (and see the <a href="https://github.com/mdn/webaudio-examples/tree/master/spacialization">source code</a> also).</p>
 
-<p><img alt="A simple UI with a rotated boombox and controls to move it left and right and in and out, and rotate it." src="web-audio-spatialization.png" style="border-style: solid; border-width: 1px;"></p>
+<p><img alt="A simple UI with a rotated boombox and controls to move it left and right and in and out, and rotate it." src="web-audio-spatialization.png"></p>
 
 <p>The boombox sits inside a room (defined by the edges of the browser viewport), and in this demo, we can move and rotate it with the provided controls. When we move the boombox, the sound it produces changes accordingly, panning as it moves to the left or right of the room, or becoming quieter as it is moved away from the user or is rotated so the speakers are facing away from them, etc. This is done by setting the different properties of the <code>PannerNode</code> object instance in relation to that movement, to emulate spacialization.</p>
 


### PR DESCRIPTION
This is part of #5438.

It removes the style attributes in web audio pages.

It was all useless styles, doing centering images, adding borders (both useless), or doing nothing.