### PR TITLE
Add Payload header type and cross link

### DIFF
--- a/files/en-us/glossary/payload_header/index.html
+++ b/files/en-us/glossary/payload_header/index.html
@@ -1,0 +1,34 @@
+---
+title: Payload header
+slug: Glossary/Payload_header
+tags:
+  - Glossary
+  - Payload header
+  - Headers
+  - WebMechanics
+---
+
+<p>A <strong>payload header</strong> is an {{Glossary("HTTP_header", "HTTP header")}} that describes the payload information related to safe transport and reconstruction of the original resource {{Glossary("Representation header", "representation")}}, from one or messages. This includes information like the length of the message payload, which part of the resource is is carried in this payload (for a multi-part message), any encoding applied for transport, message integrity checks, etc.</p>
+
+<p>Payload headers may be present in both HTTP request and response messages (i.e. in any message that is carrying payload data).</p>
+
+<p>The payload headers include: {{HTTPHeader("Content-Length")}}, {{HTTPHeader("Content-Range")}}, {{HTTPHeader("Trailer")}}, and {{HTTPHeader("Transfer-Encoding")}}.</p>
+
+<h2 id="see_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/HTTP/Headers">List of all HTTP headers</a></li>
+  <li><a href="https://datatracker.ietf.org/doc/html/rfc7231#section-3.3">RFC 7231, section 3.3: Payload semantics</a></li>
+</ul>
+
+
+<div id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Web/HTTP/Headers">List of all HTTP headers</a></li>
+    <li>{{HTTPHeader("Content-Length")}}</li>
+    <li>{{HTTPHeader("Content-Range")}}</li>
+    <li>{{HTTPHeader("Trailer")}}</li>
+    <li>{{HTTPHeader("Transfer-Encoding")}}</li>
+    <li>{{Glossary("Representation header")}}</li>
+  </ul>
+</div>

--- a/files/en-us/glossary/payload_header/index.html
+++ b/files/en-us/glossary/payload_header/index.html
@@ -8,7 +8,7 @@ tags:
   - WebMechanics
 ---
 
-<p>A <strong>payload header</strong> is an {{Glossary("HTTP_header", "HTTP header")}} that describes the payload information related to safe transport and reconstruction of the original resource {{Glossary("Representation header", "representation")}}, from one or messages. This includes information like the length of the message payload, which part of the resource is is carried in this payload (for a multi-part message), any encoding applied for transport, message integrity checks, etc.</p>
+<p>A <strong>payload header</strong> is an {{Glossary("HTTP_header", "HTTP header")}} that describes the payload information related to safe transport and reconstruction of the original resource {{Glossary("Representation header", "representation")}}, from one or messages. This includes information like the length of the message payload, which part of the resource is carried in this payload (for a multi-part message), any encoding applied for transport, message integrity checks, etc.</p>
 
 <p>Payload headers may be present in both HTTP request and response messages (i.e. in any message that is carrying payload data).</p>
 

--- a/files/en-us/glossary/representation_header/index.html
+++ b/files/en-us/glossary/representation_header/index.html
@@ -21,3 +21,14 @@ tags:
   <li><a href="https://datatracker.ietf.org/doc/html/rfc7231#section-3">RFC 7231, section 3: Representations</a></li>
   <li>{{glossary("Entity header")}}</li>
 </ul>
+
+<div id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Web/HTTP/Headers">List of all HTTP headers</a></li>
+    <li>{{HTTPHeader("Content-Type")}}</li>
+    <li>{{HTTPHeader("Content-Encoding")}}</li>
+    <li>{{HTTPHeader("Content-Language")}}</li>
+    <li>{{HTTPHeader("Content-Location")}}</li>
+    <li>{{Glossary("Payload header")}}</li>
+  </ul>
+</div>

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -8,6 +8,7 @@ tags:
   - Request header
   - Response header
   - Reference
+  - Payload header
 browser-compat: http.headers.Content-Length
 ---
 <div>{{HTTPSidebar}}</div>
@@ -18,7 +19,7 @@ browser-compat: http.headers.Content-Length
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Payload header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/content-range/index.html
+++ b/files/en-us/web/http/headers/content-range/index.html
@@ -6,7 +6,8 @@ tags:
 - HTTP Header
 - Reference
 - Response Header
-- header
+- Header
+- Payload header
 browser-compat: http.headers.Content-Range
 ---
 <div>{{HTTPSidebar}}</div>
@@ -18,7 +19,7 @@ browser-compat: http.headers.Content-Range
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}</td>
+      <td>{{Glossary("Response header")}}, {{Glossary("Payload header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -21,6 +21,7 @@ tags:
  <li>{{Glossary("Request header", "Request headers")}} contain more information about the resource to be fetched, or about the client requesting the resource.</li>
  <li>{{Glossary("Response header", "Response headers")}} hold additional information about the response, like its location or about the server providing it.</li>
  <li>{{Glossary("Representation header", "Representation headers")}} contain information about the body of the resource, like its <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>, or encoding/compression applied.</li>
+ <li>{{Glossary("Payload header","Payload headers")}} contain information representation-independent payload data, including content length and the encoding used for transport.</li>
 </ul>
 
 <p>Headers can also be grouped according to how {{Glossary("Proxy_server", "proxies")}} handle them:</p>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -21,7 +21,7 @@ tags:
  <li>{{Glossary("Request header", "Request headers")}} contain more information about the resource to be fetched, or about the client requesting the resource.</li>
  <li>{{Glossary("Response header", "Response headers")}} hold additional information about the response, like its location or about the server providing it.</li>
  <li>{{Glossary("Representation header", "Representation headers")}} contain information about the body of the resource, like its <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>, or encoding/compression applied.</li>
- <li>{{Glossary("Payload header","Payload headers")}} contain information representation-independent payload data, including content length and the encoding used for transport.</li>
+ <li>{{Glossary("Payload header","Payload headers")}} contain representation-independent information about payload data, including content length and the encoding used for transport.</li>
 </ul>
 
 <p>Headers can also be grouped according to how {{Glossary("Proxy_server", "proxies")}} handle them:</p>

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Request header
   - Response header
+  - Payload header
 browser-compat: http.headers.Trailer
 ---
 <div>{{HTTPSidebar}}</div>
@@ -25,7 +26,7 @@ browser-compat: http.headers.Trailer
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Payload header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+  - Payload header
 browser-compat: http.headers.Transfer-Encoding
 ---
 <div>{{HTTPSidebar}}</div>
@@ -37,7 +38,7 @@ browser-compat: http.headers.Transfer-Encoding
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Payload header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers mentions Representation headers, but not Payload headers, which are mentioned in the spec, and which are a  useful distinction for the non-representation headers. Note that like representation headers, these used to be Entity headers.

 This adds glossary entry for payload headers and cross-links to various places.

Fixes #5339
