### PR TITLE
Update a link in Web/JavaScript/Reference/Errors/Equal_as_assign

### DIFF
--- a/files/en-us/web/javascript/reference/errors/equal_as_assign/index.html
+++ b/files/en-us/web/javascript/reference/errors/equal_as_assign/index.html
@@ -65,6 +65,6 @@ tags:
     <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/if...else">if...else</a></code>
   </li>
   <li><a
-      href="/en-US/docs/Web/JavaScript/Reference/Operators">Comparison
+      href="/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators">Equality
       operators</a></li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Update link to "Comparison operators" with "Equality operators" because the section "Comparison operators" has been removed in the target article,

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Equal_as_assign
