### PR TITLE
Small language change in “Debugging CSS” doc

### DIFF
--- a/files/en-us/learn/css/building_blocks/debugging_css/index.html
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.html
@@ -145,7 +145,7 @@ tags:
  <li><a href="https://validator.w3.org/">HTML validator</a></li>
 </ul>
 
-<h3 id="Is_the_property_and_value_supported_by_the_browser_you_are_testing_in">Are the property and value supported by the browser you are testing in?</h3>
+<h3 id="Are_the_property_and_value_supported_by_the_browser_you_are_testing_in">Are the property and value supported by the browser you are testing in?</h3>
 
 <p>Browsers ignore CSS they don't understand. If the property or value you are using is not supported by the browser you are testing in then nothing will break, but that CSS won't be applied. DevTools will generally highlight unsupported properties and values in some way. In the screenshot below the browser does not support the subgrid value of {{cssxref("grid-template-columns")}}.</p>
 

--- a/files/en-us/learn/css/building_blocks/debugging_css/index.html
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.html
@@ -145,7 +145,7 @@ tags:
  <li><a href="https://validator.w3.org/">HTML validator</a></li>
 </ul>
 
-<h3 id="Is_the_property_and_value_supported_by_the_browser_you_are_testing_in">Is the property and value supported by the browser you are testing in?</h3>
+<h3 id="Is_the_property_and_value_supported_by_the_browser_you_are_testing_in">Are the property and value supported by the browser you are testing in?</h3>
 
 <p>Browsers ignore CSS they don't understand. If the property or value you are using is not supported by the browser you are testing in then nothing will break, but that CSS won't be applied. DevTools will generally highlight unsupported properties and values in some way. In the screenshot below the browser does not support the subgrid value of {{cssxref("grid-template-columns")}}.</p>
 

--- a/files/en-us/learn/css/building_blocks/debugging_css/index.html
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.html
@@ -145,7 +145,7 @@ tags:
  <li><a href="https://validator.w3.org/">HTML validator</a></li>
 </ul>
 
-<h3 id="Are_the_property_and_value_supported_by_the_browser_you_are_testing_in">Are the property and value supported by the browser you are testing in?</h3>
+<h3 id="are_the_property_and_value_supported_by_the_browser_you_are_testing_in">Are the property and value supported by the browser you are testing in?</h3>
 
 <p>Browsers ignore CSS they don't understand. If the property or value you are using is not supported by the browser you are testing in then nothing will break, but that CSS won't be applied. DevTools will generally highlight unsupported properties and values in some way. In the screenshot below the browser does not support the subgrid value of {{cssxref("grid-template-columns")}}.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Subject very agreement. "The property and value is supported" -> "The property and value ARE supported"

Looks like the ID of the h3 will need to be updated to, but hopefully that will be automatic...

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Debugging_CSS
> Issue number (if there is an associated issue)

> Anything else that could help us review it
