### PR TITLE
Fix ":focus-within" article’s description/summary

### DIFF
--- a/files/en-us/web/css/_colon_focus-within/index.html
+++ b/files/en-us/web/css/_colon_focus-within/index.html
@@ -14,7 +14,7 @@ browser-compat: css.selectors.focus-within
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents an element that has received focus or <em>contains</em> an element that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
+<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is a selector for an element which has focus or <em>contains</em> a child that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
 
 <pre class="brush: css no-line-numbers">/* Selects a &lt;div&gt; when one of its descendants is focused */
 div:focus-within {

--- a/files/en-us/web/css/_colon_focus-within/index.html
+++ b/files/en-us/web/css/_colon_focus-within/index.html
@@ -14,7 +14,7 @@ browser-compat: css.selectors.focus-within
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is a selector for an element which has focus or <em>contains</em> a child that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
+<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is a selector for an element that has focus or <em>contains</em> a child that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
 
 <pre class="brush: css no-line-numbers">/* Selects a &lt;div&gt; when one of its descendants is focused */
 div:focus-within {

--- a/files/en-us/web/css/_colon_focus-within/index.html
+++ b/files/en-us/web/css/_colon_focus-within/index.html
@@ -14,7 +14,7 @@ browser-compat: css.selectors.focus-within
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is a selector for an element that has focus or <em>contains</em> a child that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
+<p>The <strong><code>:focus-within</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is a selector for an element that has focus or <em>contains</em> a descendant that has received focus. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by <code>:focus</code>. (This includes descendants in <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow trees</a>.)</p>
 
 <pre class="brush: css no-line-numbers">/* Selects a &lt;div&gt; when one of its descendants is focused */
 div:focus-within {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The:focus-within CSS pseudo-class represents an element that has received focus or contains an element that has received focus.



> MDN URL of the main page changed

[https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within)



> Issue number (if there is an associated issue)
#5708

> Anything else that could help us review it

What it was reworded to: 

The:focus-within CSS pseudo-class is a selector for an element that has focus or contains a descendant that has received focus. 