### PR TITLE
Drop broken macro from “IndexedDB API” doc

### DIFF
--- a/files/en-us/web/api/indexeddb_api/index.html
+++ b/files/en-us/web/api/indexeddb_api/index.html
@@ -94,8 +94,6 @@ tags:
 <p>An early version of the specification also defined the following, now removed, interfaces. They are still documented in case you need to update previously written code:</p>
 
 <dl>
- <dt>{{domxref("IDBVersionChangeRequest")}} {{deprecated_inline}}</dt>
- <dd>Represents a request to change the version of a database. The way to change the version of the database has since changed (by calling {{domxref("IDBFactory.open")}} without also calling {{domxref("IDBDatabase.setVersion")}}), and the interface {{domxref("IDBOpenDBRequest")}} now has the functionality of the removed {{domxref("IDBVersionChangeRequest")}}.</dd>
  <dt>{{domxref("IDBDatabaseException")}}  {{deprecated_inline}}</dt>
  <dd>Represents exception conditions that can be encountered while performing database operations.</dd>
  <dt>{{domxref("IDBTransactionSync")}} {{deprecated_inline}}</dt>


### PR DESCRIPTION
`IDBVersionChangeRequest` was dropped from the spec and from implementations in ~2014.

See https://github.com/mdn/browser-compat-data/pull/7411 and https://github.com/mdn/browser-compat-data/commit/3a81e3d

And no article for `IDBVersionChangeRequest` or its members exists in MDN, which leads to this `{{domxref("IDBVersionChangeRequest")}` macro breakage.

So this change removes that broken macro call, along with another accompanying broken macro call.

Fixes https://github.com/mdn/content/issues/4571