### PR TITLE
changed-account-two-factor-authentication

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
@@ -182,7 +182,7 @@ tags:
     <p>Automatic, a few seconds<sup>1</sup></p>
    </td>
    <td>
-    <p>No</p>
+    <p>Yes</p>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
According to a blog post, the two-factor authentication is now required for publishing a Firefox extension. The MDN article says "No" instead of "Yes" in the "Account two factor authentication" column.
> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
> Issue number (if there is an associated issue)
#4395 
> Anything else that could help us review it
I created the change in the main branch