### PR TITLE
Replace spec table with {{specifications}} for api/document/*

### DIFF
--- a/files/en-us/web/api/document/activeelement/index.html
+++ b/files/en-us/web/api/document/activeelement/index.html
@@ -85,21 +85,7 @@ textarea2.addEventListener('mouseup', onMouseUp, false);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-document-activeelement',
-        'activeElement')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/adoptnode/index.html
+++ b/files/en-us/web/api/document/adoptnode/index.html
@@ -76,22 +76,7 @@ iframeImages.forEach(function(imgEl) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-adoptnode', 'document.adoptNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/all/index.html
+++ b/files/en-us/web/api/document/all/index.html
@@ -38,23 +38,7 @@ browser-compat: api.Document.all
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'obsolete.html#dom-document-all', 'all')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.<br>
-        Defined in the obsolete and legacy APIs section.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/anchors/index.html
+++ b/files/en-us/web/api/document/anchors/index.html
@@ -89,27 +89,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-anchors', 'Document.anchors')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td>Obsoleted.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-7577272', 'Document.anchors')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/animationcancel_event/index.html
+++ b/files/en-us/web/api/document/animationcancel_event/index.html
@@ -57,22 +57,7 @@ browser-compat: api.Document.animationcancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationcancel")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/animationend_event/index.html
+++ b/files/en-us/web/api/document/animationend_event/index.html
@@ -57,22 +57,7 @@ browser-compat: api.Document.animationend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationend")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/animationiteration_event/index.html
+++ b/files/en-us/web/api/document/animationiteration_event/index.html
@@ -63,22 +63,7 @@ document.onanimationiteration = () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationiteration")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/animationstart_event/index.html
+++ b/files/en-us/web/api/document/animationstart_event/index.html
@@ -59,22 +59,7 @@ browser-compat: api.Document.animationstart_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationstart")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/append/index.html
+++ b/files/en-us/web/api/document/append/index.html
@@ -64,18 +64,7 @@ doc.children; // HTMLCollection [&lt;html&gt;]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-append', 'ParentNode.append()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/applets/index.html
+++ b/files/en-us/web/api/document/applets/index.html
@@ -44,27 +44,7 @@ my_java_app = document.applets[1];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-applets', 'Document.applets')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td>Obsoleted.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-85113862', 'Document.applets')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/body/index.html
+++ b/files/en-us/web/api/document/body/index.html
@@ -45,32 +45,7 @@ alert(document.body.id); // "newBodyElement"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','dom.html#dom-document-body','Document.body')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1','dom.html#dom-document-body','Document.body')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','dom.html#dom-document-body','Document.body')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.html
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.html
@@ -88,16 +88,7 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit ame
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-document-caretpositionfrompoint','caretPositionFromPoint()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/characterset/index.html
+++ b/files/en-us/web/api/document/characterset/index.html
@@ -51,20 +51,7 @@ browser-compat: api.Document.characterSet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-characterset', 'characterSet')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/childelementcount/index.html
+++ b/files/en-us/web/api/document/childelementcount/index.html
@@ -32,16 +32,7 @@ document.childElementCount;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount', 'ParentNode.childElementCount')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/children/index.html
+++ b/files/en-us/web/api/document/children/index.html
@@ -52,18 +52,7 @@ document.children;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/close/index.html
+++ b/files/en-us/web/api/document/close/index.html
@@ -33,27 +33,7 @@ document.close();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-document-close", "document.close()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-98948567", "document.close()")}}</td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/compatmode/index.html
+++ b/files/en-us/web/api/document/compatmode/index.html
@@ -45,22 +45,7 @@ browser-compat: api.Document.compatMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-compatmode','compatMode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/contenttype/index.html
+++ b/files/en-us/web/api/document/contenttype/index.html
@@ -34,23 +34,7 @@ browser-compat: api.Document.contentType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-contenttype', 'Document.contentType')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -427,27 +427,7 @@ Accept: */*
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("DOM2 HTML", "html.html#ID-8747038", "Document.cookie")}}</td>
-			<td>{{Spec2("DOM2 HTML")}}</td>
-			<td>Initial definition</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("Cookie Prefixes")}}</td>
-			<td>{{Spec2("Cookie Prefixes")}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/copy_event/index.html
+++ b/files/en-us/web/api/document/copy_event/index.html
@@ -46,20 +46,7 @@ browser-compat: api.Document.copy_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Clipboard API', '#clipboard-event-copy')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createattribute/index.html
+++ b/files/en-us/web/api/document/createattribute/index.html
@@ -52,39 +52,7 @@ console.log(node.getAttribute("my_attrib")); // "newVal"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-document-createattribute','Document.createAttribute()')}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Precised behavior with uppercase characters</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core','core.html#ID-1084891198','Document.createAttribute()')}}
-      </td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core','core.html#ID-1084891198','Document.createAttribute()')}}
-      </td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('DOM1','level-one-core.html#ID-1084891198','Document.createAttribute()')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createcdatasection/index.html
+++ b/files/en-us/web/api/document/createcdatasection/index.html
@@ -52,23 +52,7 @@ alert(new XMLSerializer().serializeToString(docu));
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createcdatasection',
-        'document.createCDATASection')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createcomment/index.html
+++ b/files/en-us/web/api/document/createcomment/index.html
@@ -38,23 +38,7 @@ alert(new XMLSerializer().serializeToString(docu));
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createcomment',
-        'document.createComment')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createdocumentfragment/index.html
+++ b/files/en-us/web/api/document/createdocumentfragment/index.html
@@ -76,23 +76,7 @@ element.appendChild(fragment);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createdocumentfragment',
-        'Document.createDocumentFragment()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition in the DOM 1 specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createelement/index.html
+++ b/files/en-us/web/api/document/createelement/index.html
@@ -102,22 +102,7 @@ customElements.define('expanding-list', ExpandingList, { extends: "ul" });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', "#dom-document-createelement", "Document.createElement")}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createelementns/index.html
+++ b/files/en-us/web/api/document/createelementns/index.html
@@ -115,23 +115,7 @@ browser-compat: api.Document.createElementNS
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-document-createelementns",
-        "Document.createElementNS()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createevent/index.html
+++ b/files/en-us/web/api/document/createevent/index.html
@@ -87,23 +87,7 @@ elem.dispatchEvent(event);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createevent', 'document.createEvent')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createnodeiterator/index.html
+++ b/files/en-us/web/api/document/createnodeiterator/index.html
@@ -155,23 +155,7 @@ while (currentNode = nodeIterator.nextNode()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createnodeiterator',
-        'document.createNodeIterator')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/creatensresolver/index.html
+++ b/files/en-us/web/api/document/creatensresolver/index.html
@@ -40,22 +40,7 @@ browser-compat: api.Document.createNSResolver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM3 XPath', 'xpath.html#XPathEvaluator-createNSResolver', 'document.createNSResolver')}}</td>
-   <td>{{Spec2('DOM3 XPath')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createprocessinginstruction/index.html
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.html
@@ -54,42 +54,7 @@ console.log(new XMLSerializer().serializeToString(doc));
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-document-createprocessinginstruction', 'createProcessingInstruction()')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM4', '#dom-document-createprocessinginstruction', 'createProcessingInstruction()')}}</td>
-   <td>{{Spec2('DOM4')}}</td>
-   <td>Added more explicit definition of how the <code><var>data</var></code> parameter is validated.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-135944439', 'createProcessingInstruction()')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Added note that the namespace of the target name is not checked whether it is well-formed, defined what is considered an illegal character for the target name and specified the returned {{domxref("ProcessingInstruction")}} object more precisely.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-135944439', 'createProcessingInstruction()')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-135944439', 'createProcessingInstruction()')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createrange/index.html
+++ b/files/en-us/web/api/document/createrange/index.html
@@ -38,23 +38,7 @@ range.setEnd(endNode, endOffset);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createrange', 'document.createRange')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createtextnode/index.html
+++ b/files/en-us/web/api/document/createtextnode/index.html
@@ -60,22 +60,7 @@ function addTextNode(text) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createtextnode', 'Document: createTextNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createtouch/index.html
+++ b/files/en-us/web/api/document/createtouch/index.html
@@ -92,24 +92,7 @@ var touch2 = document.createTouch(window, target, 2, 25, 30, 45, 50);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Touch Events",
-        "#widl-Document-createTouch-Touch-WindowProxy-view-EventTarget-target-long-identifier-long-pageX-long-pageY-long-screenX-long-screenY",
-        "Document.createTouch()")}}</td>
-      <td>{{Spec2("Touch Events")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createtouchlist/index.html
+++ b/files/en-us/web/api/document/createtouchlist/index.html
@@ -73,24 +73,7 @@ var list2 = document.createTouchList(touch1, touch2);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Touch Events",
-        "#widl-Document-createTouchList-TouchList-Touch-touches",
-        "Document.createTouchList()")}}</td>
-      <td>{{Spec2("Touch Events")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -159,29 +159,7 @@ while(currentNode) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createtreewalker',
-        'Document.createTreeWalker')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Removed the <code>expandEntityReferences</code> parameter. Made the
-        <code>whatToShow</code> and <code>filter</code> parameters optionals.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#NodeIteratorFactory-createTreeWalker',
-        'Document.createTreeWalker')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/currentscript/index.html
+++ b/files/en-us/web/api/document/currentscript/index.html
@@ -36,23 +36,7 @@ browser-compat: api.Document.currentScript
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "dom.html#dom-document-currentscript",
-        "Document.currentScript")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/cut_event/index.html
+++ b/files/en-us/web/api/document/cut_event/index.html
@@ -40,20 +40,7 @@ browser-compat: api.Document.cut_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Clipboard API', '#clipboard-event-cut')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/defaultview/index.html
+++ b/files/en-us/web/api/document/defaultview/index.html
@@ -24,29 +24,7 @@ browser-compat: api.Document.defaultView
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-defaultview', 'Document.defaultView')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'browsers.html#dom-document-defaultview',
-        'Document.defaultView')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/designmode/index.html
+++ b/files/en-us/web/api/document/designmode/index.html
@@ -40,24 +40,7 @@ document.designMode = <em>value</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        '#making-entire-documents-editable:-the-designmode-idl-attribute', 'designMode')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dir/index.html
+++ b/files/en-us/web/api/document/dir/index.html
@@ -24,22 +24,7 @@ browser-compat: api.Document.dir
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("HTML WHATWG", "#dom-document-dir", "Document.dir")}}</td>
-			<td>{{Spec2("HTML WHATWG")}}</td>
-			<td>Initial specification</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/doctype/index.html
+++ b/files/en-us/web/api/document/doctype/index.html
@@ -45,22 +45,7 @@ console.log(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-doctype', 'Document: doctype')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/document/index.html
+++ b/files/en-us/web/api/document/document/index.html
@@ -22,22 +22,7 @@ browser-compat: api.Document.Document
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG','#dom-document-document','Document')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/documentelement/index.html
+++ b/files/en-us/web/api/document/documentelement/index.html
@@ -41,22 +41,7 @@ for (const child of firstTier) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-document-documentelement','Document.documentElement')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/documenturi/index.html
+++ b/files/en-us/web/api/document/documenturi/index.html
@@ -40,22 +40,7 @@ browser-compat: api.Document.documentURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-documenturi','documentURI')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -151,23 +151,7 @@ browser-compat: api.Document.domain
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','origin.html#relaxing-the-same-origin-restriction','document.domain')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/domcontentloaded_event/index.html
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.html
@@ -329,27 +329,7 @@ document.addEventListener('DOMContentLoaded', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#stop-parsing', 'DOMContentLoaded')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'syntax.html#the-end', 'DOMContentLoaded')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/drag_event/index.html
+++ b/files/en-us/web/api/document/drag_event/index.html
@@ -134,22 +134,7 @@ document.addEventListener("drop", function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "drag event")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dragend_event/index.html
+++ b/files/en-us/web/api/document/dragend_event/index.html
@@ -50,22 +50,7 @@ browser-compat: api.Document.dragend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "dragend")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dragenter_event/index.html
+++ b/files/en-us/web/api/document/dragenter_event/index.html
@@ -52,22 +52,7 @@ browser-compat: api.Document.dragenter_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "dragenter")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dragleave_event/index.html
+++ b/files/en-us/web/api/document/dragleave_event/index.html
@@ -50,22 +50,7 @@ browser-compat: api.Document.dragleave_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "dragleave")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dragover_event/index.html
+++ b/files/en-us/web/api/document/dragover_event/index.html
@@ -51,22 +51,7 @@ browser-compat: api.Document.dragover_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "dragover")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/dragstart_event/index.html
+++ b/files/en-us/web/api/document/dragstart_event/index.html
@@ -45,22 +45,7 @@ browser-compat: api.Document.dragstart_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "dragstart")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/drop_event/index.html
+++ b/files/en-us/web/api/document/drop_event/index.html
@@ -48,22 +48,7 @@ browser-compat: api.Document.drop_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#dndevents", "drop event")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/elementfrompoint/index.html
+++ b/files/en-us/web/api/document/elementfrompoint/index.html
@@ -86,18 +86,7 @@ browser-compat: api.Document.elementFromPoint
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-document-elementfrompoint', 'elementFromPoint()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/elementsfrompoint/index.html
+++ b/files/en-us/web/api/document/elementsfrompoint/index.html
@@ -68,18 +68,7 @@ if (document.elementsFromPoint) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-document-elementsfrompoint', 'elementsFromPoint()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/embeds/index.html
+++ b/files/en-us/web/api/document/embeds/index.html
@@ -26,22 +26,7 @@ browser-compat: api.Document.embeds
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-embeds', 'Document.embeds')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/evaluate/index.html
+++ b/files/en-us/web/api/document/evaluate/index.html
@@ -185,23 +185,7 @@ alert(alertText); // Alerts the text of all h2 elements
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator-evaluate",
-				"Document.evaluate")}}</td>
-			<td>{{Spec2("DOM3 XPath")}}</td>
-			<td>Initial specification</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -228,20 +228,7 @@ browser-compat: api.Document.execCommand
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/editing/docs/execCommand/">execCommand</a></td>
-      <td>Unofficial Draft</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/exitfullscreen/index.html
+++ b/files/en-us/web/api/document/exitfullscreen/index.html
@@ -61,23 +61,7 @@ browser-compat: api.Document.exitFullscreen
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#dom-document-exitfullscreen",
-        "Document.exitFullscreen()")}}</td>
-      <td>{{Spec2("Fullscreen")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/exitpictureinpicture/index.html
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.html
@@ -54,23 +54,7 @@ browser-compat: api.Document.exitPictureInPicture
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Picture-in-Picture", "#exit-pip",
-        "Document.exitPictureInPicture()")}}</td>
-      <td>{{Spec2("Picture-in-Picture")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/exitpointerlock/index.html
+++ b/files/en-us/web/api/document/exitpointerlock/index.html
@@ -24,23 +24,7 @@ browser-compat: api.Document.exitPointerLock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Lock','#extensions-to-the-document-interface','Document')}}
-      </td>
-      <td>{{Spec2('Pointer Lock')}}</td>
-      <td>Extend the <code>Document</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/featurepolicy/index.html
+++ b/files/en-us/web/api/document/featurepolicy/index.html
@@ -23,22 +23,7 @@ browser-compat: api.Document.featurePolicy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/firstelementchild/index.html
+++ b/files/en-us/web/api/document/firstelementchild/index.html
@@ -35,16 +35,7 @@ document.firstElementChild;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('DOM WHATWG', '#dom-parentnode-firstelementchild', 'ParentNode.firstElementChild')}}</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fonts/index.html
+++ b/files/en-us/web/api/document/fonts/index.html
@@ -41,22 +41,7 @@ browser-compat: api.Document.fonts
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#FontFaceSet-interface','FontFaceSet')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/forms/index.html
+++ b/files/en-us/web/api/document/forms/index.html
@@ -97,27 +97,7 @@ var selectFormElement = document.forms[index].elements[index];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-forms', 'Document.forms')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-1689064', 'Document.forms')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fullscreen/index.html
+++ b/files/en-us/web/api/document/fullscreen/index.html
@@ -52,22 +52,7 @@ browser-compat: api.Document.fullscreen
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Fullscreen", "#dom-document-fullscreen", "Document.fullscreen")}}</td>
-   <td>{{Spec2("Fullscreen")}}</td>
-   <td>Initial definition (as an obsolete property).</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fullscreenchange_event/index.html
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.html
@@ -59,20 +59,7 @@ browser-compat: api.Document.fullscreenchange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Fullscreen")}}</td>
-   <td>{{Spec2("Fullscreen")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fullscreenelement/index.html
+++ b/files/en-us/web/api/document/fullscreenelement/index.html
@@ -54,18 +54,7 @@ browser-compat: api.Document.fullscreenElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#dom-document-fullscreenelement", "Document.fullscreenElement")}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fullscreenenabled/index.html
+++ b/files/en-us/web/api/document/fullscreenenabled/index.html
@@ -54,23 +54,7 @@ browser-compat: api.Document.fullscreenEnabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#dom-document-fullscreenenabled",
-        "Document.fullscreenEnabled")}}</td>
-      <td>{{Spec2("Fullscreen")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/fullscreenerror_event/index.html
+++ b/files/en-us/web/api/document/fullscreenerror_event/index.html
@@ -53,20 +53,7 @@ requestor.requestFullscreen();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Fullscreen")}}</td>
-   <td>{{Spec2("Fullscreen")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getanimations/index.html
+++ b/files/en-us/web/api/document/getanimations/index.html
@@ -53,18 +53,7 @@ browser-compat: api.Document.getAnimations
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Animations', '#dom-documentorshadowroot-getanimations', 'DocumentOrShadowRoot.getAnimations()' )}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getelementbyid/index.html
+++ b/files/en-us/web/api/document/getelementbyid/index.html
@@ -104,37 +104,7 @@ var el = document.getElementById('testqq'); // el will be null!
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM1','level-one-html.html#method-getElementById','getElementById')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition for the interface</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core','core.html#ID-getElBId','getElementById')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>Supersede DOM 1</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core','core.html#ID-getElBId','getElementById')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Supersede DOM 2</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#dom-nonelementparentnode-getelementbyid','getElementById')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Intend to supersede DOM 3</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getelementsbyclassname/index.html
+++ b/files/en-us/web/api/document/getelementsbyclassname/index.html
@@ -137,23 +137,7 @@ document.getElementById("resultArea").value = result;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-getelementsbyclassname',
-        'document.getElementsByClassName')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getelementsbyname/index.html
+++ b/files/en-us/web/api/document/getelementsbyname/index.html
@@ -75,29 +75,7 @@ browser-compat: api.Document.getElementsByName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-getelementsbyname',
-        "Document.getElementsByName()")}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-71555259",
-        "Document.getElementsByName()")}}</td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getelementsbytagname/index.html
+++ b/files/en-us/web/api/document/getelementsbytagname/index.html
@@ -120,23 +120,7 @@ browser-compat: api.Document.getElementsByTagName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-document-getelementsbytagname','document.getElementsByTagName')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.html
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.html
@@ -161,23 +161,7 @@ function div2ParaElems()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-getelementsbytagnamens',
-        'document.getElementsByTagNameNS')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/getselection/index.html
+++ b/files/en-us/web/api/document/getselection/index.html
@@ -68,16 +68,7 @@ console.log(selection); // Selection object
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Selection API", "#extensions-to-document-interface", "Document.getSelection")}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/gotpointercapture_event/index.html
+++ b/files/en-us/web/api/document/gotpointercapture_event/index.html
@@ -64,24 +64,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-gotpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-gotpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/hasfocus/index.html
+++ b/files/en-us/web/api/document/hasfocus/index.html
@@ -74,23 +74,7 @@ setInterval(checkPageFocus, 300);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-document-hasfocus',
-        'Document.hasFocus()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/head/index.html
+++ b/files/en-us/web/api/document/head/index.html
@@ -48,32 +48,7 @@ browser-compat: api.Document.head
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML5.1','dom.html#dom-document-head','Document.head')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','dom.html#dom-document-head','Document.head')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','dom.html#dom-document-head','Document.head')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/hidden/index.html
+++ b/files/en-us/web/api/document/hidden/index.html
@@ -49,23 +49,7 @@ browser-compat: api.Document.hidden
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Page Visibility API','#dom-document-hidden', 'Document.hidden')}}
-      </td>
-      <td>{{Spec2('Page Visibility API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/images/index.html
+++ b/files/en-us/web/api/document/images/index.html
@@ -53,27 +53,7 @@ for(var i = 0; i &lt; ilist.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-images', 'Document.images')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-90379117', 'Document.images')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/implementation/index.html
+++ b/files/en-us/web/api/document/implementation/index.html
@@ -48,23 +48,7 @@ alert( "DOM " + modName + " " + modVer + " supported?: " + conformTest );
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-implementation',
-        'document.implementation')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/importnode/index.html
+++ b/files/en-us/web/api/document/importnode/index.html
@@ -95,29 +95,7 @@ document.getElementById("container").appendChild(newNode);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-document-importnode", "document.importNode()")}}
-      </td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Core", "core.html#Core-Document-importNode",
-        "document.importNode()")}}</td>
-      <td>{{Spec2("DOM2 Core")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -580,72 +580,7 @@ browser-compat: api.Document
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#interface-document", "Document")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td>Intend to supersede DOM 3</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "dom.html#the-document-object", "Document")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Turn the {{DOMxRef("HTMLDocument")}} interface into a <code>Document</code> extension.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM View", "#extensions-to-the-document-interface", "Document")}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td>Extend the <code>Document</code> interface</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Pointer Lock", "#extensions-to-the-document-interface", "Document")}}</td>
-   <td>{{Spec2("Pointer Lock")}}</td>
-   <td>Extend the <code>Document</code> interface</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Page Visibility API", "#extensions-to-the-document-interface", "Document")}}</td>
-   <td>{{Spec2("Page Visibility API")}}</td>
-   <td>Extend the <code>Document</code> interface with the <code>visibilityState</code> and <code>hidden</code> attributes and the <code>onvisibilitychange</code> event listener.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Selection API", "#extensions-to-document-interface", "Document")}}</td>
-   <td>{{Spec2("Selection API")}}</td>
-   <td>Adds <code>getSelection()</code>, <code>onselectstart</code> and <code>onselectionchange</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM4", "#interface-document", "Document")}}</td>
-   <td>{{Spec2("DOM4")}}</td>
-   <td>Supersede DOM 3</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 Core", "#i-Document", "Document")}}</td>
-   <td>{{Spec2("DOM3 Core")}}</td>
-   <td>Supersede DOM 2</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator", "XPathEvaluator")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Define the {{DOMxRef("XPathEvaluator")}} interface which extend document.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 Core", "#i-Document", "Document")}}</td>
-   <td>{{Spec2("DOM2 Core")}}</td>
-   <td>Supersede DOM 1</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM1", "#i-Document", "Document")}}</td>
-   <td>{{Spec2("DOM1")}}</td>
-   <td>Initial definition for the interface</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/keypress_event/index.html
+++ b/files/en-us/web/api/document/keypress_event/index.html
@@ -63,20 +63,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#event-type-keypress')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/lastelementchild/index.html
+++ b/files/en-us/web/api/document/lastelementchild/index.html
@@ -35,16 +35,7 @@ document.lastElementChild;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('DOM WHATWG', '#dom-parentnode-lastelementchild', 'ParentNode.lastElementChild')}}</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/lastmodified/index.html
+++ b/files/en-us/web/api/document/lastmodified/index.html
@@ -86,23 +86,7 @@ if (isNaN(nLastVisit) || nLastModif &gt; nLastVisit) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-lastmodified',
-        'document.lastModified')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/links/index.html
+++ b/files/en-us/web/api/document/links/index.html
@@ -35,25 +35,7 @@ for(var i = 0; i &lt; links.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-document-links', 'Document.links')}}</td>
-   <td>{{ Spec2('HTML WHATWG') }}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 HTML", "html.html#ID-7068919", "document.links")}}</td>
-   <td>{{Spec2("DOM2 HTML")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/location/index.html
+++ b/files/en-us/web/api/document/location/index.html
@@ -43,29 +43,7 @@ document.location = 'http://www.mozilla.org' // Equivalent to document.location.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#the-location-interface",
-        "Document.location")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "browsers.html#the-location-interface",
-        "Document.location")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/lostpointercapture_event/index.html
+++ b/files/en-us/web/api/document/lostpointercapture_event/index.html
@@ -65,24 +65,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-lostpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-lostpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/onfullscreenchange/index.html
+++ b/files/en-us/web/api/document/onfullscreenchange/index.html
@@ -51,23 +51,7 @@ document.documentElement.onclick = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#handler-document-onfullscreenchange",
-        "onfullscreenchange")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/onfullscreenerror/index.html
+++ b/files/en-us/web/api/document/onfullscreenerror/index.html
@@ -49,23 +49,7 @@ document.documentElement.requestFullscreen();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#handler-document-onfullscreenerror",
-        "onfullscreenerror")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/onvisibilitychange/index.html
+++ b/files/en-us/web/api/document/onvisibilitychange/index.html
@@ -36,20 +36,7 @@ browser-compat: api.Document.onvisibilitychange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Page Visibility API','#dom-document-onvisibilitychange','onvisibilitychange')}}</td>
-      <td>{{Spec2('Page Visibility API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/open/index.html
+++ b/files/en-us/web/api/document/open/index.html
@@ -100,27 +100,7 @@ document.close();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-document-open", "document.open()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-72161170", "document.open()")}}</td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/paste_event/index.html
+++ b/files/en-us/web/api/document/paste_event/index.html
@@ -45,20 +45,7 @@ browser-compat: api.Document.paste_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Clipboard API', '#clipboard-event-paste')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pictureinpictureelement/index.html
+++ b/files/en-us/web/api/document/pictureinpictureelement/index.html
@@ -52,18 +52,7 @@ browser-compat: api.Document.pictureInPictureElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Picture-in-Picture", "#dom-documentorshadowroot-pictureinpictureelement", "Document.pictureInPictureElement")}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.html
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.html
@@ -54,23 +54,7 @@ browser-compat: api.Document.pictureInPictureEnabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Picture-in-Picture", "#dom-document-pictureinpictureenabled",
-        "Document.pictureInPictureEnabled")}}</td>
-      <td>{{Spec2("Picture-in-Picture")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/plugins/index.html
+++ b/files/en-us/web/api/document/plugins/index.html
@@ -32,22 +32,7 @@ browser-compat: api.Document.plugins
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-plugins', 'Document.plugins')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointercancel_event/index.html
+++ b/files/en-us/web/api/document/pointercancel_event/index.html
@@ -64,24 +64,7 @@ browser-compat: api.Document.pointercancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointercancel-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointercancel-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerdown_event/index.html
+++ b/files/en-us/web/api/document/pointerdown_event/index.html
@@ -52,24 +52,7 @@ browser-compat: api.Document.pointerdown_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerdown-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerdown-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerenter_event/index.html
+++ b/files/en-us/web/api/document/pointerenter_event/index.html
@@ -52,24 +52,7 @@ browser-compat: api.Document.pointerenter_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerenter-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerenter-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerleave_event/index.html
+++ b/files/en-us/web/api/document/pointerleave_event/index.html
@@ -52,24 +52,7 @@ browser-compat: api.Document.pointerleave_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerleave-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerleave-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerlockchange_event/index.html
+++ b/files/en-us/web/api/document/pointerlockchange_event/index.html
@@ -50,20 +50,7 @@ browser-compat: api.Document.pointerlockchange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Lock', '#pointerlockchange-and-pointerlockerror-events')}}</td>
-   <td>{{Spec2('Pointer Lock')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerlockelement/index.html
+++ b/files/en-us/web/api/document/pointerlockelement/index.html
@@ -42,22 +42,7 @@ if (document.pointerLockElement === canvasElement) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Lock','#extensions-to-the-documentorshadowroot-mixin','pointerLockElement')}}</td>
-      <td>{{Spec2('Pointer Lock')}}</td>
-      <td>Extend the <code>Document</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerlockerror_event/index.html
+++ b/files/en-us/web/api/document/pointerlockerror_event/index.html
@@ -52,20 +52,7 @@ document.addEventListener('pointerlockerror', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Lock', '#pointerlockchange-and-pointerlockerror-events')}}</td>
-   <td>{{Spec2('Pointer Lock')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointermove_event/index.html
+++ b/files/en-us/web/api/document/pointermove_event/index.html
@@ -52,24 +52,7 @@ browser-compat: api.Document.pointermove_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointermove-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointermove-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerout_event/index.html
+++ b/files/en-us/web/api/document/pointerout_event/index.html
@@ -52,24 +52,7 @@ browser-compat: api.Document.pointerout_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerout-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerout-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerover_event/index.html
+++ b/files/en-us/web/api/document/pointerover_event/index.html
@@ -53,24 +53,7 @@ browser-compat: api.Document.pointerover_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerover-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerover-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/pointerup_event/index.html
+++ b/files/en-us/web/api/document/pointerup_event/index.html
@@ -53,24 +53,7 @@ browser-compat: api.Document.pointerup_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerup-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerup-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/prepend/index.html
+++ b/files/en-us/web/api/document/prepend/index.html
@@ -64,18 +64,7 @@ doc.children; // HTMLCollection [&lt;html&gt;]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-prepend', 'ParentNode.prepend()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandenabled/index.html
+++ b/files/en-us/web/api/document/querycommandenabled/index.html
@@ -52,22 +52,7 @@ if(flg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a
-          href="https://w3c.github.io/editing/execCommand.html#querycommandenabled()">execCommand</a>
-      </td>
-      <td></td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandstate/index.html
+++ b/files/en-us/web/api/document/querycommandstate/index.html
@@ -57,22 +57,7 @@ browser-compat: api.Document.queryCommandState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/editing/execCommand.html#querycommandstate()">execCommand</a></td>
-   <td></td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandsupported/index.html
+++ b/files/en-us/web/api/document/querycommandsupported/index.html
@@ -50,24 +50,7 @@ if(flg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a
-          href="https://w3c.github.io/editing/execCommand.html#querycommandsupported()">execCommand</a>
-      </td>
-      <td></td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/queryselector/index.html
+++ b/files/en-us/web/api/document/queryselector/index.html
@@ -133,23 +133,7 @@ browser-compat: api.Document.querySelector
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-parentnode-queryselector",
-        "document.querySelector()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/queryselectorall/index.html
+++ b/files/en-us/web/api/document/queryselectorall/index.html
@@ -158,41 +158,7 @@ inner.length; // 0
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-parentnode-queryselectorall",
-        "ParentNode.querySelectorAll()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Living standard</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("Selectors API Level 2", "#dom-parentnode-queryselectorall",
-        "ParentNode.querySelectorAll()")}}</td>
-      <td>{{Spec2("Selectors API Level 2")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-parentnode-queryselectorall",
-        "ParentNode.querySelectorAll()")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td>Initial definition</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("Selectors API Level 1", "#interface-definitions",
-        "document.querySelector()")}}</td>
-      <td>{{Spec2("Selectors API Level 1")}}</td>
-      <td>Original definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/readystate/index.html
+++ b/files/en-us/web/api/document/readystate/index.html
@@ -97,35 +97,7 @@ document.onreadystatechange = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#current-document-readiness", "Document readiness")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "#current-document-readiness", "Document readiness")}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "#current-document-readiness", "Document readiness")}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/readystatechange_event/index.html
+++ b/files/en-us/web/api/document/readystatechange_event/index.html
@@ -114,22 +114,7 @@ document.addEventListener('DOMContentLoaded', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "indices.html#event-readystatechange", "readystatechange")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/referrer/index.html
+++ b/files/en-us/web/api/document/referrer/index.html
@@ -34,23 +34,7 @@ browser-compat: api.Document.referrer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-referrer-dev', 'document.referrer')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/replacechildren/index.html
+++ b/files/en-us/web/api/document/replacechildren/index.html
@@ -53,16 +53,7 @@ document.children; // HTMLCollection []
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-replacechildren', 'ParentNode.replaceChildren()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/scripts/index.html
+++ b/files/en-us/web/api/document/scripts/index.html
@@ -39,22 +39,7 @@ if (scripts.length) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-document-scripts', 'Document.scripts')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/scroll_event/index.html
+++ b/files/en-us/web/api/document/scroll_event/index.html
@@ -74,18 +74,7 @@ document.addEventListener('scroll', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#scrolling-events')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/scrollingelement/index.html
+++ b/files/en-us/web/api/document/scrollingelement/index.html
@@ -34,21 +34,7 @@ scrollElm.scrollTop = 0;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-document-scrollingelement','scrollingElement')}}
-      </td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/selectionchange_event/index.html
+++ b/files/en-us/web/api/document/selectionchange_event/index.html
@@ -50,22 +50,7 @@ document.onselectionchange = () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Selection API', '#selectionchange-event', 'selectionchange')}}</td>
-   <td>{{Spec2('Selection API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/selectstart_event/index.html
+++ b/files/en-us/web/api/document/selectstart_event/index.html
@@ -52,20 +52,7 @@ document.onselectstart = () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Selection API', '#selectstart-event', 'selectstart')}}</td>
-   <td>{{Spec2('Selection API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/stylesheets/index.html
+++ b/files/en-us/web/api/document/stylesheets/index.html
@@ -40,16 +40,7 @@ browser-compat: api.Document.styleSheets
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM','#extensions-to-the-document-or-shadow-root-interface','DocumentOrShadowRoot.styleSheets')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/timeline/index.html
+++ b/files/en-us/web/api/document/timeline/index.html
@@ -39,20 +39,7 @@ var thisMoment = pageTimeline.currentTime;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-document-timeline', 'document.timeline' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/title/index.html
+++ b/files/en-us/web/api/document/title/index.html
@@ -70,22 +70,7 @@ browser-compat: api.Document.title
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#document.title','document.title')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/touchcancel_event/index.html
+++ b/files/en-us/web/api/document/touchcancel_event/index.html
@@ -41,18 +41,7 @@ browser-compat: api.Document.touchcancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchcancel')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/touchend_event/index.html
+++ b/files/en-us/web/api/document/touchend_event/index.html
@@ -46,18 +46,7 @@ browser-compat: api.Document.touchend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchend')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/touchmove_event/index.html
+++ b/files/en-us/web/api/document/touchmove_event/index.html
@@ -47,18 +47,7 @@ browser-compat: api.Document.touchmove_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchmove')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/touchstart_event/index.html
+++ b/files/en-us/web/api/document/touchstart_event/index.html
@@ -41,18 +41,7 @@ browser-compat: api.Document.touchstart_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchstart')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/transitioncancel_event/index.html
+++ b/files/en-us/web/api/document/transitioncancel_event/index.html
@@ -59,22 +59,7 @@ browser-compat: api.Document.transitioncancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitioncancel', 'transitioncancel')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/transitionend_event/index.html
+++ b/files/en-us/web/api/document/transitionend_event/index.html
@@ -57,22 +57,7 @@ browser-compat: api.Document.transitionend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Transitions", "#transitionend", "transitionend")}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/transitionrun_event/index.html
+++ b/files/en-us/web/api/document/transitionrun_event/index.html
@@ -55,22 +55,7 @@ browser-compat: api.Document.transitionrun_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitionrun', 'transitionrun')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/transitionstart_event/index.html
+++ b/files/en-us/web/api/document/transitionstart_event/index.html
@@ -57,22 +57,7 @@ browser-compat: api.Document.transitionstart_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitionstart', 'transitionstart')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/url/index.html
+++ b/files/en-us/web/api/document/url/index.html
@@ -38,23 +38,7 @@ browser-compat: api.Document.URL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-document-url", "Document.URL")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Defines that the property is a {{domxref("USVString")}} instead of a
-        {{domxref("DOMString")}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/visibilitychange_event/index.html
+++ b/files/en-us/web/api/document/visibilitychange_event/index.html
@@ -72,22 +72,7 @@ browser-compat: api.Document.visibilitychange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Page Visibility API','#dfn-visibilitychange','visibilitychange')}}</td>
-   <td>{{Spec2('Page Visibility API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/visibilitystate/index.html
+++ b/files/en-us/web/api/document/visibilitystate/index.html
@@ -56,22 +56,7 @@ browser-compat: api.Document.visibilityState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Page Visibility API','#visibility-states-and-the-visibilitystate-enum', 'Document.visibilityState')}}</td>
-      <td>{{Spec2('Page Visibility API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/wheel_event/index.html
+++ b/files/en-us/web/api/document/wheel_event/index.html
@@ -96,20 +96,7 @@ document.onwheel = zoom;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('UI Events','#event-type-wheel','wheel')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/write/index.html
+++ b/files/en-us/web/api/document/write/index.html
@@ -76,27 +76,7 @@ browser-compat: api.Document.write
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#dom-document-write", "document.write(...)")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 HTML", "html.html#ID-75233634", "document.write(...)")}}</td>
-   <td>{{Spec2("DOM2 HTML")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/writeln/index.html
+++ b/files/en-us/web/api/document/writeln/index.html
@@ -36,27 +36,7 @@ browser-compat: api.Document.writeln
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#dom-document-writeln", "document.writeln()")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 HTML", "html.html#ID-35318390", "document.writeln()")}}</td>
-   <td>{{Spec2("DOM2 HTML")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of 'document' to the {{Specifications}} macros. 

A few notes:
- `Document.createTouchList` and `Document.createTouch` lose their table but the spec there is outdated, no desktop browsers support them anymore. PR mdn/yari#4012 should lead to a better message displayed. I am leaving them as is.
- `Document.featurePolicy` loses its table. The spec has renamed it so no pertinent spec_url is possible. Nevertheless either the name change will be done to allexisting implementations, or Gecko will unflag its implementation: in both cases the guide and this reference article will have to be updated, and this will get fixed at that point. So I leave it as is.
- `Document.queryCommandEnabled`, `Document.queryCommandSupported`, `Document.execCommand`, `Document.queryCommandState` lose their table. I'll open an issue in mdn/browser-compat-data to deal with it: either we will add the spec (that is experimental), or leave it without (and mdn/yari#4012 will deal with it).
- `Document.all`: I've open PR mdn/browser-compat-data#10972 to get spec_url added.

All other pages look fine.