### PR TITLE
Use {{Specifications}} macro for svg/attribute/[a-f]* [DRAFT]

### DIFF
--- a/files/en-us/web/svg/attribute/accent-height/index.html
+++ b/files/en-us/web/svg/attribute/accent-height/index.html
@@ -37,22 +37,7 @@ browser-compat: svg.elements.font-face.accent-height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-   </thead>
-   <tbody>
-     <tr>
-       <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementAccentHeightAttribute", "accent-height")}}</td>
-       <td>{{Spec2("SVG1.1")}}</td>
-       <td>Initial definition</td>
-     </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/alignment-baseline/index.html
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.html
@@ -127,32 +127,7 @@ text{
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Inline", "#propdef-alignment-baseline", "alignment-baseline")}}</td>
-      <td>{{Spec2("CSS3 Inline")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "text.html#AlignmentBaselineProperty", "alignment-baseline")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Refers to the definition in CSS Inline Layout and notes the changes to <code>auto</code>, <code>before-edge</code>, <code>after-edge</code>, <code>text-before-edge</code>, and <code>text-after-edge</code></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG1.1", "text.html#AlignmentBaselineProperty", "alignment-baseline")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/alphabetic/index.html
+++ b/files/en-us/web/svg/attribute/alphabetic/index.html
@@ -36,22 +36,7 @@ browser-compat: svg.elements.font-face.alphabetic
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementAlphabeticAttribute", "alphabetic")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/arabic-form/index.html
+++ b/files/en-us/web/svg/attribute/arabic-form/index.html
@@ -45,22 +45,7 @@ browser-compat: svg.elements.glyph.arabic-form
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("SVG1.1", "fonts.html#GlyphElementArabicFormAttribute", "arabic-form")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/ascent/index.html
+++ b/files/en-us/web/svg/attribute/ascent/index.html
@@ -39,22 +39,7 @@ browser-compat: svg.elements.font-face.ascent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementAscentAttribute", "ascent")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/azimuth/index.html
+++ b/files/en-us/web/svg/attribute/azimuth/index.html
@@ -60,27 +60,7 @@ browser-compat: svg.elements.feDistantLight.azimuth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Filters 1.0", "#element-attrdef-fedistantlight-azimuth", "azimuth")}}</td>
-      <td>{{Spec2("Filters 1.0")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG1.1", "filters.html#feDistantLightAzimuthAttribute", "azimuth")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/basefrequency/index.html
+++ b/files/en-us/web/svg/attribute/basefrequency/index.html
@@ -82,27 +82,7 @@ browser-compat: svg.elements.feTurbulence.baseFrequency
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-feturbulence-basefrequency", "baseFrequency")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feTurbulenceBaseFrequencyAttribute", "baseFrequency")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/baseline-shift/index.html
+++ b/files/en-us/web/svg/attribute/baseline-shift/index.html
@@ -48,32 +48,7 @@ browser-compat: svg.attributes.presentation.baseline-shift
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Inline", "#propdef-baseline-shift", "alignment-baseline")}}</td>
-   <td>{{Spec2("CSS3 Inline")}}</td>
-   <td>Removed the <code>baseline</code> value, as it is a redundant keyword within the {{SVGAttr("vertical-align")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#BaselineShiftProperty", "alignment-baseline")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Refers to the definition in CSS Inline Layout and notes that {{SVGAttr("vertical-align")}} should be preferred.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#BaselineShiftProperty", "alignment-baseline")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/bbox/index.html
+++ b/files/en-us/web/svg/attribute/bbox/index.html
@@ -39,22 +39,7 @@ browser-compat: svg.elements.font-face.bbox
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementBboxAttribute", "bbox")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/bias/index.html
+++ b/files/en-us/web/svg/attribute/bias/index.html
@@ -35,27 +35,7 @@ browser-compat: svg.elements.feConvolveMatrix.bias
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-feconvolvematrix-bias", "bias")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feConvolveMatrixElementBiasAttribute", "bias")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/by/index.html
+++ b/files/en-us/web/svg/attribute/by/index.html
@@ -55,27 +55,7 @@ browser-compat: svg.elements.animate.by
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#ByAttribute", "by")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#ByAttribute", "by")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/cap-height/index.html
+++ b/files/en-us/web/svg/attribute/cap-height/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.font-face.cap-height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementCapHeightAttribute", "cap-height")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/clip-path/index.html
+++ b/files/en-us/web/svg/attribute/clip-path/index.html
@@ -80,27 +80,7 @@ browser-compat: svg.attributes.presentation.clip-path
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#the-clip-path", 'clip-path')}}</td>
-   <td>{{Spec2('CSS Masks')}}</td>
-   <td>Extends its application to HTML elements. The <code>clip-path</code> property replaces the deprecated {{cssxref("clip")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'masking.html#ClipPathProperty', 'clip-path')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition (applies to SVG elements only).</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/clip/index.html
+++ b/files/en-us/web/svg/attribute/clip/index.html
@@ -61,27 +61,7 @@ browser-compat: svg.attributes.presentation.clip
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Masks', '#clip-property', 'clip')}}</td>
-   <td>{{Spec2('CSS Masks')}}</td>
-   <td>Deprecates <code>clip</code> property, suggests {{cssxref("clip-path")}} as replacement.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "masking.html#ClipProperty", "clip")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
@@ -53,27 +53,7 @@ browser-compat: svg.attributes.presentation.color-interpolation-filters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#ColorInterpolationFiltersProperty", "color-interpolation")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No significant change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#ColorInterpolationFiltersProperty", "color-interpolation-filters")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/color-interpolation/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation/index.html
@@ -53,27 +53,7 @@ browser-compat: svg.attributes.presentation.color-interpolation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'painting.html#ColorInterpolation', 'color-interpolation')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>No significant change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'painting.html#ColorInterpolationProperty', 'color-interpolation')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/color-profile/index.html
+++ b/files/en-us/web/svg/attribute/color-profile/index.html
@@ -48,22 +48,7 @@ browser-compat: svg.attributes.presentation.color-profile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "color.html#ColorProfileProperty", "color-profile")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/color/index.html
+++ b/files/en-us/web/svg/attribute/color/index.html
@@ -53,27 +53,7 @@ browser-compat: svg.attributes.presentation.color
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "painting.html#ColorProperty", "color")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the restriction to which elements it applies.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "color.html#ColorProperty", "color")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/contentscripttype/index.html
+++ b/files/en-us/web/svg/attribute/contentscripttype/index.html
@@ -34,22 +34,7 @@ browser-compat: svg.elements.svg.contentScriptType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "script.html#ContentScriptTypeAttribute", "contentScriptType")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/contentstyletype/index.html
+++ b/files/en-us/web/svg/attribute/contentstyletype/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.svg.contentStyleType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "script.html#ContentScriptTypeAttribute", "contentScriptType")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/crossorigin/index.html
+++ b/files/en-us/web/svg/attribute/crossorigin/index.html
@@ -42,22 +42,7 @@ browser-compat: api.SVGImageElement.crossOrigin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('SVG2', 'embedded.html#ImageElementCrossoriginAttribute', 'crossorigin attribute')}}</td>
-			<td>{{Spec2('SVG2')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/data-_star_/index.html
+++ b/files/en-us/web/svg/attribute/data-_star_/index.html
@@ -24,20 +24,7 @@ browser-compat: svg.attributes.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', "struct.html#DataAttributes", "data-*")}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Custom data attributes are new in SVG 2.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/descent/index.html
+++ b/files/en-us/web/svg/attribute/descent/index.html
@@ -38,22 +38,7 @@ browser-compat: svg.elements.font-face.descent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#FontFaceElementDescentAttribute", "descent")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/diffuseconstant/index.html
+++ b/files/en-us/web/svg/attribute/diffuseconstant/index.html
@@ -62,27 +62,7 @@ browser-compat: svg.elements.feDiffuseLighting.diffuseConstant
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-fediffuselighting-diffuseconstant", "diffuseConstant")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feDiffuseLightingDiffuseConstantAttribute", "diffuseConstant")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/direction/index.html
+++ b/files/en-us/web/svg/attribute/direction/index.html
@@ -55,32 +55,7 @@ browser-compat: svg.attributes.presentation.direction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Writing Modes", "#direction", "direction")}}</td>
-   <td>{{Spec2("CSS3 Writing Modes")}}</td>
-   <td>Definition in CSS</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#DirectionProperty", "direction")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Refers to the CSS Writing Modes specification of the <code>direction</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#DirectionProperty", "direction")}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/display/index.html
+++ b/files/en-us/web/svg/attribute/display/index.html
@@ -73,27 +73,7 @@ browser-compat: svg.attributes.presentation.display
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "render.html#VisibilityControl", "display")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Refers to the CSS 2 specification of the <code>display</code> property, but outlines the differences regarding SVG.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#DisplayProperty", "display")}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/divisor/index.html
+++ b/files/en-us/web/svg/attribute/divisor/index.html
@@ -63,27 +63,7 @@ browser-compat: svg.elements.feConvolveMatrix.divisor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-feconvolvematrix-divisor", "divisor")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feConvolveMatrixElementDivisorAttribute", "divisor")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.html
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.html
@@ -151,32 +151,7 @@ text {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#DominantBaselineProperty", "dominant-baseline")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Refers to the specification in {{Spec2("CSS3 Inline")}} and explicitly mentions the removal of the values <code>use-script</code>, <code>no-change</code>, and <code>reset-size</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Inline", "#propdef-dominant-baseline", "dominant-baseline")}}</td>
-   <td>{{Spec2("CSS3 Inline")}}</td>
-   <td>Removed the values <code>use-script</code>, <code>no-change</code>, and <code>reset-size</code> and introduced the <code>text-top</code> value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#DominantBaselineProperty", "dominant-baseline")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/dur/index.html
+++ b/files/en-us/web/svg/attribute/dur/index.html
@@ -70,27 +70,7 @@ browser-compat: svg.elements.animate.dur
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#DurAttribute", "dur")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#DurAttribute", "dur")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/elevation/index.html
+++ b/files/en-us/web/svg/attribute/elevation/index.html
@@ -60,27 +60,7 @@ browser-compat: svg.elements.feDistantLight.elevation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-fedistantlight-elevation", "elevation")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#feDistantLightElevationAttribute", "elevation")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/enable-background/index.html
+++ b/files/en-us/web/svg/attribute/enable-background/index.html
@@ -54,22 +54,7 @@ browser-compat: svg.attributes.presentation.enable-background
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#EnableBackgroundProperty", "enable-background")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -66,24 +66,4 @@ browser-compat: svg.attributes.presentation.fill-opacity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "painting.html#FillOpacityProperty", "fill-opacity")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition for shapes and texts</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#FillOpacityProperty", "fill-opacity")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for shapes and texts</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -60,10 +60,10 @@ browser-compat: svg.attributes.presentation.fill-opacity
 
 <p class="note"><strong>Note:</strong> SVG2 introduces percentage values for <code>fill-opacity</code>, however, it is not widely supported yet (<em>See <a href="#browser_compatibility">Browser compatibility</a> below</em>) as a consequence, it is best practices to set opacity with a value in the range <code>[0-1]</code>.</p>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat}}</p>
-
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -136,24 +136,4 @@ browser-compat: svg.attributes.presentation.fill-rule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "painting.html#FillRuleProperty", "fill-rule")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition for shapes and text</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#FillRuleProperty", "fill-rule")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for shapes and text</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}

--- a/files/en-us/web/svg/attribute/fill/index.html
+++ b/files/en-us/web/svg/attribute/fill/index.html
@@ -415,38 +415,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#FillAttribute", "transform")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>Definition for animations</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "painting.html#FillProperty", "fill")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition for shapes and texts.<br>
-    Adds <code style="white-space: nowrap;">context-fill</code> and <code style="white-space: nowrap;">context-stroke</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#FillAttribute", "fill")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for animations</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "painting.html#FillProperty", "fill")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for shapes and texts</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/filter/index.html
+++ b/files/en-us/web/svg/attribute/filter/index.html
@@ -56,27 +56,7 @@ browser-compat: svg.attributes.presentation.filter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#FilterProperty", "filter")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Extended the values by several special filter functions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FilterProperty", "filter")}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/filterres/index.html
+++ b/files/en-us/web/svg/attribute/filterres/index.html
@@ -44,22 +44,7 @@ browser-compat: svg.elements.filter.filterRes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FilterElementFilterResAttribute", "filterRes")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/filterunits/index.html
+++ b/files/en-us/web/svg/attribute/filterunits/index.html
@@ -42,27 +42,7 @@ browser-compat: svg.elements.filter.filterUnits
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#element-attrdef-filter-filterunits", "filterUnits")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Initial definition</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FilterElementFilterUnitsAttribute", "filterUnits")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/flood-color/index.html
+++ b/files/en-us/web/svg/attribute/flood-color/index.html
@@ -58,27 +58,7 @@ browser-compat: svg.attributes.presentation.flood-color
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#FloodColorProperty", "flood-color")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Removed the &lt;icccolor&gt; value and aligned the value to the CSS {{cssxref("color")}} value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FloodColorProperty", "flood-color")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/flood-opacity/index.html
+++ b/files/en-us/web/svg/attribute/flood-opacity/index.html
@@ -64,27 +64,7 @@ browser-compat: svg.attributes.presentation.flood-opacity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#FloodOpacityProperty", "flood-opacity")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Aligned the value to the CSS <code>&lt;alpha-value&gt;</code> value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#FloodOpacityProperty", "flood-opacity")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-family/index.html
+++ b/files/en-us/web/svg/attribute/font-family/index.html
@@ -52,32 +52,7 @@ browser-compat: svg.attributes.presentation.font-family
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Fonts", "#generic-font-families", "generic font families")}}</td>
-   <td>{{Spec2("CSS4 Fonts")}}</td>
-   <td>Adds new generic font families, specifically: <code>system-ui</code>, <code>emoji</code>, <code>math</code>, and <code>fangsong</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-family-prop", "font-family")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>No significant change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontFamilyProperty", "font-family")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -69,27 +69,7 @@ browser-compat: svg.attributes.presentation.font-size-adjust
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-size-adjust-prop", "font-size-adjust")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontSizeAdjustProperty", "font-size-adjust")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-size/index.html
+++ b/files/en-us/web/svg/attribute/font-size/index.html
@@ -52,27 +52,7 @@ browser-compat: svg.attributes.presentation.font-size
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-size-prop", "font-size")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontSizeProperty", "font-size")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-stretch/index.html
+++ b/files/en-us/web/svg/attribute/font-stretch/index.html
@@ -36,32 +36,7 @@ browser-compat: svg.attributes.presentation.font-stretch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Fonts", "#propdef-font-stretch", "font-stretch")}}</td>
-   <td>{{Spec2("CSS4 Fonts")}}</td>
-   <td>Adds the <code>&lt;percentage&gt;</code> syntax for variable fonts.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#propdef-font-stretch", "font-stretch")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>Initial definition of <code>font-stretch</code> in CSS Fonts</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontStretchProperty", "font-stretch")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-style/index.html
+++ b/files/en-us/web/svg/attribute/font-style/index.html
@@ -59,32 +59,7 @@ browser-compat: svg.attributes.presentation.font-style
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Fonts", "#font-style-prop", "font-style")}}</td>
-   <td>{{Spec2("CSS4 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-style-prop", "font-style")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontStyleProperty", "font-style")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-variant/index.html
+++ b/files/en-us/web/svg/attribute/font-variant/index.html
@@ -54,32 +54,7 @@ browser-compat: svg.attributes.presentation.font-variant
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Fonts", "#font-variant-prop", "font-variant")}}</td>
-   <td>{{Spec2("CSS4 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-variant-prop", "font-variant")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>Added many more keywords for different types of variations.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontVariantProperty", "font-variant")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/font-weight/index.html
+++ b/files/en-us/web/svg/attribute/font-weight/index.html
@@ -52,32 +52,7 @@ browser-compat: svg.attributes.presentation.font-weight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Fonts", "#font-weight-prop", "font-weight")}}</td>
-   <td>{{Spec2("CSS4 Fonts")}}</td>
-   <td>Defines <code>font-weight</code> to accept any numbers between 1 and 1000.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts", "#font-weight-prop", "font-weight")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#FontWeightProperty", "font-weight")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/format/index.html
+++ b/files/en-us/web/svg/attribute/format/index.html
@@ -84,27 +84,7 @@ browser-compat: svg.elements.altGlyph.format
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#GlyphRefElementFormatAttribute", "format for &lt;glyphRef&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for <code>&lt;glyphRef&gt;</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#AltGlyphElementFormatAttribute", "format for &lt;altGlyph&gt;")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition for <code>&lt;altGlyph&gt;</code></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/fr/index.html
+++ b/files/en-us/web/svg/attribute/fr/index.html
@@ -84,22 +84,7 @@ browser-compat: svg.elements.radialGradient.fr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#RadialGradientElementFRAttribute", "fr")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/from/index.html
+++ b/files/en-us/web/svg/attribute/from/index.html
@@ -53,27 +53,7 @@ browser-compat: svg.elements.animate.from
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#FromAttribute", "from")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#FromAttribute", "from")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/fx/index.html
+++ b/files/en-us/web/svg/attribute/fx/index.html
@@ -84,27 +84,7 @@ browser-compat: svg.elements.radialGradient.fx
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#RadialGradientElementFXAttribute", "fx")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#RadialGradientElementFXAttribute", "fx")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/fy/index.html
+++ b/files/en-us/web/svg/attribute/fy/index.html
@@ -84,27 +84,7 @@ browser-compat: svg.elements.radialGradient.fy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#RadialGradientElementFYAttribute", "fy")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#RadialGradientElementFYAttribute", "fy")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/svg/attribute/g1/index.html
+++ b/files/en-us/web/svg/attribute/g1/index.html
@@ -43,22 +43,7 @@ browser-compat: svg.elements.hkern.g1
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#HKernElementG1Attribute", "g1")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
*DRAFT, DO NOT REVIEW (YET)*
**THIS IS TEMPORARY STALLED: spec_url in mdn/browser-compat-data are not (yet) good enough**

This is part of #1146.

This converts SVG attributes starting with a to f to the {{Specifications}} macros. This includes only attributes with BCD (we are missing some!) and with a spec table (we have some!)

Note that the order of the spec / browser-compat section was wrong for attribute/fill-rule, so I fixed it.