### PR TITLE
Remove style attributes from Web RTC pages

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
@@ -66,7 +66,7 @@ function showBufferedAmount(channel) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
@@ -62,7 +62,7 @@ dc.onbufferedamountlow = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdatachannel/label/index.html
+++ b/files/en-us/web/api/rtcdatachannel/label/index.html
@@ -56,7 +56,7 @@ document.getElementById(&quot;channel-name&quot;).innerHTML =
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdatachannel/onclose/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclose/index.html
@@ -54,7 +54,7 @@ dc.onclose = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -43,7 +43,7 @@ if (!dc.ordered) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
@@ -60,7 +60,7 @@ browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
@@ -41,7 +41,7 @@ browser-compat: api.RTCDTMFToneChangeEvent.tone
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
@@ -38,7 +38,7 @@ pc.getIdentityAssertion(); // Not mandatory, but we know that we will need it in
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
@@ -40,7 +40,7 @@ browser-compat: api.RTCPeerConnection.getReceivers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
 	<thead>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
@@ -57,7 +57,7 @@ browser-compat: api.RTCPeerConnection.getSenders
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
@@ -49,7 +49,7 @@ var state = pc.iceConnectionState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
@@ -41,7 +41,7 @@ var state = pc.iceGatheringState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
@@ -74,7 +74,7 @@ async function getIdentityAssertion(pc) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
@@ -56,7 +56,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
@@ -73,7 +73,7 @@ document.getElementById("closeButton").addEventListener("click", function(event)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
@@ -49,7 +49,7 @@ pc.setIdentityAssertion("developer.mozilla.org");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
@@ -41,7 +41,7 @@ browser-compat: api.RTCPeerConnectionIceEvent.candidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
@@ -50,7 +50,7 @@ browser-compat: api.RTCRtpReceiver.getStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.html
@@ -50,7 +50,7 @@ browser-compat: api.RTCRtpSender.getStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcrtptransceiverdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverdirection/index.html
@@ -30,31 +30,31 @@ browser-compat: api.RTCRtpTransceiverDirection
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="row" style="vertical-align: top;">Value</th>
-   <th scope="col" style="vertical-align: top;"><code>RTCRtpSender</code> behavior</th>
-   <th scope="col" style="vertical-align: top;"><code>RTCRtpReceiver</code> behavior</th>
+   <th scope="row">Value</th>
+   <th scope="col"><code>RTCRtpSender</code> behavior</th>
+   <th scope="col"><code>RTCRtpReceiver</code> behavior</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <th scope="row" style="vertical-align: top;"><a id="sendrecv"><code>"sendrecv"</code></a></th>
-   <td style="vertical-align: top;">Offers to send {{Glossary("RTP")}} data, and will do so if the other peer accepts the connection and at least one of the sender's encodings is active<sup>1</sup>.</td>
-   <td style="vertical-align: top;">Offers to receive RTP data, and does so if the other peer accepts.</td>
+   <th scope="row"><a id="sendrecv"><code>"sendrecv"</code></a></th>
+   <td>Offers to send {{Glossary("RTP")}} data, and will do so if the other peer accepts the connection and at least one of the sender's encodings is active<sup>1</sup>.</td>
+   <td>Offers to receive RTP data, and does so if the other peer accepts.</td>
   </tr>
   <tr>
-   <th scope="row" style="vertical-align: top;"><a id="sendonly"><code>"sendonly"</code></a></th>
-   <td style="vertical-align: top;">Offers to send RTP data, and will do so if the other peer accepts the connection and at least one of the sender's encodings is active<sup>1</sup>.</td>
-   <td style="vertical-align: top;">Does <em>not</em> offer to receive RTP data and will not do so.</td>
+   <th scope="row"><a id="sendonly"><code>"sendonly"</code></a></th>
+   <td>Offers to send RTP data, and will do so if the other peer accepts the connection and at least one of the sender's encodings is active<sup>1</sup>.</td>
+   <td>Does <em>not</em> offer to receive RTP data and will not do so.</td>
   </tr>
   <tr>
-   <th scope="row" style="vertical-align: top;"><a id="recvonly"><code>"recvonly"</code></a></th>
-   <td style="vertical-align: top;">Does <em>not</em> offer to send RTP data, and will not do so.</td>
-   <td style="vertical-align: top;">Offers to receive RTP data, and will do so if the other peer offers.</td>
+   <th scope="row"><a id="recvonly"><code>"recvonly"</code></a></th>
+   <td>Does <em>not</em> offer to send RTP data, and will not do so.</td>
+   <td>Offers to receive RTP data, and will do so if the other peer offers.</td>
   </tr>
   <tr>
-   <th scope="row" style="vertical-align: top;"><a id="inactive"><code>"inactive"</code></a></th>
-   <td style="vertical-align: top;">Does <em>not</em> offer to send RTP data, and will not do so.</td>
-   <td style="vertical-align: top;">Does <em>not</em> offer to receive RTP data and will not do so.</td>
+   <th scope="row"><a id="inactive"><code>"inactive"</code></a></th>
+   <td>Does <em>not</em> offer to send RTP data, and will not do so.</td>
+   <td>Does <em>not</em> offer to receive RTP data and will not do so.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
@@ -79,7 +79,7 @@ browser-compat: api.RTCSessionDescription.RTCSessionDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcsessiondescription/sdp/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/sdp/index.html
@@ -47,7 +47,7 @@ alert(pc.remoteDescription.sdp);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcsessiondescription/tojson/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/tojson/index.html
@@ -44,7 +44,7 @@ alert(JSON.stringify(sd)); // This call the toJSON() method behind the scene.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcsessiondescription/type/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.html
@@ -48,7 +48,7 @@ alert(pc.remoteDescription.type);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
+<table class="standard-table">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.html
@@ -45,7 +45,7 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call
 });</pre>
 
     <p>Let's walk through the most important parts of this code:</p>
-    <ol style="list-style-type: upper-latin">
+    <ul>
       <li>
         <p><code>call.answer(window.localStream)</code>: if <code>answerCall</code> is <code>true</code>, you'll want to call peerJS’s <code>answer()</code> function on the call to create an answer, passing it the local stream.</p>
       </li>
@@ -58,7 +58,7 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call
       <li>
         <p>If the person denies the call, we’re just going to log a message to the console.</p>
       </li>
-    </ol>
+    </ul>
   </li>
   <li>
     <p>The code you have now is enough for you to create a call and answer it. Refresh your browsers and test it out. You’ll want to make sure that both browsers have the console open or else you won’t get the prompt to answer the call. Click call, submit the peer ID for the other browser and then answer the call. The final page should look like this:</p>

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.html
@@ -31,7 +31,7 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call
 })</pre>
 
     <p>Let's walk through this code:</p>
-    <ol style="list-style-type: upper-latin">
+    <ul>
       <li>
         <p><code>const call = peer.call(code, window.localStream)</code>: This will create a call with the <code>code</code> and <code>window.localStream</code> we've previously assigned. Note that the <code>localStream</code> will be the user's <code>localStream</code>. So for caller A it'll be their stream &amp; for B, their own stream.</p>
       </li>
@@ -50,7 +50,7 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call
       <li>
       <p>Finally you want to show the correct content, so call the <code>showConnectedContent()</code> function you created earlier.</p>
       </li>
-    </ol>
+    </ul>
   <li>
     <p>To test this out, open <code>localhost:8000</code> in two browser windows and click Call inside one of them. You should see this:</p>
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.html
@@ -24,7 +24,7 @@ slug: >-
 
     <p>Let's explain the most important lines:</p>
 
-    <ol style="list-style-type:upper-latin;">
+    <ul>
       <li>
         <p><code>window.localStream = stream</code> attaches the <code>MediaStream</code> object (which we have assigned to <code>stream</code> on the previous line) to the window as the <code>localStream</code>.</p>
       </li>
@@ -34,7 +34,7 @@ slug: >-
       <li>
         <p><code>window.localAudio.autoplay = true</code> sets the <code>autoplay</code> attribute of the <code>&lt;audio&gt;</code> element to true, so that the audio plays automatically.</p>
       </li>
-    </ol>
+    </ul>
 
     <div class="notecard warning">
       <h4>Warning</h4>

--- a/files/en-us/web/api/webrtc_api/connectivity/index.html
+++ b/files/en-us/web/api/webrtc_api/connectivity/index.html
@@ -143,4 +143,4 @@ tags:
 
 <h2 id="The_entire_exchange_in_a_complicated_diagram">The entire exchange in a complicated diagram</h2>
 
-<p><a href="https://hacks.mozilla.org/wp-content/uploads/2013/07/webrtc-complete-diagram.png"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png" style="display: block; margin: 0px auto;"></a></p>
+<p><a href="https://hacks.mozilla.org/wp-content/uploads/2013/07/webrtc-complete-diagram.png"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png"></a></p>

--- a/files/en-us/web/api/webrtc_api/protocols/index.html
+++ b/files/en-us/web/api/webrtc_api/protocols/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>The client will send a request to a STUN server on the Internet who will reply with the client’s public address and whether or not the client is accessible behind the router’s NAT.</p>
 
-<p><img alt="An interaction between two users of a WebRTC application involving a STUN server." src="webrtc-stun.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="An interaction between two users of a WebRTC application involving a STUN server." src="webrtc-stun.png"></p>
 
 <h2 id="NAT">NAT</h2>
 
@@ -45,7 +45,7 @@ tags:
 
 <p><a href="https://en.wikipedia.org/wiki/TURN">Traversal Using Relays around NAT (TURN)</a> is meant to bypass the Symmetric NAT restriction by opening a connection with a TURN server and relaying all information through that server. You would create a connection with a TURN server and tell all peers to send packets to the server which will then be forwarded to you. This obviously comes with some overhead so it is only used if there are no other alternatives.</p>
 
-<p><img alt="An interaction between two users of a WebRTC application involving STUN and TURN servers." src="webrtc-turn.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="An interaction between two users of a WebRTC application involving STUN and TURN servers." src="webrtc-turn.png"></p>
 
 <h2 id="SDP">SDP</h2>
 

--- a/files/en-us/web/api/webrtc_api/taking_still_photos/index.html
+++ b/files/en-us/web/api/webrtc_api/taking_still_photos/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p><span class="seoSummary">This article shows how to use WebRTC to access the camera on a computer or mobile phone with WebRTC support and take a photo with it.</span> <a href="https://mdn-samples.mozilla.org/s/webrtc-capturestill">Try this sample</a> then read on to learn how it works.</p>
 
-<p><img alt="WebRTC-based image capture app — on the left we have a video stream taken from a webcam and a take photo button, on the right we have the still image output from taking the photo" src="web-rtc-demo.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="WebRTC-based image capture app — on the left we have a video stream taken from a webcam and a take photo button, on the right we have the still image output from taking the photo" src="web-rtc-demo.png"></p>
 
 <p>You can also jump straight to the <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill" rel="noopener">code on Github</a> if you like.</p>
 
@@ -47,7 +47,7 @@ tags:
 
 <p>That's all of the relevant HTML. The rest is just some page layout fluff and a bit of text offering a link back to this page.</p>
 
-<h2 id="The_JavaScript_code"><span style="font-size: 30px;">The JavaScript code</span></h2>
+<h2 id="The_JavaScript_code">The JavaScript code</h2>
 
 <p>Now let's take a look at the <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill/capture.js" rel="noopener">JavaScript code</a>. We'll break it up into a few bite-sized pieces to make it easier to explain.</p>
 

--- a/files/en-us/web/api/webrtc_statistics_api/index.html
+++ b/files/en-us/web/api/webrtc_statistics_api/index.html
@@ -69,7 +69,7 @@ function getConnectionStats() {
  </thead>
  <tbody>
   <tr>
-   <th scope="row" style="vertical-align: top;"><code>candidate-pair</code></th>
+   <th scope="row"><code>candidate-pair</code></th>
    <td>Statistics describing the change from one {{domxref("RTCIceTransport")}} to another, such as during an <a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ice_restart">ICE restart</a>.</td>
    <td>
     <ul class="directory-tree">
@@ -371,7 +371,7 @@ function getConnectionStats() {
    </td>
   </tr>
   <tr>
-   <th scope="row" style="vertical-align: top;"><code>transceiver</code></th>
+   <th scope="row"><code>transceiver</code></th>
    <td>Statistics related to a specific {{domxref("RTCRtpTransceiver")}}.</td>
    <td>
     <ul class="directory-tree">


### PR DESCRIPTION
This is part of #5438.

It removes the style attributes in web rtc pages.

It was all mostly styles:
- most were style in spec tables (that will go away anyway)
- a few list in list styling (I changed it to an ul that works well in this case)
- a few alignment in tables (not needed)