### PR TITLE
Corrected "else" code block formatting

### DIFF
--- a/files/en-us/web/http/caching/index.html
+++ b/files/en-us/web/http/caching/index.html
@@ -171,8 +171,8 @@ if (req.http.Accept-Encoding) {
     set req.http.Accept-Encoding = "gzip";
   }
   // elsif other encoding types to check
-else {
-  unset req.http.Accept-Encoding;
+  else {
+    unset req.http.Accept-Encoding;
   }
 }
 </pre>


### PR DESCRIPTION
There is a formatting issue with "else" code block that my change corrects.

Modified page URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#normalization

This is how "else" code block looks right now:
![image](https://user-images.githubusercontent.com/57962620/121696644-8e089b80-cacc-11eb-8d7a-48169d02eae9.png)

This is how "else" code block should look and PR is about:
![image](https://user-images.githubusercontent.com/57962620/121696719-a5e01f80-cacc-11eb-850f-ff6e95b23da7.png)
