### PR TITLE
Typo "the the" -> "the"

### DIFF
--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLImageElement.naturalHeight
   or place the image inside a container that either limits or expressly specifies the
   image height, it will be rendered this tall.</p>
 
-  <p class="notecard note"><strong>Note:</strong> Most of the the time the natural height is the actual height of the image sent by the server.
+  <p class="notecard note"><strong>Note:</strong> Most of the time the natural height is the actual height of the image sent by the server.
     Nevertheless, browsers can modify an image before pushing it to the renderer. For example, Chrome
     <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7">degrades the resolution of
     images on low-end devices</a>. In such cases, <code>naturalHeight</code> will consider the height of the image modified

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
@@ -28,7 +28,7 @@ browser-compat: api.HTMLImageElement.naturalWidth
 <p>The corresponding {{domxref("HTMLImageElement.naturalHeight", "naturalHeight")}} method
   returns the natural height of the image.</p>
 
-  <p class="notecard note"><strong>Note:</strong> Most of the the time the natural width is the actual width of the image sent by the server.
+  <p class="notecard note"><strong>Note:</strong> Most of the time the natural width is the actual width of the image sent by the server.
     Nevertheless, browsers can modify an image before pushing it to the renderer. For example, Chrome
     <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7">degrades the resolution of
     images on low-end devices</a>. In such cases, <code>naturalWidth</code> will consider the width of the image modified


### PR DESCRIPTION
This is a trivial follow-up for a typo introduced in #5734.

(2nd attempt, I didn't branch from main in my first attempt, \*shame\* on me)