### PR TITLE
Fix typo in Web/JavaScript/Reference/Errors/Called_on_incompatible_type

### DIFF
--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.html
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.html
@@ -15,7 +15,7 @@ tags:
 
 <h2 id="Message">Message</h2>
 
-<pre class="brush: js">TypeError: 'this' is not a Set object (EdgE)
+<pre class="brush: js">TypeError: 'this' is not a Set object (Edge)
 TypeError: Function.prototype.toString called on incompatible object (Firefox)
 TypeError: Function.prototype.bind called on incompatible target (Firefox)
 TypeError: Method Set.prototype.add called on incompatible receiver undefined (Chrome)


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is a typo

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Called_on_incompatible_type