### PR TITLE
Adds the missing pages to TransformStream

### DIFF
--- a/files/en-us/web/api/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/index.html
@@ -33,7 +33,7 @@ browser-compat: api.TransformStream
 
 <h3 id="Anything-to-uint8array_stream">Anything-to-uint8array stream</h3>
 
-<p>In the following example, a transform stream passes through all chunks it receives as {{domxref("Uint8Array")}} values.</p>
+<p>In the following example, a transform stream passes through all chunks it receives as {{jsxref("Uint8Array")}} values.</p>
 
 <pre class="brush: js">const transformContent = {
   start() {}, // required.
@@ -136,20 +136,7 @@ responses.reduce(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#ts-class','TransformStream')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -159,4 +146,5 @@ responses.reduce(
 
 <ul>
  <li><a href="https://whatwg-stream-visualizer.glitch.me/">WHATWG Stream Visualiser</a>, for a basic visualisation of readable, writable, and transform streams.</li>
+ <li><a href="https://web.dev/streams/">Streams—The Definitive Guide</a></li>
 </ul>

--- a/files/en-us/web/api/transformstream/readable/index.html
+++ b/files/en-us/web/api/transformstream/readable/index.html
@@ -1,0 +1,38 @@
+---
+title: TransformStream.readable
+slug: Web/API/TransformStream/readable
+tags:
+  - API
+  - Property
+  - Reference
+  - readable
+  - TransformStream
+browser-compat: api.TransformStream.readable
+---
+<p>{{APIRef("Streams")}}</p>
+
+<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("ReadableStream")}} instance controlled by this <code>TransformStream</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let readable = TransformStream.readable;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("ReadableStream")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example creates a new {{domxref("TransformStream")}} as <code>textEncoderStream</code>, and prints the value of <code>readable</code> to the console.</p>
+
+<pre class="brush: js">const textEncoderStream = new TransformStream();
+console.log(textEncoderStream.readable) // a ReadableStream</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -1,0 +1,116 @@
+---
+title: TransformStream.TransformStream()
+slug: Web/API/TransformStream/TransformStream
+tags:
+  - API
+  - Constructor
+  - Reference
+  - TransformStream
+browser-compat: api.TransformStream.TransformStream
+---
+<p>{{APIRef("Streams")}}</p>
+
+<p class="summary">The <strong><code>TransformStream()</code></strong> constructor creates a new {{domxref("TransformStream")}} object which represents a pair of streams: a {{domxref("WritableStream")}} representing the writable side, and a {{domxref("ReadableStream")}} representing the readable side.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">new TransformStream(transformer, writableStrategy, readableStrategy);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>transformer</code>{{Optional_Inline}}</dt>
+  <dd>
+    <p>An object representing the <code>transformer</code>. If not supplied the resulting stream will be an <strong>identity transform stream</strong> which forwards all chunks written to its writable side to its readable side, without any changes.</p>
+
+  <p>The transformer object can contain any of the following methods. In each method <code>controller</code> is an instance of {{domxref("TransformStreamDefaultController")}}.</p>
+
+  <dl>
+    <dt><code>start(controller)</code></dt>
+    <dd>Called when the <code>TransformStream</code> is constructed. It is typically used to enqueue chunks using {{domxref("TransformStreamDefaultController.enqueue()")}}. </dd>
+    <dt><code>transform(chunk, controller)</code></dt>
+    <dd>Called when a chunk written to the writable side is ready to be transformed, and performs the work of the transformation stream. If no <code>transform()</code> method is supplied, the identity transform is used, and the chunk will be enqueued with no changes.</dd>
+    <dt><code>flush(controller)</code></dt>
+    <dd>Called after all chunks written to the writable side have been successfully transformed, and the writable side is about to be closed.</dd>
+  </dl>
+
+</dd>
+  <dt><code>writableStrategy</code>{{Optional_Inline}}</dt>
+  <dd>An object that optionally defines a queuing strategy for the stream. This takes two
+    parameters:
+    <dl>
+      <dt>highWaterMark</dt>
+      <dd>A non-negative integer — this defines the total number of chunks that can be
+        contained in the internal queue before backpressure is applied.</dd>
+      <dt>size(chunk)</dt>
+      <dd>A method containing a parameter <code>chunk</code> — this indicates the size to
+        use for each chunk, in bytes.</dd>
+    </dl>
+  </dd>
+  <dt><code>readableStrategy</code>{{Optional_Inline}}</dt>
+  <dd>An object that optionally defines a queuing strategy for the stream. This takes two
+    parameters:
+    <dl>
+      <dt>highWaterMark</dt>
+      <dd>A non-negative integer — this defines the total number of chunks that can be
+        contained in the internal queue before backpressure is applied.</dd>
+      <dt>size(chunk)</dt>
+      <dd>A method containing a parameter <code>chunk</code> — this indicates the size to
+        use for each chunk, in bytes.</dd>
+    </dl>
+  </dd>
+</dl>
+
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>You could define your own custom
+    <code>readableStrategy</code> or <code>writableStrategy</code>, or use an instance of
+    {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}}
+    for the object values.</p>
+</div>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Transforming text to uppercase</h3>
+
+<p>The following example transforms text to uppercase chunk by chunk. This example is from <a href="https://web.dev/streams/">Streams—The Definitive Guide</a>, which has a number of examples of different types of streams.</p>
+
+<pre class="brush: js">function upperCaseStream() {
+  return new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk.toUpperCase());
+    },
+  });
+}
+
+function appendToDOMStream(el) {
+  return new WritableStream({
+    write(chunk) {
+      el.append(chunk);
+    }
+  });
+}
+
+fetch('./lorem-ipsum.txt').then((response) =>
+  response.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(upperCaseStream())
+    .pipeTo(appendToDOMStream(document.body))
+);</pre>
+
+<h3>Creating an identity transform stream</h3>
+
+<p>If no <code>transformer</code> argument is supplied then the result will be an identity transform stream which forwards all chunks written to the writable side to the readable side with no changes. In the following example an identity transform stream is used to add buffering to a pipe.</p>
+
+<pre class="brush: js">const writableStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1024 * 1024 });
+readableStream
+  .pipeThrough(new TransformStream(undefined, writableStrategy))
+  .pipeTo(writableStream);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -39,7 +39,7 @@ browser-compat: api.TransformStream.TransformStream
   <dd>An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:
     <dl>
-      <dt>highWaterMark</dt>
+      <dt><code>highWaterMark</code></dt>
       <dd>A non-negative integer — this defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
       <dt>size(chunk)</dt>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -43,7 +43,7 @@ browser-compat: api.TransformStream.TransformStream
       <dd>A non-negative integer. This defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
       <dt><code>size(chunk)</code></dt>
-      <dd>A method containing a parameter <code>chunk</code> — this indicates the size to
+      <dd>A method containing a parameter <code>chunk</code>. This indicates the size to
         use for each chunk, in bytes.</dd>
     </dl>
   </dd>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -51,7 +51,7 @@ browser-compat: api.TransformStream.TransformStream
   <dd>An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:
     <dl>
-      <dt>highWaterMark</dt>
+      <dt><code>highWaterMark</code></dt>
       <dd>A non-negative integer — this defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
       <dt>size(chunk)</dt>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -40,7 +40,7 @@ browser-compat: api.TransformStream.TransformStream
     parameters:
     <dl>
       <dt><code>highWaterMark</code></dt>
-      <dd>A non-negative integer — this defines the total number of chunks that can be
+      <dd>A non-negative integer. This defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
       <dt>size(chunk)</dt>
       <dd>A method containing a parameter <code>chunk</code> — this indicates the size to

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -52,10 +52,10 @@ browser-compat: api.TransformStream.TransformStream
     parameters:
     <dl>
       <dt><code>highWaterMark</code></dt>
-      <dd>A non-negative integer — this defines the total number of chunks that can be
+      <dd>A non-negative integer. This defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
-      <dt>size(chunk)</dt>
-      <dd>A method containing a parameter <code>chunk</code> — this indicates the size to
+      <dt><code>size(chunk)</code></dt>
+      <dd>A method containing a parameter <code>chunk</code>. This indicates the size to
         use for each chunk, in bytes.</dd>
     </dl>
   </dd>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -14,7 +14,10 @@ browser-compat: api.TransformStream.TransformStream
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">new TransformStream(transformer, writableStrategy, readableStrategy);</pre>
+<pre class="brush: js">new TransformStream();
+new TransformStream(transformer);
+new TransformStream(transformer, writableStrategy);
+new TransformStream(transformer, writableStrategy, readableStrategy);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -42,7 +42,7 @@ browser-compat: api.TransformStream.TransformStream
       <dt><code>highWaterMark</code></dt>
       <dd>A non-negative integer. This defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.</dd>
-      <dt>size(chunk)</dt>
+      <dt><code>size(chunk)</code></dt>
       <dd>A method containing a parameter <code>chunk</code> — this indicates the size to
         use for each chunk, in bytes.</dd>
     </dl>

--- a/files/en-us/web/api/transformstream/writable/index.html
+++ b/files/en-us/web/api/transformstream/writable/index.html
@@ -1,0 +1,38 @@
+---
+title: TransformStream.writable
+slug: Web/API/TransformStream/writable
+tags:
+  - API
+  - Property
+  - Reference
+  - writable
+  - TransformStream
+browser-compat: api.TransformStream.writable
+---
+<p>{{APIRef("Streams")}}</p>
+
+<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("WritableStream")}} instance controlled by this <code>TransformStream</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let writable = TransformStream.writable;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("WritableStream")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example creates a new {{domxref("TransformStream")}} as <code>textEncoderStream</code>, and prints the value of <code>writable</code> to the console.</p>
+
+<pre class="brush: js">const textEncoderStream = new TransformStream();
+console.log(textEncoderStream.writable) // a WritableStream</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/transformstream/writable/index.html
+++ b/files/en-us/web/api/transformstream/writable/index.html
@@ -22,7 +22,7 @@ browser-compat: api.TransformStream.writable
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example creates a new {{domxref("TransformStream")}} as <code>textEncoderStream</code>, and prints the value of <code>writable</code> to the console.</p>
+<p>The following example creates a new {{domxref("TransformStream")}} as a <code>textEncoderStream</code>, and prints the value of <code>writable</code> to the console.</p>
 
 <pre class="brush: js">const textEncoderStream = new TransformStream();
 console.log(textEncoderStream.writable) // a WritableStream</pre>
@@ -34,5 +34,4 @@ console.log(textEncoderStream.writable) // a WritableStream</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 


### PR DESCRIPTION
The TransformStream interface was missing the subpages, which were needed to explain other parts of the Streams spec, so here they are.

Reviewer: @jpmedley 

Related to: https://github.com/mdn/content/pull/4530