### PR TITLE
Fix wrong variable naming in performance/memory docs

### DIFF
--- a/files/en-us/web/api/performance/memory/index.html
+++ b/files/en-us/web/api/performance/memory/index.html
@@ -8,7 +8,7 @@ browser-compat: api.Performance.memory
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-    class="brush: js"><em>timingInfo</em> = <em>performance</em>.memory</pre>
+    class="brush: js"><em>memoryInfo</em> = <em>performance</em>.memory</pre>
 
 <h2 id="Attributes">Attributes</h2>
 


### PR DESCRIPTION
…alue return

> What was wrong/why is this fix needed?
This might be a copy+paste problem. The variable was related to "timing" but the right value has attributes from memory.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory

