### PR TITLE
Remove unnecessary span elements in Web API Docs

### DIFF
--- a/files/en-us/web/api/customelementregistry/get/index.html
+++ b/files/en-us/web/api/customelementregistry/get/index.html
@@ -49,7 +49,7 @@ browser-compat: api.CustomElementRegistry.get
 })
 
 // Return a reference to the my-paragraph constructor
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">let ctor = customElements.get('my-paragraph');</span></span></span>
+let ctor = customElements.get('my-paragraph');
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/element/slot/index.html
+++ b/files/en-us/web/api/element/slot/index.html
@@ -55,7 +55,7 @@ browser-compat: api.Element.slot
 
 <pre
   class="brush: js">let slottedSpan = document.querySelector('my-paragraph span')
-console.log(slottedSpan.slot); // logs <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">'my-text'</span></span></span></span></pre>
+console.log(slottedSpan.slot); // logs 'my-text'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/event/composedpath/index.html
+++ b/files/en-us/web/api/event/composedpath/index.html
@@ -78,13 +78,13 @@ browser-compat: api.Event.composedPath
   <code>&lt;open-shadow&gt;</code> element's composed path is this:</p>
 
 <pre
-  class="brush: js"><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-array"><span class="objectTitle">Array </span><span class="arrayLeftBracket">[ </span><span class="objectBox objectBox-node"><span class="tag-name">p</span></span>, <span class="objectBox objectBox-object"><span class="objectTitle">ShadowRoot</span></span>, <span class="objectBox objectBox-node"><span class="tag-name">open-shadow</span></span>, <span class="objectBox objectBox-node"><span class="tag-name">body</span></span>, <span class="objectBox objectBox-node"><span class="tag-name">html</span></span>, <span class="objectBox objectBox-document"><span class="objectTitle">HTMLDocument</span> <span class="location">https://mdn.github.io/web-components-examples/composed-composed-path/</span></span>, <span class="objectBox objectBox-Window"><span class="objectTitle">Window</span></span><span class="arrayRightBracket"> ]</span></span></span></span></span></pre>
+  class="brush: js">Array [ p, ShadowRoot, open-shadow, body, html, HTMLDocument https://mdn.github.io/web-components-examples/composed-composed-path/, Window ]</pre>
 
 <p>Whereas the <code>&lt;closed-shadow&gt;</code> element's composed path is a follows:
 </p>
 
 <pre
-  class="brush: js"><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-array"><span class="objectTitle">Array </span><span class="arrayLeftBracket">[ </span><span class="objectBox objectBox-node"><span class="tag-name">closed-shadow</span></span>, <span class="objectBox objectBox-node"><span class="tag-name">body</span></span>, <span class="objectBox objectBox-node"><span class="tag-name">html</span></span>, <span class="objectBox objectBox-document"><span class="objectTitle">HTMLDocument</span> <span class="location">https://mdn.github.io/web-components-examples/composed-composed-path/</span></span>, <span class="objectBox objectBox-Window"><span class="objectTitle">Window</span></span><span class="arrayRightBracket"> ]</span></span></span></span></span></pre>
+  class="brush: js">Array [ closed-shadow, body, html, HTMLDocument https://mdn.github.io/web-components-examples/composed-composed-path/, Window ]</pre>
 
 <p>In the second case, the event listeners only propagate as far as the
   <code>&lt;closed-shadow&gt;</code> element itself, but not to the nodes inside the

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.html
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{APIRef("Media Capabilities API")}}</div>
 
-<p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> provides several key features to help you better decide how to handle media, but also to determine how well media is being handled, in real time. These features include:</p>
+<p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> provides several key features to help you better decide how to handle media, but also to determine how well media is being handled, in real time.</span> These features include:</p>
 
 <ul>
  <li>The ability to query the browser to determine its ability to encode or decode media given a specified set of encoding parameters. These parameters may include the codecs, resolutions, bit rates, frame rates, and other such details. With the Media Capabilities API, you can determine not just if the browser can support a given format, but whether or not it can do so efficiently and smoothly. In short, this API replaces—and improves upon—the {{domxref("MediaSource")}} method {{domxref("MediaSource.isTypeSupported", "isTypeSupported()")}} or the {{domxref("HTMLMediaElement")}} method {{domxref("HTMLMediaElement.canPlayType","canPlayType()")}}.</li>

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.html
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{APIRef("Media Capabilities API")}}</div>
 
-<p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> provides several key features to help you better decide how to handle media, but also to determine how well media is being handled, in real time.</span> These features include:</p>
+<p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> provides several key features to help you better decide how to handle media, but also to determine how well media is being handled, in real time. These features include:</p>
 
 <ul>
  <li>The ability to query the browser to determine its ability to encode or decode media given a specified set of encoding parameters. These parameters may include the codecs, resolutions, bit rates, frame rates, and other such details. With the Media Capabilities API, you can determine not just if the browser can support a given format, but whether or not it can do so efficiently and smoothly. In short, this API replaces—and improves upon—the {{domxref("MediaSource")}} method {{domxref("MediaSource.isTypeSupported", "isTypeSupported()")}} or the {{domxref("HTMLMediaElement")}} method {{domxref("HTMLMediaElement.canPlayType","canPlayType()")}}.</li>
@@ -85,7 +85,7 @@ tags:
 
 <pre class="brush: js language-js">var promise = navigator.mediaCapabilities.decodingInfo(videoConfiguration);</pre>
 
-<p>The <code>decodingInfo()</code> and {{domxref("MediaCapabilities.encodingInfo", "encodingInfo()")}} methods both return promises. Once the promises state is fulfilled, you can access the <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-object"><span class="objectTitle">{{domxref("MediaCapabilitiesInfo")}} interface's <code>supported</code>, <code>smooth</code>, and <code>powerEfficient</code> properties.</span></span></span></span></span></p>
+<p>The <code>decodingInfo()</code> and {{domxref("MediaCapabilities.encodingInfo", "encodingInfo()")}} methods both return promises. Once the promises state is fulfilled, you can access the {{domxref("MediaCapabilitiesInfo")}} interface's <code>supported</code>, <code>smooth</code>, and <code>powerEfficient</code> properties.</p>
 
 <h3 id="Handling_the_response">Handling the response</h3>
 

--- a/files/en-us/web/api/medialist/index.html
+++ b/files/en-us/web/api/medialist/index.html
@@ -14,7 +14,7 @@ browser-compat: api.MediaList
 <p>The <code><strong>MediaList</strong></code> interface represents the media queries of a stylesheet, e.g. those set using a {{htmlelement("link")}} element's <code>media</code> attribute.</p>
 
 <div class="notecard note">
-<p><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string"><strong>Note</strong>: <code>MediaList</code> is a live list; updating the list using properties or methods listed below will immediately update the behavior of the document.</span></span></span></span></p>
+<p><strong>Note</strong>: <code>MediaList</code> is a live list; updating the list using properties or methods listed below will immediately update the behavior of the document.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/medialist/mediatext/index.html
+++ b/files/en-us/web/api/medialist/mediatext/index.html
@@ -26,23 +26,19 @@ mediaListInstance.mediaText = <em>string</em>;</pre>
 
 <p>A {{domxref("DOMString")}} representing the media queries of a stylesheet. Each one is
   separated by a comma, for example
-  <code><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">screen and (min-width: 480px), print</span></span></span></span></code>.
+  <code>screen and (min-width: 480px), print</code>.
 </p>
 
 <p>If you wish to set new media queries on the document, the string value must have the
-  different queries separated by commas, e.g. <span class="message-body-wrapper"><span
-      class="message-flex-body"><span class="devtools-monospace message-body"><span
-          class="objectBox objectBox-string"><code>screen, print</code>. Note that the
+  different queries separated by commas, e.g. <code>screen, print</code>. Note that the
           <code>MediaList</code> is a live list; updating the list via
           <code>mediaText</code> will immediately update the behavior of the
-          document.</span></span></span></span></p>
+          document.</p>
 
-<p><span class="message-body-wrapper"><span class="message-flex-body"><span
-        class="devtools-monospace message-body"><span
-          class="objectBox objectBox-string">Also note that is you try to set
+<p>Also note that is you try to set
           <code>mediaText</code> to <code>null</code>, it will be treated as an empty
           string, i.e. the value will be set to
-          <code>""</code>.</span></span></span></span></p>
+          <code>""</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/url/port/index.html
+++ b/files/en-us/web/api/url/port/index.html
@@ -30,7 +30,7 @@ browser-compat: api.URL.port
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">const url = new URL('<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-string">https://mydomain.com:80/svn/Repos/</span></span></span></span>');
+<pre class="brush: js">const url = new URL('https://mydomain.com:80/svn/Repos/');
 console.log(url.port); // Logs '80'
 </pre>
 

--- a/files/en-us/web/api/urlsearchparams/set/index.html
+++ b/files/en-us/web/api/urlsearchparams/set/index.html
@@ -45,7 +45,7 @@ let params = new URLSearchParams(url.search);
 
 //Add a third parameter.
 params.set('baz', 3);
-params.toString(); // <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">"foo=1&amp;bar=2&amp;baz=3"</span></span></span></span>
+params.toString(); // "foo=1&amp;bar=2&amp;baz=3"
 
 </pre>
 

--- a/files/en-us/web/api/webgl_api/compressed_texture_formats/index.html
+++ b/files/en-us/web/api/webgl_api/compressed_texture_formats/index.html
@@ -12,7 +12,7 @@ slug: Web/API/WebGL_API/Compressed_texture_formats
 
 <p>As compressed textures require hardware support, therefore no specific formats are required by WebGL; instead, a context can make different formats available, depending on hardware support. <a href="https://toji.github.io/texture-tester/">This site</a> shows which formats are supported in the used browser.</p>
 
-<p>Usage of compressed formats first requires activating the respective extension with {{domxref("WebGLRenderingContext.getExtension()")}}. If supported, it will return an extension object with constants for the added formats and the formats will also be returned by calls to <code>gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)</code>. (E.g. <code>ext.<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">COMPRESSED_RGBA_S3TC_DXT1_EXT</span></span></span></code> for the {{domxref("WEBGL_compressed_texture_s3tc")}} extension.) These can then be used with {{domxref("WebGLRenderingContext.compressedTexImage2D()", "compressedTexImage[23]D")}} or {{domxref("WebGLRenderingContext.compressedTexSubImage2D()", "compressedTexSubImage[23]D")}} instead of <code>texImage2D</code> calls.</p>
+<p>Usage of compressed formats first requires activating the respective extension with {{domxref("WebGLRenderingContext.getExtension()")}}. If supported, it will return an extension object with constants for the added formats and the formats will also be returned by calls to <code>gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)</code>. (E.g. <code>ext.COMPRESSED_RGBA_S3TC_DXT1_EXT</code> for the {{domxref("WEBGL_compressed_texture_s3tc")}} extension.) These can then be used with {{domxref("WebGLRenderingContext.compressedTexImage2D()", "compressedTexImage[23]D")}} or {{domxref("WebGLRenderingContext.compressedTexSubImage2D()", "compressedTexSubImage[23]D")}} instead of <code>texImage2D</code> calls.</p>
 
 <p>Note that WebGL makes no functionality available to compress or decompress textures: they must already be in a compressed format and can then be directly uploaded to video memory.</p>
 
@@ -83,11 +83,11 @@ slug: Web/API/WebGL_API/Compressed_texture_formats
   const ext = gl.getExtension('WEBGL_compressed_texture_s3tc'); // will be null if not supported
   if (ext) {
     // the file is already in the correct compressed format
-    const dataArrayBuffer = await fetch('/textures/foobar512x512.<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">RGBA_S3TC_DXT1</span></span></span>')
+    const dataArrayBuffer = await fetch('/textures/foobar512x512.RGBA_S3TC_DXT1')
       .then(response =&gt; response.arrayBuffer());
     gl.compressedTexImage2D(gl.TEXTURE_2D,
       0, // set the base image level
-      <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">ext.COMPRESSED_RGBA_S3TC_DXT1_EXT</span></span></span>, // the compressed format we are using
+      ext.COMPRESSED_RGBA_S3TC_DXT1_EXT, // the compressed format we are using
       512, 512, // width, height of the image
       0, // border, always 0
       new DataView(dataArrayBuffer));


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are some span elements which are unnecessary in various documents.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get
https://developer.mozilla.org/en-US/docs/Web/API/Element/slot
https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
https://developer.mozilla.org/en-US/docs/Web/API/Media_Capabilities_API/Using_the_Media_Capabilities_API
https://developer.mozilla.org/en-US/docs/Web/API/MediaList
https://developer.mozilla.org/en-US/docs/Web/API/MediaList/mediaText
https://developer.mozilla.org/en-US/docs/Web/API/URL/port
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/set
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Compressed_texture_formats
