### PR TITLE
Add notes: browser interventions affect natural{Height,Width}

### DIFF
--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.html
@@ -6,6 +6,7 @@ tags:
 - HTMLImageElement
 - Intrinsic Height
 - Reference
+- Property
 - Vertical
 - naturalHeight
 - size

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.html
@@ -21,6 +21,13 @@ browser-compat: api.HTMLImageElement.naturalHeight
   or place the image inside a container that either limits or expressly specifies the
   image height, it will be rendered this tall.</p>
 
+  <p class="notecard note"><strong>Note:</strong> Most of the the time the natural height is the actual height of the image sent by the server.
+    Nevertheless, browsers can modify an image before pushing it to the renderer. For example, Chrome
+    <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7">degrades the resolution of
+    images on low-end devices</a>. In such cases, <code>naturalHeight</code> will consider the height of the image modified
+    by such browser interventions as the natural height, and returns this value.
+  </p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
@@ -28,6 +28,13 @@ browser-compat: api.HTMLImageElement.naturalWidth
 <p>The corresponding {{domxref("HTMLImageElement.naturalHeight", "naturalHeight")}} method
   returns the natural height of the image.</p>
 
+  <p class="notecard note"><strong>Note:</strong> Most of the the time the natural width is the actual width of the image sent by the server.
+    Nevertheless, browsers can modify an image before pushing it to the renderer. For example, Chrome
+    <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7">degrades the resolution of
+    images on low-end devices</a>. In such cases, <code>naturalWidth</code> will consider the width of the image modified
+    by such browser interventions as the natural width, and returns this value.
+  </p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre


### PR DESCRIPTION
Fix #3143

Add a note explaining that both HTMLImageElement.naturalWidth and naturalHeight do not always reflect the height/width of the ressource sent by the server, but after browser interventions.