### PR TITLE
Update example.org refs → example.com in Referrer-Policy docs

### DIFF
--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -137,7 +137,7 @@ Referrer-Policy: unsafe-url
    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.org</td>
+   <td><strong>http</strong>://example.com</td>
    <td><em>(no referrer)</em></td>
   </tr>
   <tr>
@@ -177,7 +177,7 @@ Referrer-Policy: unsafe-url
    <td>https://example.com/</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.org</td>
+   <td><strong>http</strong>://example.com</td>
    <td><em>(no referrer)</em></td>
   </tr>
   <tr>
@@ -196,7 +196,7 @@ Referrer-Policy: unsafe-url
    <td>https://example.com/</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.org</td>
+   <td><strong>http</strong>://example.com</td>
    <td><em>(no referrer)</em></td>
   </tr>
   <tr>


### PR DESCRIPTION
When describing using a degraded protocol at the same domain, the table should illustrate same domain & different protocol -- looks like "example.org" is a typo

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The documentation is inadvertently showing a use case for working with cross-domain references, not simply "cross-protocol"

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

> Anything else that could help us review it

If this was intentional, I hope you'll let me know :)