### PR TITLE
Remove stray backtick in viewBox documentation

### DIFF
--- a/files/en-us/web/svg/attribute/viewbox/index.html
+++ b/files/en-us/web/svg/attribute/viewbox/index.html
@@ -35,7 +35,7 @@ svg:not(:root) { display: inline-block; }</pre>
 &lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--
   with relative unit such as percentage, the visual size
-  of the square looks unchanged regardless of the viewBox`
+  of the square looks unchanged regardless of the viewBox
   --&gt;
   &lt;rect x="0" y="0" width="100%" height="100%"/&gt;
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Just a stray punctuation.

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
