### PR TITLE
Remove unnecessary span elements in JavaScript docs

### DIFF
--- a/files/en-us/web/javascript/reference/errors/illegal_character/index.html
+++ b/files/en-us/web/javascript/reference/errors/illegal_character/index.html
@@ -57,13 +57,7 @@ var foo = 'bar';             // SyntaxError: illegal character
 var foo = 'bar';
 </pre>
 
-<p><span class="message-body-wrapper"><span class="message-flex-body"><span
-        class="devtools-monospace message-body"><span
-          class="objectBox objectBox-string">Some editors and IDEs will notify you or at
-          least use a slightly different highlighting for it, but not all. When something
-          like this happens to your code and you're not able to find the source of the
-          problem, it's often best to just delete the problematic line and retype
-          it.</span></span></span></span></p>
+<p>Some editors and IDEs will notify you or at least use a slightly different highlighting for it, but not all. When something like this happens to your code and you're not able to find the source of the problem, it's often best to just delete the problematic line and retype it.</p>
 
 <h3 id="Forgotten_characters">Forgotten characters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.html
@@ -73,7 +73,7 @@ a.join('');    // 'WindWaterFire'</pre>
 
 <pre class="brush: js">function f(a, b, c) {
   var s = Array.prototype.join.call(arguments);
-  console.log(s); // '<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">1,a,true'</span></span></span></span>
+  console.log(s); // '1,a,true'
 }
 f(1, 'a', true);
 //expected output: "1,a,true"

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.html
@@ -60,13 +60,13 @@ console.log('theTree.constructor is ' + theTree.constructor)
 <p>One can assign the <code>constructor</code> property for any value except <code>null</code> and <code>undefined</code> since those don't have a corresponding constructor function (like <code>String</code>, <code>Number</code>, <code>Boolean</code> etc.), but values which are primitives won't keep the change (with no exception thrown). This is due to the same mechanism, which allows one to set any property on primitive values (except <code>null</code> and <code>undefined</code>) with no effect. Namely whenever one uses such a primitive as an object an instance of the corresponding constructor is created and discarded right after the statement was executed.</p>
 
 <pre class="brush: js">let val = null;
-val.constructor = 1; //<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format">TypeError: <span class="objectBox objectBox-string">var is null</span></span></span></span></span>
+val.constructor = 1; //TypeError: var is null
 
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format"><span class="objectBox objectBox-string">val = 'abc';</span></span></span></span></span>
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format"><span class="objectBox objectBox-string">val.constructor = Number; //val.constructor === String</span></span></span></span></span>
+val = 'abc';
+val.constructor = Number; //val.constructor === String
 
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format"><span class="objectBox objectBox-string">val.foo = 'bar';</span></span></span></span></span> //An implicit instance of <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format"><span class="objectBox objectBox-string">String('abc') was created and assigned the prop foo</span></span></span></span></span>
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox-stackTrace reps-custom-format"><span class="objectBox objectBox-string">val.foo === undefined; //true, since a new instance of String('abc') was created for this comparison, which doesn't have the foo property</span></span></span></span></span></pre>
+val.foo = 'bar'; //An implicit instance of String('abc') was created and assigned the prop foo
+val.foo === undefined; //true, since a new instance of String('abc') was created for this comparison, which doesn't have the foo property</pre>
 
 <p>So basically one can change the value of the <code>constructor</code> property for anything, except the primitives mentioned above, <strong>note that changing the </strong><code>constructor</code><strong> property does not affect the instanceof operator</strong>:</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.html
@@ -156,13 +156,13 @@ console.log('ä'.localeCompare('a', 'sv', { sensitivity: 'base' })); // a positi
 <h3 id="Numeric_sorting">Numeric sorting</h3>
 
 <pre class="brush: js">// by default, "2" &gt; "10"
-console.log(<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">"2".localeCompare("10")</span></span></span>); // 1
+console.log("2".localeCompare("10")); // 1
 
 // numeric using options:
-console.log(<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">"2".localeCompare("10", undefined, {numeric: true})</span></span></span>); // -1
+console.log("2".localeCompare("10", undefined, {numeric: true})); // -1
 
 // numeric using locales tag:
-console.log(<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">"2".localeCompare("10", "en-u-kn-true")</span></span></span>); // -1
+console.log("2".localeCompare("10", "en-u-kn-true")); // -1
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/string/normalize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/normalize/index.html
@@ -159,7 +159,7 @@ console.log(string2.codePointAt(0).toString(16)); // f1</pre>
       href="/en-US/docs/Glossary/Ligature">ligature</a> <code>"ﬀ"</code>. It is compatible
     with two consecutive U+0066 code points (<code>"ff"</code>).</li>
   <li>the code point U+24B9 represents the symbol
-    <code><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-string">"Ⓓ"</span></span></span></span></code>.
+    <code>"Ⓓ"</code>.
     It is compatible with the U+0044 code point (<code>"D"</code>).</li>
 </ul>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are some span elements which are unnecessary in various documents.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Illegal_character
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
