### PR TITLE
Remove style attributes from Canvas API

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -304,7 +304,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 <pre class="brush: js">draw();</pre>
 </div>
 
-<p>{{EmbedLiveSample("A_lineCap_example", "180", "180", "https://mdn.mozillademos.org/files/236/Canvas_linecap.png")}}</p>
+<p>{{EmbedLiveSample("A_lineCap_example", "180", "180", "Canvas_linecap.png")}}</p>
 
 <h3 id="A_lineJoin_example">A <code>lineJoin</code> example</h3>
 
@@ -346,7 +346,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 <pre class="brush: js">draw();</pre>
 </div>
 
-<p>{{EmbedLiveSample("A_lineJoin_example", "180", "180", "https://mdn.mozillademos.org/files/237/Canvas_linejoin.png")}}</p>
+<p>{{EmbedLiveSample("A_lineJoin_example", "180", "180", "Canvas_linejoin.png")}}</p>
 
 <h3 id="A_demo_of_the_miterLimit_property">A demo of the <code>miterLimit</code> property</h3>
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -257,9 +257,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <h3 id="A_lineCap_example">A <code>lineCap</code> example</h3>
 
-<p>The <code>lineCap</code> property determines how the end points of every line are drawn. There are three possible values for this property and those are: <code>butt</code>, <code>round</code> and <code>square</code>. By default this property is set to <code>butt</code>.</p>
-
-<p><img alt="" src="canvas_linecap.png" style="float: right;"></p>
+<p>The <code>lineCap</code> property determines how the end points of every line are drawn. There are three possible values for this property and those are: <code>butt</code>, <code>round</code> and <code>square</code>. By default this property is set to <code>butt</code>:</p>
 
 <dl>
  <dt><code>butt</code></dt>
@@ -312,9 +310,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>The <code>lineJoin</code> property determines how two connecting segments (of lines, arcs or curves) with non-zero lengths in a shape are joined together (degenerate segments with zero lengths, whose specified endpoints and control points are exactly at the same position, are skipped).</p>
 
-<p>There are three possible values for this property: <code>round</code>, <code>bevel</code> and <code>miter</code>. By default this property is set to <code>miter</code>. Note that the <code>lineJoin</code> setting has no effect if the two connected segments have the same direction, because no joining area will be added in this case.</p>
-
-<p><img alt="" src="canvas_linejoin.png" style="float: right;"></p>
+<p>There are three possible values for this property: <code>round</code>, <code>bevel</code> and <code>miter</code>. By default this property is set to <code>miter</code>. Note that the <code>lineJoin</code> setting has no effect if the two connected segments have the same direction, because no joining area will be added in this case:</p>
 
 <dl>
  <dt><code>round</code></dt>

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
@@ -30,8 +30,8 @@ tags:
 
 <h2 id="Clipping_paths">Clipping paths</h2>
 
-<p><img alt="" class="internal" src="canvas_clipping_path.png" style="float: right;">A clipping path is like a normal canvas shape but it acts as a mask to hide unwanted parts of shapes. This is visualized in the image on the right. The red star shape is our clipping path. Everything that falls outside of this path won't get drawn on the canvas.</p>
-
+<p>A clipping path is like a normal canvas shape but it acts as a mask to hide unwanted parts of shapes. This is visualized in the image on the right. The red star shape is our clipping path. Everything that falls outside of this path won't get drawn on the canvas.</p>
+<img alt="" class="internal" src="canvas_clipping_path.png">
 <p>If we compare clipping paths to the <code>globalCompositeOperation</code> property we've seen above, we see two compositing modes that achieve more or less the same effect in <code>source-in</code> and <code>source-atop</code>. The most important differences between the two are that clipping paths are never actually drawn to the canvas and the clipping path is never affected by adding new shapes. This makes clipping paths ideal for drawing multiple shapes in a restricted area.</p>
 
 <p>In the chapter about <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">drawing shapes</a> I only mentioned the <code>stroke()</code> and <code>fill()</code> methods, but there's a third method we can use with paths, called <code>clip()</code>.</p>

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -18,9 +18,11 @@ tags:
 
 <h2 id="The_grid">The grid</h2>
 
-<p>Before we can start drawing, we need to talk about the canvas grid or <strong>coordinate space</strong>. Our HTML skeleton from the previous page had a canvas element 150 pixels wide and 150 pixels high.
-  <img alt="" class="internal" src="canvas_default_grid.png">
-Normally 1 unit in the grid corresponds to 1 pixel on the canvas. The origin of this grid is positioned in the <em>top left</em> corner at coordinate (0,0). All elements are placed relative to this origin. So the position of the top left corner of the blue square becomes x pixels from the left and y pixels from the top, at coordinate (x,y). Later in this tutorial we'll see how we can translate the origin to a different position, rotate the grid and even scale it, but for now we'll stick to the default.</p>
+<p>Before we can start drawing, we need to talk about the canvas grid or <strong>coordinate space</strong>. Our HTML skeleton from the previous page had a canvas element 150 pixels wide and 150 pixels high.</p>
+
+<img alt="" src="canvas_default_grid.png">
+
+<p>Normally 1 unit in the grid corresponds to 1 pixel on the canvas. The origin of this grid is positioned in the <em>top left</em> corner at coordinate (0,0). All elements are placed relative to this origin. So the position of the top left corner of the blue square becomes x pixels from the left and y pixels from the top, at coordinate (x,y). Later in this tutorial we'll see how we can translate the origin to a different position, rotate the grid and even scale it, but for now we'll stick to the default.</p>
 
 <h2 id="Drawing_rectangles">Drawing rectangles</h2>
 
@@ -320,7 +322,7 @@ Normally 1 unit in the grid corresponds to 1 pixel on the canvas. The origin of 
 </dl>
 
 <p>The difference between these is that a quadratic Bézier curve has a start and an end point (blue dots) and just one <strong>control point</strong> (indicated by the red dot) while a cubic Bézier curve uses two control points.
-  <img alt="" class="internal" src="canvas_curves.png">
+  <img alt="" src="canvas_curves.png">
 </p>
 
 <p>The <code>x</code> and <code>y</code> parameters in both of these methods are the coordinates of the end point. <code>cp1x</code> and <code>cp1y</code> are the coordinates of the first control point, and <code>cp2x</code> and <code>cp2y</code> are the coordinates of the second control point.</p>

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -18,7 +18,9 @@ tags:
 
 <h2 id="The_grid">The grid</h2>
 
-<p><img alt="" class="internal" src="canvas_default_grid.png" style="float: right;">Before we can start drawing, we need to talk about the canvas grid or <strong>coordinate space</strong>. Our HTML skeleton from the previous page had a canvas element 150 pixels wide and 150 pixels high. To the right, you see this canvas with the default grid overlayed. Normally 1 unit in the grid corresponds to 1 pixel on the canvas. The origin of this grid is positioned in the <em>top left</em> corner at coordinate (0,0). All elements are placed relative to this origin. So the position of the top left corner of the blue square becomes x pixels from the left and y pixels from the top, at coordinate (x,y). Later in this tutorial we'll see how we can translate the origin to a different position, rotate the grid and even scale it, but for now we'll stick to the default.</p>
+<p>Before we can start drawing, we need to talk about the canvas grid or <strong>coordinate space</strong>. Our HTML skeleton from the previous page had a canvas element 150 pixels wide and 150 pixels high.
+  <img alt="" class="internal" src="canvas_default_grid.png">
+Normally 1 unit in the grid corresponds to 1 pixel on the canvas. The origin of this grid is positioned in the <em>top left</em> corner at coordinate (0,0). All elements are placed relative to this origin. So the position of the top left corner of the blue square becomes x pixels from the left and y pixels from the top, at coordinate (x,y). Later in this tutorial we'll see how we can translate the origin to a different position, rotate the grid and even scale it, but for now we'll stick to the default.</p>
 
 <h2 id="Drawing_rectangles">Drawing rectangles</h2>
 
@@ -317,7 +319,9 @@ tags:
  <dd>Draws a cubic Bézier curve from the current pen position to the end point specified by <code>x</code> and <code>y</code>, using the control points specified by (<code>cp1x</code>, <code>cp1y</code>) and (cp2x, cp2y).</dd>
 </dl>
 
-<p><img alt="" class="internal" src="canvas_curves.png" style="float: right;">The difference between these can best be described using the image on the right. A quadratic Bézier curve has a start and an end point (blue dots) and just one <strong>control point</strong> (indicated by the red dot) while a cubic Bézier curve uses two control points.</p>
+<p>The difference between these is that a quadratic Bézier curve has a start and an end point (blue dots) and just one <strong>control point</strong> (indicated by the red dot) while a cubic Bézier curve uses two control points.
+  <img alt="" class="internal" src="canvas_curves.png">
+</p>
 
 <p>The <code>x</code> and <code>y</code> parameters in both of these methods are the coordinates of the end point. <code>cp1x</code> and <code>cp1y</code> are the coordinates of the first control point, and <code>cp2x</code> and <code>cp2y</code> are the coordinates of the second control point.</p>
 

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
@@ -76,13 +76,13 @@ tags:
 
 <h2 id="Translating">Translating</h2>
 
-<p><img alt="" class="internal" src="canvas_grid_translate.png" style="float: right;">The first of the transformation methods we'll look at is <code>translate()</code>. This method is used to move the canvas and its origin to a different point in the grid.</p>
+<p>The first of the transformation methods we'll look at is <code>translate()</code>. This method is used to move the canvas and its origin to a different point in the grid.</p>
 
 <dl>
  <dt>{{domxref("CanvasRenderingContext2D.translate", "translate(x, y)")}}</dt>
  <dd>Moves the canvas and its origin on the grid. <code>x</code> indicates the horizontal distance to move, and <code>y</code> indicates how far to move the grid vertically.</dd>
 </dl>
-
+<img alt="" class="internal" src="canvas_grid_translate.png">
 <p>It's a good idea to save the canvas state before doing any transformations. In most cases, it is just easier to call the <code>restore</code> method than having to do a reverse translation to return to the original state. Also if you're translating inside a loop and don't save and restore the canvas state, you might end up missing part of your drawing, because it was drawn outside the canvas edge.</p>
 
 <h3 id="A_translate_example">A <code>translate</code> example</h3>
@@ -115,13 +115,13 @@ tags:
 
 <h2 id="Rotating">Rotating</h2>
 
-<p><img alt="" class="internal" src="canvas_grid_rotate.png" style="float: right;">The second transformation method is <code>rotate()</code>. We use it to rotate the canvas around the current origin.</p>
+<p>The second transformation method is <code>rotate()</code>. We use it to rotate the canvas around the current origin.</p>
 
 <dl>
  <dt>{{domxref("CanvasRenderingContext2D.rotate", "rotate(angle)")}}</dt>
  <dd>Rotates the canvas clockwise around the current origin by the <code>angle</code> number of radians.</dd>
 </dl>
-
+<img alt="" class="internal" src="canvas_grid_rotate.png">
 <p>The rotation center point is always the canvas origin. To change the center point, we will need to move the canvas by using the <code>translate()</code> method.</p>
 
 <h3 id="A_rotate_example">A <code>rotate</code> example</h3>

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
@@ -208,7 +208,9 @@ img.src = 'data:image/gif;base64,R0lGODlhCwALAIAAAAAA3pn/ZiH5BAEAAAEALAAAAAALAAs
  <dd>Given an <code>image</code>, this function takes the area of the source image specified by the rectangle whose top-left corner is (<code>sx</code>, <code>sy</code>) and whose width and height are <code>sWidth</code> and <code>sHeight</code> and draws it into the canvas, placing it on the canvas at (<code>dx</code>, <code>dy</code>) and scaling it to the size specified by <code>dWidth</code> and <code>dHeight</code>.</dd>
 </dl>
 
-<p>To really understand what this does, it may help to look at this image: <img alt="" class="internal" src="canvas_drawimage.jpg"> The first four parameters define the location and size of the slice on the source image. The last four parameters define the rectangle into which to draw the image on the destination canvas.</p>
+<p>To really understand what this does, it may help to look at this image: </p>
+<img alt="" src="canvas_drawimage.jpg">
+<p>The first four parameters define the location and size of the slice on the source image. The last four parameters define the rectangle into which to draw the image on the destination canvas.</p>
 
 <p>Slicing can be a useful tool when you want to make compositions. You could have all elements in a single image file and use this method to composite a complete drawing. For instance, if you want to make a chart you could have a PNG image containing all the necessary text in a single file and depending on your data could change the scale of your chart fairly easily. Another advantage is that you don't need to load every image individually, which can improve load performance.</p>
 

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
@@ -208,7 +208,7 @@ img.src = 'data:image/gif;base64,R0lGODlhCwALAIAAAAAA3pn/ZiH5BAEAAAEALAAAAAALAAs
  <dd>Given an <code>image</code>, this function takes the area of the source image specified by the rectangle whose top-left corner is (<code>sx</code>, <code>sy</code>) and whose width and height are <code>sWidth</code> and <code>sHeight</code> and draws it into the canvas, placing it on the canvas at (<code>dx</code>, <code>dy</code>) and scaling it to the size specified by <code>dWidth</code> and <code>dHeight</code>.</dd>
 </dl>
 
-<p><img alt="" class="internal" src="canvas_drawimage.jpg" style="float: right;">To really understand what this does, it may help to look at the image to the right. The first four parameters define the location and size of the slice on the source image. The last four parameters define the rectangle into which to draw the image on the destination canvas.</p>
+<p>To really understand what this does, it may help to look at this image: <img alt="" class="internal" src="canvas_drawimage.jpg"> The first four parameters define the location and size of the slice on the source image. The last four parameters define the rectangle into which to draw the image on the destination canvas.</p>
 
 <p>Slicing can be a useful tool when you want to make compositions. You could have all elements in a single image file and use this method to composite a complete drawing. For instance, if you want to make a chart you could have a PNG image containing all the necessary text in a single file and depending on your data could change the scale of your chart fairly easily. Another advantage is that you don't need to load every image individually, which can improve load performance.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
@@ -97,9 +97,7 @@ ctx.fill();
 <h4 id="Result">Result</h4>
 
 <p>In this example, the path created by <code>arcTo()</code> is <strong>thick and
-    black</strong>. <span style="color: gray;">Tangent lines are gray</span>, <span
-    style="color: red;">control points are red</span>, and the <span
-    style="color: blue;">start point is blue</span>.</p>
+    black</strong>. Tangent lines are gray, control points are red, and the start point is blue.</p>
 
 <p>{{ EmbedLiveSample('How_arcTo_works', 315, 165) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
@@ -87,8 +87,8 @@ ctx.fill();</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>In this example, the <span style="color: red;">control points are red</span> and the
-  <span style="color: blue;">start and end points are blue</span>.</p>
+<p>In this example, the control points are red and the
+  start and end points are blue.</p>
 
 <p>{{ EmbedLiveSample('How_bezierCurveTo_works', 315, 165) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.html
@@ -21,8 +21,7 @@ void <em>ctx</em>.drawImage(<em>image</em>, <em>dx</em>, <em>dy</em>, <em>dWidth
 void <em>ctx</em>.drawImage(<em>image</em>, <em>sx</em>, <em>sy</em>, <em>sWidth</em>, <em>sHeight</em>, <em>dx</em>, <em>dy</em>, <em>dWidth</em>, <em>dHeight</em>);
 </pre>
 
-<p><img alt="drawImage" src="canvas_drawimage.jpg"
-    style="float: right;"></p>
+<p><img alt="drawImage" src="canvas_drawimage.jpg"</p>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
@@ -38,8 +38,7 @@ browser-compat: api.CanvasRenderingContext2D.lineJoin
 <p>There are three possible values for this property: <code>"round"</code>,
   <code>"bevel"</code>, and <code>"miter"</code>. The default is <code>"miter"</code>.</p>
 
-<p><img alt="" src="canvas_linejoin.png"
-    style="float: right;"></p>
+<p><img alt="" src="canvas_linejoin.png"></p>
 
 <dl>
   <dt><code>"round"</code></dt>
@@ -151,6 +150,5 @@ for (let i = 0; i &lt; lineJoin.length; i++) {
   <li>{{domxref("CanvasRenderingContext2D.lineCap")}}</li>
   <li>{{domxref("CanvasRenderingContext2D.lineWidth")}}</li>
   <li><a
-      href="/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors">Applying
-      styles and color</a></li>
+      href="/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors">Applying styles and color</a></li>
 </ul>

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
@@ -76,8 +76,8 @@ ctx.fill();
 
 <h4 id="Result">Result</h4>
 
-<p>In this example, the <span style="color: red;">control point is red</span> and the
-  <span style="color: blue;">start and end points are blue</span>.</p>
+<p>In this example, the control point is red and the
+  start and end points are blue.</p>
 
 <p>{{ EmbedLiveSample('How_quadraticCurveTo_works', 315, 165) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
@@ -84,8 +84,7 @@ ctx.fillRect(40, 90, 50, 20);</pre>
 
 <h4 id="Result_2">Result</h4>
 
-<p>The <span style="color: gray;">skewed rectangles are gray</span>, and the <span
-    style="color: red;">non-skewed rectangles are red</span>.</p>
+<p>The skewed rectangles are gray, and the non-skewed rectangles are red.</p>
 
 <p>{{ EmbedLiveSample('Continuing_with_a_regular_matrix', 700, 180) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
@@ -20,9 +20,7 @@ browser-compat: api.CanvasRenderingContext2D.rotate
 <pre class="brush: js">void <em>ctx</em>.rotate(<em>angle</em>);
 </pre>
 
-<p><img alt="" class="internal"
-    src="canvas_grid_rotate.png"
-    style="float: right;"></p>
+<p><img alt="" class="internal" src="canvas_grid_rotate.png"></p>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -73,9 +71,7 @@ ctx.setTransform(1, 0, 0, 1, 0, 0);
 
 <h4 id="Result">Result</h4>
 
-<p>The <span style="color: blue;">center of rotation is blue</span>. The <span
-    style="color: gray;">non-rotated rectangle is gray</span>, and the <span
-    style="color: red;">rotated rectangle is red</span>.</p>
+<p>The center of rotation is blue. The non-rotated rectangle is gray, and the rotated rectangle is red.</p>
 
 <p>{{ EmbedLiveSample('Rotating_a_shape', 700, 180) }}</p>
 
@@ -123,8 +119,7 @@ ctx.fillRect(80, 60, 140, 30);
 
 <h4 id="Result_2">Result</h4>
 
-<p>The <span style="color: gray;">non-rotated rectangle is gray</span>, and the <span
-    style="color: red;">rotated rectangle is red</span>.</p>
+<p>The non-rotated rectangle is gray, and the rotated rectangle is red.</p>
 
 <p>{{ EmbedLiveSample('Rotating_a_shape_around_its_center', 700, 180) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
@@ -77,8 +77,7 @@ ctx.fillRect(10, 10, 8, 20);
 
 <h4 id="Result">Result</h4>
 
-<p>The scaled <span style="color: red;">rectangle is red</span>, and the <span
-    style="color: gray;">non-scaled rectangle is gray</span>.</p>
+<p>The scaled rectangle is red, and the non-scaled rectangle is gray.</p>
 
 <p>{{ EmbedLiveSample('Scaling_a_shape', 700, 180) }}</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
@@ -24,9 +24,7 @@ browser-compat: api.CanvasRenderingContext2D.translate
   matrix by moving the canvas and its origin <code>x</code> units horizontally and
   <code>y</code> units vertically on the grid.</p>
 
-<p><img alt="" class="internal"
-    src="canvas_grid_translate.png"
-    style="float: right;"></p>
+<p><img alt="" class="internal" src="canvas_grid_translate.png"></p>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -75,8 +73,7 @@ ctx.fillRect(0, 0, 80, 80);
 
 <h4 id="Result">Result</h4>
 
-<p>The <span style="color: red;">moved square is red</span>, and the <span
-    style="color: gray;">unmoved square is gray</span>.</p>
+<p>The moved square is red, and the unmoved square is gray.</p>
 
 <p>{{ EmbedLiveSample('Moving_a_shape', 700, 180) }}</p>
 


### PR DESCRIPTION
This is part of #5438.

It removes the style attributes in canvas api pages.

It was either styling emphasing text ("red" actually written in red), or floating images that I put back in the flow of the text (adapting it when needed, like changing "the image to the right" to something working with the image in the flow)