### PR TITLE
WheelEvent ref - fix up to use specifications table

### DIFF
--- a/files/en-us/web/api/wheelevent/deltamode/index.html
+++ b/files/en-us/web/api/wheelevent/deltamode/index.html
@@ -43,8 +43,7 @@ browser-compat: api.WheelEvent.deltaMode
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var unit = event.deltaMode;</pre>
+<pre class="brush: js">var unit = event.deltaMode;</pre>
 
 <h2 id="Example">Example</h2>
 
@@ -53,23 +52,7 @@ browser-compat: api.WheelEvent.deltaMode
 console.log(syntheticEvent.deltaMode);
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-WheelEvent-deltaMode','WheelEvent.deltaMode')}}
-      </td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wheelevent/deltamode/index.html
+++ b/files/en-us/web/api/wheelevent/deltamode/index.html
@@ -52,6 +52,8 @@ browser-compat: api.WheelEvent.deltaMode
 console.log(syntheticEvent.deltaMode);
 </pre>
 
+<h2 id="Specifications">Specifications</h2>
+
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/wheelevent/deltax/index.html
+++ b/files/en-us/web/api/wheelevent/deltax/index.html
@@ -18,8 +18,7 @@ browser-compat: api.WheelEvent.deltaX
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var dX = event.deltaX;</pre>
+<pre class="brush: js">var dX = event.deltaX;</pre>
 
 <h2 id="Example">Example</h2>
 
@@ -30,20 +29,7 @@ console.log(syntheticEvent.deltaX);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-WheelEvent-deltaX','WheelEvent.deltaX')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wheelevent/deltay/index.html
+++ b/files/en-us/web/api/wheelevent/deltay/index.html
@@ -18,8 +18,7 @@ browser-compat: api.WheelEvent.deltaY
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var dY = event.deltaY;</pre>
+<pre class="brush: js">var dY = event.deltaY;</pre>
 
 <h2 id="Example">Example</h2>
 
@@ -30,20 +29,7 @@ console.log(syntheticEvent.deltaY);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-WheelEvent-deltaY','WheelEvent.deltaY')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wheelevent/deltaz/index.html
+++ b/files/en-us/web/api/wheelevent/deltaz/index.html
@@ -19,8 +19,7 @@ browser-compat: api.WheelEvent.deltaZ
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js">var dZ = event.deltaZ;</pre>
+<pre class="brush: js">var dZ = event.deltaZ;</pre>
 
 <h2 id="Example">Example</h2>
 
@@ -31,21 +30,7 @@ console.log(syntheticEvent.deltaZ);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Events','#widl-WheelEvent-deltaZ','WheelEvent.deltaZ')}}
-			</td>
-			<td>{{Spec2('DOM3 Events')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/index.html
@@ -78,27 +78,7 @@ browser-compat: api.WheelEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("UI Events", "#interface-wheelevent", "The <code>WheelEvent</code> interface")}}</td>
-   <td>{{Spec2("UI Events")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events', '#interface-wheelevent', 'WheelEvent')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This replaces the manual spec table with one for BCD for WheelEvent. I'm going to be doing work on this page possibly for FF90, so this is cleanup prior to real work :-)

Note, tested - the BCD data works and all of these spec tables render. Rubber stamp review required.

Related to #5385