### PR TITLE
Make '1' to '9' valid DecimalNumbers

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/json/index.html
@@ -73,7 +73,7 @@ eval(code)        // throws a SyntaxError in old engines
               <em>or</em> <var>DecimalNumber</var> <strong>.</strong> <var>Digits</var>
               <em>or</em> <var>DecimalNumber</var> <strong>.</strong> <var>Digits</var> <var>ExponentPart</var>
               <em>or</em> <var>DecimalNumber</var> <var>ExponentPart</var>
-<var>DecimalNumber</var> = <strong>0</strong>
+<var>DecimalNumber</var> = <var>Digit</var>
              <em>or</em> <var>OneToNine</var> <var>Digits</var>
 <var>ExponentPart</var> = <strong>e</strong> <var>Exponent</var>
             <em>or</em> <strong>E</strong> <var>Exponent</var>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Currently, only `0` and `10` or higher are valid JSON `DecimalNumbers`, `1` to `9` are described as invalid.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

The current page only allows `0|[1-9][0-9]+`, if summarized as a Regexp. However, `[0-9]|[1-9][0-9]*` is required to match all numbers `0`, `1`, …, `10`, …

This would also be in accordance to [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259#section-6), which says:

```
      int = zero / ( digit1-9 *DIGIT )
```