### PR TITLE
Replace spec table with {{specifications}} for api/h* (part 2) 

### DIFF
--- a/files/en-us/web/api/htmlelement/accesskeylabel/index.html
+++ b/files/en-us/web/api/htmlelement/accesskeylabel/index.html
@@ -40,37 +40,7 @@ btn.onclick = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "interaction.html#dom-accesskeylabel",
-        "HTMLElement.accessKeyLabel")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1')}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Removed. <a href="https://github.com/w3c/html/pull/144">pull w3c/html#144</a>,
-        <a href="https://github.com/w3c/html/issues/99">issue w3c/html#99</a>, <a
-          href="https://discourse.wicg.io/t/accesskeylabel-author-accessible-info-about-shortcuts/1392/3">WICG
-          discussion</a>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "editing.html#dom-accesskeylabel",
-        "HTMLElement.accessKeyLabel")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/animationcancel_event/index.html
+++ b/files/en-us/web/api/htmlelement/animationcancel_event/index.html
@@ -148,22 +148,7 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationcancel")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/animationend_event/index.html
+++ b/files/en-us/web/api/htmlelement/animationend_event/index.html
@@ -147,22 +147,7 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationend")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/animationiteration_event/index.html
+++ b/files/en-us/web/api/htmlelement/animationiteration_event/index.html
@@ -148,22 +148,7 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationiteration")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/animationstart_event/index.html
+++ b/files/en-us/web/api/htmlelement/animationstart_event/index.html
@@ -144,22 +144,7 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Animations", "#eventdef-animationevent-animationstart")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.html
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.html
@@ -89,18 +89,7 @@ function updateValue(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('UI Events', "#event-type-beforeinput", "beforeinput event")}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/click/index.html
+++ b/files/en-us/web/api/htmlelement/click/index.html
@@ -45,27 +45,7 @@ function myFunction() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-click')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-2651361')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/contenteditable/index.html
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.html
@@ -33,23 +33,7 @@ browser-compat: api.HTMLElement.contentEditable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'interaction.html#contenteditable',
-        'contenteditable')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/dir/index.html
+++ b/files/en-us/web/api/htmlelement/dir/index.html
@@ -65,32 +65,7 @@ parg.dir = "rtl";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-dir', 'dir')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 HTML')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-52460740', 'dir')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName('DOM1')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-52460740', 'dir')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.html
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.html
@@ -42,18 +42,7 @@ search.enterKeyHint = 'search';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-enterkeyhint', 'enterKeyHint')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/gotpointercapture_event/index.html
+++ b/files/en-us/web/api/htmlelement/gotpointercapture_event/index.html
@@ -64,22 +64,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-gotpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-gotpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/hidden/index.html
+++ b/files/en-us/web/api/htmlelement/hidden/index.html
@@ -128,33 +128,7 @@ h1 {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "interaction.html#dom-hidden", "HTMLElement.hidden")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "editing.html#the-hidden-attribute",
-        "HTMLElement.hidden")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "editing.html#the-hidden-attribute",
-        "HTMLElement.hidden")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/index.html
+++ b/files/en-us/web/api/htmlelement/index.html
@@ -222,45 +222,7 @@ browser-compat: api.HTMLElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#extensions-to-the-htmlelement-interface', 'HTMLElement')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>Added the following properties: <code>offsetParent</code>, <code>offsetTop</code>, <code>offsetLeft</code>, <code>offsetWidth</code>, and <code>offsetHeight</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'elements.html#htmlelement', 'HTMLElement')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Added the following properties: <code>translate</code>, <code>itemScope</code>, <code>itemType</code>, <code>itemId</code>, <code>itemRef</code>, <code>itemProp</code>, <code>properties</code>, and <code>itemValue</code>.<br>
-    Added the following method: <code>forceSpellcheck()</code>.<br>
-    Moved the <code>onXYZ</code> attributes to the {{DOMxRef("GlobalEventHandlers")}} interface and added an inheritance from it.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'dom.html#htmlelement', 'HTMLElement')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Added the following properties: <code>dataset</code>, <code>hidden</code>, <code>tabIndex</code>, <code>accessKey</code>, <code>accessKeyLabel</code>, <code>draggable</code>, <code>dropzone</code>, <code>contentEditable</code>, <code>isContentEditable</code>, <code>contextMenu</code>, <code>spellcheck</code>, <code>commandType</code>, <code>commandLabel</code>, <code>commandIcon</code>, <code>commandHidden</code>, <code>commandDisabled</code>, <code>commandChecked</code>, <code>style</code>, and all the <code>onXYZ</code> properties.<br>
-    Moved the <code>id</code> and <code>className</code> properties to the {{DOMxRef("Element")}} interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-011100101', 'HTMLElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName('DOM2 HTML')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-011100101', 'HTMLElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/inert/index.html
+++ b/files/en-us/web/api/htmlelement/inert/index.html
@@ -45,20 +45,7 @@ browser-compat: api.HTMLElement.inert
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "interaction.html#inert-subtrees", "HTMLElement.inert")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/innertext/index.html
+++ b/files/en-us/web/api/htmlelement/innertext/index.html
@@ -73,28 +73,7 @@ innerTextOutput.value = source.innerText;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'dom.html#the-innertext-idl-attribute', 'innerText')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Introduced, based on the <a
-          href="https://github.com/rocallahan/innerText-spec">draft of the innerText
-          specification</a>. See <a
-          href="https://github.com/whatwg/html/issues/465">whatwg/html#465</a> and <a
-          href="https://github.com/whatwg/compat/issues/5">whatwg/compat#5</a> for
-        history.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/input_event/index.html
+++ b/files/en-us/web/api/htmlelement/input_event/index.html
@@ -75,24 +75,7 @@ function updateValue(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "forms.html#event-input-input", "input event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events', "#event-type-input", "input event")}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/iscontenteditable/index.html
+++ b/files/en-us/web/api/htmlelement/iscontenteditable/index.html
@@ -44,32 +44,7 @@ document.getElementById('infoText2').innerHTML += document.getElementById('myTex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/lang/index.html
+++ b/files/en-us/web/api/htmlelement/lang/index.html
@@ -47,22 +47,7 @@ if (document.documentElement.lang === "en") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-59132807', 'lang')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/lostpointercapture_event/index.html
+++ b/files/en-us/web/api/htmlelement/lostpointercapture_event/index.html
@@ -65,22 +65,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-lostpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-lostpointercapture-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/offsetheight/index.html
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.html
@@ -53,22 +53,7 @@ browser-compat: api.HTMLElement.offsetHeight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-htmlelement-offsetheight', 'offsetHeight')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h3 id="Notes">Notes</h3>
 

--- a/files/en-us/web/api/htmlelement/offsetleft/index.html
+++ b/files/en-us/web/api/htmlelement/offsetleft/index.html
@@ -58,22 +58,7 @@ if (tOLeft &gt; 5) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#dom-htmlelement-offsetleft', 'offsetLeft')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/offsetparent/index.html
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.html
@@ -48,22 +48,7 @@ browser-compat: api.HTMLElement.offsetParent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-htmlelement-offsetparent', 'offsetParent')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/offsettop/index.html
+++ b/files/en-us/web/api/htmlelement/offsettop/index.html
@@ -42,22 +42,7 @@ if (topPos &gt; 10) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSSOM View', '#dom-htmlelement-offsettop', 'offsetTop')}}</td>
-			<td>{{Spec2('CSSOM View')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/offsetwidth/index.html
+++ b/files/en-us/web/api/htmlelement/offsetwidth/index.html
@@ -44,22 +44,7 @@ browser-compat: api.HTMLElement.offsetWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-htmlelement-offsetwidth', 'offsetWidth')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h3 id="Notes">Notes</h3>
 

--- a/files/en-us/web/api/htmlelement/pointercancel_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointercancel_event/index.html
@@ -70,22 +70,7 @@ para.onpointercancel = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointercancel-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointercancel-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerdown_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerdown_event/index.html
@@ -54,22 +54,7 @@ para.onpointerdown = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerdown-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerdown-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerenter_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerenter_event/index.html
@@ -55,22 +55,7 @@ para.onpointerenter = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerenter-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerenter-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerleave_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerleave_event/index.html
@@ -54,22 +54,7 @@ para.onpointerleave = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerleave-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerleave-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointermove_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointermove_event/index.html
@@ -58,27 +58,7 @@ para.onpointermove = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">comments</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointermove-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointermove-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerout_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerout_event/index.html
@@ -54,22 +54,7 @@ para.onpointerout = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerout-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerout-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerover_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerover_event/index.html
@@ -51,22 +51,7 @@ para.onpointerover = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerover-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerover-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/pointerup_event/index.html
+++ b/files/en-us/web/api/htmlelement/pointerup_event/index.html
@@ -54,22 +54,7 @@ para.onpointerup = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#the-pointerup-event')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-pointerup-event')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/title/index.html
+++ b/files/en-us/web/api/htmlelement/title/index.html
@@ -31,32 +31,7 @@ link.title = 'Wikipedia page on grapes';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-title', 'title')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 HTML')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-78276800', 'title')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName('DOM1')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-78276800', 'title')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/transitioncancel_event/index.html
+++ b/files/en-us/web/api/htmlelement/transitioncancel_event/index.html
@@ -110,22 +110,7 @@ el.addEventListener('transitionend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitioncancel', 'transitioncancel')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/transitionend_event/index.html
+++ b/files/en-us/web/api/htmlelement/transitionend_event/index.html
@@ -109,22 +109,7 @@ el.addEventListener('transitionend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Transitions", "#transitionend", "transitionend")}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/transitionrun_event/index.html
+++ b/files/en-us/web/api/htmlelement/transitionrun_event/index.html
@@ -105,22 +105,7 @@ el.addEventListener('transitionend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitionrun', 'transitionrun')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlelement/transitionstart_event/index.html
+++ b/files/en-us/web/api/htmlelement/transitionstart_event/index.html
@@ -100,22 +100,7 @@ transition.addEventListener('transitionend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transitions', '#transitionstart', 'transitionstart')}}</td>
-   <td>{{Spec2('CSS3 Transitions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlembedelement/index.html
+++ b/files/en-us/web/api/htmlembedelement/index.html
@@ -44,25 +44,7 @@ browser-compat: api.HTMLEmbedElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlembedelement", "HTMLEmbedElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Adds two obsolete properties, <code>name</code> and <code>align</code>, to help with compatibility with old Web sites.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-embed-element", "HTMLEmbedElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlfieldsetelement/index.html
+++ b/files/en-us/web/api/htmlfieldsetelement/index.html
@@ -53,43 +53,7 @@ browser-compat: api.HTMLFieldSetElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlfieldsetelement", "HTMLFieldSetElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "forms.html#the-fieldset-element", "HTMLFieldSetElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-fieldset-element", "HTMLFieldSetElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties have been added: <code>disabled</code>, <code>elements</code>, <code>name</code>, <code>type</code>, <code>valdiationMessage</code>, <code>validity</code>, and <code>willValidate</code>.<br>
-    The following methods have been added: <code>checkValidity()</code>, <code>setCustomValidity()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-7365882', 'HTMLFieldSetElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-7365882', 'HTMLFieldSetElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformcontrolscollection/index.html
+++ b/files/en-us/web/api/htmlformcontrolscollection/index.html
@@ -38,25 +38,7 @@ browser-compat: api.HTMLFormControlsCollection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "infrastructure.html#htmlformcontrolscollection", "HTMLFormControlsCollection")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change since the last snapshot, {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "infrastructure.html#htmlformcontrolscollection", "HTMLFormControlsCollection")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>In this snapshot of {{SpecName("HTML WHATWG")}}, the <code>HTMLFormControlsCollections</code> is defined for the first time.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.html
+++ b/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.html
@@ -57,28 +57,7 @@ elem1 = document.forms[0]['my-form-control'];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-htmlformcontrolscollection-nameditem",
-        "HTMLFormControlsCollection.namedItem()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "infrastructure.html#htmlformcontrolscollection",
-        "HTMLFormControlsCollection")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>In this snapshot of {{SpecName("HTML WHATWG")}}, the
-        <code>HTMLFormControlsCollections</code> is defined for the first time.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.html
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.html
@@ -31,22 +31,7 @@ form.acceptCharset = string;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-acceptcharset', 'HTMLFormElement: acceptCharset')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/action/index.html
+++ b/files/en-us/web/api/htmlformelement/action/index.html
@@ -32,22 +32,7 @@ browser-compat: api.HTMLFormElement.action
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fs-action', 'HTMLFormElement: action')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/elements/index.html
+++ b/files/en-us/web/api/htmlformelement/elements/index.html
@@ -99,27 +99,7 @@ for (i = 0; i &lt; inputs.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-elements', 'HTMLFormElement.elements')}}
-      </td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-76728479", "HTMLFormElement.elements")}}
-      </td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/enctype/index.html
+++ b/files/en-us/web/api/htmlformelement/enctype/index.html
@@ -38,22 +38,7 @@ browser-compat: api.HTMLFormElement.enctype
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fs-enctype', 'HTMLFormElement: enctype')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/formdata_event/index.html
+++ b/files/en-us/web/api/htmlformelement/formdata_event/index.html
@@ -87,22 +87,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "indices.html#event-formdata", "formdata")}}</td>
-   <td>{{Spec2("HTML  WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/index.html
+++ b/files/en-us/web/api/htmlformelement/index.html
@@ -231,27 +231,7 @@ f.submit();                               // Call the form's submit() method
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlformelement", "HTMLFormElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>The following method has been added: <code>requestAutocomplete()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "sec-forms.html#htmlformelement", "HTMLFormElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The elements properties returns an {{domxref("HTMLFormControlsCollection")}} instead of a raw {{domxref("HTMLCollection")}}. This is mainly a technical change. The following method has been added: <code>checkValidity()</code>. The following properties have been added: <code>autocomplete</code>, <code>noValidate</code>, and <code>encoding</code>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/length/index.html
+++ b/files/en-us/web/api/htmlformelement/length/index.html
@@ -48,22 +48,7 @@ browser-compat: api.HTMLFormElement.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-length', 'HTMLFormElement: length')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/method/index.html
+++ b/files/en-us/web/api/htmlformelement/method/index.html
@@ -34,22 +34,7 @@ console.log(formElement.method); // 'get'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fs-method', 'HTMLFormElement: method')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/name/index.html
+++ b/files/en-us/web/api/htmlformelement/name/index.html
@@ -36,22 +36,7 @@ if (form1name != document.form.form1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-name', 'HTMLFormElement: name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/reportvalidity/index.html
+++ b/files/en-us/web/api/htmlformelement/reportvalidity/index.html
@@ -33,29 +33,7 @@ browser-compat: api.HTMLFormElement.reportValidity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-cva-reportvalidity",
-        "HTMLFormElement.reportValidity()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "semantics.html#the-constraint-validation-api",
-        "HTMLFormElement.reportValidity()")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.html
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.html
@@ -95,22 +95,7 @@ if (myForm.requestSubmit) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-form-requestsubmit", "requestSubmit()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/reset/index.html
+++ b/files/en-us/web/api/htmlformelement/reset/index.html
@@ -38,22 +38,7 @@ browser-compat: api.HTMLFormElement.reset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-reset', 'HTMLFormElement: reset')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/reset_event/index.html
+++ b/files/en-us/web/api/htmlformelement/reset_event/index.html
@@ -64,37 +64,7 @@ form.addEventListener('reset', logReset);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "indices.html#event-reset", "reset")}}</td>
-   <td>{{Spec2("UI Events")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "fullindex.html#eventdef-global-reset", "reset")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "fullindex.html#eventdef-global-reset", "reset")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Added info that the event is not trusted.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "index.html#events-0", "reset")}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/submit/index.html
+++ b/files/en-us/web/api/htmlformelement/submit/index.html
@@ -47,22 +47,7 @@ browser-compat: api.HTMLFormElement.submit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-submit', 'HTMLFormElement: submit')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.html
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.html
@@ -74,37 +74,7 @@ form.addEventListener('submit', logSubmit);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "indices.html#event-submit", "submit")}}</td>
-   <td>{{Spec2("UI Events")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "fullindex.html#eventdef-global-submit", "submit")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "fullindex.html#eventdef-global-submit", "submit")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "index.html#events-0", "submit")}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlformelement/target/index.html
+++ b/files/en-us/web/api/htmlformelement/target/index.html
@@ -29,22 +29,7 @@ browser-compat: api.HTMLFormElement.target
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fs-target', 'HTMLFormElement: target')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlframesetelement/index.html
+++ b/files/en-us/web/api/htmlframesetelement/index.html
@@ -66,36 +66,7 @@ browser-compat: api.HTMLFrameSetElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlframesetelement", "HTMLFrameSetElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>From the {{SpecName('HTML5 W3C')}} snapshot, the {{domxref("WindowEventHandlers")}} interface now have a <code>onlanguagechange</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "obsolete.html#htmlframesetelement", "HTMLFrameSetElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of a previous {{SpecName('HTML WHATWG')}}<br>
-    Frames are now obsolete. Implements {{domxref("WindowEventHandlers")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-ID-43829095', 'HTMLBodyElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-43829095', 'HTMLBodyElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlheadelement/index.html
+++ b/files/en-us/web/api/htmlheadelement/index.html
@@ -29,40 +29,7 @@ browser-compat: api.HTMLHeadElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlheadelement", "HTMLHeadElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "document-metadata.html#the-head-element", "HTMLHeadElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-head-element", "HTMLHeadElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property has been removed: <code>profile</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-77253168', 'HTMLHeadElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-77253168', 'HTMLHeadElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlheadingelement/index.html
+++ b/files/en-us/web/api/htmlheadingelement/index.html
@@ -32,35 +32,7 @@ browser-compat: api.HTMLHeadingElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlheadingelement", "HTMLHeadingElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements", "HTMLHeadingElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The <code>align</code> property is now obsolete.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-43345119', 'HTMLHeadingElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-43345119', 'HTMLHeadingElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlhrelement/index.html
+++ b/files/en-us/web/api/htmlhrelement/index.html
@@ -44,35 +44,7 @@ browser-compat: api.HTMLHRElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlhrelement", "HTMLHRElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>The <code>color</code> property has been added, as an obsolete property, to increase compatibility with the existing web.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-hr-element", "HTMLHRElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Following properties are now obsolete: <code>align</code>, <code>noshade</code>, <code>size</code>, and <code>width</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-68228811', 'HTMLHRElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-68228811', 'HTMLHRElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlhtmlelement/index.html
+++ b/files/en-us/web/api/htmlhtmlelement/index.html
@@ -32,40 +32,7 @@ browser-compat: api.HTMLHtmlElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlhtmlelement", "HTMLHtmlElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "semantics.html#the-html-element", "HTMLHtmlElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change since the last snapshot</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "semantics.html#the-html-element", "HTMLHtmlElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The <code>version</code> element has been removed, as it is non-conforming.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-33759296', 'HTMLHtmlElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>Reflecting the element change in {{SpecName("HTML4.01")}}, the <code>version</code> property is now deprecated.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-33759296', 'HTMLHtmlElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/contentdocument/index.html
+++ b/files/en-us/web/api/htmliframeelement/contentdocument/index.html
@@ -14,22 +14,7 @@ iframeDocument.body.style.backgroundColor = "blue";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-iframe-contentdocument', 'HTMLIFrameElement: contentDocument')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/contentwindow/index.html
+++ b/files/en-us/web/api/htmliframeelement/contentwindow/index.html
@@ -26,22 +26,7 @@ x.document.getElementsByTagName("body")[0].style.backgroundColor = "blue";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-iframe-contentwindow', 'HTMLIFrameElement: contentWindow')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/csp/index.html
+++ b/files/en-us/web/api/htmliframeelement/csp/index.html
@@ -28,20 +28,7 @@ HTMLIFrameElement.csp = <em>csp</em></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP Embedded','#dom-htmliframeelement-csp','csp')}}</td>
-      <td>{{Spec2('CSP Embedded')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/featurepolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/featurepolicy/index.html
@@ -30,20 +30,7 @@ browser-compat: api.HTMLIFrameElement.featurePolicy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Feature Policy")}}</td>
-      <td>{{Spec2("Feature Policy")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/index.html
+++ b/files/en-us/web/api/htmliframeelement/index.html
@@ -67,36 +67,7 @@ browser-compat: api.HTMLIFrameElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmliframeelement", "HTMLIFrameElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>The following property has been added: <code>allowFullscreen</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-iframe-element", "HTMLIFrameElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties are now obsolete: <code>scrolling</code>, <code>marginWidth</code>, <code>marginHeight</code>, <code>longDesc</code>, <code>frameBorder</code>, and <code>align</code>.<br>
-    The following properties have been added: <code>srcdoc</code>, <code>sandbox</code>, and <code>contentWindow</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-50708718', 'HTMLIFrameElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>contentDocument</code> property has been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-50708718', 'HTMLIFrameElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
@@ -69,27 +69,7 @@ body.appendChild(iframe); // Fetch the image using the complete URL as the refer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute', 'referrerpolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td>Added the <code>referrerPolicy</code> attribute.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-iframe-referrerpolicy', 'HTMLIFrameElement: referrerPolicy')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/src/index.html
+++ b/files/en-us/web/api/htmliframeelement/src/index.html
@@ -26,23 +26,7 @@ body.appendChild(iframe); // Fetch the image using the complete URL as the refer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{SpecName("HTML WHATWG", "#dom-iframe-src", "HTMLIFrameElement: src")}}
-            </td>
-            <td>{{Spec2("HTML WHATWG")}}</td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/srcdoc/index.html
+++ b/files/en-us/web/api/htmliframeelement/srcdoc/index.html
@@ -15,22 +15,7 @@ document.body.appendChild(iframe);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#attr-iframe-srcdoc', 'HTMLIFrameElement: srcdoc')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/align/index.html
+++ b/files/en-us/web/api/htmlimageelement/align/index.html
@@ -79,28 +79,7 @@ browser-compat: api.HTMLImageElement.align
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#attr-img-align', 'HTMLImageElement.align')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#adef-align-IMG",
-        "HTMLImageElement.align")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/alt/index.html
+++ b/files/en-us/web/api/htmlimageelement/alt/index.html
@@ -278,22 +278,7 @@ p {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-alt', 'HTMLImageElement.alt')}}</td>
-      <td>{{Spec2('HTML DOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/border/index.html
+++ b/files/en-us/web/api/htmlimageelement/border/index.html
@@ -71,28 +71,7 @@ let <em>thickness</em> = <em>htmlImageElement</em>.border;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-border', 'HTMLImageElement.border')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#h-13.7.3",
-        "HTMLImageElement.border")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/complete/index.html
+++ b/files/en-us/web/api/htmlimageelement/complete/index.html
@@ -95,23 +95,7 @@ function fixRedEyeCommand() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-complete', 'HTMLImageElement.complete')}}
-      </td>
-      <td>{{Spec2('HTML DOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/crossorigin/index.html
+++ b/files/en-us/web/api/htmlimageelement/crossorigin/index.html
@@ -123,23 +123,7 @@ output {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-crossorigin',
-        'HTMLImageElement.crossOrigin')}}</td>
-      <td>{{Spec2('HTML DOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/currentsrc/index.html
+++ b/files/en-us/web/api/htmlimageelement/currentsrc/index.html
@@ -66,23 +66,7 @@ document.body.appendChild(p);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-currentsrc',
-        'HTMLImageElement.currentSrc')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/decode/index.html
+++ b/files/en-us/web/api/htmlimageelement/decode/index.html
@@ -80,20 +80,7 @@ img.decode()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-img-decode','decode()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/decoding/index.html
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.html
@@ -51,23 +51,7 @@ img.src = 'img/logo.png';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-img-decoding',
-        'decoding')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/height/index.html
+++ b/files/en-us/web/api/htmlimageelement/height/index.html
@@ -81,22 +81,7 @@ window.addEventListener("resize", updateHeight);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-height', 'HTMLImageElement.height')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/hspace/index.html
+++ b/files/en-us/web/api/htmlimageelement/hspace/index.html
@@ -56,28 +56,7 @@ browser-compat: api.HTMLImageElement.hspace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#attr-img-hspace', 'HTMLImageElement.hspace')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#h-13.7.2",
-        "HTMLImageElement.hspace")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td>Provides additional details not present in the newer specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/image/index.html
+++ b/files/en-us/web/api/htmlimageelement/image/index.html
@@ -66,20 +66,7 @@ document.body.appendChild(myImage);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "embedded-content.html#dom-image", "Image()")}}</td>
-      <td>{{spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/index.html
+++ b/files/en-us/web/api/htmlimageelement/index.html
@@ -128,44 +128,7 @@ alert(document.images[0].src);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM View", "#extensions-to-the-htmlimageelement-interface", "Extensions to HTMLImageElement")}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>Added the <code>x</code> and <code>y</code> properties.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlimageelement", "HTMLImageElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>The following properties have been added: <code>srcset</code>, <code>currentSrc</code> and <code>sizes</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-img-element", "HTMLImageElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>A constructor (with 2 optional parameters) has been added.<br>
-    The following properties are now obsolete: <code>name</code>, <code>border</code>, <code>align</code>, <code>hspace</code>, <code>vspace</code>, and <code>longdesc</code>.<br>
-    The following properties are now <code>unsigned long</code>, instead of <code>long</code>: <code>height</code>, and <code>width</code>.<br>
-    The following properties have been added: <code>crossorigin</code>, <code>naturalWidth</code>, <code>naturalHeight</code>, and <code>complete</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-17701901', 'HTMLImgElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>lowsrc</code> property has been removed.<br>
-    The following properties are now <code>long</code>, instead of <code>DOMString</code>: <code>height</code>, <code>width</code>, <code>hspace</code>, and <code>vspace</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-17701901', 'HTMLImgElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/ismap/index.html
+++ b/files/en-us/web/api/htmlimageelement/ismap/index.html
@@ -52,23 +52,7 @@ let isMap = <em>htmlImageElement</em>.isMap;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-img-ismap', 'HTMLImageElement.isMap')}}
-			</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/loading/index.html
+++ b/files/en-us/web/api/htmlimageelement/loading/index.html
@@ -116,23 +116,7 @@ browser-compat: api.HTMLImageElement.loading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#attr-img-loading", "HTMLImageElement.loading")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.html
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.html
@@ -69,24 +69,7 @@ browser-compat: api.HTMLImageElement.longDesc
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#adef-longdesc-IMG",
-        "HTMLImageElement.longDesc")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td>Provides an actual description of this property; the HTML5 spec only says it's
-        deprecated.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/name/index.html
+++ b/files/en-us/web/api/htmlimageelement/name/index.html
@@ -39,28 +39,7 @@ browser-compat: api.HTMLImageElement.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#attr-img-name', 'HTMLImageElement.name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#adef-name-IMG",
-        "HTMLImageElement.name")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td>Provides additional details not available in the HTML 5</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.html
@@ -105,23 +105,7 @@ window.addEventListener("load", event =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-naturalheight',
-        'HTMLImageElement.naturalheight')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
@@ -58,23 +58,7 @@ browser-compat: api.HTMLImageElement.naturalWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-naturalwidth',
-        'HTMLImageElement.naturalWidth')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
@@ -48,23 +48,7 @@ div.appendChild(img); // Fetch the image using the origin as the referrer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerPolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td>Added the <code>referrerPolicy</code> property.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/sizes/index.html
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.html
@@ -146,22 +146,7 @@ break50.addEventListener("click",
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-sizes', 'HTMLImageElement.sizes')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/src/index.html
+++ b/files/en-us/web/api/htmlimageelement/src/index.html
@@ -94,22 +94,7 @@ let <em>src</em> = <em>htmlImageElement</em>.src;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-src', 'HTMLImageElement.src')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/srcset/index.html
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.html
@@ -168,22 +168,7 @@ box.appendChild(newElem);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-srcset', 'HTMLImageElement.srcset')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/usemap/index.html
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.html
@@ -77,22 +77,7 @@ let <em>imageMapAnchor</em> = <em>htmlImageElement</em>.useMap;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-usemap', 'HTMLImageElement.useMap')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/vspace/index.html
+++ b/files/en-us/web/api/htmlimageelement/vspace/index.html
@@ -52,28 +52,7 @@ browser-compat: api.HTMLImageElement.vspace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-vspace', 'HTMLImageElement.vspace')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML4.01", "struct/objects.html#h-13.7.2",
-        "HTMLImageElement.vspace")}}</td>
-      <td>{{Spec2("HTML4.01")}}</td>
-      <td>The HTML 4.01 specification offers additional details.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/width/index.html
+++ b/files/en-us/web/api/htmlimageelement/width/index.html
@@ -83,22 +83,7 @@ window.addEventListener("resize", updateWidth);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-img-width', 'HTMLImageElement.width')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/x/index.html
+++ b/files/en-us/web/api/htmlimageelement/x/index.html
@@ -153,22 +153,7 @@ td &gt; img {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-htmlimageelement-x', 'HTMLImageElement.x')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/y/index.html
+++ b/files/en-us/web/api/htmlimageelement/y/index.html
@@ -52,23 +52,7 @@ browser-compat: api.HTMLImageElement.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{SpecName('CSSOM View', '#dom-htmlimageelement-y',
-                'HTMLImageElement.y')}}</td>
-            <td>{{Spec2('CSSOM View')}}</td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -376,40 +376,7 @@ browser-compat: api.HTMLInputElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlinputelement", "HTMLInputElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-input-element", "HTMLInputElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Technically, the <code>tabindex</code> and <code>accesskey</code> properties, as well as the <code>blur()</code>, <code>click()</code>, and <code>focus()</code> methods, are now defined on {{domxref("HTMLElement")}}.<br>
-    The following properties are now obsolete: <code>align</code> and <code>useMap</code>.<br>
-    The following properties have been added: <code>autocomplete</code>, <code>autofocus</code>, <code>dirName</code>, <code>files</code>, <code>formAction</code>, <code>formEnctype</code>, <code>formMethod</code>, <code>formNoValidate</code>, <code>formTarget</code>, <code>height</code>, <code>indeterminate</code>, <code>labels</code>, <code>list</code>, <code>max</code>, <code>min</code>, <code>multiple</code>, <code>pattern</code>, <code>placeholder</code>, <code>required</code>, <code>selectionDirection</code>, <code>selectionEnd</code>, <code>selectionStart</code>, <code>step</code>, <code>validationMessage</code>, <code>validity</code>, <code>valueAsDate</code>, <code>valueAsNumber</code>, <code>width</code>, and <code>willValidate</code>.<br>
-    The following methods have been added: <code>checkValidity()</code>, <code>setCustomValidity()</code>, <code>setSelectionRange()</code>, <code>stepUp()</code>, and <code>stepDown()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-6043025', 'HTMLInputElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>size</code> property is now an <code>unsigned long</code>. The <code>type</code> property must be entirely given in lowercase characters.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-6043025', 'HTMLInputElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/invalid_event/index.html
+++ b/files/en-us/web/api/htmlinputelement/invalid_event/index.html
@@ -70,32 +70,7 @@ function logValue(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'forms.html#the-constraint-validation-api', 'Invalid event') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#the-constraint-validation-api', 'Invalid event') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#the-constraint-validation-api', 'Invalid event') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/labels/index.html
+++ b/files/en-us/web/api/htmlinputelement/labels/index.html
@@ -48,27 +48,7 @@ browser-compat: api.HTMLInputElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/multiple/index.html
+++ b/files/en-us/web/api/htmlinputelement/multiple/index.html
@@ -41,22 +41,7 @@ if (fileInput.multiple == true) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#attr-input-multiple", "multiple")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/select/index.html
+++ b/files/en-us/web/api/htmlinputelement/select/index.html
@@ -59,23 +59,7 @@ browser-compat: api.HTMLInputElement.select
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', 'forms.html#dom-textarea/input-select',
-				'select')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/setrangetext/index.html
+++ b/files/en-us/web/api/htmlinputelement/setrangetext/index.html
@@ -73,29 +73,7 @@ browser-compat: api.HTMLInputElement.setRangeText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-textarea/input-setrangetext",
-        "HTMLInputElement.setSelectionRange()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-textarea/input-setrangetext",
-        "HTMLInputElement.setSelectionRange()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/setselectionrange/index.html
+++ b/files/en-us/web/api/htmlinputelement/setselectionrange/index.html
@@ -93,35 +93,7 @@ browser-compat: api.HTMLInputElement.setSelectionRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-textarea/input-setselectionrange",
-        "HTMLInputElement.setSelectionRange()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "forms.html#dom-textarea/input-setselectionrange",
-        "HTMLInputElement.setSelectionRange()")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-textarea/input-setselectionrange",
-        "HTMLInputElement.setSelectionRange()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.html
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.html
@@ -163,34 +163,7 @@ function stepondown() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "input.html#dom-input-stepdown", "stepDown()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "sec-forms.html#dom-htmlinputelement-stepdown",
-        "stepDown()")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "sec-forms.html#dom-htmlinputelement-stepdown",
-        "stepDown()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/stepup/index.html
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.html
@@ -184,34 +184,7 @@ function steponup() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "input.html#dom-input-stepup", "stepUp()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5.1", "sec-forms.html#dom-htmlinputelement-stepup",
-        "stepUp()")}}</td>
-      <td>{{Spec2("HTML5.1")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "sec-forms.html#dom-htmlinputelement-stepup",
-        "stepUp()")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.html
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.html
@@ -126,23 +126,7 @@ browser-compat: api.HTMLInputElement.webkitdirectory
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-htmlinputelement-webkitdirectory',
-        'webkitdirectory') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/htmlinputelement/webkitentries/index.html
+++ b/files/en-us/web/api/htmlinputelement/webkitentries/index.html
@@ -68,23 +68,7 @@ browser-compat: api.HTMLInputElement.webkitEntries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('File System API', '#dom-htmlinputelement-webkitentries',
-        'webkitEntries') }}</td>
-      <td>{{ Spec2('File System API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of some api/h* (partial) to the {{Specifications}} macros. 

Note that:
- `HTMLIFrameElement.srcdoc` lost its table; it will be fixed by mdn/browser-compat-data#10986
- `HTMLIFrameElement.featurePolicy` lost its table; it was bogus as featurePolicy has been renamed to permissionPolicy in the spec. I left it that way (when the renaming will happen in browsers, it will be taken care of).
- `HTMLImageElement.longDesc` lost its table; it was linking to HTML 4.01 and I don't think we should link toit. The message will be better once mdn/yari#4012 is solved (one way or another).
- `HTMLImageElement.loading` lost its table; it will be fixed by mdn/browser-compat-data#10988
- `HTMLInputElement.select` lost its table; it will be fixed by mdn/browser-compat-data#10989
- `HTMLElement.inert`lost its table; but the previous page linkes was starting by _This section does not define or create any content attribute named "inert"._ (sic). It happens that:
1. This property is not yet in the official HTML standard, although it is driven by the WICG.
2. All browsers implement it behind prefs.
So I keep it without working table for the moment: it will be dealt with when browsers unpref this property (meaning it will be in the standard).

All other pages look fine.