### PR TITLE
Http client headers updates

### DIFF
--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -56,7 +56,7 @@ browser-compat: path.to.feature.NameOfTheHeader
    <td>yes or no</td>
   </tr>
   <tr>
-   <th scope="row">{{Glossary("Simple response header", "CORS-safelisted response-header")}}</th>
+   <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
    <td>yes or no</td>
   </tr>
  </tbody>

--- a/files/en-us/web/http/headers/device-memory/index.html
+++ b/files/en-us/web/http/headers/device-memory/index.html
@@ -11,22 +11,28 @@ tags:
   - Experimental
 browser-compat: http.headers.Device-Memory
 ---
-<div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
 <p>The <strong><code>Device-Memory</code></strong> header is a <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a> header that works like <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> header which represents the approximate amount of RAM client device has.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Header type</th>
-   <td>{{Glossary("Request header")}}</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Forbidden header name")}}</th>
-   <td>?</td>
-  </tr>
- </tbody>
-</table>
+  <tbody>
+   <tr>
+    <th scope="row">Header type</th>
+    <td>{{Glossary("Request header")}}, {{Glossary("Client hints","Client hint")}}</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("Forbidden header name")}}</th>
+    <td>no</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+    <td>no</td>
+   </tr>
+  </tbody>
+ </table>
+
+<div>{{securecontext_header}}</div>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Client Hints are accessible only on secure origins (via TLS). Server has to opt in to receive <code>Device-Memory</code> header from the client by sending {{HTTPHeader("Accept-CH")}} and {{HTTPHeader("Accept-CH-Lifetime")}} response headers.</p>
@@ -36,40 +42,23 @@ browser-compat: http.headers.Device-Memory
 
 <p>The amount of device RAM can be used as a fingerprinting variable, so values for the header are intentionally coarse to reduce the potential for its misuse. The header takes on the following values: <code>0.25</code>, <code>0.5</code>, <code>1</code>, <code>2</code>, <code>4</code>, <code>8</code>.</p>
 
-<pre class="brush: html">Device-Memory: &lt;number&gt;
-</pre>
+<pre class="brush: http">Device-Memory: &lt;number&gt;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <p>Server first needs to opt in to receive <code>Device-Memory</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Device-Memory</code> and {{HTTPHeader("Accept-CH-Lifetime")}}.</p>
 
-<pre>Accept-CH: Device-Memory
+<pre class="brush: http">Accept-CH: Device-Memory
 Accept-CH-Lifetime: 86400
 </pre>
 
 <p>Then on subsequent requests the client might send <code>Device-Memory</code> header back:</p>
 
-<pre>Device-Memory: 1
-</pre>
+<pre class="brush: http">Device-Memory: 1</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Device Memory","#sec-device-memory-client-hint-header","Device-Memory")}}</td>
-   <td>{{Spec2('Device Memory')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -12,24 +12,26 @@ tags:
   - Exerimental
 browser-compat: http.headers.DPR
 ---
-<div>{{deprecated_header}}{{Non-standard_header}}</div>
-
-<div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
 <p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> header which represents the client device pixel ratio, which is the number of physical device pixels corresponding to every CSS pixel.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Header type</th>
-   <td>{{Glossary("Request header")}}</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Forbidden header name")}}</th>
-   <td>?</td>
-  </tr>
- </tbody>
-</table>
+  <tbody>
+   <tr>
+    <th scope="row">Header type</th>
+    <td>{{Glossary("Request header")}}, {{Glossary("Client hints","Client hint")}}</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("Forbidden header name")}}</th>
+    <td>no</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+    <td>no</td>
+   </tr>
+  </tbody>
+ </table>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Client Hints are accessible only on secure origins (via TLS). Server has to opt in to receive <code>DPR</code> header from the client by sending {{HTTPHeader("Accept-CH")}} and {{HTTPHeader("Accept-CH-Lifetime")}} response headers.</p>
@@ -37,21 +39,23 @@ browser-compat: http.headers.DPR
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">DPR: &lt;number&gt;
-</pre>
+<pre class="brush: http">DPR: &lt;number&gt;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <p>Server first needs to opt in to receive <code>DPR</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>DPR</code> and {{HTTPHeader("Accept-CH-Lifetime")}}.</p>
 
-<pre>Accept-CH: DPR
+<pre class="brush: http">Accept-CH: DPR
 Accept-CH-Lifetime: 86400
 </pre>
 
 <p>Then on subsequent requests the client might send <code>DPR</code> header back:</p>
 
-<pre>DPR: 1.0
-</pre>
+<pre class="brush: http">DPR: 1.0</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/save-data/index.html
+++ b/files/en-us/web/http/headers/save-data/index.html
@@ -16,6 +16,23 @@ browser-compat: http.headers.Save-Data
   requests, indicates the client's preference for reduced data usage. This could be for
   reasons such as high transfer costs, slow connection speeds, etc.</p>
 
+  <table class="properties">
+    <tbody>
+     <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Request header")}}, {{Glossary("Client hints","Client hint")}}</td>
+     </tr>
+     <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>no</td>
+     </tr>
+     <tr>
+      <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+      <td>no</td>
+     </tr>
+    </tbody>
+   </table>
+
 <p>A value of <code>On</code> indicates explicit user opt-in into a reduced data usage
   mode on the client, and when communicated to origins allows them to deliver alternative
   content to reduce the data downloaded such as smaller image and video resources,
@@ -28,7 +45,7 @@ browser-compat: http.headers.Save-Data
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Save-Data: &lt;sd-token&gt;</pre>
+<pre class="brush: http">Save-Data: &lt;sd-token&gt;</pre>
 
 <h2 id="Directives">Directives</h2>
 
@@ -56,7 +73,7 @@ Save-Data: on</pre>
 
 <p>Response:</p>
 
-<pre>HTTP/1.0 200 OK
+<pre class="brush: http">HTTP/1.0 200 OK
 Content-Length: 102832
 Vary: Accept-Encoding, Save-Data
 Cache-Control: public, max-age=31536000
@@ -69,13 +86,13 @@ Content-Type: image/jpeg
 
 <p>Request:</p>
 
-<pre>GET /image.jpg HTTP/1.0
+<pre class="brush: http">GET /image.jpg HTTP/1.0
 Host: example.com
 </pre>
 
 <p>Response:</p>
 
-<pre>HTTP/1.0 200 OK
+<pre class="brush: http">HTTP/1.0 200 OK
 Content-Length: 481770
 Vary: Accept-Encoding, Save-Data
 Cache-Control: public, max-age=31536000
@@ -86,20 +103,7 @@ Content-Type: image/jpeg
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td><a
-          href="https://datatracker.ietf.org/doc/html/draft-grigorik-http-client-hints-03#section-7">draft-grigorik-http-client-hints-03,
-          section 7: Save-Data</a></td>
-      <td>HTTP Client Hints</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/width/index.html
+++ b/files/en-us/web/http/headers/width/index.html
@@ -1,0 +1,67 @@
+---
+title: Width
+slug: Web/HTTP/Headers/Width
+tags:
+  - Width
+  - Client hints
+  - Device Memory API
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Experimental
+browser-compat: http.headers.Width
+---
+<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
+
+
+<p>The <strong><code>Width</code></strong> request header field is a {{Glossary("Client hints","client hint header")}} that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</p>
+
+<p>If the desired resource width is not known at the time of the request or the resource does not have a display width, the <code>Width</code> header field can be omitted. If <code>Width</code> occurs in a message more than once, the last value overrides all previous occurrences</p>
+
+<table class="properties">
+  <tbody>
+   <tr>
+    <th scope="row">Header type</th>
+    <td>{{Glossary("Request header")}}, {{Glossary("Client hints","Client hint")}}</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("Forbidden header name")}}</th>
+    <td>no</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+    <td>no</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: http">Width: &lt;number&gt;</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Server first needs to opt in to receive the <code>Width</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Width</code>.</p>
+
+<pre class="brush: http">Accept-CH: Width</pre>
+
+<p>Then on subsequent requests the client might send <code>Width</code> header back:</p>
+
+<pre class="brush: http">Width: 1920</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{HTTPHeader("Accept-CH")}}</li>
+ <li>{{HTTPHeader("Vary")}}</li>
+ <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+</ul>


### PR DESCRIPTION
A bit more tidying of HTTP client hint header reference pages in preparation for adding new headers discussed in:
-  #1408
- https://github.com/mdn/content/pull/4907#issuecomment-845694070 and https://github.com/mdn/content/pull/4907#issuecomment-851533679 

Most of this is boilerplate addition to match our standard templates, and using the `{{Specifications}}` macro where defined. I did also create a page for the `Width` header and populate it with the information from the parent headers page. Doesn't add "much" more than that. 

@Elchi3 You asked about specs. A lot of this stuff seems to have been implemented in Chrome without much of a spec. Anyway,
- This is chrome implementation  info: https://chromestatus.com/feature/5642300464037888
- It seems likely nothing much has been done on FF but there is "interest" due to the new client UA hints: https://bugzilla.mozilla.org/show_bug.cgi?id=935216
- Given that they are at least mentioned, I think we could include these as "somewhat official": https://wicg.github.io/client-hints-infrastructure/#client-hints-token-definition : Save-Data, DPR, Width, Viewport-Width, Viewport-Height, Device-Memory, RTT, Downlink, ECT, Sec-CH-UA, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Mobile, Sec-CH-UA-Model, Sec-CH-UA-Platform, or Sec-CH-UA-Platform-Version,


