### PR TITLE
minor code change to :focus

### DIFF
--- a/files/en-us/web/css/_colon_focus/index.html
+++ b/files/en-us/web/css/_colon_focus/index.html
@@ -32,8 +32,8 @@ input:focus {
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html no-line-numbers">&lt;input class="red-input" value="I'll be red when focused."&gt;&lt;br&gt;
-&lt;input class="blue-input" value="I'll be blue when focused."&gt;</pre>
+<pre class="brush: html no-line-numbers">&lt;div&gt;&lt;input class="red-input" value="I'll be red when focused."&gt;&lt;/div&gt;
+&lt;div&gt;&lt;input class="blue-input" value="I'll be blue when focused."&gt;&lt;/div&gt</pre>
 
 <h3 id="CSS">CSS</h3>
 
@@ -108,6 +108,6 @@ input:focus {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{CSSxRef(":focus-visible")}} {{Experimental_Inline}}</li>
+ <li>{{CSSxRef(":focus-visible")}}</li>
  <li>{{CSSxRef(":focus-within")}}</li>
 </ul>


### PR DESCRIPTION
Fixes #4099 which is a minor nit but also took the opportunity to remove the experimental macro from the link to :focus-visible. 