### PR TITLE
Use {{Specifications}} macro for svg/element/*

### DIFF
--- a/files/en-us/web/svg/element/a/index.html
+++ b/files/en-us/web/svg/element/a/index.html
@@ -119,27 +119,7 @@ svg|a:hover, svg|a:active {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "linking.html#Links", "&lt;a&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced {{SVGAttr("xlink:href")}} attribute by {{SVGAttr("href")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "linking.html#Links", "&lt;a&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/altglyph/index.html
+++ b/files/en-us/web/svg/element/altglyph/index.html
@@ -73,22 +73,7 @@ browser-compat: svg.elements.altGlyph
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#AltGlyphElement', '&lt;altGlyph&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/altglyphdef/index.html
+++ b/files/en-us/web/svg/element/altglyphdef/index.html
@@ -36,22 +36,7 @@ browser-compat: svg.elements.altGlyphDef
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#AltGlyphDefElement", "&lt;altGlyphDef&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/altglyphitem/index.html
+++ b/files/en-us/web/svg/element/altglyphitem/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.altGlyphItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#AltGlyphItemElement', '&lt;altGlyphItem&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/animate/index.html
+++ b/files/en-us/web/svg/element/animate/index.html
@@ -71,27 +71,7 @@ browser-compat: svg.elements.animate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#AnimateElement", "&lt;animate&gt;")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#AnimateElement", "&lt;animate&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/animatecolor/index.html
+++ b/files/en-us/web/svg/element/animatecolor/index.html
@@ -65,22 +65,7 @@ browser-compat: svg.elements.animateColor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#AnimateColorElement", "&lt;animateColor&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/animatemotion/index.html
+++ b/files/en-us/web/svg/element/animatemotion/index.html
@@ -85,27 +85,7 @@ browser-compat: svg.elements.animateMotion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#AnimateMotionElement", "&lt;animateMotion&gt;")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'animate.html#AnimateMotionElement', '&lt;animateMotion&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/animatetransform/index.html
+++ b/files/en-us/web/svg/element/animatetransform/index.html
@@ -65,27 +65,7 @@ browser-compat: svg.elements.animateTransform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#AnimateTransformElement", "&lt;animateTransform&gt;")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'animate.html#AnimateTransformElement', '&lt;animateTransform&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/circle/index.html
+++ b/files/en-us/web/svg/element/circle/index.html
@@ -69,27 +69,7 @@ browser-compat: svg.elements.circle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#CircleElement", "&lt;circle&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#CircleElement", "&lt;circle&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/clippath/index.html
+++ b/files/en-us/web/svg/element/clippath/index.html
@@ -80,27 +80,7 @@ browser-compat: svg.elements.clipPath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#ClipPathElement", "&lt;clipPath&gt;")}}</td>
-   <td>{{Spec2("CSS Masks")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "masking.html#EstablishingANewClippingPath", "&lt;clipPath&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/cursor/index.html
+++ b/files/en-us/web/svg/element/cursor/index.html
@@ -47,27 +47,7 @@ browser-compat: svg.elements.cursor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "interact.html#CursorElement", "&lt;cursor&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced {{SVGAttr("xlink:href")}} by {{SVGAttr("href")}} attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "interact.html#CursorElement", "&lt;cursor&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/defs/index.html
+++ b/files/en-us/web/svg/element/defs/index.html
@@ -57,27 +57,7 @@ browser-compat: svg.elements.defs
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#Head", "&lt;defs&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#Head", "&lt;defs&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/desc/index.html
+++ b/files/en-us/web/svg/element/desc/index.html
@@ -55,27 +55,7 @@ browser-compat: svg.elements.desc
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#DescriptionAndTitleElements', '&lt;desc&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#DescriptionAndTitleElements', '&lt;desc&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/discard/index.html
+++ b/files/en-us/web/svg/element/discard/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.discard
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG Animations 2', '#DiscardElement', '&lt;discard&gt;')}}</td>
-   <td>{{Spec2('SVG Animations 2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/ellipse/index.html
+++ b/files/en-us/web/svg/element/ellipse/index.html
@@ -75,27 +75,7 @@ browser-compat: svg.elements.ellipse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'shapes.html#EllipseElement', '&lt;ellipse&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Added <code>auto</code> value for <code>rx</code> and <code>ry</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'shapes.html#EllipseElement', '&lt;ellipse&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feblend/index.html
+++ b/files/en-us/web/svg/element/feblend/index.html
@@ -64,27 +64,7 @@ browser-compat: svg.elements.feBlend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feBlendElement", "&lt;feBlend&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Outsourced blend modes to {{SpecName("Compositing", "#ltblendmodegt")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feBlendElement", "&lt;feBlend&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fecolormatrix/index.html
+++ b/files/en-us/web/svg/element/fecolormatrix/index.html
@@ -164,27 +164,7 @@ A' | 0 0 0 1 0 |
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feColorMatrixElement', '&lt;feColorMatrix&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feColorMatrixElement', '&lt;feColorMatrix&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fecomponenttransfer/index.html
+++ b/files/en-us/web/svg/element/fecomponenttransfer/index.html
@@ -118,27 +118,7 @@ browser-compat: svg.elements.feComponentTransfer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feComponentTransferElement', '&lt;feComponentTransfer&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>Specified that missing transfer function elements are treated like they were specified with their {{SVGAttr("type")}} attributes set to <code>identity</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feComponentTransferElement', '&lt;feComponentTransfer&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fecomposite/index.html
+++ b/files/en-us/web/svg/element/fecomposite/index.html
@@ -239,27 +239,7 @@ browser-compat: svg.elements.feComposite
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Filters 1.0', '#feCompositeElement', '&lt;feComposite&gt;')}}</td>
-      <td>{{Spec2('Filters 1.0')}}</td>
-      <td>Added <code>lighter</code> value for <code>operator</code> attribute.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG1.1', 'filters.html#feCompositeElement', '&lt;feComposite&gt;')}}</td>
-      <td>{{Spec2('SVG1.1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feconvolvematrix/index.html
+++ b/files/en-us/web/svg/element/feconvolvematrix/index.html
@@ -108,27 +108,7 @@ browser-compat: svg.elements.feConvolveMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feConvolveMatrixElement", "&lt;feConvolveMatrix&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feConvolveMatrixElement", "&lt;feConvolveMatrix&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fediffuselighting/index.html
+++ b/files/en-us/web/svg/element/fediffuselighting/index.html
@@ -109,27 +109,7 @@ browser-compat: svg.elements.feDiffuseLighting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feDiffuseLightingElement', '&lt;feDiffuseLighting&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>Deprecated <code>kernelUnitLength</code> attribute</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feDiffuseLightingElement', '&lt;feDiffuseLighting&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fedisplacementmap/index.html
+++ b/files/en-us/web/svg/element/fedisplacementmap/index.html
@@ -66,27 +66,7 @@ browser-compat: svg.elements.feDisplacementMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feDisplacementMapElement', '&lt;feDisplacementMap&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feDisplacementMapElement', '&lt;feDisplacementMap&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fedistantlight/index.html
+++ b/files/en-us/web/svg/element/fedistantlight/index.html
@@ -39,27 +39,7 @@ browser-compat: svg.elements.feDistantLight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feDistantLightElement', '&lt;feDistantLight&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feDistantLightElement', '&lt;feDistantLight&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fedropshadow/index.html
+++ b/files/en-us/web/svg/element/fedropshadow/index.html
@@ -80,22 +80,7 @@ browser-compat: svg.elements.feDropShadow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feDropShadowElement", "&lt;feDropShadow&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feflood/index.html
+++ b/files/en-us/web/svg/element/feflood/index.html
@@ -59,27 +59,7 @@ browser-compat: svg.elements.feFlood
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feFloodElement', '&lt;feFlood&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>Removed &lt;icccolor&gt; value from {{cssxref("flood-color")}} property and defined that the alpha channel of it gets multiplied with the computed value of the {{cssxref("flood-opacity")}} property. Clarified value of <code>flood-opacity</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feFloodElement', '&lt;feFlood&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fefunca/index.html
+++ b/files/en-us/web/svg/element/fefunca/index.html
@@ -36,27 +36,7 @@ browser-compat: svg.elements.feFuncA
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feFuncAElement", "&lt;feFuncA&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feFuncAElement", "&lt;feFuncA&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fefuncb/index.html
+++ b/files/en-us/web/svg/element/fefuncb/index.html
@@ -36,27 +36,7 @@ browser-compat: svg.elements.feFuncB
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feFuncBElement', '&lt;feFuncB&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feFuncBElement', '&lt;feFuncB&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fefuncg/index.html
+++ b/files/en-us/web/svg/element/fefuncg/index.html
@@ -36,27 +36,7 @@ browser-compat: svg.elements.feFuncG
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feFuncGElement", "&lt;feFuncG&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feFuncGElement", "&lt;feFuncG&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fefuncr/index.html
+++ b/files/en-us/web/svg/element/fefuncr/index.html
@@ -36,27 +36,7 @@ browser-compat: svg.elements.feFuncR
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feFuncRElement', '&lt;feFuncR&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feFuncRElement', '&lt;feFuncR&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fegaussianblur/index.html
+++ b/files/en-us/web/svg/element/fegaussianblur/index.html
@@ -90,27 +90,7 @@ browser-compat: svg.elements.feGaussianBlur
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feGaussianBlurElement', '&lt;feGaussianBlur&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>Added {{SVGAttr("edgeMode")}} attribute</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feGaussianBlurElement', '&lt;feGaussianBlur&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feimage/index.html
+++ b/files/en-us/web/svg/element/feimage/index.html
@@ -61,27 +61,7 @@ browser-compat: svg.elements.feImage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feImageElement", "&lt;feImage&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Added {{SVGAttr("href")}} attribute and deprecated {{SVGAttr("xlink:href")}}. Added {{SVGAttr("crossorigin")}} attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feImageElement", "&lt;feImage&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/femerge/index.html
+++ b/files/en-us/web/svg/element/femerge/index.html
@@ -63,27 +63,7 @@ browser-compat: svg.elements.feMerge
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feMergeElement', '&lt;feMerge&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feMergeElement', '&lt;feMerge&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/femergenode/index.html
+++ b/files/en-us/web/svg/element/femergenode/index.html
@@ -62,27 +62,7 @@ browser-compat: svg.elements.feMergeNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#elementdef-femergenode', '&lt;feMergeNode&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feMergeNodeElement', '&lt;feMergeNode&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/femorphology/index.html
+++ b/files/en-us/web/svg/element/femorphology/index.html
@@ -115,27 +115,7 @@ browser-compat: svg.elements.feMorphology
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feMorphologyElement", "&lt;feMorphology&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feMorphologyElement", "&lt;feMorphology&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feoffset/index.html
+++ b/files/en-us/web/svg/element/feoffset/index.html
@@ -60,27 +60,7 @@ browser-compat: svg.elements.feOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feOffsetElement', '&lt;feOffset&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feOffsetElement', '&lt;feOffset&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fepointlight/index.html
+++ b/files/en-us/web/svg/element/fepointlight/index.html
@@ -64,27 +64,7 @@ browser-compat: svg.elements.fePointLight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#fePointLightElement', '&lt;fePointLight&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#fePointLightElement', '&lt;fePointLight&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fespecularlighting/index.html
+++ b/files/en-us/web/svg/element/fespecularlighting/index.html
@@ -66,27 +66,7 @@ browser-compat: svg.elements.feSpecularLighting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feSpecularLightingElement', '&lt;feSpecularLighting&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>Removed limitation of <code>specularExponent</code> attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feSpecularLightingElement', '&lt;feSpecularLighting&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fespotlight/index.html
+++ b/files/en-us/web/svg/element/fespotlight/index.html
@@ -71,27 +71,7 @@ browser-compat: svg.elements.feSpotLight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#feSpotLightElement", "&lt;feSpotLight&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feSpotLightElement", "&lt;feSpotLight&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/fetile/index.html
+++ b/files/en-us/web/svg/element/fetile/index.html
@@ -64,27 +64,7 @@ browser-compat: svg.elements.feTile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feTileElement', '&lt;feTile&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feTileElement', '&lt;feTile&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/feturbulence/index.html
+++ b/files/en-us/web/svg/element/feturbulence/index.html
@@ -60,27 +60,7 @@ browser-compat: svg.elements.feTurbulence
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Filters 1.0', '#feTurbulenceElement', '&lt;feTurbulence&gt;')}}</td>
-   <td>{{Spec2('Filters 1.0')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'filters.html#feTurbulenceElement', '&lt;feTurbulence&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/filter/index.html
+++ b/files/en-us/web/svg/element/filter/index.html
@@ -65,27 +65,7 @@ browser-compat: svg.elements.filter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#FilterElement", "&lt;filter&gt;")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FilterElement", "&lt;filter&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font-face-format/index.html
+++ b/files/en-us/web/svg/element/font-face-format/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.font-face-format
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceFormatElement", "&lt;font-face-format&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font-face-name/index.html
+++ b/files/en-us/web/svg/element/font-face-name/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.font-face-name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceNameElement", "&lt;font-face-name&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font-face-src/index.html
+++ b/files/en-us/web/svg/element/font-face-src/index.html
@@ -36,22 +36,7 @@ browser-compat: svg.elements.font-face-src
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceSrcElement", "&lt;font-face-src&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font-face-uri/index.html
+++ b/files/en-us/web/svg/element/font-face-uri/index.html
@@ -39,22 +39,7 @@ browser-compat: svg.elements.font-face-uri
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceURIElement", "&lt;font-face-uri&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font-face/index.html
+++ b/files/en-us/web/svg/element/font-face/index.html
@@ -72,22 +72,7 @@ browser-compat: svg.elements.font-face
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElement", "&lt;font-face&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/font/index.html
+++ b/files/en-us/web/svg/element/font/index.html
@@ -46,22 +46,7 @@ browser-compat: svg.elements.font
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontElement", "&lt;font&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/foreignobject/index.html
+++ b/files/en-us/web/svg/element/foreignobject/index.html
@@ -91,27 +91,7 @@ browser-compat: svg.elements.foreignObject
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'embedded.html#ForeignObjectElement', '&lt;foreignObject&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'extend.html#ForeignObjectElement', '&lt;foreignObject&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/g/index.html
+++ b/files/en-us/web/svg/element/g/index.html
@@ -57,27 +57,7 @@ browser-compat: svg.elements.g
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#GElement", "&lt;g&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#Groups", "&lt;g&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/glyph/index.html
+++ b/files/en-us/web/svg/element/glyph/index.html
@@ -83,22 +83,7 @@ browser-compat: svg.elements.glyph
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'fonts.html#GlyphElement', '&lt;glyph&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/glyphref/index.html
+++ b/files/en-us/web/svg/element/glyphref/index.html
@@ -48,22 +48,7 @@ browser-compat: svg.elements.glyphRef
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#GlyphRefElement', '&lt;glyphRef&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/hkern/index.html
+++ b/files/en-us/web/svg/element/hkern/index.html
@@ -42,22 +42,7 @@ browser-compat: svg.elements.hkern
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#HKernElement", "&lt;hkern&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/image/index.html
+++ b/files/en-us/web/svg/element/image/index.html
@@ -74,27 +74,7 @@ browser-compat: svg.elements.image
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('SVG2', 'embedded.html#ImageElement', '&lt;image&gt;')}}</td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Allows omitting <code>height</code> and <code>width</code> and introduced <code>crossorigin</code></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG1.1', 'struct.html#ImageElement', '&lt;image&gt;')}}</td>
-      <td>{{Spec2('SVG1.1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/line/index.html
+++ b/files/en-us/web/svg/element/line/index.html
@@ -70,27 +70,7 @@ browser-compat: svg.elements.line
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'shapes.html#LineElement', '&lt;line&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Changed the x1, y1, x2 and y2 attributes to take {{cssxref("&lt;length&gt;")}}s, {{cssxref("&lt;percentage&gt;")}}s and {{cssxref("&lt;number&gt;")}}s</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'shapes.html#LineElement', '&lt;line&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/lineargradient/index.html
+++ b/files/en-us/web/svg/element/lineargradient/index.html
@@ -89,27 +89,7 @@ browser-compat: svg.elements.linearGradient
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'pservers.html#LinearGradientElement', '&lt;linearGradient&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'pservers.html#LinearGradients', '&lt;linearGradient&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/marker/index.html
+++ b/files/en-us/web/svg/element/marker/index.html
@@ -96,32 +96,7 @@ browser-compat: svg.elements.marker
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Markers", "#MarkerElement", "&lt;marker&gt;")}}</td>
-   <td>{{Spec2("SVG Markers")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "painting.html#MarkerElement", "&lt;marker&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#MarkerElement", "&lt;marker&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/mask/index.html
+++ b/files/en-us/web/svg/element/mask/index.html
@@ -76,27 +76,7 @@ browser-compat: svg.elements.mask
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Masks', '#MaskElement', '&lt;mask&gt;')}}</td>
-   <td>{{Spec2('CSS Masks')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'masking.html#Masking', '&lt;mask&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/metadata/index.html
+++ b/files/en-us/web/svg/element/metadata/index.html
@@ -192,27 +192,7 @@ browser-compat: svg.elements.metadata
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#MetadataElement', '&lt;metadata&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Allowed global event attributes on the element.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'metadata.html#MetadataElement', '&lt;metadata&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/missing-glyph/index.html
+++ b/files/en-us/web/svg/element/missing-glyph/index.html
@@ -44,22 +44,7 @@ browser-compat: svg.elements.missing-glyph
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#MissingGlyphElement", "&lt;missing-glyph&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/mpath/index.html
+++ b/files/en-us/web/svg/element/mpath/index.html
@@ -74,27 +74,7 @@ browser-compat: svg.elements.mpath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#MPathElement", "&lt;mpath&gt;")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#MPathElement", "&lt;mpath&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/path/index.html
+++ b/files/en-us/web/svg/element/path/index.html
@@ -62,32 +62,7 @@ browser-compat: svg.elements.path
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Paths", "#PathElement", "&lt;path&gt;")}}</td>
-   <td>{{Spec2("SVG Paths")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "paths.html#PathElement", "&lt;path&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "paths.html#PathElement", "&lt;path&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/pattern/index.html
+++ b/files/en-us/web/svg/element/pattern/index.html
@@ -95,27 +95,7 @@ browser-compat: svg.elements.pattern
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'pservers.html#Patterns', '&lt;pattern&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'pservers.html#Patterns', '&lt;pattern&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/polygon/index.html
+++ b/files/en-us/web/svg/element/polygon/index.html
@@ -65,27 +65,7 @@ browser-compat: svg.elements.polygon
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'shapes.html#PolygonElement', '&lt;polygon&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'shapes.html#PolygonElement', '&lt;polygon&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/polyline/index.html
+++ b/files/en-us/web/svg/element/polyline/index.html
@@ -63,27 +63,7 @@ browser-compat: svg.elements.polyline
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'shapes.html#PolylineElement', '&lt;polyline&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'shapes.html#PolylineElement', '&lt;polyline&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/radialgradient/index.html
+++ b/files/en-us/web/svg/element/radialgradient/index.html
@@ -95,27 +95,7 @@ browser-compat: svg.elements.radialGradient
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'pservers.html#RadialGradients', '&lt;radialGradient&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Added <code>fr</code> attribute</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'pservers.html#RadialGradients', '&lt;radialGradient&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/rect/index.html
+++ b/files/en-us/web/svg/element/rect/index.html
@@ -81,27 +81,7 @@ browser-compat: svg.elements.rect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'shapes.html#RectElement', '&lt;rect&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'shapes.html#RectElement', '&lt;rect&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/script/index.html
+++ b/files/en-us/web/svg/element/script/index.html
@@ -74,27 +74,7 @@ browser-compat: svg.elements.script
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'interact.html#ScriptElement', '&lt;script&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'script.html#ScriptElement', '&lt;script&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/set/index.html
+++ b/files/en-us/web/svg/element/set/index.html
@@ -70,27 +70,7 @@ browser-compat: svg.elements.set
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#SetElement", "&lt;set&gt;")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'animate.html#SetElement', '&lt;set&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/stop/index.html
+++ b/files/en-us/web/svg/element/stop/index.html
@@ -66,27 +66,7 @@ browser-compat: svg.elements.stop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'pservers.html#GradientStops', '&lt;stop&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'pservers.html#GradientStops', '&lt;stop&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/style/index.html
+++ b/files/en-us/web/svg/element/style/index.html
@@ -64,27 +64,7 @@ browser-compat: svg.elements.style
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "styling.html#StyleElement", "&lt;style&gt;")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "styling.html#StyleElement", "&lt;style&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/svg/index.html
+++ b/files/en-us/web/svg/element/svg/index.html
@@ -96,27 +96,7 @@ browser-compat: svg.elements.svg
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#NewDocument', '&lt;svg&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#NewDocument', '&lt;svg&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/switch/index.html
+++ b/files/en-us/web/svg/element/switch/index.html
@@ -66,27 +66,7 @@ browser-compat: svg.elements.switch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#SwitchElement', '&lt;switch&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Clarified the evaluation of the {{SVGAttr("systemLanguage")}} attribute</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#SwitchElement', '&lt;switch&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/symbol/index.html
+++ b/files/en-us/web/svg/element/symbol/index.html
@@ -90,27 +90,7 @@ browser-compat: svg.elements.symbol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#SymbolElement', '&lt;symbol&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Allowed geometry properties to be specified on a symbol</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#SymbolElement', '&lt;symbol&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/text/index.html
+++ b/files/en-us/web/svg/element/text/index.html
@@ -87,27 +87,7 @@ browser-compat: svg.elements.text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'text.html#TextElement', '&lt;text&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#TextElement', '&lt;text&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/textpath/index.html
+++ b/files/en-us/web/svg/element/textpath/index.html
@@ -90,27 +90,7 @@ browser-compat: svg.elements.textPath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'text.html#TextPathElement', '&lt;textPath&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#TextPathElement', '&lt;textPath&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/title/index.html
+++ b/files/en-us/web/svg/element/title/index.html
@@ -55,27 +55,7 @@ browser-compat: svg.elements.title
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#TitleElement', '&lt;title&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#DescriptionAndTitleElements', '&lt;title&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/tref/index.html
+++ b/files/en-us/web/svg/element/tref/index.html
@@ -67,22 +67,7 @@ browser-compat: svg.elements.tref
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#TRefElement", "&lt;font&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/tspan/index.html
+++ b/files/en-us/web/svg/element/tspan/index.html
@@ -82,27 +82,7 @@ browser-compat: svg.elements.tspan
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'text.html#TextElement', '&lt;tspan&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'text.html#TSpanElement', '&lt;tspan&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/use/index.html
+++ b/files/en-us/web/svg/element/use/index.html
@@ -100,27 +100,7 @@ That's why the circles have different x positions, but the same stroke value.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'struct.html#UseElement', '&lt;use&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'struct.html#UseElement', '&lt;use&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -76,27 +76,7 @@ browser-compat: svg.elements.view
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'linking.html#ViewElement', '&lt;view&gt;')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'linking.html#ViewElement', '&lt;view&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/element/vkern/index.html
+++ b/files/en-us/web/svg/element/vkern/index.html
@@ -42,22 +42,7 @@ browser-compat: svg.elements.vkern
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'fonts.html#VKernElement', '&lt;vkern&gt;')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part #1146.

This converts SVG elements to the {{Specifications}} macros. This is my first PR of this type, so a thorough review is needed.

There were no comments in the section, so it was pretty trivial to replace.

reviewer: @Elchi3