### PR TITLE
Fix for-in to for-of

### DIFF
--- a/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.html
@@ -11,10 +11,10 @@ tags:
 
 <p>The JavaScript <a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">strict
     mode</a>-only exception "for-in loop head declarations may not have initializers"
-  occurs when the head of a<a
-    href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in"> for...in</a> contains
+  occurs when the head of a <a
+    href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for...in</a> contains
   an initializer expression, such as |<code>for (var i = 0 in obj)</code>|. This is not
-  allowed in for-of loops in strict mode.</p>
+  allowed in for-in loops in strict mode.</p>
 
 <h2 id="Message">Message</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This article mentions about the for-in loop rather than the for-of loop.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer