### PR TITLE
Replace spec table with {{specifications}} for api/d[a-n]*

### DIFF
--- a/files/en-us/web/api/datatransfer/cleardata/index.html
+++ b/files/en-us/web/api/datatransfer/cleardata/index.html
@@ -169,27 +169,7 @@ browser-compat: api.DataTransfer.clearData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransfer-cleardata','DataTransfer.clearData()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'editing.html#dom-datatransfer-cleardata','DataTransfer.clearData()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/datatransfer/index.html
+++ b/files/en-us/web/api/datatransfer/datatransfer/index.html
@@ -26,21 +26,7 @@ browser-compat: api.DataTransfer.DataTransfer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-datatransfer','the DataTransfer() constructor')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/dropeffect/index.html
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.html
@@ -124,27 +124,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransfer-dropeffect','dropEffect')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransfer-dropeffect','dropEffect')}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/effectallowed/index.html
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.html
@@ -124,27 +124,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-effectallowed",
-        "effectAllowed")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-effectallowed",
-        "effectAllowed")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/files/index.html
+++ b/files/en-us/web/api/datatransfer/files/index.html
@@ -42,26 +42,7 @@ browser-compat: api.DataTransfer.files
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-files", "files")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-files", "files")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/getdata/index.html
+++ b/files/en-us/web/api/datatransfer/getdata/index.html
@@ -103,27 +103,7 @@ function drop(dropevent) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-getdata",
-                "getData()")}}</td>
-            <td>{{Spec2("HTML WHATWG")}}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-getdata",
-                "getData()")}}</td>
-            <td>{{Spec2("HTML5.1")}}</td>
-            <td>Initial definition</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/index.html
+++ b/files/en-us/web/api/datatransfer/index.html
@@ -109,25 +109,7 @@ browser-compat: api.DataTransfer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'interaction.html#datatransfer','DataTransfer')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td><code>mozCursor</code>, <code>mozItemCount</code>, <code>mozSourceNode</code>, <code>mozUserCancelled</code>, <code>addElement()</code>, <code>mozClearDataAt()</code>, <code>mozGetDataAt()</code>, <code>mozSetDataAt()</code> and <code>mozTypesAt</code> are Gecko specific.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'editing.html#the-datatransfer-interface','DataTransfer')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/items/index.html
+++ b/files/en-us/web/api/datatransfer/items/index.html
@@ -94,26 +94,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-items", "items")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-items", "items")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/setdata/index.html
+++ b/files/en-us/web/api/datatransfer/setdata/index.html
@@ -106,27 +106,7 @@ function drop_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-setdata",
-        "setData()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-setdata", "setData()")}}
-      </td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/setdragimage/index.html
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.html
@@ -119,27 +119,7 @@ function drop_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransfer-setdragimage','setDragImage()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'editing.html#dom-datatransfer-setdragimage','setDragImage()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransfer/types/index.html
+++ b/files/en-us/web/api/datatransfer/types/index.html
@@ -99,26 +99,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#dom-datatransfer-types", "types")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#dom-datatransfer-types", "types")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasfile/index.html
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.html
@@ -70,27 +70,7 @@ browser-compat: api.DataTransferItem.getAsFile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitem-getasfile','getAsFile()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial value</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'editing.html#dom-datatransferitem-getasfile','getAsFile()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot of the HTML WHATWG document</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
@@ -63,20 +63,7 @@ elem.addEventListener('drop', async (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access','#drag-and-drop','getAsFileSystemHandle')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasstring/index.html
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.html
@@ -83,27 +83,7 @@ browser-compat: api.DataTransferItem.getAsString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitem-getasstring','getAsString()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'editing.html#dom-datatransferitem-getasstring','getAsString()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot fo HTML WHATWG document</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/index.html
+++ b/files/en-us/web/api/datatransferitem/index.html
@@ -45,30 +45,7 @@ browser-compat: api.DataTransferItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'interaction.html#datatransferitem','DataTransferItem')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'editing.html#datatransferitem','DataTransferItem')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>W3C snapshot of WHATWG</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('File System API', '#dom-datatransferitem-webkitgetasentry', 'DataTransferItem.webkitGetAsEntry()')}}</td>
-   <td>{{Spec2('File System API')}}</td>
-   <td>Definition of <code>webkitGetAsEntry()</code> as part of the <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory Entries API</a>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/kind/index.html
+++ b/files/en-us/web/api/datatransferitem/kind/index.html
@@ -66,26 +66,7 @@ browser-compat: api.DataTransferItem.kind
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-datatransferitem-kind','kind')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransferitem-kind','kind')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>W3C snapshot of the WHATWG document.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/type/index.html
+++ b/files/en-us/web/api/datatransferitem/type/index.html
@@ -65,26 +65,7 @@ browser-compat: api.DataTransferItem.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-datatransferitem-type','type')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransferitem-type','type')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot of the HTML WHATWG document</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
@@ -201,23 +201,7 @@ function scanFiles(item, container) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-datatransferitem-webkitgetasentry',
-        'webkitGetAsEntry()') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.html
+++ b/files/en-us/web/api/datatransferitemlist/add/index.html
@@ -145,28 +145,7 @@ function dragend_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitemlist-add','add()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransferitemlist-add','add()')}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitemlist/clear/index.html
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.html
@@ -123,29 +123,7 @@ function dragend_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitemlist-clear','clear()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransferitemlist-clear','clear()')}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitemlist/index.html
+++ b/files/en-us/web/api/datatransferitemlist/index.html
@@ -131,25 +131,7 @@ function dragend_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'interaction.html#datatransferitemlist','DataTransferItemList')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'editing.html#datatransferitemlist','DataTransferItemList')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitemlist/length/index.html
+++ b/files/en-us/web/api/datatransferitemlist/length/index.html
@@ -123,27 +123,7 @@ function dragend_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitemlist-length','length')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'editing.html#dom-datatransferitemlist-length','length')}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/datatransferitemlist/remove/index.html
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.html
@@ -138,27 +138,7 @@ function dragend_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'interaction.html#dom-datatransferitemlist-remove','remove()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'editing.html#dom-datatransferitemlist-remove','remove()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Not included in W3C HTML5 {{Spec2('HTML5 W3C')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.html
@@ -44,20 +44,7 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Compression Streams','#dom-decompressionstream-decompressionstream','DecompressionStream()')}}</td>
-    <td>{{Spec2('Compression Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/index.html
@@ -37,20 +37,7 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Compression Streams','#decompression-stream','DecompressionStream')}}</td>
-   <td>{{Spec2('Compression Streams')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/decompressionstream/readable/index.html
+++ b/files/en-us/web/api/decompressionstream/readable/index.html
@@ -29,20 +29,7 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#dom-generictransformstream-readable','readable')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.html
@@ -33,20 +33,7 @@ browser-compat: api.DedicatedWorkerGlobalScope.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-dedicatedworkerglobalscope-close', 'close()')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.html
@@ -99,20 +99,7 @@ browser-compat: api.DedicatedWorkerGlobalScope
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dedicatedworkerglobalscope', 'DedicatedWorkerGlobalScope')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.html
@@ -58,18 +58,7 @@ self.onmessage = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-message')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.html
@@ -52,18 +52,7 @@ self.onmessageerror = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-messageerror')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.html
@@ -43,20 +43,7 @@ browser-compat: api.DedicatedWorkerGlobalScope.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-dedicatedworkerglobalscope-name', 'name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
@@ -50,20 +50,7 @@ myWorker.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#handler-dedicatedworkerglobalscope-onmessage", "DedicatedWorkerGlobalScope.onmessage")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.html
@@ -26,21 +26,7 @@ browser-compat: api.DedicatedWorkerGlobalScope.onmessageerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-dedicatedworkerglobalscope-onmessageerror',
-        'onmessageerror')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
@@ -55,20 +55,7 @@ browser-compat: api.DedicatedWorkerGlobalScope.postMessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#dom-dedicatedworkerglobalscope-postmessage", "DedicatedWorkerGlobalScope.postMessage()")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/delaynode/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/delaynode/index.html
@@ -57,20 +57,7 @@ const delayNode = new DelayNode(audioCtx, {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-delaynode-delaynode','DelayNode()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/delaynode/delaytime/index.html
+++ b/files/en-us/web/api/delaynode/delaytime/index.html
@@ -39,20 +39,7 @@ myDelay.delayTime.value = 3.0;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-delaynode-delaytime', 'delayTime')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -69,20 +69,7 @@ browser-compat: api.DelayNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API', '#DelayNode', 'DelayNode')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deprecationreportbody/index.html
+++ b/files/en-us/web/api/deprecationreportbody/index.html
@@ -82,20 +82,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Reporting API","#deprecation-report","DeprecationReportBody")}}</td>
-   <td>{{Spec2("Reporting API")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicelightevent/index.html
+++ b/files/en-us/web/api/devicelightevent/index.html
@@ -30,22 +30,7 @@ browser-compat: api.DeviceLightEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("AmbientLight", "", "Ambient Light Events")}}</td>
-      <td>{{Spec2("AmbientLight")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotionevent/acceleration/index.html
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.html
@@ -47,22 +47,7 @@ browser-compat: api.DeviceMotionEvent.acceleration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
@@ -48,22 +48,7 @@ browser-compat: api.DeviceMotionEvent.accelerationIncludingGravity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/index.html
@@ -49,22 +49,7 @@ browser-compat: api.DeviceMotionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Device Orientation", "#devicemotionevent", "DeviceMotionEvent")}}</td>
-   <td>{{Spec2("Device Orientation")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotionevent/interval/index.html
+++ b/files/en-us/web/api/devicemotionevent/interval/index.html
@@ -25,22 +25,7 @@ browser-compat: api.DeviceMotionEvent.interval
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.html
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.html
@@ -47,22 +47,7 @@ browser-compat: api.DeviceMotionEvent.rotationRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/index.html
@@ -27,22 +27,7 @@ browser-compat: api.DeviceMotionEventAcceleration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Device Orientation", "#devicemotioneventacceleration", "DeviceMotionEventAcceleration")}}</td>
-   <td>{{Spec2("Device Orientation")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/x/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/x/index.html
@@ -34,23 +34,7 @@ browser-compat: api.DeviceMotionEventAcceleration.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation", "#dom-devicemotioneventacceleration-x",
-        "DeviceMotionEventAcceleration: x")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/y/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/y/index.html
@@ -34,23 +34,7 @@ browser-compat: api.DeviceMotionEventAcceleration.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation", "#dom-devicemotioneventacceleration-y",
-        "DeviceMotionEventAcceleration: y")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/z/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/z/index.html
@@ -34,23 +34,7 @@ browser-compat: api.DeviceMotionEventAcceleration.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Orientation", "#dom-devicemotioneventacceleration-z",
-        "DeviceMotionEventAcceleration: z")}}</td>
-      <td>{{Spec2("Device Orientation")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.html
@@ -35,23 +35,7 @@ browser-compat: api.DeviceMotionEventRotationRate.alpha
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation', '#dom-devicemotioneventrotationrate-alpha',
-        'DeviceMotionEventRotationRate: alpha')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotioneventrotationrate/beta/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/beta/index.html
@@ -35,23 +35,7 @@ browser-compat: api.DeviceMotionEventRotationRate.beta
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation', '#dom-devicemotioneventrotationrate-beta',
-        'DeviceMotionEventRotationRate: beta')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.html
@@ -35,23 +35,7 @@ browser-compat: api.DeviceMotionEventRotationRate.gamma
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation', '#dom-devicemotioneventrotationrate-gamma',
-        'DeviceMotionEventRotationRate: gamma')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.html
@@ -26,22 +26,7 @@ browser-compat: api.DeviceMotionEventRotationRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Device Orientation', '#devicemotioneventrotationrate', 'DeviceMotionEventRotationRate')}}</td>
-   <td>{{Spec2('Device Orientation')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/absolute/index.html
+++ b/files/en-us/web/api/deviceorientationevent/absolute/index.html
@@ -32,22 +32,7 @@ browser-compat: api.DeviceOrientationEvent.absolute
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/alpha/index.html
+++ b/files/en-us/web/api/deviceorientationevent/alpha/index.html
@@ -26,22 +26,7 @@ browser-compat: api.DeviceOrientationEvent.alpha
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Device Orientation')}}</td>
-			<td>{{Spec2('Device Orientation')}}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/beta/index.html
+++ b/files/en-us/web/api/deviceorientationevent/beta/index.html
@@ -27,22 +27,7 @@ browser-compat: api.DeviceOrientationEvent.beta
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
@@ -46,20 +46,7 @@ browser-compat: api.DeviceOrientationEvent.DeviceOrientationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Device Orientation')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/gamma/index.html
+++ b/files/en-us/web/api/deviceorientationevent/gamma/index.html
@@ -27,22 +27,7 @@ browser-compat: api.DeviceOrientationEvent.gamma
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Device Orientation')}}</td>
-      <td>{{Spec2('Device Orientation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/index.html
@@ -45,22 +45,7 @@ browser-compat: api.DeviceOrientationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Device Orientation')}}</td>
-   <td>{{Spec2('Device Orientation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/audio/index.html
@@ -73,21 +73,7 @@ browser-compat: api.DisplayMediaStreamConstraints.audio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-displaymediastreamconstraints-audio',
-        'DisplayMediaStreamConstraints.audio')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/index.html
@@ -33,20 +33,7 @@ browser-compat: api.DisplayMediaStreamConstraints
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Screen Capture', '#dom-displaymediastreamconstraints', 'DisplayMediaStreamConstraints')}}</td>
-   <td>{{Spec2('Screen Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -67,21 +67,7 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-displaymediastreamconstraints-video',
-        'DisplayMediaStreamConstraints.video')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part #1146.

This converts API interfaces (including properties & methods) starting with 'da' to 'dn' to the {{Specifications}} macros. 

A few notes:
- `DisplayMediaStreamConstraints`, `DisplayMediaStreamConstraints.audio`, and `DisplayMediaStreamConstraints` lose their spec table; it is a dictionary that is used only at one place, and BCD is broken anyway. This will be dealt when we will restructure dictionaries documentation all over the place (especially those used at one place).
- `DecompressionStream`and its 2 children lose their spec table. This will be fixed by mdn/browser-compat-data#10966.
- `DataTransferItem.getAsFileSystemHandle()` is non-standard and has bcd but no spec. The previous table was bogus anyway. I've opened mdn/yari#4012 to have a better message displayed.
- `DeviceLightEvent` is also non-standard, has bcd and no spec. The previous table was also bogus. The same mdn/yari#4012 issue will bring a better message here too.
- `DeprecationReportBody` loses its table but has no bcd info. This will be fixed when we add its bcd_info in the future.

All other pages look fine.