### PR TITLE
Drop link to obsolete “Debugging JavaScript” doc

### DIFF
--- a/files/en-us/web/javascript/reference/statements/debugger/index.html
+++ b/files/en-us/web/javascript/reference/statements/debugger/index.html
@@ -48,8 +48,6 @@ browser-compat: javascript.statements.debugger
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Mozilla/Debugging/Debugging_JavaScript">Debugging
-      JavaScript</a></li>
   <li><a href="/en-US/docs/Tools/Debugger">The Debugger in the Firefox Developer Tools</a>
   </li>
 </ul>


### PR DESCRIPTION
The “Debugging·JavaScript” article it obsolete (archived) and won’t even render due to having unsafe inline script that the current developer.mozilla.org CSP policy disallows.

Fixes https://github.com/mdn/content/issues/5882