### PR TITLE
Replace spec table with {{specifications}} for remaining api/d*

### DIFF
--- a/files/en-us/web/api/documentfragment/append/index.html
+++ b/files/en-us/web/api/documentfragment/append/index.html
@@ -53,18 +53,7 @@ fragment.children; // HTMLCollection [&lt;div&gt;]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-append', 'ParentNode.append()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/childelementcount/index.html
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.html
@@ -34,16 +34,7 @@ fragment.childElementCount; // 1
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount', 'ParentNode.childElementCount')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/children/index.html
+++ b/files/en-us/web/api/documentfragment/children/index.html
@@ -49,18 +49,7 @@ fragment.children; // HTMLCollection [&lt;p&gt;]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/documentfragment/index.html
@@ -26,21 +26,7 @@ browser-compat: api.DocumentFragment.DocumentFragment
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-documentfragment-documentfragment',
-        'DocumentFragment()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/firstelementchild/index.html
+++ b/files/en-us/web/api/documentfragment/firstelementchild/index.html
@@ -36,16 +36,7 @@ fragment.firstElementChild; // &lt;p&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('DOM WHATWG', '#dom-parentnode-firstelementchild', 'ParentNode.firstElementChild')}}</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/index.html
@@ -93,42 +93,7 @@ list.appendChild(fragment)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-documentfragment', 'DocumentFragment')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Added the constructor and the implementation of <code>ParentNode</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Selectors API Level 1', '#the-apis', 'DocumentFragment')}}</td>
-   <td>{{Spec2('Selectors API Level 1')}}</td>
-   <td>Added the <code>querySelector()</code> and <code>querySelectorAll()</code> methods.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-B63ED1A3', 'DocumentFragment')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>No change from {{SpecName('DOM2 Core')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-B63ED1A3', 'DocumentFragment')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No change from {{SpecName('DOM1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-B63ED1A3', 'DocumentFragment')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/lastelementchild/index.html
+++ b/files/en-us/web/api/documentfragment/lastelementchild/index.html
@@ -36,16 +36,7 @@ fragment.lastElementChild; // &lt;p&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('DOM WHATWG', '#dom-parentnode-lastelementchild', 'ParentNode.lastElementChild')}}</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/prepend/index.html
+++ b/files/en-us/web/api/documentfragment/prepend/index.html
@@ -55,18 +55,7 @@ fragment.children; // HTMLCollection [&lt;div&gt;, &lt;p&gt;]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-prepend', 'ParentNode.prepend()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/queryselector/index.html
+++ b/files/en-us/web/api/documentfragment/queryselector/index.html
@@ -64,27 +64,7 @@ document.querySelector('#foo\\:bar')   // Match the second div
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Selectors API Level 2', '#queryselector',
-				'DocumentFragment.querySelector')}}</td>
-			<td>{{Spec2('Selectors API Level 2')}}</td>
-			<td>No change from {{SpecName('Selectors API Level 1')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('Selectors API Level 1', '#queryselector',
-				'DocumentFragment.querySelector')}}</td>
-			<td>{{Spec2('Selectors API Level 1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/queryselectorall/index.html
+++ b/files/en-us/web/api/documentfragment/queryselectorall/index.html
@@ -42,21 +42,7 @@ browser-compat: api.DocumentFragment.querySelectorAll
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selectors API Level 1', '#queryselector',
-        'DocumentFragment.querySelectorAll')}}</td>
-      <td>{{Spec2('Selectors API Level 1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documentfragment/replacechildren/index.html
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.html
@@ -63,16 +63,7 @@ fragment.children; // HTMLCollection []
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-replacechildren', 'ParentNode.replaceChildren()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.html
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.html
@@ -45,20 +45,7 @@ cats.forEach(function(cat) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-documenttimeline-documenttimeline', 'DocumentTimeline()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documenttimeline/index.html
+++ b/files/en-us/web/api/documenttimeline/index.html
@@ -49,20 +49,7 @@ for (const cat of cats) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#the-documenttimeline-interface', 'DocumentTimeline' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documenttype/index.html
+++ b/files/en-us/web/api/documenttype/index.html
@@ -46,36 +46,7 @@ browser-compat: api.DocumentType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#documenttype', 'DocumentType')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Added implementation of the {{domxref("ChildNode")}} interface.<br>
-			Removed the <code>internalSubset</code>, <code>entities</code>, and <code>notation</code> properties.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Core', 'core.html#ID-412266927', 'DocumentType')}}</td>
-			<td>{{Spec2('DOM3 Core')}}</td>
-			<td>No change from {{SpecName('DOM2 Core')}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Core', 'core.html#ID-412266927', 'DocumentType')}}</td>
-			<td>{{Spec2('DOM2 Core')}}</td>
-			<td>Added the <code>publicID</code>, <code>systemID</code>, and <code>internalSubset</code> properties.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM1', 'level-one-core.html#ID-412266927', 'DocumentType')}}</td>
-			<td>{{Spec2('DOM1')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/documenttype/remove/index.html
+++ b/files/en-us/web/api/documenttype/remove/index.html
@@ -38,18 +38,7 @@ document.doctype; // null
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-childnode-remove', 'ChildNode.remove')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domexception/code/index.html
+++ b/files/en-us/web/api/domexception/code/index.html
@@ -29,20 +29,7 @@ browser-compat: api.DOMException.code
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebIDL', '#dom-domexception-code', 'code')}}</td>
-      <td>{{Spec2('WebIDL')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -43,20 +43,7 @@ var domException = new DOMException(message, name);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebIDL', '#dom-domexception-domexception', 'DOMException()')}}</td>
-      <td>{{Spec2('WebIDL')}}</td>
-      <td>Adds the constructor for the <code>DOMException</code> class.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domexception/index.html
+++ b/files/en-us/web/api/domexception/index.html
@@ -110,20 +110,7 @@ browser-compat: api.DOMException
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebIDL', '#idl-DOMException', 'constructor')}}</td>
-   <td>{{Spec2('WebIDL')}}</td>
-   <td>Adds the constructor for the <code>DOMException</code> class. Adds the <code>NotReadableError</code>, <code>UnknownError</code>, <code>ConstraintError</code>, <code>DataError</code>, <code>TransactionInactiveError</code>, <code>ReadOnlyError</code>, <code>VersionError</code>, <code>OperationError</code>, and <code>NotAllowedError</code> values.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domexception/message/index.html
+++ b/files/en-us/web/api/domexception/message/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMException.message
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebIDL', '#dom-domexception-message', 'message')}}</td>
-      <td>{{Spec2('WebIDL')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domexception/name/index.html
+++ b/files/en-us/web/api/domexception/name/index.html
@@ -28,22 +28,7 @@ browser-compat: api.DOMException.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebIDL', '#dom-domexception-name', 'name')}}</td>
-      <td>{{Spec2('WebIDL')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domhighrestimestamp/index.html
+++ b/files/en-us/web/api/domhighrestimestamp/index.html
@@ -90,27 +90,7 @@ let elapsedTime = performance.now() - startTime;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Highres Time Level 2', '#dom-domhighrestimestamp', 'DOMHighResTimeStamp')}}</td>
-   <td>{{Spec2('Highres Time Level 2')}}</td>
-   <td>Stricter definitions of interfaces and types.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time', '#sec-DOMHighResTimeStamp', 'DOMHighResTimeStamp')}}</td>
-   <td>{{Spec2('Highres Time')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domimplementation/createdocument/index.html
+++ b/files/en-us/web/api/domimplementation/createdocument/index.html
@@ -46,36 +46,7 @@ alert(doc.getElementById('abc')); // [object HTMLBodyElement]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-domimplementation-createdocument',
-        'DOMImplementation.createDocument')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Modified the return type of <code>createDocument()</code> from
-        {{domxref("Document")}} to {{domxref("XMLDocument")}}.<br>
-        The third argument of <code>createDocument()</code>, <em>doctype</em>, is now
-        optional and default to <code>null</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Level-2-Core-DOM-createDocument',
-        'DOMImplementation.createDocument')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName("DOM2 Core")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#Level-2-Core-DOM-createDocument',
-        'DOMImplementation.createDocument')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domimplementation/createdocumenttype/index.html
+++ b/files/en-us/web/api/domimplementation/createdocumenttype/index.html
@@ -43,33 +43,7 @@ alert(d.doctype.publicId); // -//W3C//DTD SVG 1.1//EN
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-domimplementation-createdocumenttype',
-        'DOMImplementation.createDocumentType')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName("DOM3 Core")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Level-2-Core-DOM-createDocType',
-        'DOMImplementation.createDocumentType')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName("DOM2 Core")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#Level-2-Core-DOM-createDocType',
-        'DOMImplementation.createDocumentType')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.html
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.html
@@ -93,23 +93,7 @@ browser-compat: api.DOMImplementation.createHTMLDocument
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-domimplementation-createhtmldocument',
-        'DOMImplementation.createHTMLDocument')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domimplementation/hasfeature/index.html
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.html
@@ -40,41 +40,7 @@ browser-compat: api.DOMImplementation.hasFeature
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-domimplementation-hasfeature',
-        'DOMImplementation.hasFeature')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Modified to always return <code>true</code> except for SVG features.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-5CED94D7',
-        'DOMImplementation.hasFeature')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName("DOM2 Core")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-5CED94D7',
-        'DOMImplementation.hasFeature')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-5CED94D7',
-        'DOMImplementation.hasFeature')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domimplementation/index.html
+++ b/files/en-us/web/api/domimplementation/index.html
@@ -33,37 +33,7 @@ browser-compat: api.DOMImplementation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#domimplementation', 'DOMImplementation')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Removed the <code>getFeature()</code> method.<br>
-    Added the <code>createHTMLDocument()</code> method.<br>
-    Modified the return type of <code>createDocument()</code> from {{domxref("Document")}} to {{domxref("XMLDocument")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-102161490', 'DOMImplementation')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Added the <code>getFeature()</code> method (never implemented by any user agent).</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-102161490', 'DOMImplementation')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>Added the <code>createDocument()</code> and <code>createDocumentType()</code> methods.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-102161490', 'DOMImplementation')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrix/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.html
@@ -54,20 +54,7 @@ var transformedPoint = point.matrixTransform(matrix);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrix')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/index.html
@@ -136,22 +136,7 @@ browser-compat: api.DOMMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('Geometry Interfaces', '#DOMMatrix', 'DOMMatrix') }}</td>
-   <td>{{ Spec2('Geometry Interfaces') }}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
@@ -32,21 +32,7 @@ browser-compat: api.DOMMatrixReadOnly.DOMMatrixReadOnly
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Geometry Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrixReadOnly')}}
-			</td>
-			<td>{{Spec2('Geometry Interfaces')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/flipx/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/flipx/index.html
@@ -48,20 +48,7 @@ flipped.setAttribute('transform', flippedMatrix.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('Geometry Interfaces', '#dom-dommatrixreadonly-flipx', 'DOMMatrixReadOnly.flipX()') }}</td>
-   <td>{{ Spec2('Geometry Interfaces') }}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/index.html
@@ -150,22 +150,7 @@ browser-compat: api.DOMMatrixReadOnly
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('Geometry Interfaces', '#dommatrixreadonly', 'DOMMatrixReadOnly') }}</td>
-   <td>{{ Spec2('Geometry Interfaces') }}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/scale/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/scale/index.html
@@ -121,21 +121,7 @@ document.querySelector('#transformedOrigin').setAttribute('transform', scaledMat
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Geometry Interfaces', '#dom-dommatrixreadonly-scale',
-        'DOMMatrixReadOnly.scale()') }}</td>
-      <td>{{ Spec2('Geometry Interfaces') }}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/translate/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.html
@@ -80,21 +80,7 @@ document.querySelector('#transformed').setAttribute('transform', matrix.toString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Geometry Interfaces', '#dom-dommatrixreadonly-translate',
-        'DOMMatrixReadOnly.translate()') }}</td>
-      <td>{{ Spec2('Geometry Interfaces') }}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domparser/domparser/index.html
+++ b/files/en-us/web/api/domparser/domparser/index.html
@@ -26,23 +26,7 @@ browser-compat: api.DOMParser.DOMParser
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-domparser-constructor', 'DOMParser()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domparser/index.html
+++ b/files/en-us/web/api/domparser/index.html
@@ -78,23 +78,7 @@ console.log(doc3.body.firstChild.textContent);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-parsing-and-serialization', 'DOM parsing')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.html
+++ b/files/en-us/web/api/domparser/parsefromstring/index.html
@@ -98,23 +98,7 @@ console.log(doc.documentElement.textContent);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-domparser-parsefromstring', 'parseFromString()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/dompoint/index.html
+++ b/files/en-us/web/api/dompoint/dompoint/index.html
@@ -56,20 +56,7 @@ newTopLeft.y += 100;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-dompoint', 'DOMPoint()')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/frompoint/index.html
+++ b/files/en-us/web/api/dompoint/frompoint/index.html
@@ -72,21 +72,7 @@ browser-compat: api.DOMPoint.fromPoint
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-frompoint', 'fromPoint()')}}
-      </td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/index.html
+++ b/files/en-us/web/api/dompoint/index.html
@@ -78,22 +78,7 @@ browser-compat: api.DOMPoint
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Geometry Interfaces', '#DOMPoint', 'DOMPoint')}}</td>
-			<td>{{Spec2('Geometry Interfaces')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/w/index.html
+++ b/files/en-us/web/api/dompoint/w/index.html
@@ -34,20 +34,7 @@ browser-compat: api.DOMPoint.w
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-w', 'w')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/x/index.html
+++ b/files/en-us/web/api/dompoint/x/index.html
@@ -35,20 +35,7 @@ browser-compat: api.DOMPoint.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-x', 'x')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/y/index.html
+++ b/files/en-us/web/api/dompoint/y/index.html
@@ -34,20 +34,7 @@ browser-compat: api.DOMPoint.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-y', 'y')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompoint/z/index.html
+++ b/files/en-us/web/api/dompoint/z/index.html
@@ -37,20 +37,7 @@ browser-compat: api.DOMPoint.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompoint-z', 'z')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointinit/index.html
+++ b/files/en-us/web/api/dompointinit/index.html
@@ -47,22 +47,7 @@ const windTopLeft = DOMPoint.fromPoint(pointDesc)</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-frompoint', 'DOMPointReadOnly.fromPoint()')}}</td>
-			<td>{{Spec2('Geometry Interfaces')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointinit/w/index.html
+++ b/files/en-us/web/api/dompointinit/w/index.html
@@ -56,20 +56,7 @@ var <em>wPerspective</em> = <em>DOMPointInit</em>.w;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointinit-w', 'w')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointinit/x/index.html
+++ b/files/en-us/web/api/dompointinit/x/index.html
@@ -52,20 +52,7 @@ var <em>xPos</em> = <em>DOMPointInit</em>.x;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointinit-x', 'x')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointinit/y/index.html
+++ b/files/en-us/web/api/dompointinit/y/index.html
@@ -60,20 +60,7 @@ var <em>yPos</em> = <em>DOMPointInit</em>.y;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointinit-y', 'y')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointinit/z/index.html
+++ b/files/en-us/web/api/dompointinit/z/index.html
@@ -64,20 +64,7 @@ var <em>zPos</em> = <em>DOMPointInit</em>.z;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointinit-z', 'z')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/dompointreadonly/index.html
+++ b/files/en-us/web/api/dompointreadonly/dompointreadonly/index.html
@@ -63,21 +63,7 @@ var perspectivePoint3D = new DOMPointReadOnly(50, 50, 25, 0.5);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dompointreadonly', 'DOMPointReadOnly')}}
-      </td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/frompoint/index.html
+++ b/files/en-us/web/api/dompointreadonly/frompoint/index.html
@@ -71,23 +71,7 @@ const newPoint = DOMPointReadOnly.fromPoint(origPoint)</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-frompoint',
-        'fromPoint()')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/index.html
+++ b/files/en-us/web/api/dompointreadonly/index.html
@@ -73,22 +73,7 @@ const point = new DOMPointReadOnly(100, 100, 100, 1.0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#DOMPoint', 'DOMPoint')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/tojson/index.html
+++ b/files/en-us/web/api/dompointreadonly/tojson/index.html
@@ -47,21 +47,7 @@ var pointJSON = topLeft.toJSON();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-tojson',
-        'DOMPointReadOnly.toJSON()')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/w/index.html
+++ b/files/en-us/web/api/dompointreadonly/w/index.html
@@ -39,22 +39,7 @@ browser-compat: api.DOMPointReadOnly.w
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-w', 'w')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/x/index.html
+++ b/files/en-us/web/api/dompointreadonly/x/index.html
@@ -40,22 +40,7 @@ browser-compat: api.DOMPointReadOnly.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-x', 'x')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/y/index.html
+++ b/files/en-us/web/api/dompointreadonly/y/index.html
@@ -40,22 +40,7 @@ browser-compat: api.DOMPointReadOnly.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-y', 'y')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dompointreadonly/z/index.html
+++ b/files/en-us/web/api/dompointreadonly/z/index.html
@@ -41,22 +41,7 @@ browser-compat: api.DOMPointReadOnly.z
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-dompointreadonly-z', 'z')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domquad/index.html
+++ b/files/en-us/web/api/domquad/index.html
@@ -43,20 +43,7 @@ browser-compat: api.DOMQuad
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces','#DOMQuad','DOMQuad')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrect/domrect/index.html
+++ b/files/en-us/web/api/domrect/domrect/index.html
@@ -43,20 +43,7 @@ browser-compat: api.DOMRect.DOMRect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrect-domrect', 'DOMRect()')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrect/index.html
+++ b/files/en-us/web/api/domrect/index.html
@@ -66,20 +66,7 @@ browser-compat: api.DOMRect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#DOMRect', 'DOMRect')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/bottom/index.html
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.bottom
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-bottom', 'bottom')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.html
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.html
@@ -48,23 +48,7 @@ browser-compat: api.DOMRectReadOnly.DOMRectReadOnly
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-domrectreadonly',
-        'DOMRectReadOnly()')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.html
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.html
@@ -45,20 +45,7 @@ browser-compat: api.DOMRectReadOnly.fromRect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Geometry Interfaces','#dom-domrect-fromrect','fromRect()')}}</td>
-      <td>{{Spec2('Geometry Interfaces')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/height/index.html
+++ b/files/en-us/web/api/domrectreadonly/height/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-height', 'height')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/index.html
+++ b/files/en-us/web/api/domrectreadonly/index.html
@@ -54,22 +54,7 @@ browser-compat: api.DOMRectReadOnly
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#DOMRect', 'DOMRectReadOnly')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/left/index.html
+++ b/files/en-us/web/api/domrectreadonly/left/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.left
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-left', 'left')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/right/index.html
+++ b/files/en-us/web/api/domrectreadonly/right/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.right
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-right', 'right')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/top/index.html
+++ b/files/en-us/web/api/domrectreadonly/top/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.top
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-top', 'top')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/width/index.html
+++ b/files/en-us/web/api/domrectreadonly/width/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-width', 'width')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/x/index.html
+++ b/files/en-us/web/api/domrectreadonly/x/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-x', 'x')}}</td>
-			<td>{{Spec2('Geometry Interfaces')}}</td>
-			<td>Latest spec version is an ED.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domrectreadonly/y/index.html
+++ b/files/en-us/web/api/domrectreadonly/y/index.html
@@ -27,20 +27,7 @@ browser-compat: api.DOMRectReadOnly.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Geometry Interfaces', '#dom-domrectreadonly-y', 'y')}}</td>
-   <td>{{Spec2('Geometry Interfaces')}}</td>
-   <td>Latest spec version is an ED.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domstringlist/index.html
+++ b/files/en-us/web/api/domstringlist/index.html
@@ -30,22 +30,7 @@ browser-compat: api.DOMStringList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "common-dom-interfaces.html#the-domstringlist-interface", "DOMStringList")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial specification</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domstringmap/index.html
+++ b/files/en-us/web/api/domstringmap/index.html
@@ -17,22 +17,7 @@ browser-compat: api.DOMStringMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "dom.html#domstringmap", "DOMStringMap")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/add/index.html
+++ b/files/en-us/web/api/domtokenlist/add/index.html
@@ -62,22 +62,7 @@ span.textContent = classes;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-add','add()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/contains/index.html
+++ b/files/en-us/web/api/domtokenlist/contains/index.html
@@ -63,22 +63,7 @@ if (result) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-contains','contains()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/entries/index.html
+++ b/files/en-us/web/api/domtokenlist/entries/index.html
@@ -54,23 +54,7 @@ for (let value of iterator) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#domtokenlist','entries() (as iterable&lt;Node&gt;)')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/foreach/index.html
+++ b/files/en-us/web/api/domtokenlist/foreach/index.html
@@ -91,23 +91,7 @@ classes.forEach(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#domtokenlist','forEach() (as iterable&lt;Node&gt;)')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/index.html
+++ b/files/en-us/web/api/domtokenlist/index.html
@@ -85,22 +85,7 @@ span.textContent = `span classList is "${classes}"`;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#interface-domtokenlist", "DOMTokenList")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/item/index.html
+++ b/files/en-us/web/api/domtokenlist/item/index.html
@@ -59,22 +59,7 @@ span.textContent = item;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-item','item()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/keys/index.html
+++ b/files/en-us/web/api/domtokenlist/keys/index.html
@@ -59,23 +59,7 @@ for(var value of iterator) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-      <td>{{SpecName('DOM WHATWG','#domtokenlist','keys() (as iterable&lt;Node&gt;)')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/length/index.html
+++ b/files/en-us/web/api/domtokenlist/length/index.html
@@ -50,22 +50,7 @@ span.textContent = `classList length = ${length}`;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-length','length')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/remove/index.html
+++ b/files/en-us/web/api/domtokenlist/remove/index.html
@@ -68,22 +68,7 @@ span2.textContent = classes2;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-remove','remove()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/replace/index.html
+++ b/files/en-us/web/api/domtokenlist/replace/index.html
@@ -87,22 +87,7 @@ if (result) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-replace','replace()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/supports/index.html
+++ b/files/en-us/web/api/domtokenlist/supports/index.html
@@ -50,22 +50,7 @@ if (iframe.sandbox.supports('allow-scripts')) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/toggle/index.html
+++ b/files/en-us/web/api/domtokenlist/toggle/index.html
@@ -72,22 +72,7 @@ span.addEventListener('click', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-toggle','toggle()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/value/index.html
+++ b/files/en-us/web/api/domtokenlist/value/index.html
@@ -48,22 +48,7 @@ span.textContent = classes.value;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-domtokenlist-value','value')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/domtokenlist/values/index.html
+++ b/files/en-us/web/api/domtokenlist/values/index.html
@@ -59,21 +59,7 @@ for(var value of iterator) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#domtokenlist','values() (as iterable&lt;Node&gt;)')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/doublerange/index.html
+++ b/files/en-us/web/api/doublerange/index.html
@@ -31,20 +31,7 @@ browser-compat: api.DoubleRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-doublerange', 'DoubleRange')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dragevent/datatransfer/index.html
+++ b/files/en-us/web/api/dragevent/datatransfer/index.html
@@ -46,29 +46,7 @@ dragTarget.addEventListener("dragend", function(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("HTML WHATWG", "interaction.html#dom-dragevent-datatransfer",
-				"DragEvent.dataTransfer")}}</td>
-			<td>{{Spec2("HTML WHATWG")}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName("HTML5.1", "editing.html#dom-dragevent-datatransfer",
-				"DragEvent.dataTransfer")}}</td>
-			<td>{{Spec2("HTML5.1")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dragevent/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/dragevent/index.html
@@ -47,27 +47,7 @@ browser-compat: api.DragEvent.DragEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "interaction.html#the-dragevent-interface",
-        "DragEvent")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "editing.html#the-dragevent-interface", "DragEvent")}}
-      </td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/index.html
@@ -78,25 +78,7 @@ browser-compat: api.DragEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#dragevent", "DragEvent")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "editing.html#the-dragevent-interface", "DragEvent")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.html
@@ -44,20 +44,7 @@ compressor.attack.value = 0;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-attack', 'attack')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
@@ -49,20 +49,7 @@ browser-compat: api.DynamicsCompressorNode.DynamicsCompressorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dynamicscompressornode','DynamicsCompressorNode()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/index.html
@@ -78,20 +78,7 @@ browser-compat: api.DynamicsCompressorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dynamicscompressornode', 'DynamicsCompressorNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.html
@@ -45,20 +45,7 @@ compressor.knee.value = 40;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-knee', 'knee')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.html
@@ -46,20 +46,7 @@ compressor.ratio.value = 12;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-ratio', 'ratio')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.html
@@ -35,20 +35,7 @@ var myReduction = compressor.reduction;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-reduction', 'reduction')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/release/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.html
@@ -44,20 +44,7 @@ compressor.release.value = 0.25;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-release', 'release')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.html
@@ -46,20 +46,7 @@ compressor.threshold.value = -50;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-dynamicscompressornode-threshold', 'threshold')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/d* to the {{Specifications}} macros. 

A few notes:
- `DOMHighResTimestamp` has lost its table; but it has no bcd as it is a typedef. I keep that way.
- `DOMPoint.fromPoint`, `DOMPoint.w`, `DOMPoint.x`, `DOMPoint.y`, `DOMPoint.z` lost their tables; I opened PR mdn/browser-compat-data#10975 to get the BCD fixed.

All other pages look fine.