### PR TITLE
Remove dead link from main Accessibility article

### DIFF
--- a/files/en-us/web/accessibility/index.html
+++ b/files/en-us/web/accessibility/index.html
@@ -39,8 +39,6 @@ tags:
  <dd>Until now, web developers who want to make their styled &lt;div&gt; and &lt;span&gt; based widgets accessible have lacked the proper techniques. <strong>Keyboard accessibility</strong> is part of the minimum accessibility requirements which a developer should be aware of.</dd>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA">ARIA</a></dt>
  <dd>A collection of articles to learn how to use ARIA to make your HTML documents more accessible.</dd>
- <dt><a href="/en-US/docs/Accessibility/AT_Development">Assistive technology (AT) development</a></dt>
- <dd>A collection of articles intended for AT developers</dd>
  <dt><a href="/en-US/docs/Web/Accessibility/Mobile_accessibility_checklist">Mobile accessibility checklist</a></dt>
  <dd>This document provides a concise checklist of accessibility requirements for mobile app developers.</dd>
  <dt><a href="/en-US/docs/Web/Accessibility/Cognitive_accessibility">Cognitive accessibility</a></dt>


### PR DESCRIPTION
Whatever was at /en-US/docs/Accessibility/AT_Development previously, it seems to be long-gone now, and we don’t have any replacement. So this change just drops that link for it from the /en-US/docs/Accessibility page.

Fixes https://github.com/mdn/content/issues/4426.