### PR TITLE
Replace spec table with {{specifications}} for api/h* (part 1)

### DIFF
--- a/files/en-us/web/api/hashchangeevent/index.html
+++ b/files/en-us/web/api/hashchangeevent/index.html
@@ -100,22 +100,7 @@ window.addEventListener('hashchange', locationHashChanged);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#the-hashchangeevent-interface", "HashChangeEvent")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/hashchangeevent/newurl/index.html
+++ b/files/en-us/web/api/hashchangeevent/newurl/index.html
@@ -31,20 +31,7 @@ browser-compat: api.HashChangeEvent.newURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-newurl', 'HashChangeEvent: newURL')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/hashchangeevent/oldurl/index.html
+++ b/files/en-us/web/api/hashchangeevent/oldurl/index.html
@@ -31,20 +31,7 @@ browser-compat: api.HashChangeEvent.oldURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-oldurl', 'HashChangeEvent: oldURL')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/append/index.html
+++ b/files/en-us/web/api/headers/append/index.html
@@ -68,20 +68,7 @@ myHeaders.get('Accept-Encoding'); // Returns 'deflate, gzip'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-headers-append','append()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/delete/index.html
+++ b/files/en-us/web/api/headers/delete/index.html
@@ -62,20 +62,7 @@ myHeaders.get('Content-Type'); // Returns null, as it has been deleted</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-headers-delete','delete()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/get/index.html
+++ b/files/en-us/web/api/headers/get/index.html
@@ -74,20 +74,7 @@ myHeaders.get('Accept-Encoding').split(',').map(v => v.trimStart()); // Returns 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-headers-get','get()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/has/index.html
+++ b/files/en-us/web/api/headers/has/index.html
@@ -53,20 +53,7 @@ myHeaders.has('Accept-Encoding'); // Returns false
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Fetch','#dom-headers-has','has()')}}</td>
-			<td>{{Spec2('Fetch')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/headers/index.html
+++ b/files/en-us/web/api/headers/headers/index.html
@@ -58,20 +58,7 @@ secondHeadersObj.get('Content-Type'); // Would return 'image/jpeg' — it inheri
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-headers','Headers()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/index.html
+++ b/files/en-us/web/api/headers/index.html
@@ -102,20 +102,7 @@ myHeaders.get('Content-Type') // should return 'text/xml'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#headers-class','Headers')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/headers/set/index.html
+++ b/files/en-us/web/api/headers/set/index.html
@@ -72,20 +72,7 @@ myHeaders.get('Accept-Encoding'); // Returns 'gzip'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-headers-set','set()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -41,22 +41,7 @@ browser-compat: api.HID
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-     <td>{{SpecName('WebHID', '#dom-hid', 'HID')}}</td>
-     <td>{{Spec2('WebHID')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/back/index.html
+++ b/files/en-us/web/api/history/back/index.html
@@ -42,26 +42,7 @@ browser-compat: api.History.back
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "history.html#history", "History.back()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "browsers.html#dom-history-back", "History.back()")}}
-      </td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/forward/index.html
+++ b/files/en-us/web/api/history/forward/index.html
@@ -40,25 +40,7 @@ browser-compat: api.History.forward
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "browsers.html#history", "History")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "browsers.html#history", "History")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/go/index.html
+++ b/files/en-us/web/api/history/go/index.html
@@ -61,27 +61,7 @@ history.go(0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "history.html#dom-history-go", "History.go()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "browsers.html#dom-history-go", "History.go()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/index.html
+++ b/files/en-us/web/api/history/index.html
@@ -49,27 +49,7 @@ browser-compat: api.History
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "browsers.html#the-history-interface", "History")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Adds the <code>scrollRestoration</code> attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "browsers.html#the-history-interface", "History")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/length/index.html
+++ b/files/en-us/web/api/history/length/index.html
@@ -25,27 +25,7 @@ browser-compat: api.History.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#dom-history-length", "History.length")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "browsers.html#dom-history-length", "History.length")}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/pushstate/index.html
+++ b/files/en-us/web/api/history/pushstate/index.html
@@ -102,27 +102,7 @@ window.history.pushState({}, '', url);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#dom-history-pushstate",
-        "History.pushState()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "history.html#dom-history-pushstate",
-        "History.pushState()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/replacestate/index.html
+++ b/files/en-us/web/api/history/replacestate/index.html
@@ -71,27 +71,7 @@ history.pushState(stateObj, '', 'bar.html');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "history.html#dom-history-replacestate",
-        "History.replaceState()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "history.html#dom-history-replacestate",
-        "History.replaceState()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/scrollrestoration/index.html
+++ b/files/en-us/web/api/history/scrollrestoration/index.html
@@ -52,27 +52,7 @@ if (scrollRestoration === 'manual') {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#scroll-restoration-mode", "scroll restoration
-        mode")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "browsers.html#dom-history-scrollrestoration",
-        "History.scrollRestoration")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/history/state/index.html
+++ b/files/en-us/web/api/history/state/index.html
@@ -45,26 +45,7 @@ console.log('History.state after pushState: ', history.state);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-history-state", "History.state")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "browsers.html#dom-history-state", "History.state")}}
-      </td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/download/index.html
+++ b/files/en-us/web/api/htmlanchorelement/download/index.html
@@ -31,23 +31,7 @@ browser-compat: api.HTMLAnchorElement.download
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'links.html#attr-hyperlink-download', 'download')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/hash/index.html
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.html
@@ -47,16 +47,7 @@ anchor.hash; // returns '#Examples'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-hash','HTMLHyperlinkElementUtils.hash')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/host/index.html
+++ b/files/en-us/web/api/htmlanchorelement/host/index.html
@@ -41,16 +41,7 @@ anchor.host == "developer.mozilla.org:4097"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-host','HTMLHyperlinkElementUtils.host')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/hostname/index.html
+++ b/files/en-us/web/api/htmlanchorelement/hostname/index.html
@@ -30,16 +30,7 @@ anchor.hostname; // returns 'developer.mozilla.org'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-hostname','HTMLHyperlinkElementUtils.hostname')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/href/index.html
+++ b/files/en-us/web/api/htmlanchorelement/href/index.html
@@ -33,16 +33,7 @@ anchor.href; // returns 'https://developer.mozilla.org/en-US/HTMLAnchorElement'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-href','HTMLHyperlinkElementUtils.href')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/index.html
+++ b/files/en-us/web/api/htmlanchorelement/index.html
@@ -97,16 +97,7 @@ browser-compat: api.HTMLAnchorElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlanchorelement", "HTMLAnchorElement")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/origin/index.html
+++ b/files/en-us/web/api/htmlanchorelement/origin/index.html
@@ -46,16 +46,7 @@ anchor.origin; // returns 'https://developer.mozilla.org'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-origin','HTMLHyperlinkElementUtils.origin')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/password/index.html
+++ b/files/en-us/web/api/htmlanchorelement/password/index.html
@@ -34,16 +34,7 @@ anchor.password; // returns 'flabada'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-password','HTMLHyperlinkElementUtils.password')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/pathname/index.html
+++ b/files/en-us/web/api/htmlanchorelement/pathname/index.html
@@ -33,16 +33,7 @@ anchor.pathname; // returns '/en-US/docs/HTMLAnchorElement'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-pathname','HTMLHyperlinkElementUtils.pathname')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/port/index.html
+++ b/files/en-us/web/api/htmlanchorelement/port/index.html
@@ -34,16 +34,7 @@ anchor.port; // returns '443'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-port','HTMLHyperlinkElementUtils.port')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/protocol/index.html
+++ b/files/en-us/web/api/htmlanchorelement/protocol/index.html
@@ -34,16 +34,7 @@ anchor.protocol; // returns 'https:'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-protocol','HTMLHyperlinkElementUtils.protocol')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
@@ -49,23 +49,7 @@ div.appendChild(elt); // When clicked, the link will not send a referrer header.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerPolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td>Added the <code>referrerPolicy</code> property.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/rel/index.html
+++ b/files/en-us/web/api/htmlanchorelement/rel/index.html
@@ -34,32 +34,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'semantics.html#dom-a-rel', 'rel')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("DOM2 HTML")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-3815891', 'rel')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-3815891', 'rel')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/rellist/index.html
+++ b/files/en-us/web/api/htmlanchorelement/rellist/index.html
@@ -42,23 +42,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-a-rellist', 'relList')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/search/index.html
+++ b/files/en-us/web/api/htmlanchorelement/search/index.html
@@ -47,16 +47,7 @@ let q = parseInt(params.get("q"); // returns the number 123
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-search','HTMLHyperlinkElementUtils.search')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/tostring/index.html
+++ b/files/en-us/web/api/htmlanchorelement/tostring/index.html
@@ -29,16 +29,7 @@ anchor.toString(); // returns 'https://developer.mozilla.org/en-US/docs/HTMLAnch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-hyperlink-href", 'HTMLHyperlinkElementUtils.href')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/username/index.html
+++ b/files/en-us/web/api/htmlanchorelement/username/index.html
@@ -33,16 +33,7 @@ anchor.username; // returns 'anonymous'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-username','HTMLHyperlinkElementUtils.username')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/hash/index.html
+++ b/files/en-us/web/api/htmlareaelement/hash/index.html
@@ -52,16 +52,7 @@ area.hash; // returns '#ExampleSection'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-hash','HTMLHyperlinkElementUtils.hash')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/host/index.html
+++ b/files/en-us/web/api/htmlareaelement/host/index.html
@@ -41,16 +41,7 @@ area.host == "developer.mozilla.org:4097"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-host','HTMLHyperlinkElementUtils.host')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/hostname/index.html
+++ b/files/en-us/web/api/htmlareaelement/hostname/index.html
@@ -30,16 +30,7 @@ HTMLAreaElement.hostname; // returns 'developer.mozilla.org'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-hostname','HTMLHyperlinkElementUtils.hostname')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/href/index.html
+++ b/files/en-us/web/api/htmlareaelement/href/index.html
@@ -33,16 +33,7 @@ area.href; // returns 'https://developer.mozilla.org/en-US/HTMLAreaElement'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-href','HTMLHyperlinkElementUtils.href')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/index.html
+++ b/files/en-us/web/api/htmlareaelement/index.html
@@ -76,16 +76,7 @@ browser-compat: api.HTMLAreaElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlareaelement", "HTMLAreaElement")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/origin/index.html
+++ b/files/en-us/web/api/htmlareaelement/origin/index.html
@@ -45,16 +45,7 @@ area.origin; // returns 'https://developer.mozilla.org'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-origin','HTMLHyperlinkElementUtils.origin')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/password/index.html
+++ b/files/en-us/web/api/htmlareaelement/password/index.html
@@ -34,16 +34,7 @@ area.password; // returns 'flabada'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-password','HTMLHyperlinkElementUtils.password')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/pathname/index.html
+++ b/files/en-us/web/api/htmlareaelement/pathname/index.html
@@ -33,16 +33,7 @@ area.pathname; // returns '/en-US/docs/HTMLAreaElement'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-pathname','HTMLHyperlinkElementUtils.pathname')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/port/index.html
+++ b/files/en-us/web/api/htmlareaelement/port/index.html
@@ -34,16 +34,7 @@ area.port; // returns '443'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-port','HTMLHyperlinkElementUtils.port')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/protocol/index.html
+++ b/files/en-us/web/api/htmlareaelement/protocol/index.html
@@ -34,16 +34,7 @@ area.protocol; // returns 'https:'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-protocol','HTMLHyperlinkElementUtils.protocol')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
@@ -53,23 +53,7 @@ map.appendChild(elt);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerpolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td>Added the <code>referrerPolicy</code> property.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/rel/index.html
+++ b/files/en-us/web/api/htmlareaelement/rel/index.html
@@ -34,22 +34,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-area-rel', 'rel')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/rellist/index.html
+++ b/files/en-us/web/api/htmlareaelement/rellist/index.html
@@ -43,23 +43,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-area-rellist', 'relList')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/search/index.html
+++ b/files/en-us/web/api/htmlareaelement/search/index.html
@@ -47,16 +47,7 @@ let q = parseInt(params.get("q"); // returns the number 123
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-search','HTMLHyperlinkElementUtils.search')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/tostring/index.html
+++ b/files/en-us/web/api/htmlareaelement/tostring/index.html
@@ -29,16 +29,7 @@ area.toString(); // returns 'https://developer.mozilla.org/en-US/docs/HTMLAreaEl
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-hyperlink-href", 'HTMLHyperlinkElementUtils.href')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlareaelement/username/index.html
+++ b/files/en-us/web/api/htmlareaelement/username/index.html
@@ -33,16 +33,7 @@ area.username; // returns 'anonymous'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hyperlink-username','HTMLHyperlinkElementUtils.username')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlaudioelement/audio/index.html
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.html
@@ -88,22 +88,7 @@ browser-compat: api.HTMLAudioElement.Audio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "#dom-audio", "Audio()")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlaudioelement/index.html
+++ b/files/en-us/web/api/htmlaudioelement/index.html
@@ -78,27 +78,7 @@ audioElement.addEventListener('loadeddata', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlaudioelement", "HTMLAudioElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-audio-element", "HTMLAudioElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbaseelement/index.html
+++ b/files/en-us/web/api/htmlbaseelement/index.html
@@ -31,40 +31,7 @@ browser-compat: api.HTMLBaseElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlbaseelement", "HTMLBaseElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "document-metadata.html#the-base-element", "HTMLBaseElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-base-element", "HTMLBaseElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-73629039', 'HTMLBaseElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-73629039', 'HTMLBaseElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -34,25 +34,7 @@ browser-compat: api.HTMLBaseFontElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 HTML", "html.html#ID-32774408", "HTMLBaseFontElement")}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM1", "level-one-html.html#ID-32774408", "HTMLBaseFontElement")}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbodyelement/index.html
+++ b/files/en-us/web/api/htmlbodyelement/index.html
@@ -81,41 +81,7 @@ browser-compat: api.HTMLBodyElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlbodyelement", "HTMLBodyElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Technically, the event-related properties <code>onafterprint</code>, <code>onbeforeprint</code>, <code>onbeforeunload</code>, <code>onblur</code>, <code>onerror</code>, <code>onfocus</code>, <code>onhashchange</code>, <code>onlanguagechange</code>, <code>onload</code>, <code>onmessage</code>, <code>onoffline</code>, <code>ononline</code>, <code>onpopstate</code>, <code>onresize</code>, <code>onstorage</code>, and <code>onunload</code>, have been moved to {{domxref("WindowEventHandlers")}}. <code>HTMLBodyElement</code> implements this interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "sections.html#the-body-element", "HTMLBodyElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "sections.html#the-body-element", "HTMLBodyElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties are now obsolete: <code>aLink</code>, <code>bgColor</code>, <code>background</code>, <code>link</code>, <code>text</code>, and <code>vLink</code>.<br>
-    The following properties have been added: <code>onafterprint</code>, <code>onbeforeprint</code>, <code>onbeforeunload</code>, <code>onblur</code>, <code>onerror</code>, <code>onfocus</code>, <code>onhashchange</code>, <code>onload</code>, <code>onmessage</code>, <code>onoffline</code>, <code>ononline</code>, <code>onpopstate</code>, <code>onresize</code>, <code>onstorage</code>, and <code>onunload</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-62018039', 'HTMLBodyElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-62018039', 'HTMLBodyElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbrelement/index.html
+++ b/files/en-us/web/api/htmlbrelement/index.html
@@ -29,25 +29,7 @@ browser-compat: api.HTMLBRElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlbrelement", "HTMLBRElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "textlevel-semantics.html#the-br-element", "HTMLBRElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbuttonelement/index.html
+++ b/files/en-us/web/api/htmlbuttonelement/index.html
@@ -101,51 +101,7 @@ browser-compat: api.HTMLButtonElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlbuttonelement", "HTMLButtonElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.2', "sec-forms.html#htmlbuttonelement", "HTMLButtonElement")}}</td>
-   <td>{{Spec2('HTML5.2')}}</td>
-   <td>The <code>menu</code> attribute and <code>type="menu"</code> value have been removed.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "sec-forms.html#htmlbuttonelement-htmlbuttonelement", "HTMLButtonElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>The following attribute has been added: <code>menu</code>.<br>
-    The <code>type</code> attribute can take one more value, "<code>menu</code>".</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-button-element", "HTMLButtonElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The attributes <code>tabindex</code> and <code>accesskey</code>, are now defined on {{domxref("HTMLElement")}}.<br>
-    The following attributes have been added: <code>autofocus</code>, <code>formAction</code>, <code>formEnctype</code>, <code>formMethod</code>, <code>formNoValidate</code>, <code>formTarget</code>, <code>labels</code>, <code>validity</code>, <code>validationMessage</code>, and <code>willValidate</code>.<br>
-    The following methods have been added: <code>checkValidity()</code>, <code>setCustomValidity()</code>.<br>
-    The <code>type</code> attribute is no more read-only.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-34812697', 'HTMLButtonElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-34812697', 'HTMLButtonElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbuttonelement/labels/index.html
+++ b/files/en-us/web/api/htmlbuttonelement/labels/index.html
@@ -46,22 +46,7 @@ browser-compat: api.HTMLButtonElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.html
@@ -68,23 +68,7 @@ pc.addStream(stream);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture DOM Elements', '#dom-htmlcanvaselement-capturestream',
-        'HTMLCanvasElement.captureStream()')}}</td>
-      <td>{{Spec2('Media Capture DOM Elements')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
@@ -163,35 +163,7 @@ console.log(ctx); // CanvasRenderingContext2D { ... }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#dom-canvas-getcontext",
-        "HTMLCanvasElement.getContext")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        "semantics-scripting.html#dom-htmlcanvaselement-getcontext",
-        "HTMLCanvasElement.getContext")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-getcontext",
-        "HTMLCanvasElement.getContext")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/height/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/height/index.html
@@ -44,34 +44,7 @@ console.log(canvas.height); // 300
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#attr-canvas-height",
-        "HTMLCanvasElement.height")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "scripting-1.html#attr-canvas-height",
-        "HTMLCanvasElement.height")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "scripting-1.html#attr-canvas-height",
-        "HTMLCanvasElement.height")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/index.html
@@ -71,25 +71,7 @@ browser-compat: api.HTMLCanvasElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "#htmlcanvaselement", "HTMLCanvasElement")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Primary definition of <code>HTMLCanvasElement</code>.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('Media Capture DOM Elements', '#html-canvas-element-media-capture-extensions', 'HTMLCanvasElement')}}</td>
-			<td>{{Spec2('Media Capture DOM Elements')}}</td>
-			<td>Adds the method <code>captureStream()</code>.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.html
@@ -166,34 +166,7 @@ canvas.toBlob(blobCallback('passThisString'), 'image/vnd.microsoft.icon',
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#dom-canvas-toblob",
-        "HTMLCanvasElement.toBlob")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "scripting-1.html#dom-canvas-toblob",
-        "HTMLCanvasElement.toBlob")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-toblob",
-        "HTMLCanvasElement.toBlob")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.html
@@ -138,34 +138,7 @@ function removeColors() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#dom-canvas-todataurl",
-        "HTMLCanvasElement.toDataURL")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "scripting-1.html#dom-canvas-todataurl",
-        "HTMLCanvasElement.toDataURL")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-todataurl",
-        "HTMLCanvasElement.toDataURL")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.html
@@ -40,21 +40,7 @@ gl.commit();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "canvas.html#dom-canvas-transfercontroltooffscreen",
-        "HTMLCanvasElement.transferControlToOffscreen()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.html
@@ -46,20 +46,7 @@ var gl = canvas.getContext('webgl');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', '#5.15.4', 'webglcontextcreationerror')}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
@@ -49,20 +49,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', '#5.15.2', 'webglcontextlost')}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
@@ -49,20 +49,7 @@ gl.getExtension('WEBGL_lose_context').restoreContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', '#5.15.3', 'webglcontextrestored')}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/width/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/width/index.html
@@ -44,34 +44,7 @@ console.log(canvas.width); // 300
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#attr-canvas-width",
-        "HTMLCanvasElement.width")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "scripting-1.html#attr-canvas-width",
-        "HTMLCanvasElement.width")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "scripting-1.html#attr-canvas-width",
-        "HTMLCanvasElement.width")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcollection/index.html
+++ b/files/en-us/web/api/htmlcollection/index.html
@@ -60,22 +60,7 @@ elem1 = document.forms["named.item.with.periods"];</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#htmlcollection', 'HTMLCollection')}}</td>
-   <td>{{ Spec2('DOM WHATWG') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlcollection/length/index.html
+++ b/files/en-us/web/api/htmlcollection/length/index.html
@@ -39,23 +39,7 @@ for (var i = 0; i &lt; items.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-htmlcollection-length", "HTMLCollection:
-        length")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldataelement/index.html
+++ b/files/en-us/web/api/htmldataelement/index.html
@@ -31,25 +31,7 @@ browser-compat: api.HTMLDataElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmldataelement", "HTMLDataElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'text-level-semantics.html#the-data-element', 'HTMLDataElement')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldataelement/value/index.html
+++ b/files/en-us/web/api/htmldataelement/value/index.html
@@ -28,26 +28,7 @@ browser-compat: api.HTMLDataElement.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-data-value", "HTMLDataElement.value")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','text-level-semantics.html#dom-data-value','value')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldatalistelement/index.html
+++ b/files/en-us/web/api/htmldatalistelement/index.html
@@ -29,25 +29,7 @@ browser-compat: api.HTMLDataListElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmldatalistelement", "HTMLDataListElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-datalist-element", "HTMLDataListElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldetailselement/index.html
+++ b/files/en-us/web/api/htmldetailselement/index.html
@@ -40,20 +40,7 @@ browser-compat: api.HTMLDetailsElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'interactive-elements.html#htmldetailselement', 'HTMLDetailsElement')}}</td>
-   <td>{{Spec2("Payment")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldetailselement/toggle_event/index.html
+++ b/files/en-us/web/api/htmldetailselement/toggle_event/index.html
@@ -100,22 +100,7 @@ chapters.forEach((chapter) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-toggle', 'toggle event')}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/cancel_event/index.html
+++ b/files/en-us/web/api/htmldialogelement/cancel_event/index.html
@@ -90,20 +90,7 @@ closeButton.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'indices.html#event-cancel', 'cancel') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/close/index.html
+++ b/files/en-us/web/api/htmldialogelement/close/index.html
@@ -106,28 +106,7 @@ browser-compat: api.HTMLDialogElement.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-dialog-close', 'close()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'interactive-elements.html#dom-htmldialogelement-close',
-        'close()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/close_event/index.html
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.html
@@ -90,18 +90,7 @@ closeButton.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'indices.html#event-close', 'close') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/index.html
+++ b/files/en-us/web/api/htmldialogelement/index.html
@@ -111,27 +111,7 @@ browser-compat: api.HTMLDialogElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#htmldialogelement', 'HTMLDialogElement')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.2', 'interactive-elements.html#the-dialog-element', '&lt;dialog&gt;')}}</td>
-   <td>{{Spec2('HTML5.2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/open/index.html
+++ b/files/en-us/web/api/htmldialogelement/open/index.html
@@ -107,28 +107,7 @@ var myOpenValue = dialogInstance.open;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-dialog-open', 'open')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'interactive-elements.html#dom-htmldialogelement-open',
-        'open')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.html
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.html
@@ -97,30 +97,7 @@ var myReturnValue = dialogInstance.returnValue;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-dialog-returnvalue', 'returnvalue')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'interactive-elements.html#dom-htmldialogelement-returnvalue', 'returnvalue')}}
-      </td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/show/index.html
+++ b/files/en-us/web/api/htmldialogelement/show/index.html
@@ -92,28 +92,7 @@ browser-compat: api.HTMLDialogElement.show
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-dialog-show', 'show()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', 'interactive-elements.html#dom-htmldialogelement-show',
-        'show()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.html
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.html
@@ -107,29 +107,7 @@ browser-compat: api.HTMLDialogElement.showModal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-dialog-showmodal', 'showModal()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1',
-        'interactive-elements.html#dom-htmldialogelement-showmodal', 'showModal()')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldivelement/index.html
+++ b/files/en-us/web/api/htmldivelement/index.html
@@ -30,35 +30,7 @@ browser-compat: api.HTMLDivElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmldivelement", "HTMLDivElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-div-element", "HTMLDivElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-22445964', 'HTMLDivElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-22445964', 'HTMLDivElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldlistelement/index.html
+++ b/files/en-us/web/api/htmldlistelement/index.html
@@ -30,35 +30,7 @@ browser-compat: api.HTMLDListElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmldlistelement", "HTMLDListElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-dl-element", "HTMLDListElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-52368974', 'HTMLDListElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-52368974', 'HTMLDListElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmldocument/index.html
+++ b/files/en-us/web/api/htmldocument/index.html
@@ -21,25 +21,7 @@ browser-compat: api.HTMLDocument
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#htmldocument", "HTMLDocument")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Turn the <code>HTMLDocument</code> interface into a {{DOMxRef("Document")}} extension.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 HTML", "html.html#ID-26809268", "HTMLDocument")}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>Supersedes DOM 1</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM1", "level-one-html.html#ID-26809268", "HTMLDocument")}}</td>
-   <td>{{Spec2("DOM1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of some api/h* (partial) to the {{Specifications}} macros. 

Note that:
- `HTMLBaseFontElement` loses its table, but is only supported by IE nowadays, so I leave it that way; it is soon gone.

All other pages look fine.