### PR TITLE
Adding new FontFace descriptors

### DIFF
--- a/files/en-us/web/api/fontface/ascentoverride/index.html
+++ b/files/en-us/web/api/fontface/ascentoverride/index.html
@@ -11,12 +11,12 @@ browser-compat: api.FontFace.ascentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref(""font-face/ascent-override)}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">let ascentOverride = FontFace.ascentOverride;
-FontFace.ascentOverride = a;
+FontFace.ascentOverride = '90%';
 </pre>
 
 <h3>Value</h3>
@@ -24,6 +24,10 @@ FontFace.ascentOverride = a;
 
 <h2 id="Examples">Examples</h2>
 
+<pre class="brush: css">let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'ascentOverride':'90%'});
+console.log(fontFace.ascentOverride); // 90%
+fontFace.ascentOverride = 'normal';
+console.log(fontFace.ascentOverride); // 'normal'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -32,5 +36,3 @@ FontFace.ascentOverride = a;
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/fontface/ascentoverride/index.html
+++ b/files/en-us/web/api/fontface/ascentoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.ascentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fontface/ascentoverride/index.html
+++ b/files/en-us/web/api/fontface/ascentoverride/index.html
@@ -1,0 +1,36 @@
+---
+title: FontFace.ascentOverride
+slug: Web/API/FontFace/ascentOverride
+tags:
+  - API
+  - Property
+  - Reference
+  - ascentOverride
+  - FontFace
+browser-compat: api.FontFace.ascentOverride
+---
+<div>{{APIRef("CSS Font Loading API")}}</div>
+
+<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref(""font-face/ascent-override)}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let ascentOverride = FontFace.ascentOverride;
+FontFace.ascentOverride = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString","string")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/fontface/descentoverride/index.html
+++ b/files/en-us/web/api/fontface/descentoverride/index.html
@@ -1,0 +1,53 @@
+---
+title: FontFace.descentOverride
+slug: Web/API/FontFace/descentOverride
+tags:
+  - API
+  - Property
+  - Reference
+  - descentOverride
+  - FontFace
+browser-compat: api.FontFace.descentOverride
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let adescentOverride = FontFace.descentOverride;
+// Remove this one if the property is read only.
+FontFace.descentOverride = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/fontface/descentoverride/index.html
+++ b/files/en-us/web/api/fontface/descentoverride/index.html
@@ -9,7 +9,7 @@ tags:
   - FontFace
 browser-compat: api.FontFace.descentOverride
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
 

--- a/files/en-us/web/api/fontface/descentoverride/index.html
+++ b/files/en-us/web/api/fontface/descentoverride/index.html
@@ -11,34 +11,23 @@ browser-compat: api.FontFace.descentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
+<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let adescentOverride = FontFace.descentOverride;
-// Remove this one if the property is read only.
-FontFace.descentOverride = a;
+<pre class="brush: js">let descentOverride = FontFace.descentOverride;
+FontFace.descentOverride = '90%';
 </pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("CSSOMString","string")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
-
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
-
-<pre class="brush: js">
-my code block</pre>
-
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
-
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+<pre class="brush: css">let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'descentOverride':'90%'});
+  console.log(fontFace.descentOverride); // 90%
+  fontFace.descentOverride = 'normal';
+  console.log(fontFace.descentOverride); // 'normal'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,8 +35,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/fontface/descentoverride/index.html
+++ b/files/en-us/web/api/fontface/descentoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.descentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fontface/display/index.html
+++ b/files/en-us/web/api/fontface/display/index.html
@@ -12,7 +12,7 @@ tags:
 - display
 browser-compat: api.FontFace.display
 ---
-<p>{{SeeCompatTable}}{{APIRef("CSS Font Loading API")}}</p>
+<p>{{APIRef("CSS Font Loading API")}}</p>
 
 <p>The <strong><code>display</code></strong> property of the {{domxref("FontFace")}}
   interface determines how a font face is displayed based on whether and when it is
@@ -37,8 +37,8 @@ browser-compat: api.FontFace.display
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>display</em> = FontFace.display
-FontFace.display = <em>display</em></pre>
+<pre class="brush: js">let display = FontFace.display
+FontFace.display = display</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -61,26 +61,7 @@ FontFace.display = <em>display</em></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-family','display')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS4 Fonts','#descdef-font-face-font-display','font-display')}}</td>
-      <td>{{Spec2('CSS4 Fonts')}}</td>
-      <td>Defines the values for the <code>display</code> property. (They are the same as
-        for <code>font-display</code>.)</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/family/index.html
+++ b/files/en-us/web/api/fontface/family/index.html
@@ -12,7 +12,7 @@ tags:
 - family
 browser-compat: api.FontFace.family
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p><span class="seoSummary">The <code><strong>FontFace.family</strong></code> property
     allows the author to get or set the font family of a {{domxref("FontFace")}} object.
@@ -21,8 +21,8 @@ browser-compat: api.FontFace.family
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>instanceOfFontFace</em>.family = 'font family name';
-var fontFace = <em>instanceOfFontFace</em>.family; // "font family name"</pre>
+<pre class="brush: js">instanceOfFontFace.family = 'font family name';
+let fontFace = instanceOfFontFace.family; // "font family name"</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,7 +30,7 @@ var fontFace = <em>instanceOfFontFace</em>.family; // "font family name"</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">var fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)');
+<pre class="brush: js">let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)');
 console.log(fontFace.family); // 'Roboto'
 
 fontFace.family = 'newRoboto';
@@ -39,20 +39,7 @@ console.log(fontFace.family); // 'newRoboto'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-family','family')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/featuresettings/index.html
+++ b/files/en-us/web/api/fontface/featuresettings/index.html
@@ -12,7 +12,7 @@ tags:
 - featureSettings
 browser-compat: api.FontFace.featureSettings
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>featureSettings</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets infrequently used font features that
@@ -21,8 +21,8 @@ browser-compat: api.FontFace.featureSettings
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var featureSettingDescriptor = FontFace.featureSettings;
-FontFace.featureSettings = <em>featureSettingDescriptor</em>;</pre>
+<pre class="brush: js">let featureSettingDescriptor = FontFace.featureSettings;
+FontFace.featureSettings = featureSettingDescriptor;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ FontFace.featureSettings = <em>featureSettingDescriptor</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-featuresettings','featureSettings')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/fontface/index.html
+++ b/files/en-us/web/api/fontface/fontface/index.html
@@ -54,6 +54,8 @@ new FontFace(family, source, descriptors);</pre>
       <dd>With an allowable value for {{cssxref("@font-face/unicode-range")}}.</dd>
       <dt><code>variant</code></dt>
       <dd>With an allowable value for {{cssxref("@font-face/font-variant")}}.</dd>
+      <dt><code>variationSettings</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-variation-settings")}}.</dd>
       <dt><code>weight</code></dt>
       <dd>With an allowable value for {{cssxref("@font-face/font-weight")}}.</dd>
     </ul>

--- a/files/en-us/web/api/fontface/fontface/index.html
+++ b/files/en-us/web/api/fontface/fontface/index.html
@@ -11,15 +11,15 @@ tags:
 - Reference
 browser-compat: api.FontFace.FontFace
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p>The <code><strong>FontFace()</strong></code> constructor creates a new
   {{domxref("FontFace")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var fontFace = new FontFace(family, source, descriptors);</pre>
+<pre class="brush: js">new FontFace(family, source);
+new FontFace(family, source, descriptors);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -36,15 +36,26 @@ browser-compat: api.FontFace.FontFace
     </ul>
   </dd>
   <dt>descriptors {{optional_inline}}</dt>
-  <dd>A set of optional descriptors passed as an object. It can have the following keys:
-    <ul>
-      <li><code>family</code>: Family</li>
-      <li><code>style</code>: Style</li>
-      <li><code>weight</code>: Weight</li>
-      <li><code>stretch</code>: Stretch</li>
-      <li><code>unicodeRange</code>: Unicode range</li>
-      <li><code>variant</code>: variant</li>
-      <li><code>featureSettings</code>: Feature settings</li>
+  <dd>A set of optional descriptors passed as an object. It can contain any of the descriptors available for <code>@font-face</code>:
+    <dl>
+      <dt><code>ascentOverride</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/ascent-override")}}.</dd>
+      <dt><code>descentOverride</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/descent-override")}}.</dd>
+      <dt><code>featureSettings</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-feature-settings")}}.</dd>
+      <dt><code>lineGapOverride</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/line-gap-override")}}.</dd>
+      <dt><code>stretch</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-stretch")}}.</dd>
+      <dt><code>style</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-style")}}.</dd>
+      <dt><code>unicodeRange</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/unicode-range")}}.</dd>
+      <dt><code>variant</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-variant")}}.</dd>
+      <dt><code>weight</code></dt>
+      <dd>With an allowable value for {{cssxref("@font-face/font-weight")}}.</dd>
     </ul>
   </dd>
 </dl>
@@ -64,20 +75,7 @@ browser-compat: api.FontFace.FontFace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#font-face-constructor','FontFace Constructor')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/index.html
+++ b/files/en-us/web/api/fontface/index.html
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.FontFace
 ---
-<p>{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("CSS Font Loading API")}}</p>
 
 <p>The <code><strong>FontFace</strong></code> interface represents a single usable font face. It allows control of the source of the font face, being a URL to an external resource, or a buffer; it also allows control of when the font face is loaded and its current status.</p>
 
@@ -19,22 +19,26 @@ browser-compat: api.FontFace
 
 <dl>
  <dt>{{domxref("FontFace.FontFace", "FontFace()")}}</dt>
- <dd>Constructs and returns a new <code>FontFace</code> object, built from an external resource described by an URL or from an {{domxref("ArrayBuffer")}}.</dd>
+ <dd>Constructs and returns a new <code>FontFace</code> object, built from an external resource described by an URL or from an {{jsxref("ArrayBuffer")}}.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>
 
-<p><em>This interface doesn't inherit any property.</em></p>
-
 <dl>
+ <dt>{{domxref("FontFace.ascentOverride")}}</dt>
+ <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>ascent metric</em> of the font. It is equivalent to the {{cssxref("@font-face/ascent-override", "ascent-override")}} descriptor.</dd>
+ <dt>{{domxref("FontFace.descentOverride")}}</dt>
+ <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>descent metric</em> of the font. It is equivalent to the {{cssxref("@font-face/descent-override", "descent-override")}} descriptor.</dd>
  <dt>{{domxref("FontFace.display")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that determines how a font face is displayed based on whether and when it is downloaded and ready to use.</dd>
  <dt>{{domxref("FontFace.family")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>family</em> of the font. It is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor.</dd>
  <dt>{{domxref("FontFace.featureSettings")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that retrieves or sets infrequently used font features that are not available from a font's variant properties. It is equivalent to the {{cssxref("@font-face/font-feature-settings", "font-feature-settings")}} descriptor.</dd>
+ <dt>{{domxref("FontFace.lineGapOverride")}}</dt>
+ <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>line-gap metric</em> of the font. It is equivalent to the {{cssxref("@font-face/line-gap-override", "line-gap-override")}} descriptor.</dd>
  <dt>{{domxref("FontFace.loaded")}} {{readonlyinline}}</dt>
- <dd>Returns a {{domxref("Promise")}} that resolves with the current <code>FontFace</code> object when the font specified in the object's constructor is done loading or rejects with a <code>SyntaxError</code>.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that resolves with the current <code>FontFace</code> object when the font specified in the object's constructor is done loading or rejects with a <code>SyntaxError</code>.</dd>
  <dt>{{domxref("FontFace.status")}} {{readonlyinline}}</dt>
  <dd>Returns an enumerated value indicating the status of the font, one of  <code>"unloaded"</code>, <code>"loading"</code>, <code>"loaded"</code>, or <code>"error"</code>.</dd>
  <dt>{{domxref("FontFace.stretch")}}</dt>
@@ -48,10 +52,6 @@ browser-compat: api.FontFace
  <dt>{{domxref("FontFace.weight")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that contains the <em>weight</em> of the font. It is equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.</dd>
 </dl>
-
-<h2 id="Methods">Methods</h2>
-
-<p><em>This interface doesn't inherit any method.</em></p>
 
 <dl>
  <dt>{{domxref("FontFace.load()")}}</dt>
@@ -82,5 +82,5 @@ browser-compat: api.FontFace
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/CSS/@font-face/font-family">@font-face</a></li>
+ <li><a href="/en-US/docs/Web/CSS/@font-face">@font-face</a></li>
 </ul>

--- a/files/en-us/web/api/fontface/index.html
+++ b/files/en-us/web/api/fontface/index.html
@@ -49,6 +49,8 @@ browser-compat: api.FontFace
  <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>range of unicode codepoints</em> encompassing the font. It is equivalent to the {{cssxref("@font-face/unicode-range", "unicode-range")}} descriptor.</dd>
  <dt>{{domxref("FontFace.variant")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>variant</em> of the font. It is equivalent to the {{cssxref("@font-face/font-variant", "font-variant")}} descriptor.</dd>
+ <dt>{{domxref("FontFace.variationSettings")}}</dt>
+ <dd>A {{domxref("CSSOMString")}} that retrieves or sets the <em>variation settings</em> of the font. It is equivalent to the {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.</dd>
  <dt>{{domxref("FontFace.weight")}}</dt>
  <dd>A {{domxref("CSSOMString")}} that contains the <em>weight</em> of the font. It is equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.</dd>
 </dl>

--- a/files/en-us/web/api/fontface/linegapoverride/index.html
+++ b/files/en-us/web/api/fontface/linegapoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.lineGapOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>lineGapOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p class="summary">The <strong><code>lineGapOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -36,5 +36,4 @@ console.log(fontFace.lineGapOverride); // 'normal'</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/fontface/linegapoverride/index.html
+++ b/files/en-us/web/api/fontface/linegapoverride/index.html
@@ -11,42 +11,29 @@ browser-compat: api.FontFace.lineGapOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>lineGapOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
+<p class="summary">The <strong><code>lineGapOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are <code>normal</code> indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let alineGapOverride = FontFace.lineGapOverride;
-// Remove this one if the property is read only.
-FontFace.lineGapOverride = a;
+<pre class="brush: js">let lineGapOverride = FontFace.lineGapOverride;
+FontFace.lineGapOverride = '90%';
 </pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("CSSOMString","string")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
-
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
-
-<pre class="brush: js">
-my code block</pre>
-
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
-
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+<pre class="brush: css">let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'lineGapOverride':'90%'});
+console.log(fontFace.lineGapOverride); // 90%
+fontFace.lineGapOverride = 'normal';
+console.log(fontFace.lineGapOverride); // 'normal'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/fontface/linegapoverride/index.html
+++ b/files/en-us/web/api/fontface/linegapoverride/index.html
@@ -1,0 +1,53 @@
+---
+title: FontFace.lineGapOverride
+slug: Web/API/FontFace/lineGapOverride
+tags:
+  - API
+  - Property
+  - Reference
+  - lineGapOverride
+  - FontFace
+browser-compat: api.FontFace.lineGapOverride
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>lineGapOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let alineGapOverride = FontFace.lineGapOverride;
+// Remove this one if the property is read only.
+FontFace.lineGapOverride = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/fontface/linegapoverride/index.html
+++ b/files/en-us/web/api/fontface/linegapoverride/index.html
@@ -9,7 +9,7 @@ tags:
   - FontFace
 browser-compat: api.FontFace.lineGapOverride
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>lineGapOverride</code></strong>  property of the {{domxref("FontFace")}} interface  </p>
 

--- a/files/en-us/web/api/fontface/load/index.html
+++ b/files/en-us/web/api/fontface/load/index.html
@@ -12,7 +12,7 @@ tags:
   - load
 browser-compat: api.FontFace.load
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>load()</code></strong> method of the
   {{domxref("FontFace")}} interface loads a font based on current object's
@@ -21,7 +21,7 @@ browser-compat: api.FontFace.load
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var promise = FontFace.load();</pre>
+<pre class="brush: js">let promise = FontFace.load();</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -43,20 +43,7 @@ browser-compat: api.FontFace.load
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#font-face-load','load')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/loaded/index.html
+++ b/files/en-us/web/api/fontface/loaded/index.html
@@ -12,7 +12,7 @@ tags:
 - loaded
 browser-compat: api.FontFace.loaded
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>loaded</code></strong> read-only property of the
   {{domxref("FontFace")}} interface returns a {{jsxref('Promise')}} that resolves with the
@@ -21,7 +21,7 @@ browser-compat: api.FontFace.loaded
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var aPromise = FontFace.loaded;</pre>
+<pre class="brush: js">let promise = FontFace.loaded;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ browser-compat: api.FontFace.loaded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-loaded','loaded')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/status/index.html
+++ b/files/en-us/web/api/fontface/status/index.html
@@ -12,7 +12,7 @@ tags:
 - status
 browser-compat: api.FontFace.status
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>status</code></strong> read-only property of the
   {{domxref("FontFace")}} interface returns an enumerated value indicating the status of
@@ -21,7 +21,7 @@ browser-compat: api.FontFace.status
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var status = FontFace.status;</pre>
+<pre class="brush: js">let status = FontFace.status;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ browser-compat: api.FontFace.status
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-status','status')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/stretch/index.html
+++ b/files/en-us/web/api/fontface/stretch/index.html
@@ -12,7 +12,7 @@ tags:
 - stretch
 browser-compat: api.FontFace.stretch
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>stretch</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets how the font stretches. It is
@@ -20,8 +20,8 @@ browser-compat: api.FontFace.stretch
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var stretchDescriptor = FontFace.stretch;
-FontFace.stretch = <em>stretchDescriptor</em>;</pre>
+<pre class="brush: js">let stretchDescriptor = FontFace.stretch;
+FontFace.stretch = stretchDescriptor;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ FontFace.stretch = <em>stretchDescriptor</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-stretch','stretch')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/style/index.html
+++ b/files/en-us/web/api/fontface/style/index.html
@@ -12,7 +12,7 @@ tags:
 - Style
 browser-compat: api.FontFace.style
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>style</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the font's style. It is equivalent
@@ -20,8 +20,8 @@ browser-compat: api.FontFace.style
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var style = FontFace.style;
-FontFace.style = <em>value</em>;</pre>
+<pre class="brush: js">let style = FontFace.style;
+FontFace.style = value;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ FontFace.style = <em>value</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-style','style')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/unicoderange/index.html
+++ b/files/en-us/web/api/fontface/unicoderange/index.html
@@ -12,7 +12,7 @@ tags:
 - unicodeRange
 browser-compat: api.FontFace.unicodeRange
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>unicodeRange</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the range of unicode codepoints
@@ -21,8 +21,8 @@ browser-compat: api.FontFace.unicodeRange
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var unicodeRangeDescriptor = FontFace.unicodeRange;
-FontFace.unicodeRange = <em>unicodeRangeDescriptor</em>;</pre>
+<pre class="brush: js">let unicodeRangeDescriptor = FontFace.unicodeRange;
+FontFace.unicodeRange = unicodeRangeDescriptor;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -31,21 +31,7 @@ FontFace.unicodeRange = <em>unicodeRangeDescriptor</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-unicoderange','unicodeRange')}}
-      </td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/variant/index.html
+++ b/files/en-us/web/api/fontface/variant/index.html
@@ -12,7 +12,7 @@ tags:
 - variant
 browser-compat: api.FontFace.variant
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>variant</code></strong> property of the
   {{domxref("FontFace")}} interface programmatically retrieves or sets font variant
@@ -31,20 +31,7 @@ FontFace.variant = <em>variantSubProperty</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-variant','variant')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/variationsettings/index.html
+++ b/files/en-us/web/api/fontface/variationsettings/index.html
@@ -1,0 +1,37 @@
+---
+title: FontFace.variationSettings
+slug: Web/API/FontFace/variationSettings
+tags:
+- API
+- CSS Font Loading API
+- CSSOM
+- FontFace
+- Fonts
+- Property
+- Reference
+- variationSettings
+browser-compat: api.FontFace.variationSettings
+---
+<div>{{APIRef("CSS Font Loading API")}}</div>
+
+<p class="summary">The <strong><code>variationSettings</code></strong> property of the
+  {{domxref("FontFace")}} interface retrieves or sets low-level OpenType or TrueType font variations.
+  It is equivalent to the
+  {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let variationSettingDescriptor = FontFace.variationSettings;
+FontFace.variationSettings = variationSettingDescriptor;</pre>
+
+<h3 id="Value">Value</h3>
+
+<p>A {{domxref('CSSOMString')}} containing a descriptor.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/weight/index.html
+++ b/files/en-us/web/api/fontface/weight/index.html
@@ -12,7 +12,7 @@ tags:
 - weight
 browser-compat: api.FontFace.weight
 ---
-<div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("CSS Font Loading API")}}</div>
 
 <p class="summary">The <strong><code>weight</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the weight of the font. It is
@@ -20,8 +20,8 @@ browser-compat: api.FontFace.weight
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var weightDescriptor = FontFace.weight;
-FontFace.weight = <em>weightDescriptor</em>;</pre>
+<pre class="brush: js">let weightDescriptor = FontFace.weight;
+FontFace.weight = weightDescriptor;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -30,20 +30,7 @@ FontFace.weight = <em>weightDescriptor</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-weight','weight')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
I'm trying to make sure we keep the JS APIs for new CSS properties etc. in sync as they tend to get forgotten when I add new stuff in the CSS ref. So this one adds the new FontFace descriptors.

While in there I tidied up the existing pages a bit, added the new spec tables etc. 
