### PR TITLE
Fix missing-word typo in SubmitEvent.p.submitter doc

### DIFF
--- a/files/en-us/web/api/submitevent/submitter/index.html
+++ b/files/en-us/web/api/submitevent/submitter/index.html
@@ -29,9 +29,7 @@ browser-compat: api.SubmitEvent.submitter
 
 <p>An element, indicating the element that sent
   the {{domxref("HTMLFormElement.submit_event", "submit")}} event to the form. While this
-  is often an {{HTMLElement("input")}} element whose {{domxref("HTMLInputElement.type",
-  "type")}} or a {{HTMLElement("button")}} whose {{domxref("HTMLButtonElement.type",
-  "type")}} is <code>submit</code>, it could be some other element which has initiated a
+  is often an {{HTMLElement("input")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code> or a <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code>, it could be some other element which has initiated a
   submission process.</p>
 
 <p>If the submission was not triggered by a button of some kind, the value

--- a/files/en-us/web/api/submitevent/submitter/index.html
+++ b/files/en-us/web/api/submitevent/submitter/index.html
@@ -29,7 +29,7 @@ browser-compat: api.SubmitEvent.submitter
 
 <p>An element, indicating the element that sent
   the {{domxref("HTMLFormElement.submit_event", "submit")}} event to the form. While this
-  is often an {{HTMLElement("input")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code> or a <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code>, it could be some other element which has initiated a
+  is often an {{HTMLElement("input")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code> or a {{HTMLElement("button")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code>, it could be some other element which has initiated a
   submission process.</p>
 
 <p>If the submission was not triggered by a button of some kind, the value


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/4291

Also fixes some broken macro calls.