### PR TITLE
Remove strange link

### DIFF
--- a/files/en-us/learn/forms/sending_forms_through_javascript/index.html
+++ b/files/en-us/learn/forms/sending_forms_through_javascript/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h3 id="How_is_it_different">How is it different?</h3>
 
-<p><a href="/en-US/docs/Web/Guide/AJAX">T</a>he {{domxref("XMLHttpRequest")}} (XHR) DOM object can build HTTP requests, send them, and retrieve their results. Historically, {{domxref("XMLHttpRequest")}} was designed to fetch and send <a href="/en-US/docs/Web/XML">XML</a> as an exchange format, which has since been superseded by <a href="/en-US/docs/Glossary/JSON">JSON</a>. But neither XML nor JSON fit into form data request encoding. Form data (<code>application/x-www-form-urlencoded</code>) is made of URL-encoded lists of key/value pairs. For transmitting binary data, the HTTP request is reshaped into <code>multipart/form-data</code>.</p>
+<p>The {{domxref("XMLHttpRequest")}} (XHR) DOM object can build HTTP requests, send them, and retrieve their results. Historically, {{domxref("XMLHttpRequest")}} was designed to fetch and send <a href="/en-US/docs/Web/XML">XML</a> as an exchange format, which has since been superseded by <a href="/en-US/docs/Glossary/JSON">JSON</a>. But neither XML nor JSON fit into form data request encoding. Form data (<code>application/x-www-form-urlencoded</code>) is made of URL-encoded lists of key/value pairs. For transmitting binary data, the HTTP request is reshaped into <code>multipart/form-data</code>.</p>
 
 <div class="notecard note">
 <p><strong>Note</strong>: The <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a> is often used in place of XHR these days — it is a modern, updated version of XHR, which works in a similar fashion but has some advantages. Most of the XHR code you'll see in this article could be swapped out for Fetch.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This link already exists two lines above and does not make sense here.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/Forms/Sending_forms_through_JavaScript
