### PR TITLE
FF90: Remove experimental tagging on Sec-Fetch headers

### DIFF
--- a/files/en-us/web/http/headers/sec-fetch-dest/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.html
@@ -8,10 +8,9 @@ tags:
   - HTTP Headers
   - Reference
   - Request header
-  - Experimental
 browser-compat: http.headers.Sec-Fetch-Dest
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}</p>
 
 <p>The <strong><code>Sec-Fetch-Dest</code></strong> {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the request's <em>destination</em>. That is the initiator of the original fetch request, which is where (and how) the fetched data will be used.</p>
 

--- a/files/en-us/web/http/headers/sec-fetch-mode/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-mode/index.html
@@ -8,10 +8,9 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  - Experimental
 browser-compat: http.headers.Sec-Fetch-Mode
 ---
-<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}}</div>
 
 <p>The <strong><code>Sec-Fetch-Mode</code></strong> {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the <a href="/en-US/docs/Web/API/Request/mode">mode</a> of the request.</p>
 

--- a/files/en-us/web/http/headers/sec-fetch-site/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-site/index.html
@@ -8,10 +8,9 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  - Experimental
 browser-compat: http.headers.Sec-Fetch-Site
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}</p>
 
 <p>The <strong><code>Sec-Fetch-Site</code></strong> {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the relationship between a request initiator's origin and the origin of the requested resource.</p>
 

--- a/files/en-us/web/http/headers/sec-fetch-user/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-user/index.html
@@ -8,10 +8,9 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  - Experimental
 browser-compat: http.headers.Sec-Fetch-User
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}</p>
 
 <p>The <strong><code>Sec-Fetch-User</code></strong> {{Glossary("Fetch metadata request header", "fetch metadata request header")}} is only sent for requests initiated by user activation, and its value will always be <code>?1</code>.</p>
 


### PR DESCRIPTION
This removes the experimental tagging on the Sec-Fetch-* headers. This follows from merging of this BCD PR https://github.com/mdn/browser-compat-data/pull/10679 - which in turn follows on from the fact the headers are now implemented in multiple major browsers.

part of fixing #5375 for FF90