### PR TITLE
Resizeobserverentry contentboxsize is an array and not an object

### DIFF
--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
@@ -24,8 +24,8 @@ browser-compat: api.ResizeObserverEntry.contentBoxSize
 
 <h3 id="Value">Value</h3>
 
-<p>An object containing the new content box size of the observed element. This object
-  contains two properties:</p>
+<p>An array containing objects with the new content box size of the observed element.
+  The array is necessary to support elements that have multiple fragments, which occur in multi-column scenarios. Each object in the array contains two properties:</p>
 
 <dl>
   <dt><code>blockSize</code></dt>
@@ -62,9 +62,9 @@ browser-compat: api.ResizeObserverEntry.contentBoxSize
 
 <pre class="brush: js">const resizeObserver = new ResizeObserver(entries =&gt; {
   for (let entry of entries) {
-    if(entry.contentBoxSize) {
-      entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
-                                                      (entry.contentBoxSize.blockSize/10)) + 'px';
+    if(entry.contentBoxSize && entry.contentBoxSize.length > 0) {
+      entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize[0].inlineSize/10) +
+                                                      (entry.contentBoxSize[0].blockSize/10)) + 'px';
     } else {
       entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +
                                                       (entry.contentRect.height/10)) + 'px';


### PR DESCRIPTION
According to [the specification](https://drafts.csswg.org/resize-observer/#resize-observer-entry-interface), Resizeobserverentry contentboxsize is an array and not an object.

The [borderBoxSize page](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize) is correct.
