### PR TITLE
Replace spec table with {{specifications}} for api/f*

### DIFF
--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
@@ -52,20 +52,7 @@ for (const directive of allowed){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Feature Policy","","allowsFeature")}}</td>
-      <td>{{Spec2("Feature Policy")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/featurepolicy/allowsfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/allowsfeature/index.html
@@ -57,20 +57,7 @@ if (allowed){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Feature Policy","","allowsFeature")}}</td>
-			<td>{{Spec2("Feature Policy")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/featurepolicy/features/index.html
+++ b/files/en-us/web/api/featurepolicy/features/index.html
@@ -43,20 +43,7 @@ for (const directive of supportedDirectives){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName("Feature Policy","","features")}}</td>
-            <td>{{Spec2("Feature Policy")}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
@@ -55,20 +55,7 @@ for (const origin of allowlist) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Feature Policy","","getAllowlistForFeature")}}</td>
-      <td>{{Spec2("Feature Policy")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/featurepolicy/index.html
+++ b/files/en-us/web/api/featurepolicy/index.html
@@ -33,22 +33,7 @@ browser-compat: api.FeaturePolicy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.html
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.html
@@ -37,20 +37,7 @@ browser-compat: api.FederatedCredential.FederatedCredential
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/federatedcredential/index.html
+++ b/files/en-us/web/api/federatedcredential/index.html
@@ -59,20 +59,7 @@ navigator.credentials.store(cred)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Credential Management')}}</td>
-   <td>{{Spec2('Credential Management')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/federatedcredential/protocol/index.html
+++ b/files/en-us/web/api/federatedcredential/protocol/index.html
@@ -36,22 +36,7 @@ browser-compat: api.FederatedCredential.protocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comments</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-federatedcredential-protocol','protocol')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/federatedcredential/provider/index.html
+++ b/files/en-us/web/api/federatedcredential/provider/index.html
@@ -32,22 +32,7 @@ browser-compat: api.FederatedCredential.provider
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comments</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/clientid/index.html
+++ b/files/en-us/web/api/fetchevent/clientid/index.html
@@ -37,20 +37,7 @@ browser-compat: api.FetchEvent.clientId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-fetchevent-clientid', 'clientId')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/fetchevent/index.html
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.html
@@ -61,21 +61,7 @@ browser-compat: api.FetchEvent.FetchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-fetchevent-fetchevent', 'FetchEvent()
-        constructor')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/index.html
+++ b/files/en-us/web/api/fetchevent/index.html
@@ -81,20 +81,7 @@ browser-compat: api.FetchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#dom-fetchevent-fetchevent', 'FetchEvent()')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/navigationpreload/index.html
+++ b/files/en-us/web/api/fetchevent/navigationpreload/index.html
@@ -51,21 +51,7 @@ browser-compat: api.FetchEvent.navigationPreload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
-      </td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/preloadresponse/index.html
+++ b/files/en-us/web/api/fetchevent/preloadresponse/index.html
@@ -59,21 +59,7 @@ browser-compat: api.FetchEvent.preloadResponse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#fetch-event-preloadresponse',
-        'preloadResponse')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/replacesclientid/index.html
+++ b/files/en-us/web/api/fetchevent/replacesclientid/index.html
@@ -44,21 +44,7 @@ browser-compat: api.FetchEvent.replacesClientId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-fetchevent-replacesclientid',
-        'replacesClientId')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/request/index.html
+++ b/files/en-us/web/api/fetchevent/request/index.html
@@ -76,20 +76,7 @@ browser-compat: api.FetchEvent.request
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#fetch-event-request', 'request')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/respondwith/index.html
+++ b/files/en-us/web/api/fetchevent/respondwith/index.html
@@ -131,21 +131,7 @@ browser-compat: api.FetchEvent.respondWith
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Service Workers', '#dom-fetchevent-respondwith',
-				'respondWith()')}}</td>
-			<td>{{Spec2('Service Workers')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fetchevent/resultingclientid/index.html
+++ b/files/en-us/web/api/fetchevent/resultingclientid/index.html
@@ -43,21 +43,7 @@ browser-compat: api.FetchEvent.resultingClientId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-fetchevent-resultingclientid',
-        'resultingClientId')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/file/index.html
+++ b/files/en-us/web/api/file/file/index.html
@@ -49,22 +49,7 @@ browser-compat: api.File.File
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File API')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/index.html
+++ b/files/en-us/web/api/file/index.html
@@ -67,22 +67,7 @@ browser-compat: api.File
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', "#file-section", "The <code>File</code> interface")}}</td>
-   <td>{{Spec2('File API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/lastmodified/index.html
+++ b/files/en-us/web/api/file/lastmodified/index.html
@@ -93,22 +93,7 @@ someFile.lastModified;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File API', '#file-attrs', 'lastModified')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/name/index.html
+++ b/files/en-us/web/api/file/name/index.html
@@ -42,22 +42,7 @@ browser-compat: api.File.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File API', '#file-attrs', 'name')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/type/index.html
+++ b/files/en-us/web/api/file/type/index.html
@@ -41,22 +41,7 @@ browser-compat: api.File.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-type', 'type')}}</td>
-   <td>{{Spec2('File API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/file/webkitrelativepath/index.html
+++ b/files/en-us/web/api/file/webkitrelativepath/index.html
@@ -62,23 +62,7 @@ browser-compat: api.File.webkitRelativePath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-file-webkitrelativepath',
-        'webkitRelativePath') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/filelist/index.html
+++ b/files/en-us/web/api/filelist/index.html
@@ -140,27 +140,7 @@ document.querySelector("#myfiles").onchange=pullfiles;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('File API', '#filelist-section', 'FileList')}}</td>
-			<td>{{Spec2('File API')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#concept-input-type-file-selected', 'selected files')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/abort/index.html
+++ b/files/en-us/web/api/filereader/abort/index.html
@@ -30,22 +30,7 @@ browser-compat: api.FileReader.abort
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#abort", "abort()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/abort_event/index.html
+++ b/files/en-us/web/api/filereader/abort_event/index.html
@@ -146,20 +146,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-abort-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/error/index.html
+++ b/files/en-us/web/api/filereader/error/index.html
@@ -27,22 +27,7 @@ browser-compat: api.FileReader.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#dom-filereader-error", "FileReader: error")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/error_event/index.html
+++ b/files/en-us/web/api/filereader/error_event/index.html
@@ -63,20 +63,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-error-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/filereader/index.html
+++ b/files/en-us/web/api/filereader/filereader/index.html
@@ -35,22 +35,7 @@ browser-compat: api.FileReader.FileReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API')}}</td>
-   <td>{{Spec2('File API')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/index.html
+++ b/files/en-us/web/api/filereader/index.html
@@ -122,22 +122,7 @@ browser-compat: api.FileReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("File API", "#dfn-filereader", "FileReader")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/load_event/index.html
+++ b/files/en-us/web/api/filereader/load_event/index.html
@@ -143,20 +143,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-load-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/loadend_event/index.html
+++ b/files/en-us/web/api/filereader/loadend_event/index.html
@@ -144,20 +144,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-loadend-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/loadstart_event/index.html
+++ b/files/en-us/web/api/filereader/loadstart_event/index.html
@@ -144,20 +144,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-loadstart-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/progress_event/index.html
+++ b/files/en-us/web/api/filereader/progress_event/index.html
@@ -145,20 +145,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#dfn-progress-event')}}</td>
-   <td>{{Spec2('File API')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.html
@@ -42,23 +42,7 @@ browser-compat: api.FileReader.readAsArrayBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#readAsArrayBuffer", "FileReader.readAsArrayBuffer")}}
-      </td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.html
@@ -62,22 +62,7 @@ canvas.toBlob(function (blob) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File API','#readAsBinaryString','readAsBinaryString')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/readasdataurl/index.html
+++ b/files/en-us/web/api/filereader/readasdataurl/index.html
@@ -118,22 +118,7 @@ browser-compat: api.FileReader.readAsDataURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#readAsDataURL", "readAsDataURL()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/readastext/index.html
+++ b/files/en-us/web/api/filereader/readastext/index.html
@@ -41,22 +41,7 @@ browser-compat: api.FileReader.readAsText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#readAsDataText", "readAsText()")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/readystate/index.html
+++ b/files/en-us/web/api/filereader/readystate/index.html
@@ -66,22 +66,7 @@ reader.onloadend = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("File API", "#dom-filereader-readystate", "readyState")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereader/result/index.html
+++ b/files/en-us/web/api/filereader/result/index.html
@@ -88,22 +88,7 @@ function read(callback) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("File API", "#dom-filereader-result", "result")}}</td>
-      <td>{{Spec2("File API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereadersync/index.html
+++ b/files/en-us/web/api/filereadersync/index.html
@@ -35,20 +35,7 @@ browser-compat: api.FileReaderSync
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("File API","#FileReaderSync","FileReaderSync")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -48,20 +48,7 @@ browser-compat: api.FileReaderSync.readAsArrayBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("File API","#dfn-readAsArrayBufferSync","readAsArrayBufferSync")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -37,20 +37,7 @@ readAsBinaryString(<em>Blob</em>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("File API","#dfn-readAsBinaryStringSync","readAsBinaryStringSync")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.html
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.html
@@ -30,20 +30,7 @@ readAsDataURL(<em>Blob</em>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("File API","#dfn-readAsDataURLSync","readAsDataURL")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filereadersync/readastext/index.html
+++ b/files/en-us/web/api/filereadersync/readastext/index.html
@@ -34,20 +34,7 @@ readAsText(<em>Blob</em>, <em>encoding</em>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("File API","#dfn-readAsTextSync","readAsText")}}</td>
-   <td>{{Spec2("File API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystem/index.html
+++ b/files/en-us/web/api/filesystem/index.html
@@ -38,22 +38,7 @@ browser-compat: api.FileSystem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File System API', '#api-domfilesystem', 'FileSystem')}}</td>
-   <td>{{Spec2('File System API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystem/name/index.html
+++ b/files/en-us/web/api/filesystem/name/index.html
@@ -38,22 +38,7 @@ browser-compat: api.FileSystem.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystem-name', 'name') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystem/root/index.html
+++ b/files/en-us/web/api/filesystem/root/index.html
@@ -39,22 +39,7 @@ browser-compat: api.FileSystem.root
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystem-root', 'root') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
@@ -68,23 +68,7 @@ browser-compat: api.FileSystemDirectoryEntry.createReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemdirectoryentry-createreader',
-        'createReader()') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
@@ -120,23 +120,7 @@ function loadDictionaryForLanguage(appDataDirEntry, lang) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemdirectoryentry-getdirectory',
-        'getDirectory()') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
@@ -118,23 +118,7 @@ function loadDictionaryForLanguage(appDataDirEntry, lang) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemdirectoryentry-getfile',
-        'getFile()') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/index.html
@@ -73,22 +73,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, onFs, onError);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File System API', '#api-directoryentry', 'FileSystemDirectoryEntry')}}</td>
-   <td>{{Spec2('File System API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
@@ -38,20 +38,7 @@ browser-compat: api.FileSystemDirectoryHandle.entries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle','entries')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
@@ -69,21 +69,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-getdirectoryhandle','getDirectoryHandle')}}
-      </td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -69,20 +69,7 @@ const fileHandle = currentDirHandle.getFileHandle(fileName, {create: true});</pr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','getFileHandle')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.html
@@ -78,20 +78,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle','FileSystemDirectoryHandle')}}</td>
-   <td>{{Spec2('File System Access API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -35,20 +35,7 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','keys')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
@@ -68,20 +68,7 @@ currentDirHandle.removeEntry(entryName).then( () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-removeentry','removeEntry')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
@@ -71,20 +71,7 @@ browser-compat: api.FileSystemDirectoryHandle.resolve
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','resolve')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -36,20 +36,7 @@ browser-compat: api.FileSystemDirectoryHandle.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','values')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/index.html
@@ -31,22 +31,7 @@ browser-compat: api.FileSystemDirectoryReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('File System API')}}</td>
-			<td>{{Spec2('File System API')}}</td>
-			<td>Draft of proposed API</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
@@ -59,22 +59,7 @@ browser-compat: api.FileSystemDirectoryReader.readEntries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('File System API')}}</td>
-      <td>{{Spec2('File System API')}}</td>
-      <td>Draft of proposed API</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/filesystementry/filesystem/index.html
+++ b/files/en-us/web/api/filesystementry/filesystem/index.html
@@ -41,23 +41,7 @@ browser-compat: api.FileSystemEntry.filesystem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-filesystem', 'filesystem')
-        }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystementry/fullpath/index.html
+++ b/files/en-us/web/api/filesystementry/fullpath/index.html
@@ -56,23 +56,7 @@ browser-compat: api.FileSystemEntry.fullPath
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-fullpath', 'fullPath') }}
-      </td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/filesystementry/getparent/index.html
+++ b/files/en-us/web/api/filesystementry/getparent/index.html
@@ -88,23 +88,7 @@ browser-compat: api.FileSystemEntry.getParent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-getparent', 'getParent()')
-        }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystementry/index.html
+++ b/files/en-us/web/api/filesystementry/index.html
@@ -87,22 +87,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, function(fs) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File System API')}}</td>
-   <td>{{Spec2('File System API')}}</td>
-   <td>Draft of proposed API</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/filesystementry/isdirectory/index.html
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.html
@@ -58,23 +58,7 @@ browser-compat: api.FileSystemEntry.isDirectory
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-isdirectory',
-        'isDirectory') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystementry/isfile/index.html
+++ b/files/en-us/web/api/filesystementry/isfile/index.html
@@ -57,22 +57,7 @@ browser-compat: api.FileSystemEntry.isFile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-isfile', 'isFile') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystementry/name/index.html
+++ b/files/en-us/web/api/filesystementry/name/index.html
@@ -42,22 +42,7 @@ browser-compat: api.FileSystemEntry.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystementry-name', 'name') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemfileentry/file/index.html
+++ b/files/en-us/web/api/filesystemfileentry/file/index.html
@@ -80,23 +80,7 @@ browser-compat: api.FileSystemFileEntry.file
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemfileentry-file', 'file()') }}
-      </td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemfileentry/index.html
+++ b/files/en-us/web/api/filesystemfileentry/index.html
@@ -71,22 +71,7 @@ window.requestFileSystem(window.TEMPORARY, 1024*1024, onInitFs, errorHandler);</
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('File System API', '#api-fileentry', 'FileSystemFileEntry')}}</td>
-			<td>{{Spec2('File System API')}}</td>
-			<td>Draft of proposed API</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
@@ -72,20 +72,7 @@ browser-compat: api.FileSystemFileHandle.createWritable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemfilehandle-createwritable','createWritable')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.html
@@ -57,21 +57,7 @@ browser-compat: api.FileSystemFileHandle.getFile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemfilehandle-getfile','getFile')}}
-      </td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/index.html
@@ -63,20 +63,7 @@ browser-compat: api.FileSystemFileHandle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('File System Access API','#api-filesystemfilehandle','FileSystemFileHandle')}}</td>
-   <td>{{Spec2('File System Access API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemflags/create/index.html
+++ b/files/en-us/web/api/filesystemflags/create/index.html
@@ -34,23 +34,7 @@ browser-compat: api.FileSystemFlags.create
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemflags-create', 'FileSystemFlags')
-        }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemflags/exclusive/index.html
+++ b/files/en-us/web/api/filesystemflags/exclusive/index.html
@@ -34,23 +34,7 @@ browser-compat: api.FileSystemFlags.exclusive
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-filesystemflags-exclusive',
-        'FileSystemFlags') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemflags/index.html
+++ b/files/en-us/web/api/filesystemflags/index.html
@@ -95,22 +95,7 @@ browser-compat: api.FileSystemFlags
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('File System API', '#dictdef-filesystemflags', 'FileSystemFlags') }}</td>
-   <td>{{ Spec2('File System API') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/index.html
+++ b/files/en-us/web/api/filesystemhandle/index.html
@@ -110,20 +110,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('File System Access API','#api-filesystemhandle','FileSystemHandle')}}</td>
-   <td>{{Spec2('File System Access API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.html
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.html
@@ -52,20 +52,7 @@ browser-compat: api.FileSystemHandle.isSameEntry
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemhandle-issameentry','isSameEntry')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/kind/index.html
+++ b/files/en-us/web/api/filesystemhandle/kind/index.html
@@ -61,20 +61,7 @@ async function getFile() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemhandle-kind','kind')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/name/index.html
+++ b/files/en-us/web/api/filesystemhandle/name/index.html
@@ -44,20 +44,7 @@ async function getFile() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#dom-filesystemhandle-name','name')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -84,20 +84,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemhandle-querypermission','queryPermission')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.html
@@ -77,20 +77,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemhandle-requestpermission','requestPermission')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.html
@@ -70,20 +70,7 @@ writableStream.write({ type: "truncate", size: size })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream','FileSystemWritableFileStream')}}</td>
-   <td>{{Spec2('File System Access API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
@@ -49,20 +49,7 @@ browser-compat: api.FileSystemWritableFileStream.seek
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-seek','seek')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
@@ -59,20 +59,7 @@ browser-compat: api.FileSystemWritableFileStream.truncate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-truncate','truncate')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.html
@@ -112,20 +112,7 @@ writableStream.write({ type: "truncate", size: size })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-write','write')}}</td>
-      <td>{{Spec2('File System Access API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/focusevent/focusevent/index.html
+++ b/files/en-us/web/api/focusevent/focusevent/index.html
@@ -48,20 +48,7 @@ browser-compat: api.FocusEvent.FocusEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#interface-FocusEvent', 'FocusEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/focusevent/index.html
+++ b/files/en-us/web/api/focusevent/index.html
@@ -37,27 +37,7 @@ browser-compat: api.FocusEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#interface-focusevent', 'FocusEvent')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events', '#interface-focusevent', 'FocusEvent')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/focusevent/relatedtarget/index.html
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.html
@@ -61,26 +61,7 @@ browser-compat: api.FocusEvent.relatedTarget
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('UI Events', '#idl-focusevent', 'FocusEvent.relatedTarget')}}</td>
-      <td>{{Spec2('UI Events')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-FocusEvent-relatedTarget',
-        'FocusEvent.relatedTarget')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontface/index.html
+++ b/files/en-us/web/api/fontface/index.html
@@ -62,20 +62,7 @@ browser-compat: api.FontFace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Font Loading','#fontface-interface','FontFace')}}</td>
-   <td>{{Spec2('CSS3 Font Loading')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfaceset/check/index.html
+++ b/files/en-us/web/api/fontfaceset/check/index.html
@@ -46,20 +46,7 @@ document.fonts.check("12px MyFont", "ß"); // returns true if the font 'MyFont' 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#font-face-set-check','check')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfaceset/index.html
+++ b/files/en-us/web/api/fontfaceset/index.html
@@ -52,20 +52,7 @@ browser-compat: api.FontFaceSet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Font Loading','#FontFaceSet-interface','FontFaceSet')}}</td>
-   <td>{{Spec2('CSS3 Font Loading')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfaceset/load/index.html
+++ b/files/en-us/web/api/fontfaceset/load/index.html
@@ -50,20 +50,7 @@ document.fonts.load("12px MyFont", "ß").then(…);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#font-face-set-load','load')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfaceset/ready/index.html
+++ b/files/en-us/web/api/fontfaceset/ready/index.html
@@ -35,20 +35,7 @@ browser-compat: api.FontFaceSet.ready
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontfaceset-ready','FontFaceSet')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
@@ -29,20 +29,7 @@ browser-compat: api.FontFaceSetLoadEvent.fontfaces
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontfacesetloadevent-fontfaces','fontfaces')}}</td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
@@ -38,21 +38,7 @@ browser-compat: api.FontFaceSetLoadEvent.FontFaceSetLoadEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Font Loading','#dom-fontfacesetloadevent-fontfacesetloadevent','FontFaceSetLoadEvent()')}}
-      </td>
-      <td>{{Spec2('CSS3 Font Loading')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.FontFaceSetLoadEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Font Loading','#dom-fontfacesetloadevent-fontfacesetloadevent','FontFaceSetLoadEvent')}}</td>
-   <td>{{Spec2('CSS3 Font Loading')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/append/index.html
+++ b/files/en-us/web/api/formdata/append/index.html
@@ -76,20 +76,7 @@ formData.getAll('name'); // ["true", "74", "John"]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#dom-formdata-append','append()')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/delete/index.html
+++ b/files/en-us/web/api/formdata/delete/index.html
@@ -47,20 +47,7 @@ browser-compat: api.FormData.delete
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest','#dom-formdata-delete','delete()')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/entries/index.html
+++ b/files/en-us/web/api/formdata/entries/index.html
@@ -50,21 +50,7 @@ key2, value2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest','#dom-formdata','entries() (as
-				iterator&lt;&gt;)')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/formdata/index.html
+++ b/files/en-us/web/api/formdata/formdata/index.html
@@ -68,20 +68,7 @@ let formData = new FormData(myForm);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#dom-formdata','FormData()')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/get/index.html
+++ b/files/en-us/web/api/formdata/get/index.html
@@ -57,20 +57,7 @@ formData.append('username', 'Bob');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest','#dom-formdata-get','get()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/getall/index.html
+++ b/files/en-us/web/api/formdata/getall/index.html
@@ -50,20 +50,7 @@ formData.append('username', 'Bob');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#dom-formdata-getall','getAll()')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/has/index.html
+++ b/files/en-us/web/api/formdata/has/index.html
@@ -50,20 +50,7 @@ formData.has('username'); // Returns true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest','#dom-formdata-has','has()')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/index.html
+++ b/files/en-us/web/api/formdata/index.html
@@ -53,20 +53,7 @@ browser-compat: api.FormData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#interface-formdata','FormData')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>FormData defined in XHR spec</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/keys/index.html
+++ b/files/en-us/web/api/formdata/keys/index.html
@@ -49,21 +49,7 @@ key2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest','#dom-formdata','keys() (as
-				iterator&lt;&gt;)')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/set/index.html
+++ b/files/en-us/web/api/formdata/set/index.html
@@ -61,20 +61,7 @@ formData.get('name'); // "72"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#dom-formdata-set','set()')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdata/values/index.html
+++ b/files/en-us/web/api/formdata/values/index.html
@@ -50,21 +50,7 @@ value2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest','#dom-formdata','values() (as
-				iterator&lt;&gt;)')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdataevent/formdata/index.html
+++ b/files/en-us/web/api/formdataevent/formdata/index.html
@@ -60,20 +60,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-formdataevent-formdata', 'formData')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdataevent/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.html
@@ -56,22 +56,7 @@ for (let value of fdEv.formData.values()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','form-control-infrastructure.html#the-formdataevent-interface', 'FormDataEvent')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/index.html
@@ -71,20 +71,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','form-control-infrastructure.html#the-formdataevent-interface', 'FormDataEvent')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/fullscreenoptions/navigationui/index.html
+++ b/files/en-us/web/api/fullscreenoptions/navigationui/index.html
@@ -68,23 +68,7 @@ elem.requestFullscreen({ navigationUI: "show" }).then({}).catch(err =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fullscreen", "#dictdef-fullscreenoptions", "FullscreenOptions")}}
-      </td>
-      <td>{{Spec2("Fullscreen")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/f* to the {{Specifications}} macros. 

Note that:
- `FileSystemDirectoryReader` and `FileSystemDirectoryReader.readEntries' lose their table. This will be fixed by mdn/browser-compat-data#10980.
- `FeaturePolicy` and children had bogus spec links as they were renamed to `PermissionPolicy`, but no implementation reflects this change. This will be fixed when this happen.
- The constructor `FileReader()` lost its table. This will be fixed by mdn/browser-compat-data#10981.
- `FileSystemWritableFileStream` and its three children lost their table. This will be fixed by mdn/browser-compat-data#10982.
- `FetchEvent.preloadResponse` lost its table. This will be fixed by mdn/browser-compat-data#10983.

All other pages look fine.