### PR TITLE
Drop unnecessary use of bitwise NOT in String.prototype.indexOf() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
@@ -124,7 +124,6 @@ indexOf(searchValue, fromIndex)
 
 <pre class="brush: js">'Blue Whale'.indexOf('Blue') !== -1  // true
 'Blue Whale'.indexOf('Bloe') !== -1  // false
-~('Blue Whale'.indexOf('Bloe')) // 0, which is falsy
 </pre>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
The article included the following:

```js
~('Blue Whale'.indexOf('Bloe')) //  0, which is falsy
```

But the following is also falsy:

```js
~('Blue Whale'.indexOf('Blue')) // -1, which is falsy also
```

The other existing examples which precede this one just use simple `!== -1` to show how to check the `String.prototype.indexOf()` return value. If we wanted to show the inversion of that, it would be shown simply by using `=== -1` rather than `!== -1`.

Introducing usage of the bitwise NOT operator to illustrate the inversion is just a confusing, unnecessary added complexity.

So this change drops the example that uses the bitwise NOT operator.

Fixes https://github.com/mdn/content/issues/5809.