### PR TITLE
Replace spec table with {{specifications}} for api/b*

### DIFF
--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
@@ -32,20 +32,7 @@ browser-compat: api.BackgroundFetchEvent.BackgroundFetchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#background-fetch-event','BackgroundFetchEvent')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/index.html
@@ -54,20 +54,7 @@ browser-compat: api.BackgroundFetchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#background-fetch-event','BackgroundFetchEvent')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.html
@@ -30,20 +30,7 @@ browser-compat: api.BackgroundFetchEvent.registration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#dom-backgroundfetcheventinit-registration','BackgroundFetchEvent.registration')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -91,20 +91,7 @@ method.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Fetch','#background-fetch-manager-fetch','fetch')}}</td>
-   <td>{{Spec2('Background Fetch')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.html
@@ -42,20 +42,7 @@ my code block</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Fetch','#background-fetch-manager-get','get')}}</td>
-   <td>{{Spec2('Background Fetch')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.html
@@ -42,20 +42,7 @@ browser-compat: api.BackgroundFetchManager.getIds
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Fetch','#background-fetch-manager-get-ids','getIds')}}</td>
-   <td>{{Spec2('Background Fetch')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/index.html
@@ -48,20 +48,7 @@ browser-compat: api.BackgroundFetchManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Fetch','#background-fetch-manager','BackgroundFetchManager')}}</td>
-   <td>{{Spec2('Background Fetch')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchrecord/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/index.html
@@ -42,20 +42,7 @@ browser-compat: api.BackgroundFetchRecord
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('Background Fetch','#background-fetch-record-interface','BackgroundFetchRecord')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.html
@@ -36,20 +36,7 @@ browser-compat: api.BackgroundFetchRecord.request
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('Background Fetch','#dom-backgroundfetchrecord-request','BackgroundFetchRecord.request')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
@@ -36,20 +36,7 @@ browser-compat: api.BackgroundFetchRecord.responseReady
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('Background Fetch','#dom-backgroundfetchrecord-responseready','BackgroundFetchRecord.responseReady')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.html
@@ -33,20 +33,7 @@ browser-compat: api.BackgroundFetchRegistration.abort
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-abort','BackgroundFetchRegistration.abort')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
@@ -28,20 +28,7 @@ browser-compat: api.BackgroundFetchRegistration.downloaded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-downloaded','BackgroundFetchRegistration.downloaded')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
@@ -24,20 +24,7 @@ browser-compat: api.BackgroundFetchRegistration.downloadTotal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-downloadtotal','BackgroundFetchRegistration.downloadTotal')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
@@ -42,20 +42,7 @@ browser-compat: api.BackgroundFetchRegistration.failureReason
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-failurereason','BackgroundFetchRegistration.failureReason')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.html
@@ -28,20 +28,7 @@ browser-compat: api.BackgroundFetchRegistration.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-id','BackgroundFetchRegistration.id')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/index.html
@@ -113,20 +113,7 @@ browser-compat: api.BackgroundFetchRegistration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#background-fetch-registration','BackgroundFetchRegistration')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.html
@@ -80,20 +80,7 @@ browser-compat: api.BackgroundFetchRegistration.match
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-match','BackgroundFetchRegistration.match')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
@@ -66,20 +66,7 @@ console.log(records); // an array of BackgroundFetchRecord objects
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-matchall','BackgroundFetchRegistration.matchAll')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
@@ -41,20 +41,7 @@ BackgroundRegistration.addEventListener('progress', function);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-onprogress','BackgroundFetchRegistration.onprogress')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.html
@@ -37,20 +37,7 @@ browser-compat: api.BackgroundFetchRegistration.result
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-result','BackgroundFetchRegistration.result')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
@@ -28,20 +28,7 @@ browser-compat: api.BackgroundFetchRegistration.uploaded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-uploaded','BackgroundFetchRegistration.uploaded')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
@@ -28,20 +28,7 @@ browser-compat: api.BackgroundFetchRegistration.uploadTotal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-uploadtotal','BackgroundFetchRegistration.uploadTotal')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -47,20 +47,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#backgroundfetchupdateuievent','BackgroundFetchUpdateUIEvent')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.html
@@ -58,20 +58,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#background-fetch-update-ui-event','BackgroundFetchUpdateUIEvent')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
@@ -75,20 +75,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent.updateUI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Background Fetch','#dom-backgroundfetchupdateuievent-updateui','updateUI()')}}</td>
-    <td>{{Spec2('Background Fetch')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/barcodedetector/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/barcodedetector/index.html
@@ -53,21 +53,7 @@ if (barcodeDetector) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-barcodedetector','BarcodeDetector.BarcodeDetector()')}}
-      </td>
-      <td>{{Spec2('Shape Detection API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/barcodedetector/detect/index.html
+++ b/files/en-us/web/api/barcodedetector/detect/index.html
@@ -71,20 +71,7 @@ browser-compat: api.BarcodeDetector.detect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-detect','BarcodeDetector.detect()')}}</td>
-      <td>{{Spec2('Shape Detection API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
@@ -47,21 +47,7 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-getsupportedformats','BarcodeDetector.getSupportedFormats()')}}
-      </td>
-      <td>{{Spec2('Shape Detection API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -77,20 +77,7 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Shape Detection API','#barcodedetector','BarcodeDetector')}}</td>
-   <td>{{Spec2('Shape Detection API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
+++ b/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
@@ -37,21 +37,7 @@ browser-compat: api.BaseAudioContext.audioWorklet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-audioworklet',
-        'audioWorklet')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -93,21 +93,7 @@ function draw() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createanalyser',
-        'createAnalyser()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
@@ -61,21 +61,7 @@ biquadFilter.gain.setValueAtTime(25, audioCtx.currentTime);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createbiquadfilter',
-        'createBiquadFilter()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -146,21 +146,7 @@ source.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createbuffer',
-        'createBuffer()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -88,21 +88,7 @@ button.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createbuffersource',
-        'createBufferSource()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -71,21 +71,7 @@ ac.decodeAudioData(someStereoBuffer, function(data) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createchannelmerger',
-        'createChannelMerger()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -72,21 +72,7 @@ ac.decodeAudioData(someStereoBuffer, function(data) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createchannelsplitter',
-        'createChannelSplitter()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -35,20 +35,7 @@ browser-compat: api.BaseAudioContext.createConstantSource
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-baseaudiocontext-createconstantsource','createConstantSource()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
@@ -72,21 +72,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createconvolver',
-        'createConvolver()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -82,21 +82,7 @@ rangeSynth.oninput = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createdelay',
-        'createDelay()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -79,21 +79,7 @@ button.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createdynamicscompressor',
-        'createDynamicsCompressor()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.html
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.html
@@ -97,21 +97,7 @@ function voiceMute() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-creategain',
-        'createGain()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
@@ -56,21 +56,7 @@ browser-compat: api.BaseAudioContext.createIIRFilter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createiirfilter',
-        'createIIRFilter()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
@@ -48,21 +48,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createoscillator',
-        'createOscillator')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -149,21 +149,7 @@ function positionPanner() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createpanner',
-        'createPanner()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.html
@@ -157,21 +157,7 @@ osc.stop(2);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createperiodicwave',
-				'createPeriodicWave')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
@@ -156,21 +156,7 @@ source.onended = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createscriptprocessor',
-        'createScriptProcessor')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
@@ -77,21 +77,7 @@ panNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createstereopanner',
-        'createStereoPanner()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
@@ -70,21 +70,7 @@ distortion.oversample = '4x';</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-createwaveshaper',
-        'createWaveShaper()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.html
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.html
@@ -62,21 +62,7 @@ audioCtx.currentTime;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-currenttime',
-        'currentTime')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.html
+++ b/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.html
@@ -152,23 +152,7 @@ pre.innerHTML = myScript.innerHTML;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-decodeaudiodata',
-        'decodeAudioData()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/destination/index.html
+++ b/files/en-us/web/api/baseaudiocontext/destination/index.html
@@ -48,21 +48,7 @@ gainNode.connect(audioCtx.destination);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-destination',
-        'destination')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/index.html
+++ b/files/en-us/web/api/baseaudiocontext/index.html
@@ -107,20 +107,7 @@ const finish = audioContext.destination;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#BaseAudioContext', 'BaseAudioContext')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/listener/index.html
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.html
@@ -45,20 +45,7 @@ var myListener = audioCtx.listener;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-listener', 'listener')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/onstatechange/index.html
+++ b/files/en-us/web/api/baseaudiocontext/onstatechange/index.html
@@ -41,21 +41,7 @@ browser-compat: api.BaseAudioContext.onstatechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-onstatechange',
-        'onstatechange')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.html
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.html
@@ -49,21 +49,7 @@ console.log(audioCtx.sampleRate);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-samplerate', 'sampleRate')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.html
+++ b/files/en-us/web/api/baseaudiocontext/state/index.html
@@ -69,20 +69,7 @@ function play() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-baseaudiocontext-state', 'state')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardrequest/index.html
+++ b/files/en-us/web/api/basiccardrequest/index.html
@@ -119,20 +119,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Basic Card Payment','#basiccardrequest-dictionary','BasicCardRequest')}}</td>
-			<td>{{Spec2('Basic Card Payment')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
@@ -69,21 +69,7 @@ var request = new PaymentRequest(supportedInstruments, details, options);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardrequest-supportednetworks',
-        'supportedNetworks')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/billingaddress/index.html
+++ b/files/en-us/web/api/basiccardresponse/billingaddress/index.html
@@ -65,21 +65,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-billingaddress',
-        'billingAddress')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardholdername/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardholdername/index.html
@@ -63,21 +63,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-cardholdername',
-        'cardholderName')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardnumber/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardnumber/index.html
@@ -63,21 +63,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-cardnumber',
-        'cardNumber')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
@@ -63,21 +63,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-cardsecuritycode',
-        'cardSecurityCode')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/expirymonth/index.html
+++ b/files/en-us/web/api/basiccardresponse/expirymonth/index.html
@@ -64,21 +64,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-expirymonth',
-        'expiryMonth')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/expiryyear/index.html
+++ b/files/en-us/web/api/basiccardresponse/expiryyear/index.html
@@ -64,21 +64,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Basic Card Payment', '#dom-basiccardresponse-expiryyear',
-        'expiryYear')}}</td>
-      <td>{{Spec2('Basic Card Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/index.html
+++ b/files/en-us/web/api/basiccardresponse/index.html
@@ -98,20 +98,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Basic Card Payment','#basiccardresponse-dictionary','BasicCardResponse')}}</td>
-			<td>{{Spec2('Basic Card Payment')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/charging/index.html
+++ b/files/en-us/web/api/batterymanager/charging/index.html
@@ -45,22 +45,7 @@ browser-compat: api.BatteryManager.charging
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/chargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.html
@@ -52,22 +52,7 @@ browser-compat: api.BatteryManager.chargingTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.html
@@ -54,22 +54,7 @@ browser-compat: api.BatteryManager.dischargingTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/index.html
+++ b/files/en-us/web/api/batterymanager/index.html
@@ -46,22 +46,7 @@ browser-compat: api.BatteryManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Battery API")}}</td>
-   <td>{{Spec2("Battery API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/level/index.html
+++ b/files/en-us/web/api/batterymanager/level/index.html
@@ -48,22 +48,7 @@ browser-compat: api.BatteryManager.level
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/onchargingchange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingchange/index.html
@@ -51,22 +51,7 @@ browser-compat: api.BatteryManager.onchargingchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-   <thead>
-      <tr>
-         <th scope="col">Specification</th>
-         <th scope="col">Status</th>
-         <th scope="col">Comment</th>
-      </tr>
-   </thead>
-   <tbody>
-      <tr>
-         <td>{{SpecName("Battery API")}}</td>
-         <td>{{Spec2("Battery API")}}</td>
-         <td>Initial definition</td>
-      </tr>
-   </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
@@ -52,22 +52,7 @@ browser-compat: api.BatteryManager.onchargingtimechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
@@ -52,22 +52,7 @@ browser-compat: api.BatteryManager.ondischargingtimechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/batterymanager/onlevelchange/index.html
+++ b/files/en-us/web/api/batterymanager/onlevelchange/index.html
@@ -53,22 +53,7 @@ browser-compat: api.BatteryManager.onlevelchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/beforeunloadevent/index.html
+++ b/files/en-us/web/api/beforeunloadevent/index.html
@@ -58,20 +58,7 @@ window.addEventListener("beforeunload", function( event ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "browsing-the-web.html#the-beforeunloadevent-interface", "BeforeUnloadEvent")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
@@ -159,20 +159,7 @@ browser-compat: api.BiquadFilterNode.BiquadFilterNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-biquadfilternode-biquadfilternode','BiquadFilterNode()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/detune/index.html
+++ b/files/en-us/web/api/biquadfilternode/detune/index.html
@@ -63,20 +63,7 @@ biquadFilter.detune.value = 100;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-biquadfilternode-detune', 'detune')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.html
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.html
@@ -64,20 +64,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-biquadfilternode-frequency', 'frequency')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.html
+++ b/files/en-us/web/api/biquadfilternode/gain/index.html
@@ -64,20 +64,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-biquadfilternode-gain', 'gain')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.html
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.html
@@ -119,21 +119,7 @@ calcFrequencyResponse();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-biquadfilternode-getfrequencyresponse',
-        'getFrequencyResponse()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/index.html
@@ -155,20 +155,7 @@ browser-compat: api.BiquadFilterNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#biquadfilternode', 'BiquadFilterNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/q/index.html
+++ b/files/en-us/web/api/biquadfilternode/q/index.html
@@ -69,20 +69,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-biquadfilternode-q', 'Q')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/biquadfilternode/type/index.html
+++ b/files/en-us/web/api/biquadfilternode/type/index.html
@@ -128,20 +128,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API', '#dom-biquadfilternode-type', 'type')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/arraybuffer/index.html
+++ b/files/en-us/web/api/blob/arraybuffer/index.html
@@ -49,20 +49,7 @@ var <em>buffer</em> = await <em>blob</em>.arrayBuffer();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("File API", "#dom-blob-arraybuffer", "Blob.arrayBuffer()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/blob/index.html
+++ b/files/en-us/web/api/blob/blob/index.html
@@ -57,22 +57,7 @@ var oMyBlob = new Blob(aFileParts, {type : 'text/html'}); // the blob</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File API', '#constructorBlob', 'Blob()')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/index.html
+++ b/files/en-us/web/api/blob/index.html
@@ -123,20 +123,7 @@ reader.readAsArrayBuffer(blob);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('File API', '#blob-section', 'The <code>Blob</code> interface')}}</td>
-   <td>{{Spec2('File API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/size/index.html
+++ b/files/en-us/web/api/blob/size/index.html
@@ -46,20 +46,7 @@ for (var i = 0; i &lt; files.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File API', '#dfn-size', 'Blob.size')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/slice/index.html
+++ b/files/en-us/web/api/blob/slice/index.html
@@ -55,20 +55,7 @@ browser-compat: api.Blob.slice
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("File API", "#dfn-slice", "Blob.slice()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/stream/index.html
+++ b/files/en-us/web/api/blob/stream/index.html
@@ -56,20 +56,7 @@ browser-compat: api.Blob.stream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("File API", "#dom-blob-stream", "Blob.stream()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/text/index.html
+++ b/files/en-us/web/api/blob/text/index.html
@@ -54,20 +54,7 @@ var <em>text</em> = await <em>blob</em>.text();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("File API", "#dom-blob-text", "Blob.text()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blob/type/index.html
+++ b/files/en-us/web/api/blob/type/index.html
@@ -57,20 +57,7 @@ for (i = 0; i &lt; files.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File API', '#dfn-type', 'Blob.type')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blobevent/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/blobevent/index.html
@@ -36,20 +36,7 @@ browser-compat: api.BlobEvent.BlobEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording', '#dom-blobevent-blobevent', 'BlobEvent: BlobEvent')}}</td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blobevent/data/index.html
+++ b/files/en-us/web/api/blobevent/data/index.html
@@ -24,21 +24,7 @@ browser-compat: api.BlobEvent.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording', '#dom-blobevent-data', 'BlobEvent.data')}}
-      </td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/index.html
@@ -43,20 +43,7 @@ browser-compat: api.BlobEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('MediaStream Recording', '#blobevent-section', 'BlobEvent')}}</td>
-   <td>{{Spec2('MediaStream Recording')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/blobevent/timecode/index.html
+++ b/files/en-us/web/api/blobevent/timecode/index.html
@@ -29,20 +29,7 @@ browser-compat: api.BlobEvent.timecode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording','#dom-blobevent-timecode','timecode')}}</td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/getavailability/index.html
+++ b/files/en-us/web/api/bluetooth/getavailability/index.html
@@ -57,21 +57,7 @@ browser-compat: api.Bluetooth.getAvailability
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetooth-getavailability",
-        "getAvailability()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/getdevices/index.html
+++ b/files/en-us/web/api/bluetooth/getdevices/index.html
@@ -45,20 +45,7 @@ browser-compat: api.Bluetooth.getDevices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetooth-getdevices", "getDevices()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/index.html
+++ b/files/en-us/web/api/bluetooth/index.html
@@ -71,20 +71,7 @@ Bluetooth includes ServiceEventHandlers;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#bluetooth', 'Bluetooth')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
+++ b/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
@@ -27,20 +27,7 @@ browser-compat: api.Bluetooth.onavailabilitychanged
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#bluetooth", "Bluetooth")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/referringdevice/index.html
+++ b/files/en-us/web/api/bluetooth/referringdevice/index.html
@@ -26,21 +26,7 @@ browser-compat: api.Bluetooth.referringDevice
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetooth-referringdevice",
-        "referringDevice")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetooth/requestdevice/index.html
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.html
@@ -97,21 +97,7 @@ navigator.bluetooth.requestDevice(options).then(function(device) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#dom-bluetooth-requestdevice', 'requestDevice()')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.authenticatedSignedWrites
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites','authenticatedSignedWrites')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
@@ -31,20 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.broadcast
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-broadcast','broadcast')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
@@ -59,20 +59,7 @@ if (characteristic.properties.notify) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Bluetooth','#characteristicproperties-interface','BluetoothCharacteristicProperties')}}</td>
-   <td>{{Spec2('Web Bluetooth')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
@@ -31,20 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.indicate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-indicate','indicate')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
@@ -31,20 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.notify
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-notify','notify')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
@@ -31,20 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.read
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-read','read')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
@@ -32,21 +32,7 @@ browser-compat: api.BluetoothCharacteristicProperties.reliableWrite
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-reliablewrite','reliableWrite')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.writableAuxiliaries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writableauxiliaries','writableAuxiliaries')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
@@ -31,20 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.write
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-write','write')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothCharacteristicProperties.writeWithoutResponse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writewithoutresponse','authenticatedSignedWrites')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/gatt/index.html
+++ b/files/en-us/web/api/bluetoothdevice/gatt/index.html
@@ -27,20 +27,7 @@ browser-compat: api.BluetoothDevice.gatt
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#dom-bluetoothdevice-gatt', 'gattServer')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/id/index.html
+++ b/files/en-us/web/api/bluetoothdevice/id/index.html
@@ -27,20 +27,7 @@ browser-compat: api.BluetoothDevice.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#dom-bluetoothdevice-id', 'id')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/index.html
+++ b/files/en-us/web/api/bluetoothdevice/index.html
@@ -111,20 +111,7 @@ BluetoothDevice implements ServiceEventHandlers;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#bluetoothdevice', 'BluetoothDevice')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/name/index.html
+++ b/files/en-us/web/api/bluetoothdevice/name/index.html
@@ -35,20 +35,7 @@ browser-compat: api.BluetoothDevice.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#dom-bluetoothdevice-name', 'name')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattcharacteristic-getdescriptor", "getDescriptor()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.html
@@ -31,22 +31,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptors
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattcharacteristic-getdescriptors", "getDescriptors()")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -65,20 +65,7 @@ BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Web Bluetooth", "#bluetoothremotegattcharacteristic", "BluetoothRemoteGATTCharacteristic")}}</td>
-   <td>{{Spec2("Web Bluetooth")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.html
@@ -29,21 +29,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.properties
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-properties",
-        "properties")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.html
@@ -30,21 +30,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.readValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-readvalue",
-        "readValue()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.html
@@ -29,21 +29,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.service
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-service",
-        "service")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.html
@@ -30,22 +30,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.startNotifications
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattcharacteristic-startnotifications",
-        "startNotifications()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.html
@@ -30,22 +30,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.stopNotifications
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattcharacteristic-stopnotifications",
-        "stopNotifications()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.uuid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-uuid",
-        "uuid")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.html
@@ -29,21 +29,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-value",
-        "value")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
@@ -38,21 +38,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattcharacteristic-writevalue",
-        "writeValue()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
@@ -30,21 +30,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.characteristic
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-characteristic','characteristic')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
@@ -63,21 +63,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#bluetoothremotegattdescriptor",
-        "BluetoothRemoteGATTDescriptor")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
@@ -32,20 +32,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.readValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-readvalue','readValue()')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
@@ -30,21 +30,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-uuid','uuid')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
@@ -30,21 +30,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-value','value')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
@@ -37,20 +37,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.writeValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-writevalue','writeValue()')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.html
@@ -34,21 +34,7 @@ browser-compat: api.BluetoothRemoteGATTServer.connect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth', '#dom-bluetoothremotegattserver-connect',
-        'connect()')}}</td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/connected/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/connected/index.html
@@ -25,21 +25,7 @@ browser-compat: api.BluetoothRemoteGATTServer.connected
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattserver-connected",
-        "connected")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/device/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/device/index.html
@@ -22,21 +22,7 @@ browser-compat: api.BluetoothRemoteGATTServer.device
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattserver-device", "device")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.html
@@ -31,21 +31,7 @@ browser-compat: api.BluetoothRemoteGATTServer.disconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattserver-disconnect",
-        "disconnect()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.html
@@ -37,21 +37,7 @@ browser-compat: api.BluetoothRemoteGATTServer.getPrimaryService
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattserver-getprimaryservice",
-        "getPrimaryService()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.html
@@ -37,21 +37,7 @@ browser-compat: api.BluetoothRemoteGATTServer.getPrimaryServices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattserver-getprimaryservices",
-        "getPrimaryServices()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattserver/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.html
@@ -66,21 +66,7 @@ browser-compat: api.BluetoothRemoteGATTServer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#bluetoothremotegattserver",
-        "BluetoothRemoteGATTServer")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/device/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/device/index.html
@@ -29,21 +29,7 @@ browser-compat: api.BluetoothRemoteGATTService.device
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattservice-device','device')}}
-      </td>
-      <td>{{Spec2('Web Bluetooth')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.html
@@ -40,21 +40,7 @@ browser-compat: api.BluetoothRemoteGATTService.getCharacteristic
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattservice-getcharacteristic",
-        "getCharacteristic()")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.html
@@ -39,22 +39,7 @@ browser-compat: api.BluetoothRemoteGATTService.getCharacteristics
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattservice-getcharacteristics", "getCharacteristics()")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getincludedservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getincludedservice/index.html
@@ -36,22 +36,7 @@ browser-compat: api.BluetoothRemoteGATTService.getIncludedService
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattservice-getincludedservice", "getIncludedService()")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getincludedservices/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getincludedservices/index.html
@@ -37,22 +37,7 @@ browser-compat: api.BluetoothRemoteGATTService.getIncludedServices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth",
-        "#dom-bluetoothremotegattservice-getincludedservices", "getIncludedServices()")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.html
@@ -74,21 +74,7 @@ browser-compat: api.BluetoothRemoteGATTService
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#bluetoothremotegattservice",
-        "BluetoothRemoteGATTService")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.html
@@ -29,21 +29,7 @@ browser-compat: api.BluetoothRemoteGATTService.isPrimary
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattservice-isprimary",
-        "isPrimary")}}</td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattservice/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/uuid/index.html
@@ -28,21 +28,7 @@ browser-compat: api.BluetoothRemoteGATTService.uuid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Bluetooth", "#dom-bluetoothremotegattservice-uuid", "uuid")}}
-      </td>
-      <td>{{Spec2("Web Bluetooth")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/arraybuffer/index.html
+++ b/files/en-us/web/api/body/arraybuffer/index.html
@@ -96,20 +96,7 @@ play.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-arraybuffer','arrayBuffer()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/blob/index.html
+++ b/files/en-us/web/api/body/blob/index.html
@@ -62,20 +62,7 @@ fetch(myRequest)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-blob','blob()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/body/index.html
+++ b/files/en-us/web/api/body/body/index.html
@@ -72,20 +72,7 @@ fetch('./tortoise.png')
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-body','body')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/bodyused/index.html
+++ b/files/en-us/web/api/body/bodyused/index.html
@@ -64,20 +64,7 @@ fetch('https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg').the
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-bodyused','bodyUsed')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/formdata/index.html
+++ b/files/en-us/web/api/body/formdata/index.html
@@ -48,20 +48,7 @@ browser-compat: api.Body.formData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-formdata','formData()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/index.html
+++ b/files/en-us/web/api/body/index.html
@@ -65,20 +65,7 @@ fetch('https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg')
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#body-mixin','Body')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/json/index.html
+++ b/files/en-us/web/api/body/json/index.html
@@ -71,22 +71,7 @@ fetch(myRequest)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fetch", "#dom-body-json", "Body.json()")}}</td>
-      <td>{{Spec2("Fetch")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/body/text/index.html
+++ b/files/en-us/web/api/body/text/index.html
@@ -72,22 +72,7 @@ function getData(pageId) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-body-text','text()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
@@ -42,21 +42,7 @@ bc.postMessage('New listening connected!');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-broadcastchannel",
-        "BroadcastChannel()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/close/index.html
+++ b/files/en-us/web/api/broadcastchannel/close/index.html
@@ -38,21 +38,7 @@ bc.close();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-broadcastchannel-close",
-        "BroadcastChannel.close()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/index.html
@@ -67,20 +67,7 @@ browser-compat: api.BroadcastChannel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "comms.html#broadcastchannel", "BroadcastChannel")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/message_event/index.html
+++ b/files/en-us/web/api/broadcastchannel/message_event/index.html
@@ -144,18 +144,7 @@ channel.addEventListener('message', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-message')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/messageerror_event/index.html
+++ b/files/en-us/web/api/broadcastchannel/messageerror_event/index.html
@@ -59,18 +59,7 @@ channel.onmessageerror = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-messageerror')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/name/index.html
+++ b/files/en-us/web/api/broadcastchannel/name/index.html
@@ -40,21 +40,7 @@ bc.close();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-broadcastchannel-name",
-        "BroadcastChannel.name")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/onmessage/index.html
+++ b/files/en-us/web/api/broadcastchannel/onmessage/index.html
@@ -42,21 +42,7 @@ browser-compat: api.BroadcastChannel.onmessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "comms.html#handler-broadcastchannel-onmessage",
-				"BroadcastChannel.onmessage")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/onmessageerror/index.html
+++ b/files/en-us/web/api/broadcastchannel/onmessageerror/index.html
@@ -26,21 +26,7 @@ browser-compat: api.BroadcastChannel.onmessageerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-broadcastchannel-onmessageerror',
-        'onmessageerror')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/broadcastchannel/postmessage/index.html
+++ b/files/en-us/web/api/broadcastchannel/postmessage/index.html
@@ -28,21 +28,7 @@ browser-compat: api.BroadcastChannel.postMessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-broadcastchannel-postmessage",
-        "BroadcastChannel.postmessage()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
@@ -59,20 +59,7 @@ var size = queuingStrategy.size(chunk);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#blqs-constructor","ByteLengthQueuingStrategy()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.html
@@ -52,20 +52,7 @@ var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#blqs-class','ByteLengthQueuingStrategy')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
@@ -54,20 +54,7 @@ var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#blqs-size","size")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part #1146.

This converts API interfaces (including properties & methods) starting with 'a' to the {{Specifications}} macros. 

There were no comments in the section, so it was pretty trivial to replace.

All looks fine.