### PR TITLE
Replace spec table with {{specifications}} for api/c[r-z]*

### DIFF
--- a/files/en-us/web/api/crashreportbody/index.html
+++ b/files/en-us/web/api/crashreportbody/index.html
@@ -50,20 +50,7 @@ browser-compat: api.CrashReportBody
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Reporting API","#crash-report","CrashReportBody")}}</td>
-   <td>{{Spec2("Reporting API")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credential/id/index.html
+++ b/files/en-us/web/api/credential/id/index.html
@@ -28,20 +28,7 @@ browser-compat: api.Credential.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credential/index.html
+++ b/files/en-us/web/api/credential/index.html
@@ -53,22 +53,7 @@ console.assert(pwdCredential.type === "password");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Credential Management')}}</td>
-   <td>{{Spec2('Credential Management')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credential/type/index.html
+++ b/files/en-us/web/api/credential/type/index.html
@@ -31,20 +31,7 @@ browser-compat: api.Credential.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credentialscontainer/create/index.html
+++ b/files/en-us/web/api/credentialscontainer/create/index.html
@@ -74,26 +74,7 @@ browser-compat: api.CredentialsContainer.create
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credentialscontainer-get','get()')}}
-      </td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebAuthn')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credentialscontainer/get/index.html
+++ b/files/en-us/web/api/credentialscontainer/get/index.html
@@ -87,26 +87,7 @@ browser-compat: api.CredentialsContainer.get
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credentialscontainer-get','get()')}}
-      </td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebAuthn')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credentialscontainer/index.html
+++ b/files/en-us/web/api/credentialscontainer/index.html
@@ -43,25 +43,7 @@ browser-compat: api.CredentialsContainer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Credential Management')}}</td>
-			<td>{{Spec2('Credential Management')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebAuthn')}}</td>
-			<td>{{Spec2('WebAuthn')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
@@ -44,21 +44,7 @@ browser-compat: api.CredentialsContainer.preventSilentAccess
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credentialscontainer-preventsilentaccess','preventSilentAccess()')}}
-      </td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credentialscontainer/store/index.html
+++ b/files/en-us/web/api/credentialscontainer/store/index.html
@@ -66,20 +66,7 @@ if ("PasswordCredential" in window) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/crypto/getrandomvalues/index.html
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.html
@@ -92,22 +92,7 @@ for (var i = 0; i &lt; array.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Crypto API', '#Crypto-method-getRandomValues')}}</td>
-      <td>{{Spec2('Web Crypto API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/crypto/index.html
+++ b/files/en-us/web/api/crypto/index.html
@@ -48,22 +48,7 @@ browser-compat: api.Crypto
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Web Crypto API", "#crypto-interface", "Crypto")}}</td>
-   <td>{{Spec2("Web Crypto API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/crypto/subtle/index.html
+++ b/files/en-us/web/api/crypto/subtle/index.html
@@ -27,20 +27,7 @@ browser-compat: api.Crypto.subtle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-Crypto', 'Crypto.subtle') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cryptokey/index.html
+++ b/files/en-us/web/api/cryptokey/index.html
@@ -90,20 +90,7 @@ browser-compat: api.CryptoKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('Web Crypto API', '#dfn-CryptoKey', 'CryptoKey') }}</td>
-   <td>{{ Spec2('Web Crypto API') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cryptokeypair/index.html
+++ b/files/en-us/web/api/cryptokeypair/index.html
@@ -45,20 +45,7 @@ browser-compat: api.CryptoKeyPair
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('Web Crypto API', '#dfn-CryptoKeyPair', 'CryptoKeyPair') }}</td>
-   <td>{{ Spec2('Web Crypto API') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css/escape/index.html
+++ b/files/en-us/web/api/css/escape/index.html
@@ -55,20 +55,7 @@ CSS.escape('\0')              // "\ufffd", the Unicode REPLACEMENT CHARACTER</pr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM', '#the-css.escape()-method', 'CSS.escape()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css/index.html
+++ b/files/en-us/web/api/css/index.html
@@ -48,32 +48,7 @@ browser-compat: api.CSS
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Painting API','#dom-css-paintworklet','paintWorklet')}}</td>
-   <td>{{Spec2('CSS Painting API')}}</td>
-   <td>Adds the <code>paintWorklet</code> static property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM', '#the-css.escape()-method', 'CSS')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td>Adds the <code>escape()</code> static method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Conditional', '#the-css-interface', 'CSS')}}</td>
-   <td>{{Spec2('CSS3 Conditional')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css/paintworklet/index.html
+++ b/files/en-us/web/api/css/paintworklet/index.html
@@ -42,20 +42,7 @@ browser-compat: api.CSS.paintWorklet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Painting API','#dom-css-paintworklet','paintWorklet')}}</td>
-      <td>{{Spec2('CSS Painting API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css/registerproperty/index.html
+++ b/files/en-us/web/api/css/registerproperty/index.html
@@ -113,21 +113,7 @@ button {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Properties and Values API', '#the-registerproperty-function',
-        'The registerProperty() function')}}</td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css/supports/index.html
+++ b/files/en-us/web/api/css/supports/index.html
@@ -58,22 +58,7 @@ result = CSS.supports(`(transform-style: preserve) or (-moz-transform-style: pre
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Conditional', '#dom-css-supports', 'CSS: supports()') }}</td>
-      <td>{{ Spec2('CSS3 Conditional') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssanimation/animationname/index.html
+++ b/files/en-us/web/api/cssanimation/animationname/index.html
@@ -51,21 +51,7 @@ console.log(animations[0].animationName);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Animations 2', '#dom-cssanimation-animationname',
-        'animationName')}}</td>
-      <td>{{Spec2('CSS3 Animations 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssanimation/index.html
+++ b/files/en-us/web/api/cssanimation/index.html
@@ -54,20 +54,7 @@ console.log(animations[0]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Animations 2', '#the-CSSAnimation-interface', 'CSSAnimation')}}</td>
-   <td>{{Spec2('CSS3 Animations 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.html
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.html
@@ -44,23 +44,7 @@ console.log(text);  // "(min-width: 400px)"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Conditional', '#dom-cssconditionrule-conditiontext',
-        'conditionText') }}</td>
-      <td>{{ Spec2('CSS3 Conditional') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssconditionrule/index.html
+++ b/files/en-us/web/api/cssconditionrule/index.html
@@ -31,22 +31,7 @@ browser-compat: api.CSSConditionRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Conditional', '#the-cssconditionrule-interface', 'CSSConditionRule') }}</td>
-   <td>{{ Spec2('CSS3 Conditional') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/index.html
+++ b/files/en-us/web/api/csscounterstylerule/index.html
@@ -53,22 +53,7 @@ browser-compat: api.CSSCounterStyleRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Counter Styles", "#the-csscounterstylerule-interface", "CSSCounterStyleRule")}}</td>
-   <td>{{Spec2("CSS3 Counter Styles")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssfontfacerule/index.html
+++ b/files/en-us/web/api/cssfontfacerule/index.html
@@ -45,27 +45,7 @@ console.log(myRules[0]); //a CSSFontFaceRule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Fonts', '#om-fontface', 'CSSFontFaceRule')}}</td>
-			<td>{{Spec2('CSS4 Fonts')}}</td>
-			<td>Supersedes definition in {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSFontFaceRule', 'CSSFontFaceRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssfontfacerule/style/index.html
+++ b/files/en-us/web/api/cssfontfacerule/style/index.html
@@ -38,27 +38,7 @@ browser-compat: api.CSSFontFaceRule.style
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Fonts', '#dom-cssfontfacerule-style', 'CSSFontFaceRule.style')}}</td>
-			<td>{{Spec2('CSS4 Fonts')}}</td>
-			<td>Supersedes definition in {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSFontFaceRule', 'CSSFontFaceRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -52,22 +52,7 @@ browser-compat: api.CSSGroupingRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSSOM', '#cssgroupingrule', 'CSSGroupingRule') }}</td>
-   <td>{{ Spec2('CSSOM') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssimagevalue/index.html
+++ b/files/en-us/web/api/cssimagevalue/index.html
@@ -54,20 +54,7 @@ console.log( allComputedStyles.get('background-image').toString() );
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#imagevalue-objects','CSSImageValue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -41,29 +41,7 @@ console.log(myRules[0].href); //returns style.css</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssimportrule-href', 'CSSImportRule.href')}}
-			</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}
-			</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssimportrule/index.html
+++ b/files/en-us/web/api/cssimportrule/index.html
@@ -42,27 +42,7 @@ console.log(myRules[0]); //a CSSImportRule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#cssimportrule', 'CSSImportRule')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssimportrule/media/index.html
+++ b/files/en-us/web/api/cssimportrule/media/index.html
@@ -39,29 +39,7 @@ console.log(myRules[0].media); //returns a MediaList</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssimportrule-media', 'CSSImportRule.media')}}
-			</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}
-			</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.html
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.html
@@ -41,29 +41,7 @@ console.log(myRules[0].styleSheet); //returns a CSSStyleSheet object</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssimportrule-stylesheet',
-				'CSSImportRule.styleSheet')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}
-			</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframerule/index.html
+++ b/files/en-us/web/api/csskeyframerule/index.html
@@ -53,22 +53,7 @@ console.log(keyframes[0]); // a CSSKeyframeRule representing an individual keyfr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#interface-csskeyframerule', 'CSSKeyframeRule')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframerule/keytext/index.html
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.html
@@ -52,22 +52,7 @@ console.log(keyframes[0].keyText); // a string containing 0%</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#dom-csskeyframerule-keytext', 'CSSKeyframeRule.keyText')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframerule/style/index.html
+++ b/files/en-us/web/api/csskeyframerule/style/index.html
@@ -57,22 +57,7 @@ console.log(keyframes[0].style); // a CSSStyleDeclaration</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#dom-csskeyframerule-style', 'CSSKeyframeRule.style')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/appendrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/appendrule/index.html
@@ -50,22 +50,7 @@ console.log(keyframes.cssRules); // a CSSRuleList object with two rules</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#interface-csskeyframesrule-appendrule', 'CSSKeyframesRule.appendRule')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.html
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.html
@@ -44,22 +44,7 @@ console.log(keyframes.cssRules); // a CSSRuleList object with two rules</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#dom-csskeyframesrule-cssrules', 'CSSKeyframesRule.cssRules')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/deleterule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/deleterule/index.html
@@ -61,22 +61,7 @@ console.log(keyframes.cssRules); // a CSSRuleList object with one rule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#dom-csskeyframesrule-deleterule', 'CSSKeyframesRule.deleteRule()')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/findrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/findrule/index.html
@@ -58,22 +58,7 @@ console.log(keyframes.findRule('to'));  // a CSSKeyframeRule object</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#interface-csskeyframesrule-findrule', 'CSSKeyframesRule.findRule()')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/index.html
@@ -60,22 +60,7 @@ let keyframes = myRules[0]; // a CSSKeyframesRule </pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#interface-csskeyframesrule', 'CSSKeyframesRule')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/name/index.html
+++ b/files/en-us/web/api/csskeyframesrule/name/index.html
@@ -45,22 +45,7 @@ console.log(keyframes.name); // "slidein"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Animations', '#dom-csskeyframesrule-name', 'CSSKeyframesRule.name')}}</td>
-   <td>{{Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
@@ -64,20 +64,7 @@ console.dir( keyword );
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csskeywordvalue-csskeywordvalue','CSSKeywordValue')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/index.html
@@ -52,20 +52,7 @@ console.log( myElement.get('display').value);  // 'initial'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#keywordvalue-objects','CSSKeywordValue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.html
+++ b/files/en-us/web/api/csskeywordvalue/value/index.html
@@ -45,20 +45,7 @@ indicator.attributeStyleMap.get('display').value // 'initial'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csskeywordvalue-value','undefined')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
@@ -44,20 +44,7 @@ browser-compat: api.CSSMathInvert.CSSMathInvert
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#cssmathinvert','CSSMathInvert')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CSSMathInvert
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssmathinvert','CSSMathInvert')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathinvert/value/index.html
+++ b/files/en-us/web/api/cssmathinvert/value/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSMathInvert.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#dom-cssmathinvert-value','CSSMathInvert.value')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.html
@@ -45,20 +45,7 @@ browser-compat: api.CSSMathMax.CSSMathMax
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#cssmathmax','CSSMathMax')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CSSMathMax
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssmathmax','CSSMathMax')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmax/values/index.html
+++ b/files/en-us/web/api/cssmathmax/values/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSMathMax.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#dom-cssmathmax-values','CSSMathMax.values')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.html
@@ -45,20 +45,7 @@ browser-compat: api.CSSMathMin.CSSMathMin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#cssmathmin','CSSMathMin')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CSSMathMin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssmathmin','CSSMathMin')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathmin/values/index.html
+++ b/files/en-us/web/api/cssmathmin/values/index.html
@@ -33,20 +33,7 @@ browser-compat: api.CSSMathMin.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#dom-cssmathmin-values','CSSMathMin.values')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSMathNegate.CSSMathNegate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#cssmathnegate','CSSMathNegate')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CSSMathNegate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssmathnegate','CSSMathNegate')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathnegate/value/index.html
+++ b/files/en-us/web/api/cssmathnegate/value/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSMathNegate.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#dom-cssmathnegate-value','CSSMathNegate.value')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
@@ -33,20 +33,7 @@ browser-compat: api.CSSMathProduct.CSSMathProduct
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmathproduct-cssmathproduct','CSSMathProduct()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSMathProduct
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssmathproduct','CSSMathProduct')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathproduct/values/index.html
+++ b/files/en-us/web/api/cssmathproduct/values/index.html
@@ -31,20 +31,7 @@ browser-compat: api.CSSMathProduct.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmathproduct-values','values')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSMathSum.CSSMathSum
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssmathsum','CSSMathSum()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/index.html
@@ -77,20 +77,7 @@ console.log( styleMap.get('width').values[1].value.unit ); // 'px'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssmathsum','CSSMathSum')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathsum/values/index.html
+++ b/files/en-us/web/api/cssmathsum/values/index.html
@@ -29,20 +29,7 @@ browser-compat: api.CSSMathSum.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmathsum-values','values')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathvalue/index.html
+++ b/files/en-us/web/api/cssmathvalue/index.html
@@ -73,20 +73,7 @@ console.log( styleMap.get('width').values[1].value );  // -20
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#complex-numeric','CSSMathValue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.html
+++ b/files/en-us/web/api/cssmathvalue/operator/index.html
@@ -100,20 +100,7 @@ console.log( styleMap.get('width').values[1].operator ) // 'negate'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmathvalue-operator','CSSMathValue.operator')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
@@ -38,20 +38,7 @@ browser-compat: api.CSSMatrixComponent.CSSMatrixComponent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmatrixcomponent-cssmatrixcomponent','CSSMatrixComponent')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSMatrixComponent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssmatrixcomponent','CSSMatrixComponent')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
@@ -38,21 +38,7 @@ browser-compat: api.CSSMatrixComponent.matrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssmatrixcomponent-cssmatrixcomponent-matrix-options-matrix','matrix')}}
-      </td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmediarule/index.html
+++ b/files/en-us/web/api/cssmediarule/index.html
@@ -45,32 +45,7 @@ console.log(myRules[0]); // a CSSMediaRule representing the media query.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Conditional', '#the-cssmediarule-interface', 'CSSMediaRule') }}</td>
-   <td>{{ Spec2('CSS3 Conditional')}}</td>
-   <td>Make it derived from the {{domxref("CSSConditionRule")}}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSSOM', '#the-cssmediarule-interface', 'CSSMediaRule') }}</td>
-   <td>{{ Spec2('CSSOM') }}</td>
-   <td>No changes from {{SpecName('DOM2 Style')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSMediaRule', 'CSSMediaRule') }}</td>
-   <td>{{ Spec2('DOM2 Style') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssmediarule/media/index.html
+++ b/files/en-us/web/api/cssmediarule/media/index.html
@@ -46,32 +46,7 @@ console.log(myRules[0].media); // a MediaList</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{ SpecName('CSS3 Conditional', '#dom-cssmediarule-media',
-        'CSSMediaRule.media') }}
-      </td>
-      <td>{{ Spec2('CSS3 Conditional')}}</td>
-      <td>Make it derived from the {{domxref("CSSConditionRule")}}.</td>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('DOM2 Style', 'css.html#CSS-CSSMediaRule', 'CSSMediaRule.media') }}
-      </td>
-      <td>{{ Spec2('DOM2 Style') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnamespacerule/index.html
+++ b/files/en-us/web/api/cssnamespacerule/index.html
@@ -40,22 +40,7 @@ console.log(myRules[0]); //a CSSNamespaceRule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSSOM', '#the-cssnamespacerule-interface', 'CSSNamespaceRule') }}</td>
-   <td>{{ Spec2('CSSOM') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.html
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.html
@@ -33,20 +33,7 @@ console.log(myRules[0].namespaceURI); //http://www.w3.org/1999/xhtml</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM','#dom-cssnamespacerule-namespaceuri','namespaceURI')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.html
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.html
@@ -35,20 +35,7 @@ console.log(myRules[1].namespaceURI); "svg"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM','#dom-cssnamespacerule-namespaceuri','namespaceURI')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericarray/index.html
+++ b/files/en-us/web/api/cssnumericarray/index.html
@@ -28,20 +28,7 @@ browser-compat: api.CSSNumericArray
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssnumericarray','CSSNumericArray')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericarray/length/index.html
+++ b/files/en-us/web/api/cssnumericarray/length/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSNumericArray.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericarray-length','length')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/add/index.html
+++ b/files/en-us/web/api/cssnumericvalue/add/index.html
@@ -49,20 +49,7 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-add','add')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/div/index.html
+++ b/files/en-us/web/api/cssnumericvalue/div/index.html
@@ -49,20 +49,7 @@ mathProduct.toString();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-div','div')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/equals/index.html
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.html
@@ -60,20 +60,7 @@ console.log(CSS.cm("1").equal(CSS.in("0.393701")));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-equals','equals')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/index.html
+++ b/files/en-us/web/api/cssnumericvalue/index.html
@@ -74,20 +74,7 @@ browser-compat: api.CSSNumericValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#numeric-value','CSSNumericValue')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/max/index.html
+++ b/files/en-us/web/api/cssnumericvalue/max/index.html
@@ -54,20 +54,7 @@ console.log(CSS.cm("1").max(CSS.in("0.393701")).toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-max','max')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/min/index.html
+++ b/files/en-us/web/api/cssnumericvalue/min/index.html
@@ -54,20 +54,7 @@ console.log(CSS.cm("1").max(CSS.in("0.393701")).toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-min','min')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/mul/index.html
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.html
@@ -49,20 +49,7 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-mul','mul')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/parse/index.html
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.html
@@ -51,20 +51,7 @@ browser-compat: api.CSSNumericValue.parse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-parse','parse')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/sub/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.html
@@ -51,20 +51,7 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-sub','sub')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/sum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sum/index.html
@@ -51,7 +51,20 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Specification</th>
+      <th scope="col">Status</th>
+      <th scope="col">Comment</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-sub','sub')}}</td>
+      <td>{{Spec2('CSS Typed OM')}}</td>
+      <td>Initial definition.</td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/sum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sum/index.html
@@ -51,20 +51,7 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-sub','sub')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/to/index.html
+++ b/files/en-us/web/api/cssnumericvalue/to/index.html
@@ -50,20 +50,7 @@ console.log(CSS.px("23").to("cm").toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-to','to')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.html
@@ -51,20 +51,7 @@ v.toSum("px", "percent").toString() // =&gt; "calc(1000.39px + 4%)"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-tosum','toSum')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/type/index.html
+++ b/files/en-us/web/api/cssnumericvalue/type/index.html
@@ -46,20 +46,7 @@ let cssNumericType = mathSum.type();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssnumericvalue-type','type')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspagerule/index.html
+++ b/files/en-us/web/api/csspagerule/index.html
@@ -44,27 +44,7 @@ console.log(myRules[0]); // a CSSPageRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#the-csspagerule-interface', 'CSSPageRule')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPageRule', 'CSSPageRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspagerule/selectortext/index.html
+++ b/files/en-us/web/api/csspagerule/selectortext/index.html
@@ -39,27 +39,7 @@ console.log(myRules[1].selectorText); // returns the string ":first"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-csspagerule-selectortext', 'CSSPageRule.selectorText')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPageRule', 'CSSPageRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspagerule/style/index.html
+++ b/files/en-us/web/api/csspagerule/style/index.html
@@ -45,27 +45,7 @@ console.log(myRules[0].style); // returns a CSSStyleDeclaration object</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssstylerule-style', 'CSSPageRule.style')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td>No changes from {{SpecName('DOM2 Style')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPageRule', 'CSSPageRule')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssperspective/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.html
@@ -48,20 +48,7 @@ browser-compat: api.CSSPerspective.CSSPerspective
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssperspective','CSSPerspective')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSPerspective
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssperspective','CSSPerspective')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssperspective/length/index.html
+++ b/files/en-us/web/api/cssperspective/length/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSPerspective.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssperspective-length','length')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
@@ -48,21 +48,7 @@ browser-compat: api.CSSPrimitiveValue.getCounterValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-getCounterValue',
-        'CSSPrimitiveValue.getCounterValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -141,21 +141,7 @@ console.log(cssValue.getFloatValue(CSSPrimitiveValue.CSS_CM));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-getFloatValue',
-        'CSSPrimitiveValue.getFloatValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -52,21 +52,7 @@ console.log(cssValue.getRectValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-getRectValue',
-        'CSSPrimitiveValue.getRectValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -52,21 +52,7 @@ console.log(cssValue.getRGBColorValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-getRGBColorValue',
-        'CSSPrimitiveValue.getRGBColorValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -50,21 +50,7 @@ console.log(cssValue.getStringValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-getStringValue',
-        'CSSPrimitiveValue.getStringValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -163,20 +163,7 @@ browser-compat: api.CSSPrimitiveValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue', 'CSSPrimitiveValue')}}</td>
-   <td>{{Spec2('DOM2 Style')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -175,21 +175,7 @@ console.log(cssValue.primitiveType);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-primitiveType',
-        'CSSPrimitiveValue.primitiveType')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -139,21 +139,7 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-setFloatValue',
-        'CSSPrimitiveValue.setFloatValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -83,21 +83,7 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSPrimitiveValue-setStringValue',
-        'CSSPrimitiveValue.setStringValue')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspropertyrule/index.html
+++ b/files/en-us/web/api/csspropertyrule/index.html
@@ -52,20 +52,7 @@ console.log(myRules[0]); //a CSSPropertyRule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-     <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-     </tr>
-     <tr>
-      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule','CSSPropertyRule')}}</td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-     </tr>
-    </tbody>
-   </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspropertyrule/inherits/index.html
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.html
@@ -39,20 +39,7 @@ console.log(myRules[0].inherits); //returns false</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-inherits','Inherits')}}</td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.html
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.html
@@ -41,20 +41,7 @@ console.log(myRules[0].initialValue); //the string "#c0ffee"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-initialvalue','InitialValue')}}</td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspropertyrule/name/index.html
+++ b/files/en-us/web/api/csspropertyrule/name/index.html
@@ -40,21 +40,7 @@ console.log(myRules[0].name); //the string "--property-name"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-name','Name')}}
-      </td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspropertyrule/syntax/index.html
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.html
@@ -39,20 +39,7 @@ console.log(myRules[0].syntax); //the string "&lt;color&gt;"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-syntax','Syntax')}}</td>
-      <td>{{Spec2('CSS Properties and Values API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspseudoelement/element/index.html
+++ b/files/en-us/web/api/csspseudoelement/element/index.html
@@ -44,21 +44,7 @@ console.log(myElement.nextSibling === cssPseudoElement);        // Outputs false
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS4 Pseudo-Elements', '#dom-csspseudoelement-element', 'element')}}
-      </td>
-      <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspseudoelement/index.html
+++ b/files/en-us/web/api/csspseudoelement/index.html
@@ -50,20 +50,7 @@ console.log(cssPseudoElement.type); // Outputs '::before'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#CSSPseudoElement-interface', 'CSSPseudoElement')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csspseudoelement/type/index.html
+++ b/files/en-us/web/api/csspseudoelement/type/index.html
@@ -47,20 +47,7 @@ console.log(mySelector === typeOfPseudoElement); // Outputs true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS4 Pseudo-Elements', '#dom-csspseudoelement-type', 'type')}}</td>
-      <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/angle/index.html
+++ b/files/en-us/web/api/cssrotate/angle/index.html
@@ -33,20 +33,7 @@ browser-compat: api.CSSRotate.angle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssrotate-angle','angle')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.html
@@ -59,20 +59,7 @@ browser-compat: api.CSSRotate.CSSRotate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssrotate','cssrotate')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/index.html
@@ -42,20 +42,7 @@ browser-compat: api.CSSRotate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssrotate','cssrotate')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/x/index.html
+++ b/files/en-us/web/api/cssrotate/x/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSRotate.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssrotate-x','x')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/y/index.html
+++ b/files/en-us/web/api/cssrotate/y/index.html
@@ -33,20 +33,7 @@ browser-compat: api.CSSRotate.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssrotate-y','y')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrotate/z/index.html
+++ b/files/en-us/web/api/cssrotate/z/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSRotate.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssrotate-z','z')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrule/csstext/index.html
+++ b/files/en-us/web/api/cssrule/csstext/index.html
@@ -47,22 +47,7 @@ console.log(stylesheet.cssRules[0].cssText); // body { background-color: darkblu
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssrule-csstext", "CSSRule: cssText")}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrule/index.html
+++ b/files/en-us/web/api/cssrule/index.html
@@ -54,47 +54,7 @@ console.log(myRules);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-    <td>{{SpecName('CSSOM', '#css-rules', 'CSSRule')}}</td>
-    <td>{{Spec2('CSSOM')}}</td>
-    <td>Obsoleted values <code>CHARSET_RULE</code> and <code>UNKNOWN_RULE</code>. Added value <code>NAMESPACE_RULE</code>. Deprecates <code>CSSRule.type</code>.</td>
-  </tr>
-  <tr>
-    <td>{{SpecName("CSS3 Animations",'#interface-cssrule', 'CSSRule')}}</td>
-    <td>{{Spec2('CSS3 Animations')}}</td>
-    <td>Added values <code>KEYFRAMES_RULE</code> and <code>KEYFRAME_RULE</code>.</td>
-  </tr>
-  <tr>
-    <td>{{SpecName('CSS4 Fonts', '#om-fontfeaturevalues', 'CSSRule')}}</td>
-    <td>{{Spec2('CSS4 Fonts')}}</td>
-    <td>Added value <code>FONT_FEATURE_VALUES_RULE</code>.</td>
-  </tr>
-  <tr>
-    <td>{{SpecName("CSS3 Counter Styles", "#extensions-to-cssrule-interface", 'CSSRule')}}</td>
-    <td>{{Spec2("CSS3 Counter Styles")}}</td>
-    <td>Added value <code>COUNTER_STYLE_RULE</code>.</td>
-  </tr>
-  <tr>
-    <td>{{SpecName("CSS3 Conditional", '#extensions-to-cssrule-interface', 'CSSRule')}}</td>
-    <td>{{Spec2('CSS3 Conditional')}}</td>
-    <td>Added value <code>SUPPORTS_RULE</code>. (<code>DOCUMENT_RULE</code> has been pushed to CSS Conditional Rules Level 4)</td>
-  </tr>
-  <tr>
-    <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSRule', 'CSSRule')}}</td>
-    <td>{{Spec2('DOM2 Style')}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrule/parentrule/index.html
+++ b/files/en-us/web/api/cssrule/parentrule/index.html
@@ -49,22 +49,7 @@ console.log(childRules[0].parentRule); // a CSSMediaRule</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.html
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.html
@@ -34,22 +34,7 @@ console.log(myRules.parentStyleSheet);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -150,21 +150,7 @@ console.log(myRules[0].type);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#concept-css-rule-type', 'CSSRule.type')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td>Obsoleted values <code>CHARSET_RULE</code> and <code>UNKNOWN_RULE</code>. Added
-        value <code>NAMESPACE_RULE</code>. Deprecates <code>CSSRule.type</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSRule', 'CSSRule.type')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -39,22 +39,7 @@ var first_rule = document.styleSheets[0].cssRules[0];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM', '#the-cssrulelist-interface', 'CSSRuleList')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssscale/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/cssscale/index.html
@@ -47,20 +47,7 @@ browser-compat: api.CSSScale.CSSScale
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssscale-cssscale','CSSScale')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/index.html
@@ -40,20 +40,7 @@ browser-compat: api.CSSScale
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#cssscale','CSSScale')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssscale/x/index.html
+++ b/files/en-us/web/api/cssscale/x/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSScale.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssscale-x','x')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssscale/y/index.html
+++ b/files/en-us/web/api/cssscale/y/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSScale.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssscale-y','y')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssscale/z/index.html
+++ b/files/en-us/web/api/cssscale/z/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSScale.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssscale-z','z')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskew/ax/index.html
+++ b/files/en-us/web/api/cssskew/ax/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSSkew.ax
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskew-ax','ax')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskew/ay/index.html
+++ b/files/en-us/web/api/cssskew/ay/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSSkew.ay
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskew-ay','ay')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskew/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/cssskew/index.html
@@ -40,20 +40,7 @@ browser-compat: api.CSSSkew.CSSSkew
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskew-cssskew','cssskew()')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/index.html
@@ -39,20 +39,7 @@ browser-compat: api.CSSSkew
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssskew','cssskew')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewx/ax/index.html
+++ b/files/en-us/web/api/cssskewx/ax/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSSkewX.ax
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskewx-ax','ax')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewx/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/cssskewx/index.html
@@ -38,20 +38,7 @@ browser-compat: api.CSSSkewX.CSSSkewX
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskewx-cssskewx','CSSskewX()')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSSkewX
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssskewx','cssskewx')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewy/ay/index.html
+++ b/files/en-us/web/api/cssskewy/ay/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSSkewY.ay
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssskewy-ay','ay')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewy/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/cssskewy/index.html
@@ -38,20 +38,7 @@ browser-compat: api.CSSSkewY.CSSSkewY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssskewy-cssskewy','CSSskewY()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/index.html
@@ -42,20 +42,7 @@ browser-compat: api.CSSSkewY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssskewy','CSSSkewY')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
@@ -39,22 +39,7 @@ console.log(rule.style.cssFloat); //right</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM", "#dom-cssstyledeclaration-cssfloat", "CSSStyleDeclaration.cssFloat")}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/csstext/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/csstext/index.html
@@ -28,22 +28,7 @@ browser-compat: api.CSSStyleDeclaration.cssText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM", "#dom-cssstyledeclaration-csstext", "CSSStyleDeclaration: cssText")}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
@@ -48,25 +48,7 @@ var rgbObj = style.getPropertyCSSValue('color').getRGBColorValue();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Declared as obsolete in <a
-          href="https://lists.w3.org/Archives/Public/www-style/2003Oct/0347.html">July
-          2003</a>.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.html
@@ -45,29 +45,7 @@ var isImportant = declaration.getPropertyPriority('margin') === 'important';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-getpropertypriority',
-        'CSSStyleDeclaration.getPropertyPriority()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.html
@@ -43,29 +43,7 @@ var value = declaration.getPropertyValue('margin'); // "1px 2px"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-getpropertyvalue',
-        'CSSStyleDeclaration.getPropertyValue()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -73,27 +73,7 @@ console.log(styleObj.cssText);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM', '#the-cssstyledeclaration-interface', 'CSSStyleDeclaration')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td>Merged the <strong>DOM Level 2 Style</strong> <code>CSS2Properties</code> interface into <code>CSSStyleDeclaration</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration', 'CSSStyleDeclaration')}}</td>
-   <td>{{Spec2('DOM2 Style')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/item/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/item/index.html
@@ -48,29 +48,7 @@ var propertyName = style.item(1); // or style[1] - returns the second style list
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-item',
-        'CSSStyleDeclaration.item()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/length/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.html
@@ -37,29 +37,7 @@ browser-compat: api.CSSStyleDeclaration.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-length',
-				'CSSStyleDeclaration.length')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-				'CSSStyleDeclaration')}}</td>
-			<td>{{Spec2('DOM2 Style')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/parentrule/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/parentrule/index.html
@@ -35,29 +35,7 @@ var rule = declaration.parentRule;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-parentrule',
-        'CSSStyleDeclaration.parentRule')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/removeproperty/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/removeproperty/index.html
@@ -51,29 +51,7 @@ var oldValue = declaration.removeProperty('background-color');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-removeproperty',
-        'CSSStyleDeclaration.removeProperty()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.html
@@ -194,29 +194,7 @@ colorBtn.addEventListener('click', setRandomColor);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstyledeclaration-setproperty',
-        'CSSStyleDeclaration.setProperty()')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleDeclaration',
-        'CSSStyleDeclaration')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylerule/index.html
+++ b/files/en-us/web/api/cssstylerule/index.html
@@ -48,27 +48,7 @@ console.log(myRules[0]); // a CSSStyleRule representing the h1.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSSOM', '#the-cssstylerule-interface', 'CSSStyleRule') }}</td>
-   <td>{{ Spec2('CSSOM') }}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('DOM2 Style', 'css.html#CSS-CSSStyleRule', 'CSSRule') }}</td>
-   <td>{{ Spec2('DOM2 Style') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.html
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.html
@@ -36,23 +36,7 @@ console.log(myRules[0].selectorText); // a string containing "h1".</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM', '#dom-cssstylerule-selectortext',
-				'CSSStyleRule.selectorText')}}</td>
-			<td>{{Spec2('CSSOM')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylerule/style/index.html
+++ b/files/en-us/web/api/cssstylerule/style/index.html
@@ -53,22 +53,7 @@ console.log(myRules[0].style); // a CSSStyleDeclaration representing the declara
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM", "#dom-cssstylerule-style", "CSSStyleRule: style")}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylerule/stylemap/index.html
+++ b/files/en-us/web/api/cssstylerule/stylemap/index.html
@@ -40,20 +40,7 @@ Object.values(stylesheet.cssRules).forEach(block =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('CSS Typed OM','#dom-cssstylerule-stylemap','styleMap')}}</td>
-            <td>{{Spec2('CSS Typed OM')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/addrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/addrule/index.html
@@ -71,21 +71,7 @@ browser-compat: api.CSSStyleSheet.addRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-addrule", 'CSSStyleSheet.addRule()')}}
-      </td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/cssrules/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssrules/index.html
@@ -59,21 +59,7 @@ for (let rule of ruleList) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-cssrules", 'CSSStyleSheet.cssRules')}}
-      </td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/deleterule/index.html
+++ b/files/en-us/web/api/cssstylesheet/deleterule/index.html
@@ -50,21 +50,7 @@ browser-compat: api.CSSStyleSheet.deleteRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-deleterule",
-        'CSSStyleSheet.deleteRule()')}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -151,25 +151,7 @@ browser-compat: api.CSSStyleSheet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM", "#cssstylesheet", 'CSSStyleSheet')}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 Style", "css.html#CSS-CSSStyleSheet", "CSSStyleSheet")}}</td>
-   <td>{{Spec2("DOM2 Style")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.html
@@ -187,27 +187,7 @@ function addStylesheetRules (rules) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssstylesheet-insertrule',
-        'CSSStyleSheet.insertRule')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td>No change from {{SpecName('DOM2 Style')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSStyleSheet-insertRule',
-        'CSSStyleSheet.insertRule')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/ownerrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/ownerrule/index.html
@@ -64,21 +64,7 @@ for (let rule of ruleList) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-ownerrule", 'CSSStyleSheet.ownerRule')}}
-      </td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/removerule/index.html
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.html
@@ -64,21 +64,7 @@ browser-compat: api.CSSStyleSheet.removeRule
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-removerule",
-        'CSSStyleSheet.removeRule()')}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylesheet/rules/index.html
+++ b/files/en-us/web/api/cssstylesheet/rules/index.html
@@ -47,20 +47,7 @@ browser-compat: api.CSSStyleSheet.rules
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-cssstylesheet-rules", 'CSSStyleSheet.rules')}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylevalue/index.html
+++ b/files/en-us/web/api/cssstylevalue/index.html
@@ -41,20 +41,7 @@ browser-compat: api.CSSStyleValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#stylevalue-objects','CSSStyleValue')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylevalue/parse/index.html
+++ b/files/en-us/web/api/cssstylevalue/parse/index.html
@@ -51,20 +51,7 @@ browser-compat: api.CSSStyleValue.parse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssstylevalue-parse','parse()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstylevalue/parseall/index.html
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.html
@@ -41,21 +41,7 @@ browser-compat: api.CSSStyleValue.parseAll
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssstylevalue-parseall','parseAll()')}}
-			</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csssupportsrule/index.html
+++ b/files/en-us/web/api/csssupportsrule/index.html
@@ -40,23 +40,7 @@ console.log(myRules[0]); // a CSSSupportsRule representing the feature query.</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Conditional', '#the-csssupportsrule-interface',
-        'CSSSupportsRule') }}</td>
-      <td>{{ Spec2('CSS3 Conditional') }}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/index.html
+++ b/files/en-us/web/api/csstransformcomponent/index.html
@@ -40,20 +40,7 @@ browser-compat: api.CSSTransformComponent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#csstransformcomponent','CSSTransformComponent')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.html
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.html
@@ -31,20 +31,7 @@ browser-compat: api.CSSTransformComponent.is2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformcomponent-is2d','is2D')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
@@ -49,21 +49,7 @@ browser-compat: api.CSSTransformComponent.toMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformcomponent-tomatrix','toMatrix()')}}
-      </td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.html
@@ -38,20 +38,7 @@ browser-compat: api.CSSTransformComponent.toString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#CSSTransformComponent-stringification-behavior','toString()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
@@ -47,20 +47,7 @@ browser-compat: api.CSSTransformValue.CSSTransformValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM')}}</td>
-      <td>{{Spec2('CSS Typed OM','#csstransformvalue','cssTransformValue')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/entries/index.html
+++ b/files/en-us/web/api/csstransformvalue/entries/index.html
@@ -43,20 +43,7 @@ browser-compat: api.CSSTransformValue.entries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/foreach/index.html
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.html
@@ -52,20 +52,7 @@ browser-compat: api.CSSTransformValue.forEach
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/index.html
@@ -72,20 +72,7 @@ browser-compat: api.CSSTransformValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#csstransformvalue','cssTransformValue')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/is2d/index.html
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.html
@@ -37,20 +37,7 @@ browser-compat: api.CSSTransformValue.is2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue-is2d','is2D')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/keys/index.html
+++ b/files/en-us/web/api/csstransformvalue/keys/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSTransformValue.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/length/index.html
+++ b/files/en-us/web/api/csstransformvalue/length/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSTransformValue.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue-length','length')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.html
@@ -45,20 +45,7 @@ browser-compat: api.CSSTransformValue.toMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue-tomatrix','toMatrix()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransformvalue/values/index.html
+++ b/files/en-us/web/api/csstransformvalue/values/index.html
@@ -37,20 +37,7 @@ browser-compat: api.CSSTransformValue.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstransformvalue')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransition/index.html
+++ b/files/en-us/web/api/csstransition/index.html
@@ -56,20 +56,7 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions Level 2', '#the-CSSTransition-interface', 'CSSTransition')}}</td>
-   <td>{{Spec2('CSS3 Transitions Level 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstransition/transitionproperty/index.html
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.html
@@ -55,21 +55,7 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Transitions Level 2', '#dom-csstransition-transitionproperty',
-        'transitionProperty')}}</td>
-      <td>{{Spec2('CSS3 Transitions Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstranslate/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.html
@@ -63,21 +63,7 @@ browser-compat: api.CSSTranslate.CSSTranslate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstranslate-csstranslate','CSSTranslate')}}
-      </td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/index.html
@@ -40,20 +40,7 @@ browser-compat: api.CSSTranslate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM')}}</td>
-   <td>{{Spec2('CSS Typed OM','#csstranslate','CSSTranslate')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstranslate/x/index.html
+++ b/files/en-us/web/api/csstranslate/x/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSTranslate.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstranslate-x','x')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstranslate/y/index.html
+++ b/files/en-us/web/api/csstranslate/y/index.html
@@ -32,20 +32,7 @@ browser-compat: api.CSSTranslate.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-csstranslate-y','y')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/csstranslate/z/index.html
+++ b/files/en-us/web/api/csstranslate/z/index.html
@@ -36,20 +36,7 @@ browser-compat: api.CSSTranslate.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-csstranslate-z','z')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
@@ -44,20 +44,7 @@ browser-compat: api.CSSUnitValue.CSSUnitValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#simple-numeric','CSSUnitValue')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/index.html
@@ -49,20 +49,7 @@ browser-compat: api.CSSUnitValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#simple-numeric','CSSUnitValue')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunitvalue/unit/index.html
+++ b/files/en-us/web/api/cssunitvalue/unit/index.html
@@ -42,21 +42,7 @@ console.log( pos.y.unit ); // "em"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssunitvalue-unit','CSSUnitValue.unit')}}
-			</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunitvalue/value/index.html
+++ b/files/en-us/web/api/cssunitvalue/value/index.html
@@ -43,20 +43,7 @@ console.log( pos.y.value ); // 10
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM','#dom-cssunitvalue-value','CSSUnitValue.value')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
@@ -42,20 +42,7 @@ console.log( values ); // CSSUnparsedValue {0: "1em", 1: "#445566", 2: "-45px", 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','CSSUnparsedValue')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.html
@@ -41,20 +41,7 @@ browser-compat: api.CSSUnparsedValue.entries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','entries()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.html
@@ -54,20 +54,7 @@ browser-compat: api.CSSUnparsedValue.forEach
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','forEach()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/index.html
@@ -47,20 +47,7 @@ browser-compat: api.CSSUnparsedValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','CSSUnparsedValue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSUnparsedValue.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','keys()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/length/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.html
@@ -39,20 +39,7 @@ console.log( values.length ) // 3</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssunparsedvalue-length','length')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/values/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.html
@@ -34,20 +34,7 @@ browser-compat: api.CSSUnparsedValue.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#cssunparsedvalue','values()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -33,21 +33,7 @@ console.log(cssValue.cssText);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValue-cssText', 'CSSValue.cssText')}}
-      </td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -67,21 +67,7 @@ console.log(cssValue.cssValueType);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValue-cssValueType',
-        'CSSValue.cssValueType')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -51,20 +51,7 @@ browser-compat: api.CSSValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValue', 'CSSValue')}}</td>
-   <td>{{Spec2('DOM2 Style')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -38,20 +38,7 @@ browser-compat: api.CSSValueList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValuesList', 'CSSValuesList')}}</td>
-   <td>{{Spec2('DOM2 Style')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/item/index.html
+++ b/files/en-us/web/api/cssvaluelist/item/index.html
@@ -39,21 +39,7 @@ browser-compat: api.CSSValueList.item
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValueList-item',
-        'CSSValueList.item')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/length/index.html
+++ b/files/en-us/web/api/cssvaluelist/length/index.html
@@ -30,21 +30,7 @@ browser-compat: api.CSSValueList.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSValueList-length',
-        'CSSValueList.length')}}</td>
-      <td>{{Spec2('DOM2 Style')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
@@ -37,23 +37,7 @@ browser-compat: api.CSSVariableReferenceValue.CSSVariableReferenceValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-cssvariablereferencevalue','CSSVariableReferenceValue()')}}
-      </td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
@@ -30,22 +30,7 @@ browser-compat: api.CSSVariableReferenceValue.fallback
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-fallback','fallback')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.html
@@ -37,20 +37,7 @@ browser-compat: api.CSSVariableReferenceValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#cssvariablereferencevalue','CSSVariableReferenceValue')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
@@ -31,22 +31,7 @@ browser-compat: api.CSSVariableReferenceValue.variable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-variable','variable')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customelementregistry/define/index.html
+++ b/files/en-us/web/api/customelementregistry/define/index.html
@@ -235,22 +235,7 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG",
-        "custom-elements.html#dom-customelementregistry-define",
-        "customElements.define()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customelementregistry/get/index.html
+++ b/files/en-us/web/api/customelementregistry/get/index.html
@@ -54,21 +54,7 @@ browser-compat: api.CustomElementRegistry.get
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "custom-elements.html#dom-customelementregistry-get",
-        "customElements.get()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customelementregistry/index.html
+++ b/files/en-us/web/api/customelementregistry/index.html
@@ -76,20 +76,7 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "custom-elements.html#customelementregistry", "CustomElementRegistry")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customelementregistry/upgrade/index.html
+++ b/files/en-us/web/api/customelementregistry/upgrade/index.html
@@ -55,22 +55,7 @@ console.assert(el instanceof SpiderMan);    // upgraded!
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG",
-        "custom-elements.html#dom-customelementregistry-upgrade",
-        "customElements.upgrade()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customelementregistry/whendefined/index.html
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.html
@@ -94,21 +94,7 @@ container.removeChild(placeholder);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-customelementregistry-whendefined",
-        "customElements.whenDefined()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customevent/customevent/index.html
+++ b/files/en-us/web/api/customevent/customevent/index.html
@@ -63,22 +63,7 @@ obj.dispatchEvent(event);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-customevent-customevent','CustomEvent()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customevent/detail/index.html
+++ b/files/en-us/web/api/customevent/detail/index.html
@@ -46,22 +46,7 @@ let myDetail = <em>event.detail</em>;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-customevent-detail','detail')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customevent/index.html
+++ b/files/en-us/web/api/customevent/index.html
@@ -48,22 +48,7 @@ browser-compat: api.CustomEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#interface-customevent','CustomEvent')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/customevent/initcustomevent/index.html
+++ b/files/en-us/web/api/customevent/initcustomevent/index.html
@@ -50,23 +50,7 @@ browser-compat: api.CustomEvent.initCustomEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-customevent-initcustomevent','CustomEvent')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition, but already deprecated in favor of the use of a constructor,
-        {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part #1146.

This converts API interfaces (including properties & methods) starting with 'cr' to 'cz' to the {{Specifications}} macros. 

A few notes:
- **`CSSConditionRule.conditionText`** is losing its spec table. I'm updating mdn/bcd (compat data was also missing) in mdn/browser-compat-data#10968; it will be automatically fixed after that PR lands.
- **`CSSNumericValue.sum`** was bogus (looked like half .sub–half .sum). I've removed it from this PR and opened mdn/content#5924  for its removal (not in the spec, not in chromium, and marked as draft).
- A bunch of de deprecated properties/methods/interface are losing their spec table. I opened mdn/browser-compat-data#10970 to get them back (and, anyway, we'll decide there how to deal with these): `CSSStyleDeclaration.getPropertyCSSValue()`, `CSSValueList` and 2 children, `CSSValue` and 2 children, `CSSPrimitiveValue` and 6 children. 
- **`CrashReportBody`** has no bcd and seems partially documented. It will be revisited anyway when bcd will be added. So I kept it. 

All other pages look fine.