### PR TITLE
Fixes "disabled" attribute's title on the Input Password page

### DIFF
--- a/files/en-us/web/html/element/input/password/index.html
+++ b/files/en-us/web/html/element/input/password/index.html
@@ -234,13 +234,6 @@ browser-compat: html.elements.input.input-password
 
 <p>{{EmbedLiveSample("Validation_sample1", 600, 40)}}</p>
 
-<dl>
- <dt><code id="disabled">disabled</code></dt>
- <dd>
- <p>This Boolean attribute indicates that the password field is not available for interaction. Additionally, disabled field values aren't submitted with the form.</p>
- </dd>
-</dl>
-
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Requesting_a_Social_Security_number">Requesting a Social Security number</h3>

--- a/files/en-us/web/html/element/input/password/index.html
+++ b/files/en-us/web/html/element/input/password/index.html
@@ -235,7 +235,7 @@ browser-compat: html.elements.input.input-password
 <p>{{EmbedLiveSample("Validation_sample1", 600, 40)}}</p>
 
 <dl>
-  <dt><code id="disabled">disabled</code></dt>
+ <dt><code id="disabled">disabled</code></dt>
  <dd>
  <p>This Boolean attribute indicates that the password field is not available for interaction. Additionally, disabled field values aren't submitted with the form.</p>
  </dd>

--- a/files/en-us/web/html/element/input/password/index.html
+++ b/files/en-us/web/html/element/input/password/index.html
@@ -235,7 +235,7 @@ browser-compat: html.elements.input.input-password
 <p>{{EmbedLiveSample("Validation_sample1", 600, 40)}}</p>
 
 <dl>
- <dt>{{attr-("disabled")}}</dt>
+  <dt><code id="disabled">disabled</code></dt>
  <dd>
  <p>This Boolean attribute indicates that the password field is not available for interaction. Additionally, disabled field values aren't submitted with the form.</p>
  </dd>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The "disabled" attribute title was being displayed incorrectly

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/password

> Issue number (if there is an associated issue)


> Anything else that could help us review it

Here's a picture of the bugged behaviour:
![image](https://user-images.githubusercontent.com/14653741/120944652-073e7200-c70c-11eb-813b-1560d4b6ffea.png)
