### PR TITLE
Replace spec table with {{specifications}} for api/g*

### DIFF
--- a/files/en-us/web/api/gainnode/gain/index.html
+++ b/files/en-us/web/api/gainnode/gain/index.html
@@ -37,20 +37,7 @@ gainNode.gain.value = 0.5;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-gainnode-gain', 'gain')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gainnode/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/gainnode/index.html
@@ -50,20 +50,7 @@ browser-compat: api.GainNode.GainNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API','#dom-gainnode-gainnode','GainNode()')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -68,20 +68,7 @@ browser-compat: api.GainNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#gainnode', 'GainNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/axes/index.html
+++ b/files/en-us/web/api/gamepad/axes/index.html
@@ -56,20 +56,7 @@ browser-compat: api.Gamepad.axes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Gamepad", "#dom-gamepad-axes", "Gamepad.axes")}}</td>
-      <td>{{Spec2("Gamepad")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/buttons/index.html
+++ b/files/en-us/web/api/gamepad/buttons/index.html
@@ -88,20 +88,7 @@ browser-compat: api.Gamepad.buttons
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Gamepad", "#dom-gamepad-buttons", "Gamepad.buttons")}}</td>
-      <td>{{Spec2("Gamepad")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/connected/index.html
+++ b/files/en-us/web/api/gamepad/connected/index.html
@@ -36,21 +36,7 @@ console.log(gp.connected);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepad-connected", "Gamepad.connected")}}
-			</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -41,20 +41,7 @@ browser-compat: api.Gamepad.displayId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#gamepad-getvrdisplays-attribute', 'displayId')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/hand/index.html
+++ b/files/en-us/web/api/gamepad/hand/index.html
@@ -35,20 +35,7 @@ browser-compat: api.Gamepad.hand
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('GamepadExtensions', '#dom-gamepad-hand', 'hand')}}</td>
-			<td>{{Spec2('GamepadExtensions')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/hapticactuators/index.html
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.html
@@ -29,20 +29,7 @@ browser-compat: api.Gamepad.hapticActuators
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#partial-gamepad-interface', 'hapticActuators')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/id/index.html
+++ b/files/en-us/web/api/gamepad/id/index.html
@@ -48,20 +48,7 @@ browser-compat: api.Gamepad.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepad-id", "Gamepad.id")}}</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -59,30 +59,7 @@ browser-compat: api.Gamepad
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Gamepad", "#gamepad-interface", "Gamepad")}}</td>
-   <td>{{Spec2("Gamepad")}}</td>
-   <td>Initial definition</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#gamepad-getvrdisplays-attribute', 'displayId')}}</td>
-   <td>{{Spec2("WebVR 1.1")}}</td>
-   <td>Defines the {{domxref("Gamepad.displayId")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("GamepadExtensions", "#partial-gamepad-interface", "Gamepad extensions")}}</td>
-   <td>{{Spec2("GamepadExtensions")}}</td>
-   <td>Defines the {{anch("Experimental extensions to Gamepad")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/index/index.html
+++ b/files/en-us/web/api/gamepad/index/index.html
@@ -38,20 +38,7 @@ browser-compat: api.Gamepad.index
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepad-index", "Gamepad.index")}}</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/mapping/index.html
+++ b/files/en-us/web/api/gamepad/mapping/index.html
@@ -38,20 +38,7 @@ console.log(gp.mapping);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepad-mapping", "Gamepad.mapping")}}</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/pose/index.html
+++ b/files/en-us/web/api/gamepad/pose/index.html
@@ -29,20 +29,7 @@ browser-compat: api.Gamepad.pose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#partial-gamepad-interface', 'pose')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/timestamp/index.html
+++ b/files/en-us/web/api/gamepad/timestamp/index.html
@@ -44,21 +44,7 @@ console.log(gp.timestamp);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepad-timestamp", "Gamepad.timestamp")}}
-			</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadbutton/index.html
+++ b/files/en-us/web/api/gamepadbutton/index.html
@@ -68,20 +68,7 @@ browser-compat: api.GamepadButton
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Gamepad", "#gamepadbutton-interface", "GamepadButton")}}</td>
-   <td>{{Spec2("Gamepad")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadbutton/pressed/index.html
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.html
@@ -36,21 +36,7 @@ if(gp.buttons[0].pressed == true) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Gamepad", "#dom-gamepadbutton-pressed", "GamepadButton.pressed")}}
-      </td>
-      <td>{{Spec2("Gamepad")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadbutton/value/index.html
+++ b/files/en-us/web/api/gamepadbutton/value/index.html
@@ -40,21 +40,7 @@ if(gp.buttons[0].value &gt; 0) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#dom-gamepadbutton-value", "GamepadButton.value")}}
-			</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadevent/gamepad/index.html
+++ b/files/en-us/web/api/gamepadevent/gamepad/index.html
@@ -36,21 +36,7 @@ browser-compat: api.GamepadEvent.gamepad
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Gamepad", "#dom-gamepadevent-gamepad", "GamepadEvent.gamepad")}}
-      </td>
-      <td>{{Spec2("Gamepad")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadevent/gamepadevent/index.html
+++ b/files/en-us/web/api/gamepadevent/gamepadevent/index.html
@@ -36,20 +36,7 @@ browser-compat: api.GamepadEvent.GamepadEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Gamepad','#gamepadevent-interface','GamepadEvent_')}}</td>
-			<td>{{Spec2('Gamepad')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadevent/index.html
+++ b/files/en-us/web/api/gamepadevent/index.html
@@ -46,20 +46,7 @@ browser-compat: api.GamepadEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Gamepad", "#gamepadevent-interface", "GamepadEvent")}}</td>
-			<td>{{Spec2("Gamepad")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/index.html
@@ -39,20 +39,7 @@ browser-compat: api.GamepadHapticActuator
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#gamepadhapticactuator-interface', 'GamepadHapticActuator')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.html
@@ -43,20 +43,7 @@ browser-compat: api.GamepadHapticActuator.pulse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadhapticactuator-pulse', 'pulse()')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/type/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/type/index.html
@@ -34,20 +34,7 @@ browser-compat: api.GamepadHapticActuator.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('GamepadExtensions', '#dom-gamepadhapticactuatortype', 'GamepadHapticActuatorType')}}</td>
-			<td>{{Spec2('GamepadExtensions')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/angularacceleration/index.html
+++ b/files/en-us/web/api/gamepadpose/angularacceleration/index.html
@@ -33,20 +33,7 @@ browser-compat: api.GamepadPose.angularAcceleration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-angularacceleration', 'angularAcceleration')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/angularvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/angularvelocity/index.html
@@ -33,20 +33,7 @@ browser-compat: api.GamepadPose.angularVelocity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-angularvelocity', 'angularVelocity')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.html
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.html
@@ -31,20 +31,7 @@ browser-compat: api.GamepadPose.hasOrientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-hasorientation', 'hasOrientation')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasposition/index.html
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.html
@@ -31,20 +31,7 @@ browser-compat: api.GamepadPose.hasPosition
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-hasposition', 'hasPosition')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/index.html
+++ b/files/en-us/web/api/gamepadpose/index.html
@@ -46,20 +46,7 @@ browser-compat: api.GamepadPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#gamepadpose-interface', 'GamepadPose')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearacceleration/index.html
+++ b/files/en-us/web/api/gamepadpose/linearacceleration/index.html
@@ -33,20 +33,7 @@ browser-compat: api.GamepadPose.linearAcceleration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-linearacceleration', 'linearAcceleration')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/linearvelocity/index.html
@@ -33,20 +33,7 @@ browser-compat: api.GamepadPose.linearVelocity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-linearvelocity', 'linearVelocity')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/orientation/index.html
+++ b/files/en-us/web/api/gamepadpose/orientation/index.html
@@ -46,20 +46,7 @@ browser-compat: api.GamepadPose.orientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-orientation', 'orientation')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepadpose/position/index.html
+++ b/files/en-us/web/api/gamepadpose/position/index.html
@@ -45,20 +45,7 @@ browser-compat: api.GamepadPose.position
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('GamepadExtensions', '#dom-gamepadpose-position', 'position')}}</td>
-   <td>{{Spec2('GamepadExtensions')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocation/clearwatch/index.html
+++ b/files/en-us/web/api/geolocation/clearwatch/index.html
@@ -62,22 +62,7 @@ id = navigator.geolocation.watchPosition(success, error, options);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocation/getcurrentposition/index.html
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.html
@@ -70,22 +70,7 @@ navigator.geolocation.getCurrentPosition(success, error, options);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocation/index.html
+++ b/files/en-us/web/api/geolocation/index.html
@@ -39,22 +39,7 @@ browser-compat: api.Geolocation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#geolocation_interface')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocation/watchposition/index.html
+++ b/files/en-us/web/api/geolocation/watchposition/index.html
@@ -75,23 +75,7 @@ id = navigator.geolocation.watchPosition(success, error, options);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocation-watchposition', 'watchPosition()')}}
-      </td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/accuracy/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/accuracy/index.html
@@ -30,23 +30,7 @@ browser-compat: api.GeolocationCoordinates.accuracy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-accuracy',
-        'Coordinates.accuracy')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/altitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/altitude/index.html
@@ -31,23 +31,7 @@ browser-compat: api.GeolocationCoordinates.altitude
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-altitude',
-        'Coordinates.altitude')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
@@ -29,23 +29,7 @@ browser-compat: api.GeolocationCoordinates.altitudeAccuracy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-altitudeaccuracy',
-        'GeolocationCoordinates.altitudeAccuracy')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/heading/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/heading/index.html
@@ -34,23 +34,7 @@ browser-compat: api.GeolocationCoordinates.heading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-heading',
-        'GeolocationCoordinates.heading')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/index.html
@@ -40,22 +40,7 @@ browser-compat: api.GeolocationCoordinates
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#coordinates_interface', 'GeolocationCoordinates')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/latitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/latitude/index.html
@@ -25,22 +25,7 @@ browser-compat: api.GeolocationCoordinates.latitude
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-latitude', 'GeolocationCoordinates.latitude')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.html
@@ -108,23 +108,7 @@ button.addEventListener("click", function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-longitude',
-        'Coordinates.longitude')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/speed/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/speed/index.html
@@ -27,23 +27,7 @@ browser-compat: api.GeolocationCoordinates.speed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationcoordinates-speed',
-        'GeolocationCoordinates.speed')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationposition/coords/index.html
+++ b/files/en-us/web/api/geolocationposition/coords/index.html
@@ -29,23 +29,7 @@ browser-compat: api.GeolocationPosition.coords
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationposition-coords',
-        'GeolocationPosition.coords')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationposition/index.html
+++ b/files/en-us/web/api/geolocationposition/index.html
@@ -30,22 +30,7 @@ browser-compat: api.GeolocationPosition
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#position_interface', 'GeolocationPosition')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationposition/timestamp/index.html
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.html
@@ -25,22 +25,7 @@ browser-compat: api.GeolocationPosition.timestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#dom-geolocationposition-timestamp', 'GeolocationPosition.timestamp')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/code/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/code/index.html
@@ -58,23 +58,7 @@ browser-compat: api.GeolocationPositionError.code
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationpositionerror-code',
-        'PositionError.code')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/index.html
@@ -55,22 +55,7 @@ browser-compat: api.GeolocationPositionError
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#position_error_interface', 'GeolocationPositionError')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/message/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/message/index.html
@@ -27,23 +27,7 @@ browser-compat: api.GeolocationPositionError.message
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-geolocationpositionerror-message',
-        'GeolocationPositionError.message')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -215,42 +215,7 @@ browser-compat: api.GlobalEventHandlers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Selection API",'', 'Extension to GlobalEventHandlers')}}</td>
-   <td>{{Spec2('Selection API')}}</td>
-   <td>Adds <code>onselectionchange.</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Lock', '#extensions-to-the-document-interface', 'Extension of Document')}}</td>
-   <td>{{Spec2('Pointer Lock')}}</td>
-   <td>Adds <code>onpointerlockchange</code> and <code>onpointerlockerror</code> on {{domxref("Document")}}. It is experimentally implemented on <code>GlobalEventHandlers</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#globaleventhandlers', 'GlobalEventHandlers')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change since the latest snapshot, {{SpecName("HTML5.1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', '#globaleventhandlers', 'GlobalEventHandlers')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. Added <code>onsort</code> since the {{SpecName("HTML5 W3C")}} snapshot.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "#globaleventhandlers", "GlobalEventHandlers")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. Creation of <code>GlobalEventHandlers</code> (properties where on the target before it).</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.html
@@ -51,20 +51,7 @@ browser-compat: api.GlobalEventHandlers.onabort
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onabort','onabort')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -204,20 +204,7 @@ browser-compat: api.GlobalEventHandlers.onanimationcancel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationcancel','onanimationcancel')}}</td>
-      <td>{{Spec2('CSS3 Animations')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -53,20 +53,7 @@ browser-compat: api.GlobalEventHandlers.onanimationend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationend','onanimationend')}}</td>
-      <td>{{Spec2('CSS3 Animations')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -187,21 +187,7 @@ box.onanimationiteration = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationiteration','onanimationiteration')}}
-      </td>
-      <td>{{Spec2('CSS3 Animations')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -200,20 +200,7 @@ box.onanimationend = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationstart','onanimationstart')}}</td>
-      <td>{{Spec2('CSS3 Animations')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
@@ -85,20 +85,7 @@ button.onauxclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('UI Events','#event-type-auxclick','onauxclick')}}</td>
-      <td>{{Spec2('UI Events')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onblur/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onblur/index.html
@@ -70,20 +70,7 @@ function inputFocus() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onblur','onblur')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncancel/index.html
@@ -40,20 +40,7 @@ browser-compat: api.GlobalEventHandlers.oncancel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-oncancel','oncancel')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
@@ -31,20 +31,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplay;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-oncanplay','oncanplay')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
@@ -31,20 +31,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplaythrough;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-oncanplaythrough','oncanplaythrough')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onchange/index.html
@@ -64,20 +64,7 @@ function handleChange(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onchange','onchange')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.html
@@ -92,22 +92,7 @@ function inputChange(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onclick','onclick')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onclose/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclose/index.html
@@ -46,20 +46,7 @@ browser-compat: api.GlobalEventHandlers.onclose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onclose','onclose')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -123,20 +123,7 @@ window.onpointerdown = play;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-oncontextmenu','oncontextmenu')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
@@ -37,20 +37,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncuechange;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-oncuechange','oncuechange')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
@@ -62,21 +62,7 @@ function logDoubleClick(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-ondblclick','ondblclick')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondrag/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondrag/index.html
@@ -85,25 +85,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondrag", "ondrag")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondrag", "ondrag")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragend/index.html
@@ -119,26 +119,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondragend", "ondragend")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondragend", "ondragend")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragenter/index.html
@@ -120,26 +120,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondragenter",
-        "ondragenter")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondragenter", "ondragenter")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragleave/index.html
@@ -121,26 +121,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondragleave",
-        "ondragleave")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondragleave", "ondragleave")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragover/index.html
@@ -86,26 +86,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondragover", "ondragover")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondragover", "ondragover")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragstart/index.html
@@ -86,26 +86,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondragstart",
-        "ondragstart")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondragstart", "ondragstart")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondrop/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondrop/index.html
@@ -86,25 +86,7 @@ function dragover_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "indices.html#ix-handler-ondrop", "ondrop")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "index.html#ix-handler-ondrop", "ondrop")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
@@ -30,20 +30,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.ondurationchange;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-ondurationchange','ondurationchange')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onemptied/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onemptied/index.html
@@ -35,20 +35,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onemptied;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('HTML WHATWG','#handler-onemptied','onemptied')}}</td>
-            <td>{{Spec2('HTML WHATWG')}}</td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onended/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onended/index.html
@@ -30,20 +30,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onended;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onended','onended')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onerror/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.html
@@ -93,20 +93,7 @@ browser-compat: api.GlobalEventHandlers.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onerror','onerror')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onfocus/index.html
@@ -74,20 +74,7 @@ function inputFocus() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onfocus','onfocus')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onformdata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onformdata/index.html
@@ -67,21 +67,7 @@ formElem.onformdata = (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onformdata','onformdata')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
@@ -44,23 +44,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2', '#the-gotpointercapture-event',
-        'ongotpointercapture')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oninput/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninput/index.html
@@ -66,22 +66,7 @@ function handleInput(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#ix-handler-oninput", "oninput")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
@@ -79,20 +79,7 @@ function submit(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-oninvalid','oninvalid')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
@@ -58,22 +58,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onkeydown','onkeydown')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -138,21 +138,7 @@ input.onpaste = event =&gt; false;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onkeypress','onkeypress')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
@@ -58,20 +58,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onkeyup','onkeyup')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onload/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onload/index.html
@@ -77,22 +77,7 @@ browser-compat: api.GlobalEventHandlers.onload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "webappapis.html#handler-onload", "onload")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
@@ -30,20 +30,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadeddata;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onloadeddata','onloadeddata')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
@@ -29,20 +29,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadedmetadata;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onloadedmetadata','onloadedmetadata')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
@@ -54,23 +54,7 @@ image.addEventListener('loadend', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "webappapis.html#handler-onloadstart",
-        "onloadstart")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
@@ -45,21 +45,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2', '#the-lostpointercapture-event',
-        'onlostpointercapture')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
@@ -99,21 +99,7 @@ document.onmouseup = hideView;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onmousedown','onmousedown')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
@@ -30,20 +30,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseenter;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onmouseenter','onmouseenter')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
@@ -30,20 +30,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseleave;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onmouseleave','onmouseleave')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
@@ -99,21 +99,7 @@ links.forEach(link =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onmousemove','onmousemove')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -54,21 +54,7 @@ function logMouseOut() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onmouseout','onmouseout')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -53,21 +53,7 @@ function logMouseOut() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onmouseover','onmouseover')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
@@ -104,20 +104,7 @@ document.onmouseup = release;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onmouseup','onmouseup')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpause/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpause/index.html
@@ -29,20 +29,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onpause;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onpause','onpause')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplay/index.html
@@ -46,20 +46,7 @@ function alertPlay() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onplay','onplay')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onplaying/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplaying/index.html
@@ -30,22 +30,7 @@ var <var>handlerFunction</var> = <var>element</var>.onplaying;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onplaying','onplaying')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointercancel',
-        'onpointercancel')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointercancel',
-        'onpointercancel')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
@@ -158,29 +158,7 @@ function handleUp(evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerdown',
-        'onpointerdown')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerdown',
-        'onpointerdown')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerenter',
-        'onpointerenter')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerenter',
-        'onpointerenter')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerleave/index.html
@@ -64,29 +64,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerleave',
-        'onpointerleave')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerleave',
-        'onpointerleave')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointermove',
-        'onpointermove')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointermove',
-        'onpointermove')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerout',
-        'onpointerout')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerout',
-        'onpointerout')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerover',
-        'onpointerover')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerover',
-        'onpointerover')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
@@ -57,29 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-globaleventhandlers-onpointerup',
-        'onpointerup')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-GlobalEventHandlers-onpointerup',
-        'onpointerup')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onreset/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onreset/index.html
@@ -61,20 +61,7 @@ form.onreset = logReset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onreset','onreset')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onresize/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onresize/index.html
@@ -54,20 +54,7 @@ window.onresize = resize;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onresize','onresize')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onscroll/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onscroll/index.html
@@ -83,27 +83,7 @@ function logScroll(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#handler-onscroll','onscroll')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 Events", "#event-type-scroll", "onscroll")}}</td>
-      <td>{{Spec2("DOM3 Events")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselect/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselect/index.html
@@ -59,20 +59,7 @@ textarea.onselect = logSelection;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onselect','onselect')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -41,20 +41,7 @@ document.onselectionchange = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Selection API','#dom-globaleventhandlers-onselectionchange','GlobalEventHandlers.onselectionchange')}}</td>
-   <td>{{Spec2('Selection API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -51,21 +51,7 @@ browser-compat: api.GlobalEventHandlers.onselectstart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API','#dom-globaleventhandlers-onselectstart','GlobalEventHandlers.onselectstart')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
@@ -75,20 +75,7 @@ function submit(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onsubmit','onsubmit')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
@@ -62,22 +62,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-globaleventhandlers-ontouchcancel')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
@@ -60,22 +60,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-globaleventhandlers-ontouchend')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
@@ -59,20 +59,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-globaleventhandlers-ontouchmove')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
@@ -61,20 +61,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-globaleventhandlers-ontouchstart')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -145,23 +145,7 @@ box.ontransitioncancel = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitioncancel','ontransitioncancel')}}
-      </td>
-      <td>{{Spec2('CSS3 Transitions')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -126,22 +126,7 @@ box.ontransitionend = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitionend','ontransitionend')}}</td>
-      <td>{{Spec2('CSS3 Transitions')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onwheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onwheel/index.html
@@ -97,22 +97,7 @@ document.onwheel = zoom;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onwheel','onwheel')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -54,27 +54,7 @@ browser-compat: api.GravitySensor.GravitySensor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Accelerometer','#dom-gravitysensor-gravitysensor','GravitySensor')}}
-      </td>
-      <td>{{Spec2('Accelerometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/index.html
@@ -47,25 +47,7 @@ gravitySensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Generic Sensor')}}</td>
-			<td>{{Spec2('Generic Sensor')}}</td>
-			<td>Defines sensors in general.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('Accelerometer','#gravitysensor-interface','GravitySensor')}}</td>
-			<td>{{Spec2('Accelerometer')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gyroscope/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/gyroscope/index.html
@@ -46,25 +46,7 @@ browser-compat: api.Gyroscope.Gyroscope
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Gyroscope','#dom-gyroscope-gyroscope','Gyroscope')}}</td>
-      <td>{{Spec2('Gyroscope')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/index.html
@@ -54,25 +54,7 @@ gyroscope.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Generic Sensor')}}</td>
-   <td>{{Spec2('Generic Sensor')}}</td>
-   <td>Defines sensors in general.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Gyroscope','#gyroscope-interface','Gyroscope')}}</td>
-   <td>{{Spec2('Gyroscope')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gyroscope/x/index.html
+++ b/files/en-us/web/api/gyroscope/x/index.html
@@ -47,25 +47,7 @@ gyroscope.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Gyroscope','#gyroscope-x','x')}}</td>
-      <td>{{Spec2('Gyroscope')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gyroscope/y/index.html
+++ b/files/en-us/web/api/gyroscope/y/index.html
@@ -47,25 +47,7 @@ gyroscope.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Gyroscope','#gyroscope-y','y')}}</td>
-      <td>{{Spec2('Gyroscope')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gyroscope/z/index.html
+++ b/files/en-us/web/api/gyroscope/z/index.html
@@ -47,25 +47,7 @@ gyroscope.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Gyroscope','#gyroscope-z','z')}}</td>
-      <td>{{Spec2('Gyroscope')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/g* to the {{Specifications}} macros. 

Note that:
- Gamepad.displayID lost its spec table. It is deprecated, and only in Firefox (removed from the other browsers), so I'll leave it like this.

All other pages look fine.