### PR TITLE
Remove typo in JavaScript Array Sort page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
@@ -87,7 +87,7 @@ sort(function compareFn(firstEl, secondEl) { ... })
   <li>If <code>compareFunction(a, b)</code> returns a value ≤ 0, leave <code>a</code> and <code>b</code> in the same order.
     <div class="notecard note">
       <p><strong>Note:</strong> The <a href="https://www.ecma-international.org/ecma-262/10.0/index.html#sec-intro">ECMAScript Standard, 10th edition</a> (2019) 
-        algorithm mandates stable sorting, which means than elements that compare equal must remain in their original order with respect to each other. 
+        algorithm mandates stable sorting, which means elements that compare equal must remain in their original order with respect to each other. 
         This behaviour may not be respected by older browsers.</p>
     </div>
   </li>


### PR DESCRIPTION
Change "which means than elements that compare equal..." to "which means elements that compare equal..."

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Removed a typo from a page.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

> Issue number (if there is an associated issue)
N/A

> Anything else that could help us review it
N/A
