### PR TITLE
MDN API page templates for browser-compat pt 2

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -6,24 +6,51 @@ tags:
   - Constructor
   - Template
   - constructor subpage
-  - reference page
+  - Reference
 browser-compat: path.to.feature.NameOfTheConstructor
 ---
 <div>{{MDNSidebar}}</div>
 
-<div class="note">
+
+<div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
+	
+<h3 id="Page_front_matter">Page front matter</h3>
+	
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the constructor.</p>
+	
+<pre>---
+title: NameOfTheParentInterface.NameOfTheConstructor
+slug: Web/API/NameOfTheParentInterface/NameOfTheConstructor
+tags:
+  - API
+  - Constructor
+  - Reference
+  - Experimental
+  - Non-standard
+  - Deprecated
+browser-compat: path.to.feature.NameOfTheConstructor
+---</pre>
 
-<h3 id="Title_and_slug">Title and slug</h3>
-
-<p>An API constructor subpage should have a <em>title</em> of <em>Name</em>Of<em>TheParentInterface + "." + Name</em>Of<em>TheParentInterface</em> + "()". For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <em>Request.Request()</em>.</p>
-
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheParentInterface</em> without the parentheses, so <code>Request()</code>'s slug is <em>Request</em>.</p>
+<dl>
+	<dt><strong>Title</strong></dt>
+	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheParentInterface</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <code>Request.Request()</code>.</dd>
+	<dt>slug</dt>
+	<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheParentInterface</code>. Note that the name of the method in the slug omits the parenthesis (it ends in "NameOfTheParentInterface" not "NameOfTheParentInterface()").</dd>
+	<dt>tags</dt>
+    <dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Constructor</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>IDBIndex</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+	
+	  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+	<dt>browser-compat</dt>
+	<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheConstructor</code> with the query string for the constructor in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+	  
+	  <p>Note that you may first need to create/update an entry for the API constructor in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+	</dl>
 
 <h3 id="Top_macros">Top macros</h3>
-
+	
 <p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
-
+	
 <ul>
 	<li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
 	<li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
@@ -33,18 +60,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 	<div>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
 	</li>
 </ul>
-
-<h3 id="Tags">Tags</h3>
-
-<p>In an API constructor subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Constructor</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>IDBIndex</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
-
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
+	
 </div>
 
 <div>{{draft}}{{SeeCompatTable}}{{securecontext_header}}{{deprecated_header}}{{APIRef("GroupDataName")}}</div>
@@ -93,22 +109,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("NameOfSpecificationFromSpecName","#document-fragment-linking-directly-to-constructor-definition","NameOfTheConstructor")}}</td>
-			<td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -11,7 +11,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 ---
 <div>{{MDNSidebar}}</div>
 
-
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 	
@@ -60,8 +60,8 @@ browser-compat: path.to.feature.NameOfTheConstructor
 	<div>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
 	</li>
 </ul>
-	
 </div>
+<!-- Remove div above here before publishing -->
 
 <div>{{draft}}{{SeeCompatTable}}{{securecontext_header}}{{deprecated_header}}{{APIRef("GroupDataName")}}</div>
 

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
@@ -11,6 +11,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 ---
 <div>{{MDNSidebar}}</div>
 
+<!-- Remove div below here before publishing -->
 <div class="note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
@@ -46,6 +47,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 
 <p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
 </div>
+<!-- Remove div above here before publishing -->
 
 <div>{{draft}}{{SeeCompatTable}}{{securecontext_header}}{{deprecated_header}}{{APIRef("GroupDataName")}}</div>
 

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
@@ -12,40 +12,53 @@ browser-compat: path.to.feature.NameOfTheProperty
 <div>{{MDNSidebar}}</div>
 
 <!-- Remove div below here before publishing -->
-<div class="note">
-<h2 id="Remove_before_publishing">Remove before publishing</h2>
-
-<h3 id="Title_and_slug">Title and slug</h3>
-
-<p>An API event handler subpage should have a <em>title</em> of <em>Name</em>Of<em>TheParentInterface + "." + NameOfTheEventHandler</em>. For example, the <a href="/en-US/docs/Web/API/Window/onvrdisplaypresentchange">onvrdisplaypresentchange</a> event handler of the <a href="/en-US/docs/Web/API/Window">Window</a> interface has a <em>title</em> of <em>Window.onvrdisplaypresentchange</em>.</p>
-
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheEventHandler</em>, so <code>onvrdisplaypresentchange</code>'s slug is <em>onvrdisplaypresentchange</em>.</p>
-
-<h3 id="Top_macros">Top macros</h3>
-
-<p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
-
-<ul>
-	<li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
-	<li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
-	<li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
-	<li>\{{deprecated_header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
-	<li>
-	<div>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
-	</li>
-</ul>
-
-<h3 id="Tags">Tags</h3>
-
-<p>In an API event handler subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Property</strong>, <strong>Event handler</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>Window</strong>), the name of the method (e.g. <strong>onvrdisplaypresentchange</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
-
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
+<div class="notecard note">
+	<h2 id="Remove_before_publishing">Remove before publishing</h2>
+	  
+	<h3 id="Page_front_matter">Page front matter</h3>
+	  
+	<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular event handler.</p>
+	  
+	<pre>---
+	title: NameOfTheParentInterface.NameOfTheEventHandler
+	slug: Web/API/NameOfTheParentInterface.NameOfTheEventHandler
+	tags:
+	   - API
+	   - Event Handler
+	   - Event
+	   - Reference
+	   - Experimental
+	   - Non-standard
+	   - Deprecated
+	  browser-compat: path.to.feature.NameOfTheEventHandler
+	---</pre>
+	
+	<dl>
+	  <dt><strong>Title</strong></dt>
+	  <dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheEventHandler</em>. For example, the <a href="/en-US/docs/Web/API/Window/ondevicemotion">ondevicemotion</a> event handler of the <a href="/en-US/docs/Web/API/Window">Window</a> interface has a <em>title</em> of <code>Window.ondevicemotion</code>.</dd>
+	  <dt>slug</dt>
+	  <dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheEventHandler</code>.</dd>
+	  <dt>tags</dt>
+	  <dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Property</strong>, <strong>Event handler</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>Window</strong>), the name of the method (e.g. <strong>onvrdisplaypresentchange</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+	  
+		<p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+	  <dt>browser-compat</dt>
+	  <dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheEventHandler</code> with the query string for the event handler in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+		
+		<p>Note that you may first need to create/update an entry for the API and its event handler in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+	</dl>
+	  
+	<h3 id="Top_macros">Top macros</h3>
+	  
+	<p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
+	  
+	<ul>
+		<li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+		<li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+		<li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+		<li>\{{deprecated_header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+		<li>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
+	</ul>
 </div>
 <!-- Remove div above here before publishing -->
 
@@ -73,22 +86,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("NameOfSpecificationFromSpecName","#document-fragment-linking-directly-to-event-handler-definition","NameOfTheProperty")}}</td>
-			<td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.html
@@ -6,58 +6,65 @@ tags:
   - Event
   - Event subpage
   - Template
-  - reference page
+  - Reference
 browser-compat: path.to.feature.NameOfTheEvent_event
 ---
 <div>{{MDNSidebar}}</div>
 
-<!-- Remove below here before publishing -->
-
-<h2 id="Remove_this_section_before_publishing">Remove this section before publishing</h2>
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
-<h3 id="Title_and_slug">Title and slug</h3>
+<h2 id="Remove_before_publishing">Remove before publishing</h2>
+  
+<h3 id="Page_front_matter">Page front matter</h3>
+  
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular event.</p>
+  
+<pre>---
+title: 'NameOfTheParentInterface: NameOfTheEvent event'
+slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event
+tags:
+   - API
+   - NameOfTheEvent
+   - Event
+   - Reference
+   - Experimental
+  browser-compat: path.to.feature.NameOfTheEvent_event
+---</pre>
 
-<p>An API event subpage should have a <em>title</em> of <em>Name</em>Of<em>TheParentInterface + ": " + NameOfTheEvent + " event"</em>. For example, the <a href="/en-US/docs/Web/API/Window/orientationchange_event">orientationchange</a> event of the <a href="/en-US/docs/Web/API/Window">Window</a> interface has a <em>title</em> of <em>Window: orientationchange</em> event.</p>
-
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheEventHandler + "_event</em>", so <code>vrdisplaypresentchange</code>'s slug is <em>vrdisplaypresentchange</em>_event.</p>
-
+<dl>
+  <dt><strong>Title</strong></dt>
+  <dd>Title heading displayed at top of page. Format as "<em>NameOfTheParentInterface</em><strong>:</strong> <em>NameOfTheEvent</em> <strong>event</strong>". For example, the <a href="/en-US/docs/Web/API/Window/animationcancel_event">animationcancel</a> event of the <a href="/en-US/docs/Web/API/Window">Window</a> interface has a <em>title</em> of <code>Window: animationcancel event</code>.</dd>
+  <dt>slug</dt>
+  <dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event</code>.</dd>
+  <dt>tags</dt>
+  <dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Event</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>Window</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+  
+    <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+  <dt>browser-compat</dt>
+  <dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheEvent_event</code> with the query string for the event in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+    
+    <p>Note that you may first need to create/update an entry for the API and its event in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+</dl>
+  
 <h3 id="Top_macros">Top macros</h3>
-
-<p>There are several macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
-
+  
+<p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
+  
 <ul>
- <li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
- <li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
- <li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
- <li>\{{deprecated_header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
- <li>
-  <div>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to the <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/GroupData.json">GroupData.json</a> file in our Yari repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
- </li>
+  <li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+  <li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+  <li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+  <li>\{{deprecated_header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+  <li>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to the <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/GroupData.json">GroupData.json</a> file in our Yari repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
 </ul>
-
-<h3 id="Tags">Tags</h3>
-
-<p>In an API event subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Event</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>Window</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility_h3">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
-
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
-
-<h3 id="Event_reference_link">Event reference link</h3>
-
-<p>Add a link to this new page from the <a href="/en-US/docs/Web/Events">Event reference</a>.</p>
 
 <h3 id="Parent_object_link">Parent object link</h3>
 
-<p>Add a link to this new page from its parent object's <em>Events</em> section (add this section if needed). For example <a href="/en-US/docs/Web/API/Element/wheel_event">Element: wheel event</a> is linked from <a href="/en-US/docs/Web/API/Element#events"><code>Element</code> > Events</a>.</p>
+<p>Add a link to this new page from its parent object's <em>Events</em> section. For example <a href="/en-US/docs/Web/API/Element/wheel_event">Element: wheel event</a> is linked from <a href="/en-US/docs/Web/API/Element#events"><code>Element</code> > Events</a>.</p>
 
+<p>If the parent object does not have an <em>Events</em> section, then add one. If this is a new "class" of event, then you should add link to this section of the parent from the <a href="/en-US/docs/Web/Events">Event reference</a>.</p>
 </div>
-
-<!-- Remove above here before publishing -->
+<!-- Remove div above here before publishing -->
 
 <div>{{draft()}}{{SeeCompatTable}}{{securecontext_header}}{{deprecated_header}}{{APIRef("GroupDataName")}}</div>
 
@@ -100,22 +107,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("NameOfSpecificationFromSpecName","#document-fragment-linking-directly-to-event-definition","NameOfTheEvent")}}</td>
-   <td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -9,8 +9,8 @@ tags:
 ---
 <div>{{MDNSidebar}}</div>
 
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
-
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
 <h3 id="Page_front_matter">Page front matter</h3>
@@ -38,7 +38,6 @@ tags:
   <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
 </dl>
 
-
 <h3 id="Top_macros">Top macros</h3>
 
 <p>There are three macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
@@ -50,7 +49,6 @@ tags:
 	<div><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
 	</li>
 </ul>
-
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
@@ -69,6 +67,7 @@ tags:
 <p>Use the <code>\{{specifications("path.to.feature.Interface")}}</code> macro to add tables for the main specifications.</p>
 
 </div>
+<!-- Remove div above here before publishing -->
 
 <div>{{draft}}{{securecontext_header}}{{APIRef("GroupDataName")}}</div>
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -32,7 +32,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 <dl>
 <dt><strong>Title</strong></dt>
-<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheMethod</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/IDBIndex/count">count()</a> method of the <a href="/en-US/docs/Web/API/IDBIndex">IDBIndex</a> interface has a <em>title</em> of "IDBIndex.count()".</dd>
+<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheMethod</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/IDBIndex/count">count()</a> method of the <a href="/en-US/docs/Web/API/IDBIndex">IDBIndex</a> interface has a <em>title</em> of <code>IDBIndex.count()</code>.</dd>
 <dt>slug</dt>
 <dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheMethod</code>. Note that the name of the method in the slug omits the parenthesis (it ends in "NameOfTheMethod" not "NameOfTheMethod()").</dd>
 <dt>tags</dt>

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -11,6 +11,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 ---
 <p>{{MDNSidebar}}</p>
 
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
@@ -51,14 +52,14 @@ browser-compat: path.to.feature.NameOfTheMethod
 <p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
 
 <ul>
- <li><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
- <li><code>\{{Draft}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
- <li><code>\{{SeeCompatTable}}</code> — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
- <li><code>\{{SecureContext_Header}}</code> — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
- <li><code>\{{Deprecated_Header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+  <li><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
+  <li><code>\{{Draft}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+  <li><code>\{{SeeCompatTable}}</code> — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+  <li><code>\{{SecureContext_Header}}</code> — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+  <li><code>\{{Deprecated_Header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
 </ul>
-
 </div>
+<!-- Remove div above here before publishing -->
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_header}}{{Deprecated_Header}}</p>
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
@@ -43,7 +43,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 	  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
 
 	<dt>browser-compat</dt>
-	<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheProperty</code> with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+	<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheProperty</code> with the query string for the property in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
 	  
 	  <p>Note that you may first need to create/update an entry for the API property in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
 </dl>

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
@@ -11,6 +11,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 ---
 <p>{{MDNSidebar}}</p>
 
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 	
@@ -60,8 +61,8 @@ browser-compat: path.to.feature.NameOfTheProperty
 	<li>\{{SecureContext_Header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
 	<li>\{{Deprecated_Header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
 </ul>
-
 </div>
+<!-- Remove div above here before publishing -->
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_Header}}{{Deprecated_Header}}</p>
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
@@ -11,14 +11,43 @@ browser-compat: path.to.feature.NameOfTheProperty
 ---
 <p>{{MDNSidebar}}</p>
 
-<div class="note">
+<div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
+	
+<h3 id="Page_front_matter">Page front matter</h3>
+	
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular property.</p>
+	
+<pre>---
+title: NameOfTheParentInterface.NameOfTheProperty
+slug: Web/API/NameOfTheParentInterface/NameOfTheProperty
+tags:
+  - API
+  - NameOfTheProperty
+  - Property
+  - Reference
+  - Experimental
+  - Deprecated
+  - Non-standard
+browser-compat: path.to.feature.NameOfTheProperty
+---</pre>
 
-<h3 id="Title_and_slug">Title and slug</h3>
+<dl>
+	<dt><strong>Title</strong></dt>
+	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheProperty</em>. For example, the <a href="/en-US/docs/Web/API/VRDisplay/capabilities">capabilities</a> property of the <a href="/en-US/docs/Web/API/VRDisplay">VRDisplay</a> interface has a <em>title</em> of <em>VRDisplay.capabilities</em>.</dd>
+	<dt>slug</dt>
+	<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheProperty</code>.</dd>
+	<dt>tags</dt>
+	<dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Property</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>VRDisplay</strong>), the name of the property (e.g. <strong>capabilities</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+	
+	  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
 
-<p>An API property subpage should have a <em>title</em> of <em>Name</em>Of<em>TheParentInterface + "." + NameOfTheProperty</em>. For example, the <a href="/en-US/docs/Web/API/VRDisplay/capabilities">capabilities</a> property of the <a href="/en-US/docs/Web/API/VRDisplay">VRDisplay</a> interface has a <em>title</em> of <em>VRDisplay.capabilities</em>.</p>
+	<dt>browser-compat</dt>
+	<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheProperty</code> with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+	  
+	  <p>Note that you may first need to create/update an entry for the API property in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+</dl>
 
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheProperty</em>, so <code>capabilities</code>'s slug is <em>capabilities</em>.</p>
 
 <h3 id="Top_macros">Top macros</h3>
 
@@ -32,17 +61,6 @@ browser-compat: path.to.feature.NameOfTheProperty
 	<li>\{{Deprecated_Header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
 </ul>
 
-<h3 id="Tags">Tags</h3>
-
-<p>In an API method subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Property</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>VRDisplay</strong>), the name of the method (e.g. <strong>capabilities</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
-
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
 </div>
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_Header}}{{Deprecated_Header}}</p>
@@ -73,22 +91,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("NameOfSpecification", "#document-fragment-linking-directly-to-property-definition", "NameOfTheProperty")}}</td>
-			<td>{{Spec2("NameOfSpecification")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
@@ -9,6 +9,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 ---
 <p>{{MDNSidebar}}</p>
 
+<!-- Remove div below here before publishing -->
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
@@ -57,6 +58,7 @@ browser-compat: path.to.feature.NameOfTheInterface
  <li><code>\{{Interface_Overview("<em>GroupDataName</em>")}} {{Experimental_Inline}}</code> — this generates the main body of the page (Constructor, Properties, Methods and Events).</li>
 </ul>
 </div>
+<!-- Remove div above here before publishing -->
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_Header}}{{Deprecated_Header}}</p>
 

--- a/files/en-us/web/api/request/request/index.html
+++ b/files/en-us/web/api/request/request/index.html
@@ -172,22 +172,7 @@ var myRequest = new Request('flowers.jpg', myInit);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request','Request()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -197,7 +182,6 @@ var myRequest = new Request('flowers.jpg', myInit);
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Service_Worker_API">ServiceWorker API</a></li>
-  <li><a href="/en-US/docs/Web/HTTP/CORS">HTTP access control (CORS)</a>
-  </li>
+  <li><a href="/en-US/docs/Web/HTTP/CORS">HTTP access control (CORS)</a></li>
   <li><a href="/en-US/docs/Web/HTTP">HTTP</a></li>
 </ul>

--- a/files/en-us/web/api/window/animationcancel_event/index.html
+++ b/files/en-us/web/api/window/animationcancel_event/index.html
@@ -55,22 +55,7 @@ browser-compat: api.Window.animationcancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationcancel")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -348,9 +348,9 @@ browser-compat: api.Window
 <p><em>This interface inherits event handlers from the {{domxref("EventTarget")}} interface and implements event handlers from {{domxref("WindowEventHandlers")}}.</em></p>
 
 <dl>
- <dt>{{domxref("Window.onappinstalled")}}</dt>
+ <dt>{{domxref("Window.onappinstalled")}} {{deprecated_inline}}</dt>
  <dd>Called when the page is installed as a webapp. See {{domxref("Window/appinstalled_event", "appinstalled")}} event.</dd>
- <dt>{{domxref("Window.onbeforeinstallprompt")}}</dt>
+ <dt>{{domxref("Window.onbeforeinstallprompt")}} {{non-standard_inline}}</dt>
  <dd>An event handler property dispatched before a user is prompted to save a web site to a home screen on mobile.</dd>
  <dt><code>Window.ondevicelight</code> {{deprecated_inline}}</dt>
  <dd>An event handler property for any ambient light levels changes (see {{domxref("DeviceLightEvent")}}).</dd>
@@ -374,19 +374,19 @@ browser-compat: api.Window
  <dd>An event handler for handled {{jsxref("Promise")}} rejection events.</dd>
  <dt><code>Window.onuserproximity</code> {{deprecated_inline}}</dt>
  <dd>An event handler property for user proximity events (see {{domxref("UserProximityEvent")}}).</dd>
- <dt>{{domxref("Window.onvrdisplayconnect")}}</dt>
+ <dt>{{domxref("Window.onvrdisplayconnect")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when a compatible VR device has been connected to the computer (when the {{event("vrdisplayconnected")}} event fires).</dd>
- <dt>{{domxref("Window.onvrdisplaydisconnect")}}</dt>
+ <dt>{{domxref("Window.onvrdisplaydisconnect")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when a compatible VR device has been disconnected from the computer (when the {{event("vrdisplaydisconnected")}} event fires).</dd>
- <dt>{{domxref("Window.onvrdisplayactivate")}}</dt>
+ <dt>{{domxref("Window.onvrdisplayactivate")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when a display is able to be presented to (when the {{event("vrdisplayactivate")}} event fires), for example if an HMD has been moved to bring it out of standby, or woken up by being put on.</dd>
- <dt>{{domxref("Window.onvrdisplaydeactivate")}}</dt>
+ <dt>{{domxref("Window.onvrdisplaydeactivate")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when a display can no longer be presented to (when the {{event("vrdisplaydeactivate")}} event fires), for example if an HMD has gone into standby or sleep mode due to a period of inactivity.</dd>
- <dt>{{domxref("Window.onvrdisplayblur")}}</dt>
+ <dt>{{domxref("Window.onvrdisplayblur")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when presentation to a display has been paused for some reason by the browser, OS, or VR hardware (when the {{event("vrdisplayblur")}} event fires) — for example, while the user is interacting with a system menu or browser, to prevent tracking or loss of experience.</dd>
- <dt>{{domxref("Window.onvrdisplayfocus")}}</dt>
+ <dt>{{domxref("Window.onvrdisplayfocus")}} {{deprecated_inline}}</dt>
  <dd>Represents an event handler that will run when presentation to a display has resumed after being blurred (when the {{event("vrdisplayfocus")}} event fires).</dd>
- <dt>{{domxref("Window.onvrdisplaypresentchange")}}</dt>
+ <dt>{{domxref("Window.onvrdisplaypresentchange")}} {{deprecated_inline}}</dt>
  <dd>represents an event handler that will run when the presenting state of a VR device changes — i.e. goes from presenting to not presenting, or vice versa (when the {{event("vrdisplaypresentchange")}} event fires).</dd>
 </dl>
 

--- a/files/en-us/web/api/window/ondevicemotion/index.html
+++ b/files/en-us/web/api/window/ondevicemotion/index.html
@@ -27,22 +27,8 @@ browser-compat: api.Window.ondevicemotion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
@@ -12,6 +12,7 @@ tags:
 - Window
 - events
 - onvrdisplaypresentchange
+- Deprecated
 browser-compat: api.Window.onvrdisplaypresentchange
 ---
 <div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>


### PR DESCRIPTION
This fixes the remainder of the API templates docs in line with previous example here: #5225 - ie using BCD path in the page frontmatter `browser-compat` key and just use `{{Compat}}` and specifications macros as a placeholder. 

