### PR TITLE
Remove unnecessary span elements in various docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
@@ -101,12 +101,12 @@ function onError(error) {
   console.log(error);
 }
 
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-keyword">var</span> <span class="cm-def">gettingTopSites</span> <span class="cm-operator">=</span> <span class="cm-variable">browser</span>.<span class="cm-property">topSites</span>.<span class="cm-property">get</span>({</span></span></span>
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-property">  includeBlocked</span>: <span class="cm-atom">true</span>,</span></span></span>
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-property">  onePerDomain</span>: <span class="cm-atom">false</span></span></span></span>
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">});</span></span></span>
+var gettingTopSites = browser.topSites.get({
+  includeBlocked: true,
+  onePerDomain: false
+});
 
-<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="cm-variable">gettingTopSites</span>.<span class="cm-property">then</span>(<span class="cm-variable">logTopSites</span>, <span class="cm-variable">onError</span>);</span></span></span></pre>
+gettingTopSites.then(logTopSites, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
@@ -40,14 +40,14 @@ browser-compat: webextensions.api.webRequest.CertificateInfo
  </dd>
  <dt><code>issuer</code></dt>
  <dd><code>String</code>. Name of the organization that issued this certificate, represented as a Distinguished Name and formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".</dd>
- <dd>For example: "<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US</span></span></span></span>".</dd>
+ <dd>For example: "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US".</dd>
  <dt><code>rawDER</code></dt>
  <dd><code>Array</code> of <code>Number</code>. If <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/getSecurityInfo" title="Use this function to get detailed information about the TLS connection associated with a particular request."><code>webRequest.getSecurityInfo()</code></a> was called with the <code>rawDER</code> option present and set to <code>true</code>, this will contain the DER encoding of the certificate.</dd>
  <dt><code>serialNumber</code></dt>
  <dd><code>String</code>. The certificate's <a href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2">serial number</a>.</dd>
  <dt><code>subject</code></dt>
  <dd><code>String</code>. Name of the organization that issued this certificate, represented as a Distinguished Name and formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".</dd>
- <dd>For example: "<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US</span></span></span></span>".</dd>
+ <dd>For example: "CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US".</dd>
  <dt><code>subjectPublicKeyInfoDigest</code></dt>
  <dd>
  <p><code>Object</code>. An object containing the following properties:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.webRequest.SecurityInfo
  </ul>
  </dd>
  <dt><code>cipherSuite</code> {{optional_inline}}</dt>
- <dd><code>String</code>. Cipher suite used for the connection, formatted as per the <a href="https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5">TLS specification</a>: for example, "<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256</span></span></span></span>".</dd>
+ <dd><code>String</code>. Cipher suite used for the connection, formatted as per the <a href="https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5">TLS specification</a>: for example, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256".</dd>
  <dt><code>errorMessage</code> {{optional_inline}}</dt>
  <dd>
  <p><code>String</code>. If there was a problem with the TLS handshake (for example, the certificate had expired, or a trusted root could not be found, or a certificate was revoked) then <code>status</code> will be "broken" and the <code>errorMessage</code> property will contain a string describing the error, taken from Firefox's internal list of error codes.</p>

--- a/files/en-us/tools/debugger/source_map_errors/index.html
+++ b/files/en-us/tools/debugger/source_map_errors/index.html
@@ -62,8 +62,8 @@ tags:
 
 <p>See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1437937">Bug 1437937: WebExtensions Doesn't Find Source Maps</a> for details.</p>
 
-<pre class="brush: html"><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">Source-Map-Fehler: TypeError: NetworkError when attempting to fetch resource.
+<pre class="brush: html">Source-Map-Fehler: TypeError: NetworkError when attempting to fetch resource.
  Ressourcen-Adresse: moz-extension://c7f0f003-4fcf-49fd-8ec0-c49361266581/background.js
- Source-Map-Adresse: background.js.map</span></span></span></pre>
+ Source-Map-Adresse: background.js.map</pre>
 
 <p>The only workaround is to manually change the map URL to a public one (http://localhost:1234/file.map.js) and start a local webserver at this port.</p>

--- a/files/en-us/web/http/cors/errors/index.html
+++ b/files/en-us/web/http/cors/errors/index.html
@@ -31,12 +31,12 @@ tags:
 
 <p>The text of the error message will be something similar to the following:</p>
 
-<pre>Cross<span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">-Origin Request Blocked: The Same Origin Policy disallows
+<pre>Cross-Origin Request Blocked: The Same Origin Policy disallows
 reading the remote resource at <em>https://some-url-here</em>. (<em>Reason:
-additional information here</em>).</span></span></span></pre>
+additional information here</em>).</pre>
 
 <div class="note">
-<p><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><strong>Note:</strong> For security reasons, specifics about what went wrong with a CORS request <em>are not available to JavaScript code</em>. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.</span></span></span></p>
+<p><strong>Note:</strong> For security reasons, specifics about what went wrong with a CORS request <em>are not available to JavaScript code</em>. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.</p>
 </div>
 
 <h2 id="CORS_error_messages">CORS error messages</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are some span elements which are unnecessary in various documents.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/CertificateInfo
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/SecurityInfo
https://developer.mozilla.org/en-US/docs/Tools/Debugger/Source_map_errors
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors
