### PR TITLE
Fix missing-word typo in Function.prototype.bind() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
@@ -132,7 +132,7 @@ boundGetX();
 
 <p>These arguments (if any) follow the provided <code>this</code> value and are then
   inserted at the start of the arguments passed to the target function, followed by
-  whatever arguments are passed bound function at the time it is called.</p>
+  whatever arguments are passed to the bound function at the time it is called.</p>
 
 <pre class="brush: js">function list() {
   return Array.prototype.slice.call(arguments);


### PR DESCRIPTION
Add "to the" to clarify the meaning of this sentence.

Whilst the full meaning of the sentence can be ascertained through context, I feel it is important to have complete grammatical correctness to make the content easier to understand.

MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind