### PR TITLE
Replace comparision operator with equality operator

### DIFF
--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.html
@@ -27,7 +27,7 @@ tags:
 <p>There was an unexpected assignment somewhere. This might be due to a mismatch of a <a
     href="/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators">assignment
     operator</a> and a <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators">comparison
+    href="/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators">equility
     operator</a>, for example. While a single "<code>=</code>" sign assigns a value to a
   variable, the "<code>==</code>" or "<code>===</code>" operators compare a value.</p>
 
@@ -46,7 +46,7 @@ var str = 'Hello, '
 // ReferenceError: invalid assignment left-hand side
 </pre>
 
-<p>In the <code>if</code> statement, you want to use a comparison operator ("=="), and for
+<p>In the <code>if</code> statement, you want to use a equility operator ("=="), and for
   the string concatenation, the plus ("+") operator is needed.</p>
 
 <pre class="brush: js example-good">if (Math.PI == 3 || Math.PI == 4) {
@@ -65,6 +65,6 @@ var str = 'Hello, '
       href="/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators">Assignment
       operators</a></li>
   <li><a
-      href="/en-US/docs/Web/JavaScript/Reference/Operators">Comparison
+      href="/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators">Equality
       operators</a></li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

"Comparision operators" is already removed from the target reference.
Replace them with "Equility operator".

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side