### PR TITLE
Replace spec table with {{specifications}} for api/c[b-q]*

### DIFF
--- a/files/en-us/web/api/cdatasection/index.html
+++ b/files/en-us/web/api/cdatasection/index.html
@@ -48,43 +48,7 @@ browser-compat: api.CDATASection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#interface-cdatasection", "CDATASection")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Re-added in <a href="https://github.com/whatwg/dom/pull/295">issue #295</a> due
-        to web breakage</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#cdatasection", "CDATASection")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td>Removed in favor of the more generic {{DOMxRef("Text")}} interface</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 Core", "core.html#ID-667469212", "CDATASection")}}</td>
-      <td>{{Spec2("DOM3 Core")}}</td>
-      <td>No change from {{SpecName("DOM2 Core")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Core", "core.html#ID-667469212", "CDATASection")}}</td>
-      <td>{{Spec2("DOM2 Core")}}</td>
-      <td>No change from {{SpecName("DOM1")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM1", "level-one-core.html#ID-667469212", "CDATASection")}}</td>
-      <td>{{Spec2("DOM1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.html
@@ -54,20 +54,7 @@ var myMerger = new ChannelMergerNode(ac, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#channelmergernode','ChannelMergerNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/index.html
@@ -65,20 +65,7 @@ browser-compat: api.ChannelMergerNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#channelmergernode', 'ChannelMergerNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
@@ -51,20 +51,7 @@ var mySplitter = new ChannelSplitterNode(ac, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#channelsplitternode','ChannelSplitterNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/index.html
@@ -66,20 +66,7 @@ browser-compat: api.ChannelSplitterNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#channelsplitternode', 'ChannelSplitterNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/appenddata/index.html
+++ b/files/en-us/web/api/characterdata/appenddata/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CharacterData.appendData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-appenddata','appendData()')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/data/index.html
+++ b/files/en-us/web/api/characterdata/data/index.html
@@ -20,20 +20,7 @@ browser-compat: api.CharacterData.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-data','data')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/deletedata/index.html
+++ b/files/en-us/web/api/characterdata/deletedata/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CharacterData.deleteData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-deletedata','deleteData()')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/index.html
+++ b/files/en-us/web/api/characterdata/index.html
@@ -52,35 +52,7 @@ browser-compat: api.CharacterData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#characterdata', 'CharacterData')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Added implementation of the {{domxref("ChildNode")}} and {{domxref("Element")}} interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-FF21A306', 'CharacterData')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>No change from {{SpecName('DOM2 Core')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-FF21A306', 'CharacterData')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No change from {{SpecName('DOM1')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-FF21A306', 'CharacterData')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/insertdata/index.html
+++ b/files/en-us/web/api/characterdata/insertdata/index.html
@@ -40,20 +40,7 @@ browser-compat: api.CharacterData.insertData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-insertdata','insertData()')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/length/index.html
+++ b/files/en-us/web/api/characterdata/length/index.html
@@ -19,20 +19,7 @@ browser-compat: api.CharacterData.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-length','length')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/remove/index.html
+++ b/files/en-us/web/api/characterdata/remove/index.html
@@ -34,18 +34,7 @@ text.remove(); // Removes the text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-childnode-remove', 'ChildNode.remove')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/replacedata/index.html
+++ b/files/en-us/web/api/characterdata/replacedata/index.html
@@ -41,20 +41,7 @@ browser-compat: api.CharacterData.replaceData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-replacedata','replaceData()')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/characterdata/substringdata/index.html
+++ b/files/en-us/web/api/characterdata/substringdata/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CharacterData.substringData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM WHATWG','#dom-characterdata-substringdata','substringData()')}}</td>
-    <td>{{Spec2('DOM WHATWG')}}</td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/childnode/after/index.html
+++ b/files/en-us/web/api/childnode/after/index.html
@@ -156,20 +156,7 @@ minified:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-childnode-after', 'ChildNode.after()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/childnode/before/index.html
+++ b/files/en-us/web/api/childnode/before/index.html
@@ -117,20 +117,7 @@ console.log(parent.outerHTML);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-childnode-before', 'ChildNode.before()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/childnode/index.html
+++ b/files/en-us/web/api/childnode/index.html
@@ -34,27 +34,7 @@ browser-compat: api.ChildNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-childnode', 'ChildNode')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Split the <code>ElementTraversal</code> interface in {{domxref("ParentNode")}} and <code>ChildNode</code>. <code>previousElementSibling</code> and <code>nextElementSibling</code> are now defined on the latter. The {{domxref("CharacterData")}} and {{domxref("DocumentType")}} implemented the new interfaces. Added the <code>remove()</code>, <code>before()</code>, <code>after()</code> and <code>replaceWith()</code> methods.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Element Traversal', '#interface-elementTraversal', 'ElementTraversal')}}</td>
-   <td>{{Spec2('Element Traversal')}}</td>
-   <td>Added the initial definition of its properties to the <code>ElementTraversal</code> pure interface and use it on {{domxref("Element")}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/api/client/frametype/index.html
+++ b/files/en-us/web/api/client/frametype/index.html
@@ -28,20 +28,7 @@ browser-compat: api.Client.frameType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#client-frametype', 'frameType')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/client/id/index.html
+++ b/files/en-us/web/api/client/id/index.html
@@ -28,20 +28,7 @@ browser-compat: api.Client.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#client-id', 'id')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/client/index.html
+++ b/files/en-us/web/api/client/index.html
@@ -37,20 +37,7 @@ browser-compat: api.Client
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#client', 'Client')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/client/postmessage/index.html
+++ b/files/en-us/web/api/client/postmessage/index.html
@@ -78,23 +78,7 @@ browser-compat: api.Client.postMessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-client-postmessage-message-options',
-        'postMessage()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/client/type/index.html
+++ b/files/en-us/web/api/client/type/index.html
@@ -54,20 +54,7 @@ self.addEventListener("message", function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#client-type', 'type')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/client/url/index.html
+++ b/files/en-us/web/api/client/url/index.html
@@ -48,20 +48,7 @@ browser-compat: api.Client.url
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#client-url', 'url')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clients/claim/index.html
+++ b/files/en-us/web/api/clients/claim/index.html
@@ -52,20 +52,7 @@ browser-compat: api.Clients.claim
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#clients-claim', 'claim()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clients/get/index.html
+++ b/files/en-us/web/api/clients/get/index.html
@@ -43,20 +43,7 @@ browser-compat: api.Clients.get
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-clients-get', 'get()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clients/index.html
+++ b/files/en-us/web/api/clients/index.html
@@ -68,20 +68,7 @@ browser-compat: api.Clients
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#clients', 'Clients')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clients/matchall/index.html
+++ b/files/en-us/web/api/clients/matchall/index.html
@@ -64,20 +64,7 @@ browser-compat: api.Clients.matchAll
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#clients-matchall', 'Clients: matchall')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clients/openwindow/index.html
+++ b/files/en-us/web/api/clients/openwindow/index.html
@@ -76,21 +76,7 @@ self.addEventListener('notificationclick', e =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#clients-openwindow', 'Clients: openWindow')}}
-      </td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard/index.html
+++ b/files/en-us/web/api/clipboard/index.html
@@ -63,20 +63,7 @@ browser-compat: api.Clipboard
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Clipboard API','#clipboard-interface','Clipboard')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard/read/index.html
+++ b/files/en-us/web/api/clipboard/read/index.html
@@ -92,20 +92,7 @@ navigator.permissions.query({name: "clipboard-read"}).then(result =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboard-read','read()')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard/readtext/index.html
+++ b/files/en-us/web/api/clipboard/readtext/index.html
@@ -57,20 +57,7 @@ browser-compat: api.Clipboard.readText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboard-readtext','readText()')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard/write/index.html
+++ b/files/en-us/web/api/clipboard/write/index.html
@@ -97,20 +97,7 @@ browser-compat: api.Clipboard.write
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboard-write','write()')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard/writetext/index.html
+++ b/files/en-us/web/api/clipboard/writetext/index.html
@@ -58,20 +58,7 @@ browser-compat: api.Clipboard.writeText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboard-writetext','writeText()')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.html
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.html
@@ -37,23 +37,7 @@ browser-compat: api.ClipboardEvent.clipboardData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Clipboard API', '#clipboardevent-clipboarddata',
-        'ClipboardEvent.clipboardData') }}</td>
-      <td>{{ Spec2('Clipboard API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.html
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.html
@@ -52,23 +52,7 @@ browser-compat: api.ClipboardEvent.ClipboardEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Clipboard API', '#dom-clipboardevent-clipboardevent',
-        'ClipboardEvent()') }}</td>
-      <td>{{ Spec2('Clipboard API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboardevent/index.html
+++ b/files/en-us/web/api/clipboardevent/index.html
@@ -39,22 +39,7 @@ browser-compat: api.ClipboardEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('Clipboard API', '#clipboard-event-interfaces', 'ClipboardEvent') }}</td>
-   <td>{{ Spec2('Clipboard API') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.html
@@ -72,20 +72,7 @@ browser-compat: api.ClipboardItem.ClipboardItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#clipboarditem','ClipboardItem')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboarditem/gettype/index.html
+++ b/files/en-us/web/api/clipboarditem/gettype/index.html
@@ -70,20 +70,7 @@ browser-compat: api.ClipboardItem.getType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboarditem-gettype-type-type','ClipboardItem.getType()')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/index.html
@@ -107,20 +107,7 @@ browser-compat: api.ClipboardItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Clipboard API','#clipboarditem','ClipboardItem')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.html
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.html
@@ -52,20 +52,7 @@ browser-compat: api.ClipboardItem.presentationStyle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboarditem-presentationstyle','ClipboardItem.presentationStyle')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboarditem/types/index.html
+++ b/files/en-us/web/api/clipboarditem/types/index.html
@@ -60,20 +60,7 @@ browser-compat: api.ClipboardItem.types
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Clipboard API','#dom-clipboarditem-types','ClipboardItem.types')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/closeevent/closeevent/index.html
+++ b/files/en-us/web/api/closeevent/closeevent/index.html
@@ -47,22 +47,7 @@ browser-compat: api.CloseEvent.CloseEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','comms.html#closeevent','CloseEvent()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/closeevent/index.html
+++ b/files/en-us/web/api/closeevent/index.html
@@ -160,22 +160,7 @@ browser-compat: api.CloseEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'web-sockets.html#the-closeevent-interface', 'CloseEvent') }}</td>
-   <td>{{ Spec2('HTML WHATWG') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/comment/comment/index.html
+++ b/files/en-us/web/api/comment/comment/index.html
@@ -26,20 +26,7 @@ comment2 = new Comment(&quot;This is a comment&quot;);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-comment-comment', 'Comment: Comment')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/comment/index.html
+++ b/files/en-us/web/api/comment/index.html
@@ -30,35 +30,7 @@ browser-compat: api.Comment
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#comment', 'Comment')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Added the constructor.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-1728279322', 'Comment')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>No change from {{SpecName('DOM2 Core')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-1728279322', 'Comment')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No change from {{SpecName('DOM1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-1728279322', 'Comment')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.html
@@ -45,22 +45,7 @@ browser-compat: api.CompositionEvent.CompositionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#dom-compositionevent-compositionevent','CompositionEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/data/index.html
+++ b/files/en-us/web/api/compositionevent/data/index.html
@@ -37,22 +37,7 @@ browser-compat: api.CompositionEvent.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#dom-compositionevent-data','data')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/index.html
@@ -44,25 +44,7 @@ browser-compat: api.CompositionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('UI Events', '#interface-compositionevent', 'CompositionEvent')}}</td>
-			<td>{{Spec2('UI Events')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Events', '#idl-compositionevent', 'CompositionEvent')}}</td>
-			<td>{{Spec2('DOM3 Events')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -48,23 +48,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#idl-interface-CompositionEvent-initializers','initCompositionEvent()')}}
-      </td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/locale/index.html
+++ b/files/en-us/web/api/compositionevent/locale/index.html
@@ -27,22 +27,7 @@ browser-compat: api.CompositionEvent.locale
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No longer in the spec, but still supported.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compressionstream/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.html
@@ -43,20 +43,7 @@ browser-compat: api.CompressionStream.CompressionStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Compression Streams','#dom-compressionstream-compressionstream','CompressionStream()')}}</td>
-    <td>{{Spec2('Compression Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CompressionStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Compression Streams','#compression-stream','CompressionStream')}}</td>
-   <td>{{Spec2('Compression Streams')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compressionstream/readable/index.html
+++ b/files/en-us/web/api/compressionstream/readable/index.html
@@ -29,20 +29,7 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#dom-generictransformstream-readable','readable')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/assert/index.html
+++ b/files/en-us/web/api/console/assert/index.html
@@ -87,22 +87,7 @@ for (let number = 2; number &lt;= 5; number += 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#assert", "console.assert()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/clear/index.html
+++ b/files/en-us/web/api/console/clear/index.html
@@ -22,22 +22,7 @@ browser-compat: api.Console.clear
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#clear", "console.clear()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/count/index.html
+++ b/files/en-us/web/api/console/count/index.html
@@ -88,22 +88,7 @@ console.count("alice");</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#count", "console.count()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/countreset/index.html
+++ b/files/en-us/web/api/console/countreset/index.html
@@ -96,22 +96,7 @@ console.count("alice");</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#count", "console.countReset()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/debug/index.html
+++ b/files/en-us/web/api/console/debug/index.html
@@ -53,22 +53,7 @@ console.debug(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#debug", "console.debug()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/dir/index.html
+++ b/files/en-us/web/api/console/dir/index.html
@@ -42,22 +42,7 @@ browser-compat: api.Console.dir
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#dir", "console.dir()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/dirxml/index.html
+++ b/files/en-us/web/api/console/dirxml/index.html
@@ -31,22 +31,7 @@ browser-compat: api.Console.dirxml
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#dirxml", "console.dirxml()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/error/index.html
+++ b/files/en-us/web/api/console/error/index.html
@@ -42,22 +42,7 @@ console.error(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#error", "console.error()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/group/index.html
+++ b/files/en-us/web/api/console/group/index.html
@@ -68,22 +68,7 @@ console.log("Back to the outer level");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#group", "console.group()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/groupcollapsed/index.html
+++ b/files/en-us/web/api/console/groupcollapsed/index.html
@@ -40,23 +40,7 @@ browser-compat: api.Console.groupCollapsed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#groupcollapsed", "console.groupCollapsed()")}}
-			</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/groupend/index.html
+++ b/files/en-us/web/api/console/groupend/index.html
@@ -31,22 +31,7 @@ browser-compat: api.Console.groupEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#groupend", "console.groupEnd()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/index.html
+++ b/files/en-us/web/api/console/index.html
@@ -249,22 +249,7 @@ foo();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Console API')}}</td>
-   <td>{{Spec2('Console API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/info/index.html
+++ b/files/en-us/web/api/console/info/index.html
@@ -43,22 +43,7 @@ console.info(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#info", "console.info()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/log/index.html
+++ b/files/en-us/web/api/console/log/index.html
@@ -88,22 +88,7 @@ console.log(<var>msg</var> [, <var>subst1</var>, ..., <var>substN</var>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#log", "console.log()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/table/index.html
+++ b/files/en-us/web/api/console/table/index.html
@@ -142,22 +142,7 @@ console.table(data, columns);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#table", "console.table()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/time/index.html
+++ b/files/en-us/web/api/console/time/index.html
@@ -39,22 +39,7 @@ browser-compat: api.Console.time
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#time", "console.time()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/timeend/index.html
+++ b/files/en-us/web/api/console/timeend/index.html
@@ -55,22 +55,7 @@ console.timeEnd("answer time");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#timeend", "console.timeEnd()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/timelog/index.html
+++ b/files/en-us/web/api/console/timelog/index.html
@@ -73,22 +73,7 @@ console.timeEnd("answer time");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#timelog", "console.timeLog()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/trace/index.html
+++ b/files/en-us/web/api/console/trace/index.html
@@ -61,22 +61,7 @@ foo
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("Console API", "#trace", "console.trace()")}}</td>
-			<td>{{Spec2("Console API")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console/warn/index.html
+++ b/files/en-us/web/api/console/warn/index.html
@@ -46,22 +46,7 @@ console.warn(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Console API", "#warn", "console.warn()")}}</td>
-      <td>{{Spec2("Console API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
@@ -58,20 +58,7 @@ let myConstantSource = new ConstantSourceNode(audioContext, { offset: 0.5 });</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-constantsourcenode-constantsourcenode','ConstantSourceNode: ConstantSourceNode')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/index.html
@@ -100,20 +100,7 @@ gainNode3.connect(context.destination);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#ConstantSourceNode', 'ConstantSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/constantsourcenode/offset/index.html
+++ b/files/en-us/web/api/constantsourcenode/offset/index.html
@@ -83,20 +83,7 @@ constantSource.connect(gainNode3.gain);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-constantsourcenode-offset', 'offset')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/constrainboolean/index.html
+++ b/files/en-us/web/api/constrainboolean/index.html
@@ -32,20 +32,7 @@ browser-compat: api.ConstrainBoolean
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-constrainboolean', 'ConstrainBoolean')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p>Technically, <code>ConstrainBoolean</code> is actually based on an intermediary dictionary named <code>ConstrainBooleanParameters</code>, which adds <code>exact</code> and <code>ideal</code> to the simple Boolean type. However, for the sake of documentation clarity, the intermediate type (present only because of quirks in {{Glossary("WebIDL")}} syntax) is ignored here.</p>

--- a/files/en-us/web/api/constraindomstring/index.html
+++ b/files/en-us/web/api/constraindomstring/index.html
@@ -38,20 +38,7 @@ browser-compat: api.ConstrainDOMString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Media Capture', '#dom-constraindomstring', 'ConstrainDOMString')}}</td>
-			<td>{{Spec2('Media Capture')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p>Technically, <code>ConstrainDOMString</code> is actually based on an intermediary dictionary named <code>ConstrainDOMStringParameters</code>, which adds <code>exact</code> and <code>ideal</code> to {{domxref("DOMString")}}. However, for the sake of documentation clarity, the intermediate type (present only because of quirks in {{Glossary("WebIDL")}} syntax) is ignored here.</p>

--- a/files/en-us/web/api/constraindouble/index.html
+++ b/files/en-us/web/api/constraindouble/index.html
@@ -30,20 +30,7 @@ browser-compat: api.ConstrainDouble
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-constraindouble', 'ConstrainDouble')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p>Technically, <code>ConstrainDouble</code> is actually based on an intermediary dictionary named <code>ConstrainDoubleRange</code>, which adds <code>exact</code> and <code>ideal</code> to {{domxref("DoubleRange")}}, with <code>ConstrainDouble</code> being a type that can be either a long integer or a <code>DoubleRange</code>. However, for the sake of documentation clarity, the intermediate type (present only because of quirks in {{Glossary("WebIDL")}} syntax) is ignored here.</p>

--- a/files/en-us/web/api/constrainulong/index.html
+++ b/files/en-us/web/api/constrainulong/index.html
@@ -31,20 +31,7 @@ browser-compat: api.ConstrainULong
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-constrainulong', 'ConstrainULong')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p>Technically, <code>ConstrainULong</code> is actually based on an intermediary dictionary named <code>ConstrainULongRange</code>, which adds <code>exact</code> and <code>ideal</code> to {{domxref("ULongRange")}}, with <code>ConstrainULong</code> being a type that can be either a long integer or a <code>ULongRange</code>. However, for the sake of documentation clarity, the intermediate type (present only because of quirks in {{Glossary("WebIDL")}} syntax) is ignored here.</p>

--- a/files/en-us/web/api/contactsmanager/getproperties/index.html
+++ b/files/en-us/web/api/contactsmanager/getproperties/index.html
@@ -72,20 +72,7 @@ browser-compat: api.ContactsManager.getProperties
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Contact Picker API','#dom-contactsmanager-getproperties','getProperties')}}</td>
-      <td>{{Spec2('Contact Picker API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contactsmanager/index.html
+++ b/files/en-us/web/api/contactsmanager/index.html
@@ -79,20 +79,7 @@ async function getContacts() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Contact Picker API','#contacts-manager','ContactsManager')}}</td>
-   <td>{{Spec2('Contact Picker API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contactsmanager/select/index.html
+++ b/files/en-us/web/api/contactsmanager/select/index.html
@@ -88,20 +88,7 @@ async function getContacts() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Contact Picker API','#contacts-manager-select','select')}}</td>
-      <td>{{Spec2('Contact Picker API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindex/add/index.html
+++ b/files/en-us/web/api/contentindex/add/index.html
@@ -139,20 +139,7 @@ self.registration.index.add(item);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#content-index-add','add')}}</td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindex/delete/index.html
+++ b/files/en-us/web/api/contentindex/delete/index.html
@@ -70,20 +70,7 @@ browser-compat: api.ContentIndex.delete
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#content-index-delete','delete')}}</td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindex/getall/index.html
+++ b/files/en-us/web/api/contentindex/getall/index.html
@@ -124,20 +124,7 @@ browser-compat: api.ContentIndex.getAll
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#dom-contentindex-getall','getAll')}}</td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindex/index.html
+++ b/files/en-us/web/api/contentindex/index.html
@@ -159,20 +159,7 @@ const contentIndexItems = self.registration.index.getAll();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Content Index API','#content-index','ContentIndex')}}</td>
-   <td>{{Spec2('Content Index API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.html
@@ -59,21 +59,7 @@ ciEvent.id; // should return 'unique-content-id'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#content-index-event','ContentIndexEvent')}}
-      </td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindexevent/id/index.html
+++ b/files/en-us/web/api/contentindexevent/id/index.html
@@ -44,20 +44,7 @@ browser-compat: api.ContentIndexEvent.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#content-index-event','id')}}</td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/index.html
@@ -52,20 +52,7 @@ browser-compat: api.ContentIndexEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Content Index API','#content-index-event','ContentIndexEvent')}}</td>
-   <td>{{Spec2('Content Index API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/convolvernode/buffer/index.html
+++ b/files/en-us/web/api/convolvernode/buffer/index.html
@@ -63,20 +63,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-convolvernode-buffer', 'buffer')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -67,20 +67,7 @@ browser-compat: api.ConvolverNode.ConvolverNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-convolvernode-convolvernode','ConvolverNode()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/index.html
@@ -96,20 +96,7 @@ reverb.connect(audioCtx.destination);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API', '#ConvolverNode', 'ConvolverNode')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/convolvernode/normalize/index.html
+++ b/files/en-us/web/api/convolvernode/normalize/index.html
@@ -67,20 +67,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-convolvernode-normalize', 'normalize')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -70,20 +70,7 @@ cookieStore.set({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-changed','CookieChangeEvent.changed')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CookieChangeEvent.CookieChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-cookiechangeevent','CookieChangeEvent()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -62,20 +62,7 @@ browser-compat: api.CookieChangeEvent.deleted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-deleted','CookieStoreManager.deleted')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -61,20 +61,7 @@ cookieStore.set({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieChangeEvent','CookieChangeEvent')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/delete/index.html
+++ b/files/en-us/web/api/cookiestore/delete/index.html
@@ -63,20 +63,7 @@ console.log(result);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStore-delete','CookieStore.delete()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -98,20 +98,7 @@ if (cookie) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStore-get','CookieStore.get()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/getall/index.html
+++ b/files/en-us/web/api/cookiestore/getall/index.html
@@ -63,20 +63,7 @@ if (cookies) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStore-getAll','CookieStore.getAll()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/index.html
+++ b/files/en-us/web/api/cookiestore/index.html
@@ -58,20 +58,7 @@ cookieStore.set({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/onchange/index.html
+++ b/files/en-us/web/api/cookiestore/onchange/index.html
@@ -34,20 +34,7 @@ CookieStore.addEventListener('change', function() { ... })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-cookiestore-onchange','CookieStore.onchange')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestore/set/index.html
+++ b/files/en-us/web/api/cookiestore/set/index.html
@@ -87,20 +87,7 @@ cookieStore.set({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CookieStoreManager.getSubscriptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStoreManager-getSubscriptions','CookieStoreManager.getSubscriptions()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/index.html
+++ b/files/en-us/web/api/cookiestoremanager/index.html
@@ -40,20 +40,7 @@ await registration.cookies.subscribe(subscriptions);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStoreManager','CookieStoreManager')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.html
@@ -57,20 +57,7 @@ cookieStore.set({name: 'cookie1', value: 'cookie-value', path: '/path/two/'}); /
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStoreManager-subscribe','CookieStoreManager.subscribe()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
@@ -51,20 +51,7 @@ await registration.cookies.unsubscribe(subscriptions);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#CookieStoreManager-unsubscribe','CookieStoreManager.unsubscribe()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
@@ -59,20 +59,7 @@ var size = queuingStrategy.size();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#cqs-constructor","CountQueuingStrategy()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/index.html
@@ -54,20 +54,7 @@ var size = queueingStrategy.size();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#cqs-class','CountQueuingStrategy')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/size/index.html
@@ -52,20 +52,7 @@ var size = queuingStrategy.size();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#cqs-size","size")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part #1146.

This converts API interfaces (including properties & methods) starting with 'cb' to 'cq' to the {{Specifications}} macros. 

I kept the few comments that were below as they weren't directly speaking about the spec.

All looks fine, except:
- **ChildNode[.*]** have no bcd (but the `{{Compat}}` macro already): I kept the change to `{{Specifications}}`; they are part of a mixin and will go away soon;

- **ContentIndexEvent()** and **.id** have no bcd entries. I opened a PR (mdn/browser-compat-data#10963) to fix this;
- **CompressionStream** (and children) have no spec on their bcd entries. I opened a PR (mdn/browser-compat-data#10966) too;
- **CookieStoreManager** (and children) have no spec on their bcd entries. I opened a PR (mdn/browser-compat-data#10964) too.
- **CookieStore** (and children) have no spec on their bcd entries. I opened a PR (mdn/browser-compat-data#10965) too.
These four groups of spec tables in error will be hopefully fixed by end of next week once the new bcd package is generated.

- 3 children of **CompositionEvent** have no spec on their bcd entries, because these never were in a published spec. Before the spec they were temporary in was liste with the info that it wasn't there; no there is a missing spec_url message.

All the other pages look great.