### PR TITLE
fix: moved space outside of link

### DIFF
--- a/files/en-us/web/http/headers/authorization/index.html
+++ b/files/en-us/web/http/headers/authorization/index.html
@@ -74,7 +74,7 @@ tags:
 <pre>Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 </pre>
 
-<p>See also<a href="/en-US/docs/Web/HTTP/Authentication"> HTTP authentication</a> for
+<p>See also <a href="/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a> for
   examples on how to configure Apache or nginx servers to password protect your site with
   HTTP basic authentication.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The documentation was linking the space before the text.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
