### PR TITLE
Drop warning from “Public class fields” doc

### DIFF
--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
@@ -9,19 +9,6 @@ browser-compat: javascript.classes.public_class_fields
 ---
 <div>{{JsSidebar("Classes")}}</div>
 
-<div class="note">
-  <p><strong>Note:</strong> This page describes experimental features.</p>
-
-  <p>Both public and private field declarations are an <a
-      href="https://github.com/tc39/proposal-class-fields">experimental feature (stage
-      3)</a> proposed at <a href="https://tc39.es/">TC39</a>, the JavaScript
-    standards committee.</p>
-
-  <p>Support in browsers is limited, but the feature can be used through a build step with
-    systems like <a href="https://babeljs.io/">Babel</a>. See the <a
-      href="#browser_compatibility">compat information</a> below.</p>
-</div>
-
 <p>Both static and instance public fields are writable, enumerable, and configurable
   properties. As such, unlike their private counterparts, they participate in prototype
   inheritance.</p>


### PR DESCRIPTION
In April, the Class Fields proposal reached Stage 4 and was merged into the ES Spec. Also, Safari 14.1 shipped with full support, so the statement “support in browsers is limited” is no longer true — since all current browsers now have support.

That all makes the warning note in the “Public·class·fields” article no longer accurate and no longer necessary at all — so this change completely removes it.