### PR TITLE
adding to an example to make it clearer

### DIFF
--- a/files/en-us/web/css/all/index.html
+++ b/files/en-us/web/css/all/index.html
@@ -73,6 +73,8 @@ Phasellus eget velit sagittis.</pre>
   font-size: small;
   background-color: #F0F0F0;
   color: blue;
+  margin: 0;
+  padding: 0;
 }
 
 blockquote {


### PR DESCRIPTION
Fixes #4169

The initial CSS was missing the fact that margin and padding were set to 0, which was making on of the examples less clear. So I have added it in.
