### PR TITLE
Drop outdated visibilitychange Support notes

### DIFF
--- a/files/en-us/web/api/document/onvisibilitychange/index.html
+++ b/files/en-us/web/api/document/onvisibilitychange/index.html
@@ -17,15 +17,6 @@ browser-compat: api.Document.onvisibilitychange
   event handler that is called when a {{event("visibilitychange")}} event reaches this
   object.</p>
 
-<div class="notecard warning">
-  <p>Safari doesn’t fire the
-    <code><a href="/en-US/docs/Web/API/Document/visibilitychange_event">visibilitychange</a></code>
-    event as expected when <code>visibilityState</code> transitions to
-    <code>hidden</code>; so for that case, you need to also include code to listen for the
-    <code><a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a></code> event.
-  </p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js"><em>obj</em>.onvisibilitychange = <em>function</em>;

--- a/files/en-us/web/api/document/visibilitystate/index.html
+++ b/files/en-us/web/api/document/visibilitystate/index.html
@@ -27,14 +27,6 @@ browser-compat: api.Document.visibilityState
   <dd>The page content is not visible to the user. In practice this means that the
     document is either a background tab or part of a minimized window, or the OS screen
     lock is active.</dd>
-  <dd>
-    <div class="notecard warning">Safari doesn’t fire the
-      <code><a href="/en-US/docs/Web/API/Document/visibilitychange_event">visibilitychange</a></code>
-      event as expected when <code>visibilityState</code> transitions to
-      <code>hidden</code>; so for that case, you need to also include code to listen for
-      the <code><a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a></code>
-      event.</div>
-  </dd>
   <dt><code>prerender</code> {{deprecated_inline}}</dt>
   <dd>The page content is being prerendered and is not visible to the user (considered
     hidden for purposes of


### PR DESCRIPTION
https://trac.webkit.org/changeset/267614/webkit shipped in Safari 14 and fixed a problem in Safari’s `visibilitychange` behavior which had led to some warning notes being added to associated MDN articles.

So this change updates the MDN articles to drop those notes. Fixes https://github.com/mdn/content/issues/5834

Related BCD issue: https://github.com/mdn/browser-compat-data/pull/10897