### PR TITLE
Added note of .setAttribute's influence over reset

### DIFF
--- a/files/en-us/web/api/htmlformelement/reset/index.html
+++ b/files/en-us/web/api/htmlformelement/reset/index.html
@@ -21,6 +21,11 @@ browser-compat: api.HTMLFormElement.reset
   mask the form's reset method. It does not reset other attributes in the input, such as
   <code>disabled</code>.</p>
 
+<p>Note that if {{domxref("Element.setAttribute", "setAttribute()")}} is called to set
+  the value of a particular attribute, a subsequent call to <code>reset()</code> won’t
+  reset the attribute to its default value, but instead will keep the attribute at
+  whatever value the {{domxref("Element.setAttribute", "setAttribute()")}} call set it to.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js"><em>HTMLFormElement</em>.reset()


### PR DESCRIPTION
Ran into an issue of .reset() not working as expected.  Turns out
node.setAttribute("checked", true); was the culprit

https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset
