### PR TITLE
Remove IDs from CSS docs, part 1

### DIFF
--- a/files/en-us/web/css/@font-face/src/index.html
+++ b/files/en-us/web/css/@font-face/src/index.html
@@ -39,9 +39,9 @@ src: local(font), url(path/to/font.svg) format("svg"),
 
 <dl>
  <dt><code>&lt;url&gt; [ format( &lt;string&gt;# ) ]?</code></dt>
- <dd>Specifies an external reference consisting of a {{cssxref("&lt;url&gt;")}}, followed by an optional hint using the <code id="format()">format()</code> function to describe the format of the font resource referenced by that URL. The format hint contains a comma-separated list of format strings that denote well-known font formats. If a user agent doesn't support the specified formats, it skips downloading the font resource. If no format hints are supplied, the font resource is always downloaded.</dd>
+ <dd>Specifies an external reference consisting of a {{cssxref("&lt;url&gt;")}}, followed by an optional hint using the <code>format()</code> function to describe the format of the font resource referenced by that URL. The format hint contains a comma-separated list of format strings that denote well-known font formats. If a user agent doesn't support the specified formats, it skips downloading the font resource. If no format hints are supplied, the font resource is always downloaded.</dd>
  <dt><code>&lt;font-face-name&gt;</code></dt>
- <dd>Specifies the name of a locally-installed font face using the <code id="local()">local()</code> function, which uniquely identifies a single font face within a larger family. The name can optionally be enclosed in quotes.</dd>
+ <dd>Specifies the name of a locally-installed font face using the <code>local()</code> function, which uniquely identifies a single font face within a larger family. The name can optionally be enclosed in quotes.</dd>
 </dl>
 
 <h2 id="Description">Description</h2>

--- a/files/en-us/web/css/@font-feature-values/index.html
+++ b/files/en-us/web/css/@font-feature-values/index.html
@@ -19,17 +19,17 @@ browser-compat: css.at-rules.font-feature-values
 <h3 id="Feature_value_blocks">Feature value blocks</h3>
 
 <dl>
- <dt id="@swash"><code>@swash</code></dt>
+ <dt><code>@swash</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "swash()", "#swash()")}} functional notation of {{cssxref("font-variant-alternates")}}. A swash feature value definition allows only one value: <code>ident1: 2</code> is valid, but <code>ident2: 2 4</code> isn't.</dd>
- <dt id="@annotation"><code>@annotation</code></dt>
+ <dt><code>@annotation</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "annotation()", "#annotation()")}} functional notation of {{cssxref("font-variant-alternates")}}. An annotation feature value definition allows only one value: <code>ident1: 2</code> is valid, but <code>ident2: 2 4</code> isn't.</dd>
- <dt id="@ornaments"><code>@ornaments</code></dt>
+ <dt><code>@ornaments</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "ornaments()", "#ornaments()")}} functional notation of {{cssxref("font-variant-alternates")}}. An ornaments feature value definition allows only one value: <code>ident1: 2</code> is valid, but <code>ident2: 2 4</code> isn't.</dd>
- <dt id="@stylistic"><code>@stylistic</code></dt>
+ <dt><code>@stylistic</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "stylistic()", "#stylistic()")}} functional notation of {{cssxref("font-variant-alternates")}}. A stylistic feature value definition allows only one value: <code>ident1: 2</code> is valid, but <code>ident2: 2 4</code> isn't.</dd>
- <dt id="@styleset"><code>@styleset</code></dt>
+ <dt><code>@styleset</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "styleset()", "#styleset()")}} functional notation of {{cssxref("font-variant-alternates")}}. A styleset feature value definition allows an unlimited number of values: <code>ident1: 2 4 12 1</code> maps to the OpenType values <code>ss02</code>, <code>ss04</code>, <code>ss12</code>, and <code>ss01</code>. Note that values higher than <code>99</code> are valid, but don't map to any OpenType values and are ignored.</dd>
- <dt id="@character-variant"><code>@character-variant</code></dt>
+ <dt><code>@character-variant</code></dt>
  <dd>Specifies a feature name that will work with the {{cssxref("font-variant-alternates", "character-variant()", "#character-variant()")}} functional notation of {{cssxref("font-variant-alternates")}}. A character-variant feature value definition allows either one or two values: <code>ident1: 3</code> maps to <code>cv03=1</code>, and <code>ident2: 2 4</code> maps to <code>cv02=4</code>, but <code>ident2: 2 4 5</code> is invalid.</dd>
 </dl>
 

--- a/files/en-us/web/css/_colon_in-range/index.html
+++ b/files/en-us/web/css/_colon_in-range/index.html
@@ -29,7 +29,6 @@ input:in-range {
 
 <h2 id="Examples">Examples</h2>
 
-<div id="example">
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;form action="" id="form1"&gt;
@@ -70,7 +69,6 @@ input:out-of-range + label::after {
 }</pre>
 
 <h3 id="Result">Result</h3>
-</div>
 
 <p>{{EmbedLiveSample('Examples', 600, 140)}}</p>
 

--- a/files/en-us/web/css/_colon_out-of-range/index.html
+++ b/files/en-us/web/css/_colon_out-of-range/index.html
@@ -31,7 +31,6 @@ input:out-of-range {
 
 <h2 id="Examples">Examples</h2>
 
-<div id="example">
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;form action="" id="form1"&gt;
@@ -73,7 +72,6 @@ input:out-of-range + label::after {
 }</pre>
 
 <h3 id="Result">Result</h3>
-</div>
 
 <div>{{EmbedLiveSample('Examples', 600, 140)}}</div>
 

--- a/files/en-us/web/css/angle/index.html
+++ b/files/en-us/web/css/angle/index.html
@@ -26,13 +26,13 @@ browser-compat: css.types.angle
 <h3 id="Units">Units</h3>
 
 <dl>
- <dt><code><a id="deg">deg</a></code></dt>
+ <dt><code>deg</code></dt>
  <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Degree_%28angle%29">degrees</a>. One full circle is <code>360deg</code>. Examples: <code>0deg</code>, <code>90deg</code>, <code>14.23deg</code>.</dd>
- <dt id="grad"><code>grad</code></dt>
+ <dt><code>grad</code></dt>
  <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Gradian">gradians</a>. One full circle is <code>400grad</code>. Examples: <code>0grad</code>, <code>100grad</code>, <code>38.8grad</code>.</dd>
- <dt id="rad"><code>rad</code></dt>
+ <dt><code>rad</code></dt>
  <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Radian">radians</a>. One full circle is 2π radians which approximates to <code>6.2832rad</code>. <code>1rad</code> is 180/π degrees. Examples: <code>0rad</code>, <code>1.0708rad</code>, <code>6.2832rad</code>.</dd>
- <dt id="turn"><code>turn</code></dt>
+ <dt><code>turn</code></dt>
  <dd>Represents an angle in a number of turns. One full circle is <code>1turn</code>. Examples: <code>0turn</code>, <code>0.25turn</code>, <code>1.2turn</code>.</dd>
 </dl>
 

--- a/files/en-us/web/css/animation/index.html
+++ b/files/en-us/web/css/animation/index.html
@@ -70,13 +70,13 @@ animation: slidein 3s;
 <h3 id="Values">Values</h3>
 
 <dl>
-	<dt><code id="&lt;single-animation-iteration-count&gt;">&lt;single-animation-iteration-count&gt;</code></dt>
+	<dt><code>&lt;single-animation-iteration-count&gt;</code></dt>
 	<dd>The number of times the animation is played. The value must be one of those available in {{cssxref("animation-iteration-count")}}.</dd>
-	<dt id="&lt;single-animation-direction&gt;"><code>&lt;single-animation-direction&gt;</code></dt>
+	<dt><code>&lt;single-animation-direction&gt;</code></dt>
 	<dd>The direction in which the animation is played. The value must be one of those available in {{cssxref("animation-direction")}}.</dd>
-	<dt id="&lt;single-animation-fill-mode&gt;"><code>&lt;single-animation-fill-mode&gt;</code></dt>
+	<dt><code>&lt;single-animation-fill-mode&gt;</code></dt>
 	<dd>Determines how styles should be applied to the animation's target before and after its execution. The value must be one of those available in {{cssxref("animation-fill-mode")}}.</dd>
-	<dt id="&lt;single-animation-play-state&gt;"><code>&lt;single-animation-play-state&gt;</code></dt>
+	<dt><code>&lt;single-animation-play-state&gt;</code></dt>
 	<dd>Determines whether the animation is playing or not. The value must be one of those available in {{cssxref("animation-play-state")}}.</dd>
 </dl>
 

--- a/files/en-us/web/css/attribute_selectors/index.html
+++ b/files/en-us/web/css/attribute_selectors/index.html
@@ -56,9 +56,9 @@ a[class~="logo"] {
  <dd>Represents elements with an attribute name of <em>attr</em> whose value is suffixed (followed) by <em>value</em>.</dd>
  <dt><code>[<em>attr</em>*=<em>value</em>]</code></dt>
  <dd>Represents elements with an attribute name of <em>attr</em> whose value contains at least one occurrence of <em>value</em> within the string.</dd>
- <dt id="case-insensitive"><code>[<em>attr</em> <em>operator</em> <em>value</em> i]</code></dt>
+ <dt><code>[<em>attr</em> <em>operator</em> <em>value</em> i]</code></dt>
  <dd>Adding an <code>i</code> (or <code>I</code>) before the closing bracket causes the value to be compared case-insensitively (for characters within the ASCII range).</dd>
- <dt id="case-sensitive"><code>[<em>attr</em> <em>operator</em> <em>value</em> s]</code> {{Experimental_Inline}}</dt>
+ <dt><code>[<em>attr</em> <em>operator</em> <em>value</em> s]</code> {{Experimental_Inline}}</dt>
  <dd>Adding an <code>s</code> (or <code>S</code>) before the closing bracket causes the value to be compared case-sensitively (for characters within the ASCII range).</dd>
 </dl>
 

--- a/files/en-us/web/css/background-attachment/index.html
+++ b/files/en-us/web/css/background-attachment/index.html
@@ -36,7 +36,7 @@ background-attachment: unset;
 
 <dl>
  <dt><code>fixed</code></dt>
- <dd>The background is fixed relative to the viewport. Even if an element has a scrolling mechanism, the background doesn't move with the element. (This is not compatible with {{cssxref("background-clip", "background-clip: text", "#text")}}.)</dd>
+ <dd>The background is fixed relative to the viewport. Even if an element has a scrolling mechanism, the background doesn't move with the element. (This is not compatible with {{cssxref("background-clip", "background-clip: text", "#values")}}.)</dd>
  <dt><code>local</code></dt>
  <dd>The background is fixed relative to the element's contents. If the element has a scrolling mechanism, the background scrolls with the element's contents, and the background painting area and background positioning area are relative to the scrollable area of the element rather than to the border framing them.</dd>
  <dt><code>scroll</code></dt>

--- a/files/en-us/web/css/background-clip/index.html
+++ b/files/en-us/web/css/background-clip/index.html
@@ -50,7 +50,7 @@ background-clip: unset;
  <dd>The background extends to the outside edge of the padding. No background is drawn beneath the border.</dd>
  <dt><code>content-box</code></dt>
  <dd>The background is painted within (clipped to) the content box.</dd>
- <dt><code id="text">text</code> {{experimental_inline}}</dt>
+ <dt><code>text</code> {{experimental_inline}}</dt>
  <dd>The background is painted within (clipped to) the foreground text.</dd>
 </dl>
 

--- a/files/en-us/web/css/background-color/index.html
+++ b/files/en-us/web/css/background-color/index.html
@@ -54,12 +54,12 @@ background-color: transparent;
 background-color: transparent;
 </pre>
 
-<p>The <code>background-color</code> property is specified as a single <code><a href="#color">&lt;color&gt;</a></code> value.</p>
+<p>The <code>background-color</code> property is specified as a single <code>>&lt;color&gt;</code> value.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
-	<dt><a id="color"></a>{{cssxref("&lt;color&gt;")}}</dt>
+	<dt>{{cssxref("&lt;color&gt;")}}</dt>
 	<dd>The uniform color of the background. It is rendered behind any {{cssxref("background-image")}} that is specified, although the color will still be visible through any transparency in the image.</dd>
 </dl>
 

--- a/files/en-us/web/css/background-image/index.html
+++ b/files/en-us/web/css/background-image/index.html
@@ -27,7 +27,7 @@ browser-compat: css.properties.background-image
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>Each background image is specified either as the keyword <code><a href="#none">none</a></code> or as an {{cssxref("&lt;image&gt;")}} value.</p>
+<p>Each background image is specified either as the keyword <code>none</code> or as an {{cssxref("&lt;image&gt;")}} value.</p>
 
 <p>To specify multiple background images, supply multiple values, separated by a comma:</p>
 
@@ -38,9 +38,9 @@ browser-compat: css.properties.background-image
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Is a keyword denoting the absence of images.</dd>
- <dt id="image"><code>&lt;image&gt;</code></dt>
+ <dt><code>&lt;image&gt;</code></dt>
  <dd>Is an {{cssxref("&lt;image&gt;")}} denoting the image to display. There can be several of them, separated by commas, as <a href="/en-US/docs/Web/Guide/CSS/Using_multiple_backgrounds">multiple backgrounds</a> are supported.</dd>
 </dl>
 

--- a/files/en-us/web/css/background-position/index.html
+++ b/files/en-us/web/css/background-position/index.html
@@ -47,12 +47,12 @@ background-position: initial;
 background-position: unset;
 </pre>
 
-<p>The <code>background-position</code> property is specified as one or more <code><a href="#position">&lt;position&gt;</a></code> values, separated by commas.</p>
+<p>The <code>background-position</code> property is specified as one or more <code>&lt;position&gt;</code> values, separated by commas.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="position"><code>&lt;position&gt;</code></dt>
+ <dt><code>&lt;position&gt;</code></dt>
  <dd>A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be <code>center</code>. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s).</dd>
  <dd>
  <p><strong>1-value syntax:</strong> the value may be:</p>

--- a/files/en-us/web/css/background-size/index.html
+++ b/files/en-us/web/css/background-size/index.html
@@ -51,9 +51,9 @@ background-size: unset;
 <p>The <code>background-size</code> property is specified in one of the following ways:</p>
 
 <ul>
- <li>Using the keyword values <code><a href="#contain">contain</a></code> or <code><a href="#cover">cover</a></code>.</li>
- <li>Using a width value only, in which case the height defaults to <code><a href="#auto">auto</a></code><a href="#auto">.</a></li>
- <li>Using both a width and a height value, in which case the first sets the width and the second sets the height. Each value can be a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or <code><a href="#auto">auto</a></code>.</li>
+ <li>Using the keyword values <code>contain</code> or <code>cover</code>.</li>
+ <li>Using a width value only, in which case the height defaults to <code>auto</code>.</li>
+ <li>Using both a width and a height value, in which case the first sets the width and the second sets the height. Each value can be a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or <code>auto</code>.</li>
 </ul>
 
 <p>To specify the size of multiple background images, separate the value for each one with a comma.</p>
@@ -61,15 +61,15 @@ background-size: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="contain"><code>contain</code></dt>
- <dd>Scales the image as large as possible within its container without cropping or stretching the image. If the container is larger than the image, this will result in image tiling, unless the <code><a href="#contain">background-repeat</a></code> property is set to <code><a href="#contain">no-repeat</a></code>.</dd>
- <dt id="cover"><code>cover</code></dt>
+ <dt><code>contain</code></dt>
+ <dd>Scales the image as large as possible within its container without cropping or stretching the image. If the container is larger than the image, this will result in image tiling, unless the {{cssxref("background-repeat")}} property is set to <code>no-repeat</code>.</dd>
+ <dt><code>cover</code></dt>
  <dd>Scales the image as large as possible to fill the container, stretching the image if necessary. If the proportions of the image differ from the element, it is cropped either vertically or horizontally so that no empty space remains.</dd>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd>Scales the background image in the corresponding direction such that its intrinsic proportions are maintained.</dd>
- <dt id="length">{{cssxref("&lt;length&gt;")}}</dt>
+ <dt>{{cssxref("&lt;length&gt;")}}</dt>
  <dd>Stretches the image in the corresponding dimension to the specified length. Negative values are not allowed.</dd>
- <dt id="percentage">{{cssxref("&lt;percentage&gt;")}}</dt>
+ <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
  <dd>Stretches the image in the corresponding dimension to the specified percentage of the <em>background positioning area</em>. The background positioning area is determined by the value of {{cssxref("background-origin")}} (by default, the padding box). However, if the background's {{cssxref("background-attachment")}} value is <code>fixed</code>, the positioning area is instead the entire {{glossary("viewport")}}. Negative values are not allowed.</dd>
 </dl>
 

--- a/files/en-us/web/css/background/index.html
+++ b/files/en-us/web/css/background/index.html
@@ -54,34 +54,34 @@ background: no-repeat center/80% url("../img/image.png");
 <ul>
  <li>Each layer may include zero or one occurrences of any of the following values:
   <ul>
-   <li><code><a href="#attachment">&lt;attachment&gt;</a></code></li>
-   <li><code><a href="#bg-image">&lt;bg-image&gt;</a></code></li>
-   <li><code><a href="#position">&lt;position&gt;</a></code></li>
-   <li><code><a href="#bg-size">&lt;bg-size&gt;</a></code></li>
-   <li><code><a href="#repeat-style">&lt;repeat-style&gt;</a></code></li>
+   <li><code>&lt;attachment&gt;</code></li>
+   <li><code>&lt;bg-image&gt;</code></li>
+   <li><code>&lt;position&gt;</code></li>
+   <li><code>&lt;bg-size&gt;</code></li>
+   <li><code>&lt;repeat-style&gt;</code></li>
   </ul>
  </li>
- <li>The <code><a href="#bg-size">&lt;bg-size&gt;</a></code> value may only be included immediately after <code><a href="#position">&lt;position&gt;</a></code>, separated with the '/' character, like this: "<code>center/80%</code>".</li>
- <li>The <code><a href="#box">&lt;box&gt;</a></code> value may be included zero, one, or two times. If included once, it sets both {{cssxref("background-origin")}} and {{cssxref("background-clip")}}. If it is included twice, the first occurrence sets {{cssxref("background-origin")}}, and the second sets {{cssxref("background-clip")}}.</li>
- <li>The <code><a href="#background-color">&lt;background-color&gt;</a></code> value may only be included in the last layer specified.</li>
+ <li>The <code>&lt;bg-size&gt;</code> value may only be included immediately after <code>&lt;position&gt;</code>, separated with the '/' character, like this: "<code>center/80%</code>".</li>
+ <li>The <code>&lt;box&gt;</code> value may be included zero, one, or two times. If included once, it sets both {{cssxref("background-origin")}} and {{cssxref("background-clip")}}. If it is included twice, the first occurrence sets {{cssxref("background-origin")}}, and the second sets {{cssxref("background-clip")}}.</li>
+ <li>The <code>&lt;background-color&gt;</code> value may only be included in the last layer specified.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="attachment"><code>&lt;attachment&gt;</code></dt>
+ <dt><code>&lt;attachment&gt;</code></dt>
  <dd>See {{cssxref("background-attachment")}}</dd>
- <dt id="box"><code>&lt;box&gt;</code></dt>
+ <dt><code>&lt;box&gt;</code></dt>
  <dd>See {{cssxref("background-clip")}} and {{cssxref("background-origin")}}</dd>
- <dt id="background-color"><code>&lt;background-color&gt;</code></dt>
+ <dt><code>&lt;background-color&gt;</code></dt>
  <dd>See {{cssxref("background-color")}}</dd>
- <dt id="bg-image"><code>&lt;bg-image&gt;</code></dt>
+ <dt><code>&lt;bg-image&gt;</code></dt>
  <dd>See {{Cssxref("background-image")}}</dd>
- <dt id="position"><code>&lt;position&gt;</code></dt>
+ <dt><code>&lt;position&gt;</code></dt>
  <dd>See {{cssxref("background-position")}}</dd>
- <dt id="repeat-style"><code>&lt;repeat-style&gt;</code></dt>
+ <dt><code>&lt;repeat-style&gt;</code></dt>
  <dd>See {{cssxref("background-repeat")}}</dd>
- <dt id="bg-size"><code>&lt;bg-size&gt;</code></dt>
+ <dt><code>&lt;bg-size&gt;</code></dt>
  <dd>See {{cssxref("background-size")}}.</dd>
 </dl>
 

--- a/files/en-us/web/css/basic-shape/index.html
+++ b/files/en-us/web/css/basic-shape/index.html
@@ -30,7 +30,7 @@ browser-compat: css.types.basic-shape
 <p>The following shapes are supported. All <code>&lt;basic-shape&gt;</code> values use functional notation and are defined here using the <a href="/en-US/docs/Web/CSS/Value_definition_syntax">value definition syntax</a>.</p>
 
 <dl>
- <dt><code><a id="inset()"></a>{{cssxref("basic-shape/inset()","inset()")}}</code></dt>
+ <dt><code>{{cssxref("basic-shape/inset()","inset()")}}</code></dt>
  <dd>
  <pre class="brush: css">inset( &lt;shape-arg&gt;{1,4} [round &lt;border-radius&gt;]? )</pre>
 
@@ -42,7 +42,7 @@ browser-compat: css.types.basic-shape
 
  <p>A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.</p>
  </dd>
- <dt><code><a id="circle()"></a>{{cssxref("basic-shape/circle()","circle()")}}</code></dt>
+ <dt><code>{{cssxref("basic-shape/circle()","circle()")}}</code></dt>
  <dd>
  <pre class="brush: css">circle( [&lt;shape-radius&gt;]? [at &lt;position&gt;]? )</pre>
 
@@ -50,7 +50,7 @@ browser-compat: css.types.basic-shape
 
  <p>The {{cssxref("&lt;position&gt;")}} argument defines the center of the circle. This defaults to center if omitted.</p>
  </dd>
- <dt><code><a id="ellipse()"></a>{{cssxref("basic-shape/ellipse()","ellipse()")}}</code></dt>
+ <dt><code>{{cssxref("basic-shape/ellipse()","ellipse()")}}</code></dt>
  <dd>
  <pre class="brush: css">ellipse( [&lt;shape-radius&gt;{2}]? [at &lt;position&gt;]? )</pre>
 
@@ -58,7 +58,7 @@ browser-compat: css.types.basic-shape
 
  <p>The position argument defines the center of the ellipse. This defaults to center if omitted.</p>
  </dd>
- <dt><code><a id="polygon()"></a>{{cssxref("basic-shape/polygon()","polygon()")}}</code></dt>
+ <dt><code>{{cssxref("basic-shape/polygon()","polygon()")}}</code></dt>
  <dd>
  <pre class="brush: css">polygon( [&lt;fill-rule&gt;,]? [&lt;shape-arg&gt; &lt;shape-arg&gt;]# )</pre>
 
@@ -66,7 +66,7 @@ browser-compat: css.types.basic-shape
 
  <p>Each pair argument in the list represents <em>x<sub>i</sub></em> and <em>y<sub>i</sub></em> - the x and y axis coordinates of the i<sup>th</sup> vertex of the polygon.</p>
  </dd>
- <dt><code><a id="path()"></a>path()</code></dt>
+ <dt><code>path()</code></dt>
  <dd>
  <pre class="brush: css">path( [&lt;fill-rule&gt;,]? &lt;string&gt;)</pre>
 

--- a/files/en-us/web/css/border-image-slice/index.html
+++ b/files/en-us/web/css/border-image-slice/index.html
@@ -23,9 +23,9 @@ browser-compat: css.properties.border-image-slice
 <p>The above diagram illustrates the location of each region.</p>
 
 <ul>
- <li>Zones 1-4 are <span id="corner-regions">corner regions</span>. Each one is used a single time to form the corners of the final border image.</li>
- <li>Zones 5-8 are <span id="edge-regions">edge regions</span>. These are <a href="/en-US/docs/Web/CSS/border-image-repeat">repeated, scaled, or otherwise modified</a> in the final border image to match the dimensions of the element.</li>
- <li>Zone 9 is the <span id="middle-region">middle region</span>. It is discarded by default, but is used like a background image if the keyword <code>fill</code> is set.</li>
+ <li>Zones 1-4 are corner regions. Each one is used a single time to form the corners of the final border image.</li>
+ <li>Zones 5-8 are edge regions. These are <a href="/en-US/docs/Web/CSS/border-image-repeat">repeated, scaled, or otherwise modified</a> in the final border image to match the dimensions of the element.</li>
+ <li>Zone 9 is the middle region. It is discarded by default, but is used like a background image if the keyword <code>fill</code> is set.</li>
 </ul>
 
 <p>The {{cssxref("border-image-repeat")}}, {{cssxref("border-image-width")}}, and {{cssxref("border-image-outset")}} properties determine how these regions are used to form the final border image.</p>

--- a/files/en-us/web/css/border-radius/index.html
+++ b/files/en-us/web/css/border-radius/index.html
@@ -118,9 +118,9 @@ border-radius: unset;
 </table>
 
 <dl>
- <dt><a id="&lt;length&gt;">{{cssxref("&lt;length&gt;")}}</a></dt>
+ <dt>{{cssxref("&lt;length&gt;")}}</dt>
  <dd>Denotes the size of the circle radius, or the semi-major and semi-minor axes of the ellipse, using length values. Negative values are invalid.</dd>
- <dt><a id="&lt;percentage&gt;">{{cssxref("&lt;percentage&gt;")}}</a></dt>
+ <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
  <dd>Denotes the size of the circle radius, or the semi-major and semi-minor axes of the ellipse, using percentage values. Percentages for the horizontal axis refer to the width of the box; percentages for the vertical axis refer to the height of the box. Negative values are invalid.</dd>
 </dl>
 

--- a/files/en-us/web/css/border/index.html
+++ b/files/en-us/web/css/border/index.html
@@ -55,11 +55,11 @@ border: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;line-width&gt;"><code>&lt;line-width&gt;</code></dt>
+ <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Sets the thickness of the border. Defaults to <code>medium</code> if absent. See {{Cssxref("border-width")}}.</dd>
- <dt id="&lt;line-style&gt;"><code>&lt;line-style&gt;</code></dt>
+ <dt><code>&lt;line-style&gt;</code></dt>
  <dd>Sets the style of the border. Defaults to <code>none</code> if absent. See {{Cssxref("border-style")}}.</dd>
- <dt id="&lt;color&gt;">{{cssxref("&lt;color&gt;")}}</dt>
+ <dt>{{cssxref("&lt;color&gt;")}}</dt>
  <dd>Sets the color of the border. Defaults to <code>currentcolor</code> if absent. See {{Cssxref("border-color")}}.</dd>
 </dl>
 

--- a/files/en-us/web/css/box-shadow/index.html
+++ b/files/en-us/web/css/box-shadow/index.html
@@ -59,9 +59,9 @@ box-shadow: unset;
  <li>Two, three, or four <code><a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a></code> values.
 
   <ul>
-   <li>If only two values are given, they are interpreted as <code><a href="#offset-x">&lt;offset-x&gt;&lt;offset-y&gt;</a></code> values.</li>
-   <li>If a third value is given, it is interpreted as a <code><a href="#blur-radius">&lt;blur-radius&gt;</a></code>.</li>
-   <li>If a fourth value is given, it is interpreted as a <code><a href="#spread-radius">&lt;spread-radius&gt;</a></code>.</li>
+   <li>If only two values are given, they are interpreted as <code>&lt;offset-x&gt;</code> and <code>&lt;offset-y&gt;</code> values.</li>
+   <li>If a third value is given, it is interpreted as a <code>&lt;blur-radius&gt;</code>.</li>
+   <li>If a fourth value is given, it is interpreted as a <code>&lt;spread-radius&gt;</code>.</li>
   </ul>
  </li>
  <li>Optionally, the <code><a href="#inset">inset</a></code> keyword.</li>
@@ -73,20 +73,20 @@ box-shadow: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="inset"><code>inset</code></dt>
+ <dt><code>inset</code></dt>
  <dd>If not specified (default), the shadow is assumed to be a drop shadow (as if the box were raised above the content).<br>
  The presence of the <code>inset</code> keyword changes the shadow to one inside the frame (as if the content was depressed inside the box). Inset shadows are drawn inside the border (even transparent ones), above the background, but below content.</dd>
- <dt id="offset-x"><code>&lt;offset-x&gt;</code> <code>&lt;offset-y&gt;</code></dt>
+ <dt><code>&lt;offset-x&gt;</code> <code>&lt;offset-y&gt;</code></dt>
  <dd>These are two {{cssxref("&lt;length&gt;")}} values to set the shadow offset. <code>&lt;offset-x&gt;</code> specifies the horizontal distance. Negative values place the shadow to the left of the element. <code>&lt;offset-y&gt;</code> specifies the vertical distance. Negative values place the shadow above the element. See {{cssxref("&lt;length&gt;")}} for possible units.<br>
  If both values are <code>0</code>, the shadow is placed behind the element (and may generate a blur effect if <code>&lt;blur-radius&gt;</code> and/or <code>&lt;spread-radius&gt;</code> is set).</dd>
- <dt id="blur-radius"><code>&lt;blur-radius&gt;</code></dt>
+ <dt><code>&lt;blur-radius&gt;</code></dt>
  <dd>This is a third {{cssxref("&lt;length&gt;")}} value. The larger this value, the bigger the blur, so the shadow becomes bigger and lighter. Negative values are not allowed. If not specified, it will be <code>0</code> (the shadow's edge is sharp). The specification does not include an exact algorithm for how the blur radius should be calculated, however, it does elaborate as follows:</dd>
  <dd>
  <blockquote>…for a long, straight shadow edge, this should create a color transition the length of the blur distance that is perpendicular to and centered on the shadow’s edge, and that ranges from the full shadow color at the radius endpoint inside the shadow to fully transparent at the endpoint outside it.</blockquote>
  </dd>
- <dt id="spread-radius"><code>&lt;spread-radius&gt;</code></dt>
+ <dt><code>&lt;spread-radius&gt;</code></dt>
  <dd>This is a fourth {{cssxref("&lt;length&gt;")}} value. Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be <code>0</code> (the shadow will be the same size as the element).</dd>
- <dt id="color"><code>&lt;color&gt;</code></dt>
+ <dt><code>&lt;color&gt;</code></dt>
  <dd>See {{cssxref("&lt;color&gt;")}} values for possible keywords and notations.<br>
  If not specified, it defaults to {{cssxref("color_value#currentcolor_keyword")}}.</dd>
 </dl>
@@ -109,7 +109,6 @@ box-shadow: unset;
 
 <p>In this example, we include three shadows: an inset shadow, a regular drop shadow, and a 2px shadow that creates a border effect (we could have used an {{cssxref('outline')}} instead for that third shadow).</p>
 
-<div id="Examples1">
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;blockquote&gt;&lt;q&gt;You may shoot me with your words,&lt;br/&gt;
@@ -128,7 +127,6 @@ But still, like air, I'll rise.&lt;/q&gt;
              0 0  0 2px rgb(255,255,255),
              0.3em 0.3em 1em rgba(0,0,0,0.3);
 }</pre>
-</div>
 
 <h4 id="Result">Result</h4>
 
@@ -136,7 +134,6 @@ But still, like air, I'll rise.&lt;/q&gt;
 
 <h3 id="Setting_zero_for_offset_and_blur">Setting zero for offset and blur</h3>
 
-<div id="Examples2">
 <p>When the <code>x-offset</code>, <code>y-offset</code>, and <code>blur</code> are all zero, the box shadow will be a solid-colored outline of equal-size on all sides. The shadows are drawn back to front, so the first shadow sits on top of subsequent shadows. When the <code>border-radius</code> is set to 0, as is the default, the corners of the shadow will be, well, corners. Had we put in a <code>border-radius</code> of any other value, the corners would have been rounded.</p>
 
 <p>We added a margin the size of the widest box-shadow to ensure the shadow doesn't overlap adjacent elements or go beyond the border of the containing box. A box-shadow does not impact <a href="/en-US/docs/Web/CSS/CSS_Box_Model">box model</a> dimensions.</p>
@@ -155,11 +152,10 @@ But still, like air, I'll rise.&lt;/q&gt;
 }</pre>
 
 <h4 id="Result_2">Result</h4>
-</div>
 
 <p>{{EmbedLiveSample('Setting_zero_for_offset_and_blur', '300', '300')}}</p>
 
-<h2 class="cleared" id="Specifications">Specifications</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/css/shape-outside/index.html
+++ b/files/en-us/web/css/shape-outside/index.html
@@ -78,7 +78,7 @@ shape-outside: unset;
  </dl>
  </dd>
  <dt>{{cssxref("&lt;basic-shape&gt;")}}</dt>
- <dd>The float area is computed based on the shape created by of one of <code><a href="/en-US/docs/Web/CSS/basic-shape#inset()">inset()</a></code>, <code><a href="/en-US/docs/Web/CSS/basic-shape#circle()">circle()</a></code>, <code><a href="/en-US/docs/Web/CSS/basic-shape#ellipse()">ellipse()</a></code>,  <code><a href="/en-US/docs/Web/CSS/basic-shape#polygon()">polygon()</a></code>, or as added in the level 2 specification <code>path()</code>. If a <code>&lt;shape-box&gt;</code> is also supplied, it defines the reference box for the <code>&lt;basic-shape&gt;</code> function. Otherwise, the reference box defaults to <code>margin-box</code>.</dd>
+ <dd>The float area is computed based on the shape created by of one of {{cssxref("basic-shape/inset()","inset()")}}, {{cssxref("basic-shape/circle()","circle()")}}, {{cssxref("basic-shape/ellipse()","ellipse()")}},  {{cssxref("basic-shape/polygon()","polygon()")}} or, as added in the level 2 specification, <code>path()</code>. If a <code>&lt;shape-box&gt;</code> is also supplied, it defines the reference box for the <code>&lt;basic-shape&gt;</code> function. Otherwise, the reference box defaults to <code>margin-box</code>.</dd>
  <dt>{{cssxref("&lt;image&gt;")}}</dt>
  <dd>The float area is extracted and computed based on the alpha channel of the specified {{cssxref("&lt;image&gt;")}} as defined by {{cssxref("shape-image-threshold")}}.</dd>
  <dd>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/5865 .

In preparation for Markdown, I'd like to remove `id` attributes in our CSS docs that are not attached to headings. This is the first part of that work. I've tried to find places where other pages are using these IDs as fragments and updated them to make as much sense as possible.
