### PR TITLE
Fix code examples in “Template literals” & String.raw() docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.html
@@ -2,19 +2,19 @@
 title: String.raw()
 slug: Web/JavaScript/Reference/Global_Objects/String/raw
 tags:
-- ECMAScript 2015
-- JavaScript
-- Method
-- Reference
-- String
-- Polyfill
+  - ECMAScript 2015
+  - JavaScript
+  - Method
+  - Reference
+  - String
+  - Polyfill
 browser-compat: javascript.builtins.String.raw
 ---
 <div>{{JSRef}}</div>
 
 <p>The static <strong><code>String.raw()</code></strong> method
     is a tag function of <a
-      href="/en-US/docs/Web/JavaScript/Reference/template_strings">template literals</a>.
+      href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>.
     This is <em>similar</em> to the <code>r</code> prefix in Python, or the <code>@</code>
     prefix in C# for string literals. (But it is not <em>identical</em>; see explanations
     in <a href="https://bugs.chromium.org/p/v8/issues/detail?id=5016">this issue</a>.)
@@ -25,10 +25,10 @@ browser-compat: javascript.builtins.String.raw
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code>String.raw(<var>callSite</var>, <var>...substitutions</var>)
+<pre class="brush: js">String.raw(callSite, ...substitutions)
 
-String.raw`<var>templateString</var>`
-</code></pre>
+String.raw`templateString`
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -60,7 +60,7 @@ String.raw`<var>templateString</var>`
 <p>In most cases, <code>String.raw()</code> is used with template literal. The first
   syntax mentioned above is only rarely used, because the JavaScript engine will call this
   with proper arguments for you, (just like with other <a
-    href="/en-US/docs/Web/JavaScript/Reference/template_strings#Tagged_template_literals">tag
+    href="/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_template_literals">tag
     functions</a>).</p>
 
 <p><code>String.raw()</code> is the only built-in tag function of template literals. It
@@ -117,7 +117,7 @@ String.raw({ raw: 'test' }, 0, 1, 2); // 't0e1s2t'
 
 <ul>
   <li>A polyfill of <code>String.raw</code> is available in <a href="https://github.com/zloirock/core-js#ecmascript-string-and-regexp"><code>core-js</code></a></li>
-  <li><a href="/en-US/docs/Web/JavaScript/Reference/template_strings">Template literals</a>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">Template literals</a>
   </li>
   <li>{{jsxref("String")}}</li>
   <li><a href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar">Lexical grammar</a>

--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.html
@@ -72,12 +72,12 @@ String.raw`templateString`
 <h3 id="Using_String.raw">Using String.raw()</h3>
 
 <pre class="brush: js">String.raw`Hi\n${2+3}!`;
-// 'Hi\n5!', the character after 'Hi'
+// 'Hi\\n5!', the character after 'Hi'
 // is not a newline character,
 // '\' and 'n' are two characters.
 
 String.raw`Hi\u000A!`;
-// 'Hi\u000A!', same here, this time we will get the
+// 'Hi\\u000A!', same here, this time we will get the
 //  \, u, 0, 0, 0, A, 6 characters.
 // All kinds of escape characters will be ineffective
 // and backslashes will be present in the output string.
@@ -86,7 +86,7 @@ String.raw`Hi\u000A!`;
 
 let name = 'Bob';
 String.raw`Hi\n${name}!`;
-// 'Hi\nBob!', substitutions are processed.
+// 'Hi\\nBob!', substitutions are processed.
 
 // Normally you would not call String.raw() as a function,
 // but to simulate `foo${2 + 3}bar${'Java' + 'Script'}baz` you can do:

--- a/files/en-us/web/javascript/reference/template_literals/index.html
+++ b/files/en-us/web/javascript/reference/template_literals/index.html
@@ -2,15 +2,15 @@
 title: Template literals (Template strings)
 slug: Web/JavaScript/Reference/Template_literals
 tags:
-- ECMAScript 2015
-- Guide
-- JavaScript
-- React
-- String
-- Template Strings
-- Template literals
-- Template string
-- strings
+  - ECMAScript 2015
+  - Guide
+  - JavaScript
+  - React
+  - String
+  - Template Strings
+  - Template literals
+  - Template string
+  - strings
 browser-compat: javascript.grammar.template_literals
 ---
 <div>{{JsSidebar("More")}}</div>
@@ -192,7 +192,7 @@ t3Closure({name: 'MDN', age: 30}); //"I'm MDN. I'm almost 30 years old."
 <p>The special <code>raw</code> property, available on the first argument to the tag
   function, allows you to access the raw strings as they were entered, without processing
   <a
-    href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Using_special_characters_in_strings">escape
+    href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#using_special_characters_in_strings">escape
     sequences</a>.</p>
 
 <pre class="brush: js">function tag(strings) {

--- a/files/en-us/web/javascript/reference/template_literals/index.html
+++ b/files/en-us/web/javascript/reference/template_literals/index.html
@@ -208,13 +208,13 @@ tag`string text line 1 \n string text line 2`;
   like the default template function and string concatenation would create.</p>
 
 <pre class="brush: js">let str = String.raw`Hi\n${2+3}!`;
-// "Hi\n5!"
+// "Hi\\n5!"
 
 str.length;
 // 6
 
 Array.from(str).join(',');
-// "H,i,\,n,5,!"
+// "H,i,\\,n,5,!"
 </pre>
 
 <h3 id="Tagged_templates_and_escape_sequences">Tagged templates and escape sequences</h3>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/2371