### PR TITLE
Replace spec table with {{specifications}} for api/e[e-z]*

### DIFF
--- a/files/en-us/web/api/element/scrollto/index.html
+++ b/files/en-us/web/api/element/scrollto/index.html
@@ -50,23 +50,7 @@ element.scrollTo(<em>options</em>)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSSOM View', '#dom-element-scrollto-options-options',
-        'element.scrollTo()') }}</td>
-      <td>{{ Spec2('CSSOM View') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/scrolltop/index.html
+++ b/files/en-us/web/api/element/scrolltop/index.html
@@ -61,22 +61,7 @@ var <var>intElemScrollTop</var> = someElement.scrollTop;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#dom-element-scrolltop', 'scrollTop')}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/scrollwidth/index.html
+++ b/files/en-us/web/api/element/scrollwidth/index.html
@@ -112,23 +112,7 @@ browser-compat: api.Element.scrollWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th>Specification</th>
-			<th>Status</th>
-			<th>Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("CSSOM View", "#dom-element-scrollwidth",
-				"Element.scrollWidth")}}</td>
-			<td>{{Spec2("CSSOM View")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/select_event/index.html
+++ b/files/en-us/web/api/element/select_event/index.html
@@ -63,20 +63,7 @@ input.addEventListener('select', logSelection);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#event-type-select', 'select')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/setattribute/index.html
+++ b/files/en-us/web/api/element/setattribute/index.html
@@ -107,20 +107,7 @@ b.setAttribute("disabled", "");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-element-setattribute','setAttribute()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/setattributenode/index.html
+++ b/files/en-us/web/api/element/setattributenode/index.html
@@ -58,21 +58,7 @@ alert(d2.attributes[1].value);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-element-setattributenode','setAttributeNode()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/setattributenodens/index.html
+++ b/files/en-us/web/api/element/setattributenodens/index.html
@@ -47,22 +47,7 @@ alert(d2.attributes[1].value) // returns: `utterleft'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-element-setattributenodens', 'document.setAttributeNodeNS')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/setattributens/index.html
+++ b/files/en-us/web/api/element/setattributens/index.html
@@ -41,23 +41,7 @@ d.setAttributeNS('http://www.mozilla.org/ns/specialspace', 'spec:align', 'center
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-element-setattributens',
-				'document.setAttributeNS')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/setpointercapture/index.html
+++ b/files/en-us/web/api/element/setpointercapture/index.html
@@ -121,29 +121,7 @@ slider.onpointerup = stopSliding;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-element-setpointercapture',
-        'setPointerCapture')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events',
-        '#widl-Element-setPointerCapture-void-long-pointerId', 'setPointerCapture')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/shadowroot/index.html
+++ b/files/en-us/web/api/element/shadowroot/index.html
@@ -78,20 +78,7 @@ attributeChangedCallback(name, oldValue, newValue) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-shadowroot', 'shadowRoot')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/show_event/index.html
+++ b/files/en-us/web/api/element/show_event/index.html
@@ -50,20 +50,7 @@ browser-compat: api.Element.show_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "webappapis.html#handler-onshow", "show event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/slot/index.html
+++ b/files/en-us/web/api/element/slot/index.html
@@ -59,20 +59,7 @@ console.log(slottedSpan.slot); // logs 'my-text'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-element-slot','slot')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/tagname/index.html
+++ b/files/en-us/web/api/element/tagname/index.html
@@ -66,20 +66,7 @@ console.log(span.tagName);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-tagname', 'Element: tagName')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/toggleattribute/index.html
+++ b/files/en-us/web/api/element/toggleattribute/index.html
@@ -93,23 +93,7 @@ button.addEventListener("click", function(){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-element-toggleattribute',
-				'Element.toggleAttribute')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/touchcancel_event/index.html
+++ b/files/en-us/web/api/element/touchcancel_event/index.html
@@ -43,18 +43,7 @@ browser-compat: api.Element.touchcancel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchcancel')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/touchend_event/index.html
+++ b/files/en-us/web/api/element/touchend_event/index.html
@@ -45,20 +45,7 @@ browser-compat: api.Element.touchend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchend')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/touchmove_event/index.html
+++ b/files/en-us/web/api/element/touchmove_event/index.html
@@ -43,20 +43,7 @@ browser-compat: api.Element.touchmove_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchmove')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/touchstart_event/index.html
+++ b/files/en-us/web/api/element/touchstart_event/index.html
@@ -43,20 +43,7 @@ browser-compat: api.Element.touchstart_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events', '#event-touchstart')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/wheel_event/index.html
+++ b/files/en-us/web/api/element/wheel_event/index.html
@@ -91,22 +91,7 @@ el.onwheel = zoom;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events','#event-type-wheel','wheel')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/errorevent/index.html
+++ b/files/en-us/web/api/errorevent/index.html
@@ -43,27 +43,7 @@ browser-compat: api.ErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'webappapis.html#the-errorevent-interface', 'ErrorEvent') }}</td>
-   <td>{{ Spec2('HTML WHATWG') }}</td>
-   <td>Added the <code>error</code> property and the 5th parameter to the constructor.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'webappapis.html#the-errorevent-interface', 'ErrorEvent') }}</td>
-   <td>{{ Spec2('HTML5 W3C') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/bubbles/index.html
+++ b/files/en-us/web/api/event/bubbles/index.html
@@ -51,27 +51,7 @@ browser-compat: api.Event.bubbles
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-event-bubbles', 'Event.bubbles')}}</td>
-   <td>{{ Spec2('DOM WHATWG') }}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Events', '#Events-Event-canBubble', 'Event.bubbles')}}</td>
-   <td>{{ Spec2('DOM2 Events') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/cancelable/index.html
+++ b/files/en-us/web/api/event/cancelable/index.html
@@ -77,27 +77,7 @@ document.addEventListener('wheel', preventScrollWheel);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-cancelable', 'Event.cancelable')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-Event-canCancel', 'Event.cancelable')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/cancelbubble/index.html
+++ b/files/en-us/web/api/event/cancelbubble/index.html
@@ -37,20 +37,7 @@ var <em>bool</em> = <em>event</em>.cancelBubble;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-cancelbubble', 'cancelBubble')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/composed/index.html
+++ b/files/en-us/web/api/event/composed/index.html
@@ -111,22 +111,7 @@ browser-compat: api.Event.composed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-composed', 'composed')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/composedpath/index.html
+++ b/files/en-us/web/api/event/composedpath/index.html
@@ -92,20 +92,7 @@ browser-compat: api.Event.composedPath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-composedpath', 'composedPath()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/currenttarget/index.html
+++ b/files/en-us/web/api/event/currenttarget/index.html
@@ -65,38 +65,7 @@ document.body.addEventListener('click', hide, false);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-currenttarget", "Event.currentTarget")}}
-      </td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-event-currenttarget", "Event.currentTarget")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 Events", "#dfn-current-event-target", "current event target")}}
-      </td>
-      <td>{{Spec2("DOM3 Events")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-Event-currentTarget",
-        "Event.currentTarget")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/defaultprevented/index.html
+++ b/files/en-us/web/api/event/defaultprevented/index.html
@@ -62,22 +62,7 @@ document.addEventListener('click', logClick);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-event-defaultprevented', 'Event.defaultPrevented()')}}</td>
-   <td>{{ Spec2('DOM WHATWG') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/event/index.html
+++ b/files/en-us/web/api/event/event/index.html
@@ -57,22 +57,7 @@ myDiv.dispatchEvent(evt);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-event-event','Event()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/eventphase/index.html
+++ b/files/en-us/web/api/event/eventphase/index.html
@@ -197,30 +197,7 @@ function Clear() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-eventphase", "Event.eventPhase")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-event-eventphase", "Event.eventPhase")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-Event-eventPhase", "Event.eventPhase")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/index.html
+++ b/files/en-us/web/api/event/index.html
@@ -171,20 +171,7 @@ browser-compat: api.Event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-event', 'Event')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/initevent/index.html
+++ b/files/en-us/web/api/event/initevent/index.html
@@ -64,26 +64,7 @@ elem.dispatchEvent(event);</code>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-initevent','Event.initEvent()')}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>From {{SpecName('DOM2 Events')}}, deprecated it, superseded by event
-        constructors.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-Event-initEvent','Event.initEvent()')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/istrusted/index.html
+++ b/files/en-us/web/api/event/istrusted/index.html
@@ -37,26 +37,7 @@ browser-compat: api.Event.isTrusted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-istrusted', 'Event.isTrusted')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#trusted-events', 'Trusted events')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Adds requirements regarding trusted and untrusted events, though it does not
-        itself define the <code>isTrusted</code> property.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/preventdefault/index.html
+++ b/files/en-us/web/api/event/preventdefault/index.html
@@ -156,29 +156,7 @@ function displayWarning(msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-preventdefault',
-        'Event.preventDefault()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-Event-preventDefault',
-        'Event.preventDefault()')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/returnvalue/index.html
+++ b/files/en-us/web/api/event/returnvalue/index.html
@@ -58,22 +58,7 @@ var <em>bool</em> = <em>event</em>.returnValue;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-returnvalue", "returnValue")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Added for legacy compatibility.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/srcelement/index.html
+++ b/files/en-us/web/api/event/srcelement/index.html
@@ -16,20 +16,7 @@ browser-compat: api.Event.srcElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-event-srcelement', 'Event.srcElement')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/stopimmediatepropagation/index.html
+++ b/files/en-us/web/api/event/stopimmediatepropagation/index.html
@@ -27,23 +27,7 @@ browser-compat: api.Event.stopImmediatePropagation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-stopimmediatepropagation',
-        'Event.stopImmediatePropagation()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/stoppropagation/index.html
+++ b/files/en-us/web/api/event/stoppropagation/index.html
@@ -42,33 +42,7 @@ browser-compat: api.Event.stopPropagation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-stoppropagation",
-        "Event.stopPropagation()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-event-stoppropagation", "Event.stopPropagation()")}}
-      </td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-Event-stopPropagation",
-        "Event.stopPropagation()")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/target/index.html
+++ b/files/en-us/web/api/event/target/index.html
@@ -54,32 +54,7 @@ ul.addEventListener('click', hide, false);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-target", "Event.target")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-event-target", "Event.target")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-Event-target", "Event.target")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/timestamp/index.html
+++ b/files/en-us/web/api/event/timestamp/index.html
@@ -88,22 +88,7 @@ event.timeStamp;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-event-timestamp", "Event.timeStamp")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/event/type/index.html
+++ b/files/en-us/web/api/event/type/index.html
@@ -62,27 +62,7 @@ document.addEventListener('click', getEventType, false);     // third</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-event-type', 'Event.type')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-Event-type', 'Event.type')}}</td>
-      <td>{{ Spec2('DOM2 Events') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventlistener/handleevent/index.html
+++ b/files/en-us/web/api/eventlistener/handleevent/index.html
@@ -44,29 +44,7 @@ browser-compat: api.EventListener.handleEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-eventlistener-handleevent',
-				'EventListener.handleEvent()')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Events', '#Events-EventListener-handleEvent',
-				'EventListener.handleEvent()')}}</td>
-			<td>{{Spec2('DOM2 Events')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventlistener/index.html
+++ b/files/en-us/web/api/eventlistener/index.html
@@ -62,27 +62,7 @@ buttonElement.addEventListener('click', {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#callbackdef-eventlistener', 'EventListener')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Events', '#Events-EventListener', 'EventListener')}}</td>
-   <td>{{Spec2('DOM2 Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/close/index.html
+++ b/files/en-us/web/api/eventsource/close/index.html
@@ -52,20 +52,7 @@ button.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-eventsource-close", "close()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/error_event/index.html
+++ b/files/en-us/web/api/eventsource/error_event/index.html
@@ -50,18 +50,7 @@ evtSource.onerror = (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-error", "error event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/eventsource/index.html
@@ -55,20 +55,7 @@ evtSource.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-eventsource", "EventSource()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/index.html
@@ -133,18 +133,7 @@ evtSource.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "server-sent-events.html#the-eventsource-interface", "EventSource")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/message_event/index.html
+++ b/files/en-us/web/api/eventsource/message_event/index.html
@@ -59,18 +59,7 @@ evtSource.addEventListener('message', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-message", "message event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/onerror/index.html
+++ b/files/en-us/web/api/eventsource/onerror/index.html
@@ -36,21 +36,7 @@ browser-compat: api.EventSource.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#handler-eventsource-onerror", "onerror")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/onmessage/index.html
+++ b/files/en-us/web/api/eventsource/onmessage/index.html
@@ -41,21 +41,7 @@ browser-compat: api.EventSource.onmessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#handler-eventsource-onmessage",
-        "onmessage")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/onopen/index.html
+++ b/files/en-us/web/api/eventsource/onopen/index.html
@@ -35,21 +35,7 @@ browser-compat: api.EventSource.onopen
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#handler-eventsource-onopen", "onopen")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/readystate/index.html
+++ b/files/en-us/web/api/eventsource/readystate/index.html
@@ -44,21 +44,7 @@ console.log(evtSource.readyState);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-eventsource-readystate",
-        "readyState")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/url/index.html
+++ b/files/en-us/web/api/eventsource/url/index.html
@@ -37,20 +37,7 @@ console.log(evtSource.url);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-eventsource-url", "url")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventsource/withcredentials/index.html
+++ b/files/en-us/web/api/eventsource/withcredentials/index.html
@@ -40,21 +40,7 @@ console.log(evtSource.withCredentials);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "comms.html#dom-eventsource-withcredentials",
-        "withCredentials")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -1047,35 +1047,7 @@ window.addEventListener('scroll', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-eventtarget-addeventlistener",
-        "EventTarget.addEventListener()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-eventtarget-addeventlistener",
-        "EventTarget.addEventListener()")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-EventTarget-addEventListener",
-        "EventTarget.addEventListener()")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.html
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.html
@@ -71,23 +71,7 @@ browser-compat: api.EventTarget.dispatchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-eventtarget-dispatchevent',
-        'EventTarget.dispatchEvent()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td>Initial definition in the DOM 2 Events specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventtarget/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.html
@@ -49,21 +49,7 @@ let newValue = myEventTarget.secret; // == 7</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-eventtarget-eventtarget', 'EventTarget()
-        constructor')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/index.html
@@ -82,32 +82,7 @@ EventTarget.prototype.dispatchEvent = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#interface-eventtarget', 'EventTarget')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Events', 'DOM3-Events.html#interface-EventTarget', 'EventTarget')}}</td>
-			<td>{{Spec2('DOM3 Events')}}</td>
-			<td>A few parameters are now optional (<code><var>listener</var></code>), or accepts the <code>null</code> value (<code><var>useCapture</var></code>).</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Events', 'events.html#Events-EventTarget', 'EventTarget')}}</td>
-			<td>{{Spec2('DOM2 Events')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.html
@@ -173,35 +173,7 @@ mouseOverTarget.addEventListener('mouseover', function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-eventtarget-removeeventlistener",
-        "EventTarget.removeEventListener()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#dom-eventtarget-removeeventlistener",
-        "EventTarget.removeEventListener()")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Events", "#Events-EventTarget-removeEventListener",
-        "EventTarget.removeEventListener()")}}</td>
-      <td>{{Spec2("DOM2 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_blend_minmax/index.html
+++ b/files/en-us/web/api/ext_blend_minmax/index.html
@@ -41,20 +41,7 @@ gl.blendEquationSeparate(ext.MIN_EXT, ext.MAX_EXT);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_blend_minmax', '', 'EXT_blend_minmax')}}</td>
-   <td>{{Spec2('EXT_blend_minmax')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_color_buffer_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_float/index.html
@@ -53,20 +53,7 @@ gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA16F, 256, 256);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_color_buffer_float', '', 'EXT_color_buffer_float')}}</td>
-   <td>{{Spec2('EXT_color_buffer_float')}}</td>
-   <td>Initial definition for WebGL.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.html
@@ -50,20 +50,7 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RBGA16F_EXT, 256, 256);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_color_buffer_half_float', '', 'EXT_color_buffer_half_float')}}</td>
-   <td>{{Spec2('EXT_color_buffer_half_float')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
@@ -45,20 +45,7 @@ ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
@@ -37,20 +37,7 @@ var query = ext.createQueryExt();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
@@ -43,20 +43,7 @@ ext.deleteQueryEXT(query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
@@ -44,20 +44,7 @@ ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
@@ -56,20 +56,7 @@ var currentQuery = ext.getQueryEXT(ext.TIMESTAMP_EXT,
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
@@ -63,20 +63,7 @@ if (available &amp;&amp; !disjoint) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.html
@@ -89,20 +89,7 @@ browser-compat: api.EXT_disjoint_timer_query
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-   <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
@@ -45,20 +45,7 @@ ext.isQueryEXT(query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
@@ -49,20 +49,7 @@ ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EXT_disjoint_timer_query', '', 'EXT_disjoint_timer_query')}}</td>
-      <td>{{Spec2('EXT_disjoint_timer_query')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_float_blend/index.html
+++ b/files/en-us/web/api/ext_float_blend/index.html
@@ -58,18 +58,7 @@ gl.drawArrays(gl.POINTS, 0, 1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td><a href="https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/">EXT_float_blend</a></td>
-   <td>Draft</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_frag_depth/index.html
+++ b/files/en-us/web/api/ext_frag_depth/index.html
@@ -36,20 +36,7 @@ void main() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_frag_depth', "", "EXT_frag_depth")}}</td>
-   <td>{{Spec2('EXT_frag_depth')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_shader_texture_lod/index.html
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.html
@@ -56,20 +56,7 @@ void main(){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_shader_texture_lod', '', 'EXT_shader_texture_lod')}}</td>
-   <td>{{Spec2('EXT_shader_texture_lod')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_srgb/index.html
+++ b/files/en-us/web/api/ext_srgb/index.html
@@ -46,20 +46,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, ext.SRGB_EXT, 512, 512, 0,
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_sRGB', '', 'EXT_sRGB')}}</td>
-   <td>{{Spec2('EXT_sRGB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_texture_compression_bptc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_bptc/index.html
@@ -47,18 +47,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_BPTC_UNORM_EXT, 12
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td><a href="https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/">EXT_texture_compression_bptc</a></td>
-   <td>Community Approved</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_texture_compression_rgtc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_rgtc/index.html
@@ -47,18 +47,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RED_RGTC1_EXT, 128, 128
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td><a href="https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/">EXT_texture_compression_rgtc</a></td>
-   <td>Community Approved</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
@@ -45,20 +45,7 @@ if (ext){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_texture_filter_anisotropic', "", "EXT_texture_filter_anisotropic")}}</td>
-   <td>{{Spec2('EXT_texture_filter_anisotropic')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ext_texture_norm16/index.html
+++ b/files/en-us/web/api/ext_texture_norm16/index.html
@@ -83,16 +83,7 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA16_EXT, 1, 1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EXT_texture_norm16', "", "EXT_texture_norm16")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -70,20 +70,7 @@ cookieStore.set({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-changed','ExtendableCookieChangeEvent.changed')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -62,20 +62,7 @@ browser-compat: api.ExtendableCookieChangeEvent.deleted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-deleted','ExtendableCookieStoreManager.deleted')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -39,20 +39,7 @@ browser-compat: api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-extendablecookiechangeevent','ExtendableCookieChangeEvent()')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -66,20 +66,7 @@ self.addEventListener('cookiechange', event => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Cookie Store API','#ExtendableCookieChangeEvent','ExtendableCookieChangeEvent')}}</td>
-    <td>{{Spec2('Cookie Store API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendableevent/extendableevent/index.html
+++ b/files/en-us/web/api/extendableevent/extendableevent/index.html
@@ -35,21 +35,7 @@ browser-compat: api.ExtendableEvent.ExtendableEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendableevent-extendableevent',
-        'ExtendableEvent')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendableevent/index.html
+++ b/files/en-us/web/api/extendableevent/index.html
@@ -94,20 +94,7 @@ self.addEventListener('install', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#extendableevent', 'ExtendableEvent')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendableevent/waituntil/index.html
+++ b/files/en-us/web/api/extendableevent/waituntil/index.html
@@ -71,21 +71,7 @@ browser-compat: api.ExtendableEvent.waitUntil
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendableevent-waituntil', 'waitUntil()')}}
-      </td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/data/index.html
+++ b/files/en-us/web/api/extendablemessageevent/data/index.html
@@ -53,21 +53,7 @@ self.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendablemessageevent-data',
-        'ExtendableMessageEvent.data')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.html
+++ b/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.html
@@ -55,22 +55,7 @@ var myEME = new ExtendableMessageEvent('message', init);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers',
-        '#dom-extendablemessageevent-extendablemessageevent',
-        'ExtendableMessageEvent()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/index.html
+++ b/files/en-us/web/api/extendablemessageevent/index.html
@@ -76,20 +76,7 @@ addEventListener('message', event =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#extendablemessageevent', 'ExtendableMessageEvent')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/lasteventid/index.html
+++ b/files/en-us/web/api/extendablemessageevent/lasteventid/index.html
@@ -54,21 +54,7 @@ self.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendablemessageevent-lasteventid',
-        'ExtendableMessageEvent.lastEventId')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/origin/index.html
+++ b/files/en-us/web/api/extendablemessageevent/origin/index.html
@@ -53,21 +53,7 @@ self.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendablemessageevent-origin',
-        'ExtendableMessageEvent.origin')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/ports/index.html
+++ b/files/en-us/web/api/extendablemessageevent/ports/index.html
@@ -53,21 +53,7 @@ self.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendablemessageevent-ports',
-        'ExtendableMessageEvent.ports')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/source/index.html
+++ b/files/en-us/web/api/extendablemessageevent/source/index.html
@@ -54,21 +54,7 @@ self.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-extendablemessageevent-source',
-        'ExtendableMessageEvent.source')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/e[a-l]* to the {{Specifications}} macros. 

Only Element/show_event lost its table, but it was a bogus link to the W3C HTML 5.2 spec. The event is deprecated and no more reference in WHATWG HTML, so I think we can keep it that way (it will have a nicer error message soon, as it is no more on a standard track).

All other pages look fine.