### PR TITLE
html/element/input: Escape dot in regular expression for email

### DIFF
--- a/files/en-us/web/html/element/input/email/index.html
+++ b/files/en-us/web/html/element/input/email/index.html
@@ -309,7 +309,7 @@ label::after {
  &lt;div class="emailBox"&gt;
    &lt;label for="emailAddress"&gt;Your e-mail address&lt;/label&gt;&lt;br&gt;
    &lt;input id="emailAddress" type="email" size="64" maxLength="64" required
-          placeholder="username@beststartupever.com" pattern=".+@beststartupever.com"
+          placeholder="username@beststartupever.com" pattern=".+@beststartupever\.com"
           title="Please provide only a Best Startup Ever corporate e-mail address"&gt;
  &lt;/div&gt;
 


### PR DESCRIPTION
While the `Pattern_validation` example suggested that it checks for
`beststartupever.com` the pattern accepted any character instead of
the dot before `com`. So it matched for example
`foo@beststartupeverZcom`.

While it's harmless in our setting, we want to alert users that they have to
escape dots in regular expressions if they intend to only match dots, we set a
good example and escape the dot before `com`.

The relevant MDN page is:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#pattern_validation