### PR TITLE
Fix syntax block in `Array.prototype.find()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -36,20 +36,22 @@ browser-compat: javascript.builtins.Array.find
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">
+const array = [...]
+
 // Arrow function
-find((element) => { ... } )
-find((element, index) => { ... } )
-find((element, index, array) => { ... } )
+array.find((element) => { ... } )
+array.find((element, index) => { ... } )
+array.find((element, index, array) => { ... } )
 
 // Callback function
-find(callbackFn)
-find(callbackFn, thisArg)
+array.find(callbackFn)
+array.find(callbackFn, thisArg)
 
 // Inline callback function
-find(function callbackFn(element) { ... })
-find(function callbackFn(element, index) { ... })
-find(function callbackFn(element, index, array){ ... })
-find(function callbackFn(element, index, array) { ... }, thisArg)
+array.find(function callbackFn(element) { ... })
+array.find(function callbackFn(element, index) { ... })
+array.find(function callbackFn(element, index, array){ ... })
+array.find(function callbackFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>


### PR DESCRIPTION
use `array.find()` instead of `find()`

I think this could potentially throw beginners off who are unfamiliar with it.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

find used as top level function, instead of on Array.prototype in the Syntax block

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

> Issue number (if there is an associated issue)

> Anything else that could help us review it
