### PR TITLE
Delete SVG page that was a stub for a subpage long gone

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -6274,7 +6274,6 @@
 /en-US/docs/SVG/Namespaces_Crash_Course	/en-US/docs/Web/SVG/Namespaces_Crash_Course
 /en-US/docs/SVG/Namespaces_Crash_Course/Example	/en-US/docs/Web/SVG/Namespaces_Crash_Course/Example
 /en-US/docs/SVG/Other_Resources	/en-US/docs/Web/SVG/Other_Resources
-/en-US/docs/SVG/Replaced_Element	/en-US/docs/Web/SVG/Replaced_Element
 /en-US/docs/SVG/SVG_animation_with_SMIL	/en-US/docs/Web/SVG/SVG_animation_with_SMIL
 /en-US/docs/SVG/SVG_as_an_Image	/en-US/docs/Web/SVG/SVG_as_an_Image
 /en-US/docs/SVG/Scripting	/en-US/docs/Web/SVG/Scripting

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -158212,15 +158212,6 @@
       "Jonathan_Watt"
     ]
   },
-  "Web/SVG/Replaced_Element": {
-    "modified": "2019-01-16T15:14:52.941Z",
-    "contributors": [
-      "kscarfone",
-      "Jeremie",
-      "ethertank",
-      "Anonymous"
-    ]
-  },
   "Web/SVG/SVG_1.1_Support_in_Firefox": {
     "modified": "2019-03-24T00:13:24.445Z",
     "contributors": [

--- a/files/en-us/web/svg/replaced_element/index.html
+++ b/files/en-us/web/svg/replaced_element/index.html
@@ -1,7 +1,0 @@
----
-title: Replaced Element
-slug: Web/SVG/Replaced_Element
-tags:
-  - SVG
----
-<p>{{wiki.localize('System.API.page-generated-for-subpage')}}</p>


### PR DESCRIPTION
Fix #2270

I did:
`yarn content delete Web/SVG/Replaced_Element`