### PR TITLE
correct links

### DIFF
--- a/files/en-us/web/javascript/reference/errors/already_has_pragma/index.html
+++ b/files/en-us/web/javascript/reference/errors/already_has_pragma/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>A source map has been specified more than once for a given JavaScript source.</p>
 
-<p>JavaScript sources are often combined and minified to make delivering them from the server more efficient. With <a href="http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/">source maps</a>, the debugger can map the code being executed to the original source files. There are two ways to assign a source map, either by using a comment or by setting a header to the JavaScript file.</p>
+<p>JavaScript sources are often combined and minified to make delivering them from the server more efficient. With <a href="https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/">source maps</a>, the debugger can map the code being executed to the original source files. There are two ways to assign a source map, either by using a comment or by setting a header to the JavaScript file.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -42,5 +42,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Tools/Debugger/How_to/Use_a_source_map">How to use a source map – Firefox Tools documentation</a></li>
- <li><a href="http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/">Introduction to source maps – HTML5 rocks</a></li>
+ <li><a href="https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/">Introduction to source maps – HTML5 rocks</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.html
+++ b/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.html
@@ -2,9 +2,9 @@
 title: 'SyntaxError: invalid regular expression flag "x"'
 slug: Web/JavaScript/Reference/Errors/Bad_regexp_flag
 tags:
-- Error
-- JavaScript
-- SyntaxError
+  - Error
+  - JavaScript
+  - SyntaxError
 ---
 <div>{{jsSidebar("Errors")}}</div>
 
@@ -119,7 +119,7 @@ SyntaxError: Invalid regular expression flags (Chrome)
 <ul>
   <li><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">Regular
       expressions</a></li>
-  <li><a href="http://xregexp.com/flags/">XRegEx flags</a> – regular expression library
+  <li><a href="https://xregexp.com/flags/">XRegEx flags</a> – regular expression library
     that provides four new flags (<code>n</code>, <code>s</code>, <code>x</code>,
     <code>A</code>)</li>
 </ul>

--- a/files/en-us/web/javascript/reference/errors/reserved_identifier/index.html
+++ b/files/en-us/web/javascript/reference/errors/reserved_identifier/index.html
@@ -2,15 +2,15 @@
 title: 'SyntaxError: "x" is a reserved identifier'
 slug: Web/JavaScript/Reference/Errors/Reserved_identifier
 tags:
-- Error
-- Errors
-- JavaScript
-- SyntaxError
+  - Error
+  - Errors
+  - JavaScript
+  - SyntaxError
 ---
 <div>{{jsSidebar("Errors")}}</div>
 
 <p>The JavaScript exception "<em>variable</em> is a reserved identifier" occurs when <a
-    href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords">reserved
+    href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords">reserved
     keywords</a> are used as identifiers.</p>
 
 <h2 id="Message">Message</h2>
@@ -25,7 +25,7 @@ SyntaxError: Unexpected reserved word (Chrome)</pre>
 
 <h2 id="What_went_wrong">What went wrong?</h2>
 
-<p><a href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords">Reserved
+<p><a href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords">Reserved
     keywords</a> will throw in if they are used as identifiers. These are reserved in
   strict mode and sloppy mode:</p>
 
@@ -87,5 +87,5 @@ class DocArchiver {}
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="http://wiki.c2.com/?GoodVariableNames">Good variable names</a></li>
+  <li><a href="https://wiki.c2.com/?GoodVariableNames">Good variable names</a></li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Update some links.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Already_has_pragma
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_regexp_flag
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Reserved_identifier


