### PR TITLE
Replace spec table with {{specifications}} for api/h* (part 3)

### DIFF
--- a/files/en-us/web/api/htmllabelelement/control/index.html
+++ b/files/en-us/web/api/htmllabelelement/control/index.html
@@ -39,22 +39,7 @@ browser-compat: api.HTMLLabelElement.control
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-label-control', 'control')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllabelelement/form/index.html
+++ b/files/en-us/web/api/htmllabelelement/form/index.html
@@ -37,22 +37,7 @@ browser-compat: api.HTMLLabelElement.form
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'forms.html#dom-label-form', 'form')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllabelelement/htmlfor/index.html
+++ b/files/en-us/web/api/htmllabelelement/htmlfor/index.html
@@ -37,22 +37,7 @@ browser-compat: api.HTMLLabelElement.htmlFor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-label-htmlfor', 'htmlFor')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllabelelement/index.html
+++ b/files/en-us/web/api/htmllabelelement/index.html
@@ -34,36 +34,7 @@ browser-compat: api.HTMLLabelElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmllabelelement", "HTMLLabelElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-label-element", "HTMLLabelElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The property <code>accessKey</code> is now defined on {{domxref("HTMLElement")}}.<br>
-    The following property has been added: <code>control</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-13691394', 'HTMLLabelElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-13691394', 'HTMLLabelElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllegendelement/index.html
+++ b/files/en-us/web/api/htmllegendelement/index.html
@@ -36,41 +36,7 @@ browser-compat: api.HTMLLegendElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmllegendelement", "HTMLLegendElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "forms.html#the-legend-element", "HTMLLegendElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-legend-element", "HTMLLegendElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The property <code>accessKey</code> is now defined on {{domxref("HTMLElement")}}.<br>
-    The following property is now obsolete: <code>align</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-21482039', 'HTMLLegendElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-21482039', 'HTMLLegendElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllielement/index.html
+++ b/files/en-us/web/api/htmllielement/index.html
@@ -34,35 +34,7 @@ browser-compat: api.HTMLLIElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmllielement", "HTMLLIElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-li-element", "HTMLLIElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property is now obsolete: <code>type</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-74680021', 'HTMLLIElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-74680021', 'HTMLLIElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllinkelement/as/index.html
+++ b/files/en-us/web/api/htmllinkelement/as/index.html
@@ -31,20 +31,7 @@ HTMLLinkElement.<em>as</em> = <em>as</em></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Preload','#as-attribute','as')}}</td>
-      <td>{{Spec2('Preload')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllinkelement/index.html
+++ b/files/en-us/web/api/htmllinkelement/index.html
@@ -67,46 +67,7 @@ browser-compat: api.HTMLLinkElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Preload")}}</td>
-   <td>{{Spec2("Preload")}}</td>
-   <td>Defines <code>&lt;link rel="preload"&gt;</code>, and the <code>as</code> property. Note that currently Firefox only supports preloading of cacheable resources.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmllinkelement", "HTMLLinkElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Adds the following properties: <code>crossOrigin</code>, <code>referrerPolicy</code>, and <code>as</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "document-metadata.html#the-link-element", "HTMLLinkElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-link-element", "HTMLLinkElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties are now obsolete: <code>charset</code>, <code>rev</code>, and <code>shape</code>.<br>
-    The following properties have been added: <code>relList</code>, and <code>sizes</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-35143001', 'HTMLLinkElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>Added a second inheritence, the <code>LinkStyle</code> interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-35143001', 'HTMLLinkElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
@@ -31,23 +31,7 @@ links[0].referrerPolicy; // "no-referrer"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerPolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllinkelement/rel/index.html
+++ b/files/en-us/web/api/htmllinkelement/rel/index.html
@@ -38,32 +38,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'semantics.html#attr-link-rel', 'rel')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("DOM2 HTML")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-41369587', 'rel')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-41369587', 'rel')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmllinkelement/rellist/index.html
+++ b/files/en-us/web/api/htmllinkelement/rellist/index.html
@@ -43,22 +43,7 @@ for (var i = 0; i &lt; length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'semantics.html#dom-link-rellist', 'relList')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmapelement/index.html
+++ b/files/en-us/web/api/htmlmapelement/index.html
@@ -33,35 +33,7 @@ browser-compat: api.HTMLMapElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlmapelement", "HTMLMapElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-map-element", "HTMLMapElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Adds the <code>images</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-94109203', 'HTMLAreaElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-94109203', 'HTMLAreaElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmarqueeelement/index.html
+++ b/files/en-us/web/api/htmlmarqueeelement/index.html
@@ -82,35 +82,7 @@ browser-compat: api.HTMLMarqueeElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG","obsolete.html#htmlmarqueeelement","HTMLMarqueeElement")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Made obsolete in favor of CSS but define its expected behavior for backward compatibility.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2","obsolete.html#htmlmarqueeelement","HTMLMarqueeElement")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1","obsolete.html#htmlmarqueeelement-htmlmarqueeelement","HTMLMarqueeElement")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C","obsolete.html#htmlmarqueeelement","HTMLMarqueeElement")}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Made obsolete in favor of CSS but define its expected behavior for backward compatibility.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.html
@@ -52,24 +52,7 @@ video.appendChild(source);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-abort")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-abort")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/audiotracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/audiotracks/index.html
@@ -68,27 +68,7 @@ for (var i = 0; i &lt; video.audioTracks.length; i += 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-audiotracks",
-        "HTMLMediaElement.audioTracks")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.audioTracks")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/autoplay/index.html
+++ b/files/en-us/web/api/htmlmediaelement/autoplay/index.html
@@ -75,27 +75,7 @@ var <em>autoplay</em> = <em>HTMLMediaElement</em>.autoplay;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "embedded-content.html#dom-media-autoplay",
-        "HTMLMediaElement.autoplay")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.autoplay")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/buffered/index.html
+++ b/files/en-us/web/api/htmlmediaelement/buffered/index.html
@@ -34,25 +34,7 @@ console.log(obj.buffered); // TimeRanges { length: 0 }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "media.html#dom-media-buffered", "buffered")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions','#htmlmediaelement-extensions')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Specifies a new algorithm for returning the buffered ranges of an element whose source is a {{domxref("MediaSource")}} object.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/canplay_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplay_event/index.html
@@ -68,22 +68,7 @@ video.oncanplay = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-canplay", "canplay media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-canplay", "canplay media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.html
@@ -70,22 +70,7 @@ video.oncanplaythrough = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-canplaythrough", "canplaythrough media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-canplaythrough", "canplaythrough media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/canplaytype/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplaytype/index.html
@@ -66,26 +66,7 @@ console.log(obj.canPlayType('video/mp4')); // "maybe"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-navigator-canplaytype", "canplaytype")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.canplaytype")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.html
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.html
@@ -60,20 +60,7 @@ browser-compat: api.HTMLMediaElement.captureStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture DOM Elements','#dom-htmlmediaelement-capturestream','captureStream()')}}</td>
-      <td>{{Spec2('Media Capture DOM Elements')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/controller/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.html
@@ -28,20 +28,7 @@ browser-compat: api.HTMLMediaElement.controller
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.controller")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/controls/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controls/index.html
@@ -33,27 +33,7 @@ obj.controls = true;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-controls", "HTMLMediaElement.controls")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.controls")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/controlslist/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controlslist/index.html
@@ -30,23 +30,7 @@ browser-compat: api.HTMLMediaElement.controlsList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://wicg.github.io/controls-list/#solution-outline">Controls List
-          API: Solution outline</a></td>
-      <td></td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/crossorigin/index.html
+++ b/files/en-us/web/api/htmlmediaelement/crossorigin/index.html
@@ -15,25 +15,7 @@ browser-compat: api.HTMLMediaElement.crossOrigin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#attr-media-crossorigin", "HTMLMediaElement.crossOrigin")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.crossOrigin")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.html
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.html
@@ -38,27 +38,7 @@ console.log(obj.currentSrc); // ""
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-currentsrc",
-        "HTMLMediaElement.currentSrc")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.currentSrc")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/currenttime/index.html
+++ b/files/en-us/web/api/htmlmediaelement/currenttime/index.html
@@ -65,27 +65,7 @@ console.log(video.currentTime);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "embedded-content.html#dom-media-currenttime",
-        "HTMLMediaElement.currentTime")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.currentTime")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/defaultmuted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultmuted/index.html
@@ -32,25 +32,7 @@ console.log(videoEle.outerHTML); // &lt;video muted=""&gt;&lt;/video&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#dom-media-defaultmuted", "HTMLMediaElement.defaultMuted")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.defaultMuted")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
@@ -31,25 +31,7 @@ console.log(obj.defaultPlaybackRate); // 1
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#dom-media-defaultplaybackrate", "HTMLMediaElement.defaultPlaybackRate")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.defaultPlaybackRate")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.html
+++ b/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.html
@@ -25,21 +25,7 @@ obj.disableRemotePlayback = true;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Remote Playback', "#the-disableremoteplayback-attribute",
-                "disableRemotePlayback")}}</td>
-            <td>{{Spec2('Remote Playback')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/duration/index.html
+++ b/files/en-us/web/api/htmlmediaelement/duration/index.html
@@ -39,27 +39,7 @@ console.log(obj.duration); // NaN
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-duration", "HTMLMediaElement.duration")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.duration")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/durationchange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/durationchange_event/index.html
@@ -68,22 +68,7 @@ video.ondurationchange = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-durationchange", "durationchange media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-durationchange", "durationchange media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/emptied_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/emptied_event/index.html
@@ -68,22 +68,7 @@ video.onemptied = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-emptied", "emptied media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-emptied", "emptied media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/ended/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ended/index.html
@@ -38,26 +38,7 @@ console.log(obj.ended); // false
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-ended", "HTMLMediaElement.ended")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.ended")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.html
@@ -79,22 +79,7 @@ video.onended = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-ended", "ended media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-ended", "ended media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/error/index.html
+++ b/files/en-us/web/api/htmlmediaelement/error/index.html
@@ -45,26 +45,7 @@ videoElement.src = "https://example.com/bogusvideo.mp4";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-error", "HTMLMediaElement.error")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.error")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/error_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/error_event/index.html
@@ -48,24 +48,7 @@ video.setAttribute('src', videoSrc);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-error")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-error")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.html
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.html
@@ -48,21 +48,7 @@ myVideo.fastSeek(20);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'embedded-content.html#dom-media-fastseek','fastSeek()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition; living specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -232,32 +232,7 @@ browser-compat: api.HTMLMediaElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('EME', '#introduction', 'Encrypted Media Extensions')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Adds {{domxref("MediaKeys")}}, {{domxref("MediaEncryptedEvent")}}, {{domxref("setMediaKeys")}}, {{domxref("onencrypted")}}, and {{domxref("onwaitingforkey")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "the-video-element.html#htmlmediaelement", "HTMLMediaElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/load/index.html
+++ b/files/en-us/web/api/htmlmediaelement/load/index.html
@@ -86,28 +86,7 @@ mediaElem.load();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "media.html#dom-media-load",
-        "HTMLMediaElement.load()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C',
-        "semantics-embedded-content.html#dom-htmlmediaelement-load",
-        "HTMLMediaElement.load()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.html
@@ -74,22 +74,7 @@ video.onloadeddata = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "media.html#event-media-loadeddata", "loadeddata media event")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-loadeddata", "loadeddata media event")}}</td>
-			<td>{{Spec2('HTML5 W3C')}}</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.html
@@ -99,22 +99,7 @@ video.onloadedmetadata = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-loadedmetadata", "loadedmetadata media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-loadedmetadata", "canplay media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/loadstart_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loadstart_event/index.html
@@ -127,24 +127,7 @@ loadVideo.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-loadstart", "loadstart media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-loadstart", "loadstart media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/loop/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loop/index.html
@@ -31,25 +31,7 @@ obj.loop = true; // true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#dom-media-loop", "HTMLMediaElement.loop")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.loop")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
@@ -28,20 +28,7 @@ browser-compat: api.HTMLMediaElement.mediaGroup
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.mediaGroup")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/muted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/muted/index.html
@@ -32,26 +32,7 @@ console.log(obj.muted); // false
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-muted", "HTMLMediaElement.muted")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.muted")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/networkstate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/networkstate/index.html
@@ -82,27 +82,7 @@ obj.addEventListener('playing', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-networkstate",
-        "HTMLMediaElement.networkState")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.networkState")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/onencrypted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onencrypted/index.html
@@ -20,20 +20,7 @@ browser-compat: api.HTMLMediaElement.onencrypted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('EME','#dom-htmlmediaelement-onencrypted','onencrypted')}}</td>
-            <td>{{Spec2('EME')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/onerror/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onerror/index.html
@@ -37,20 +37,7 @@ browser-compat: api.HTMLMediaElement.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onerror','onerror')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.html
@@ -21,21 +21,7 @@ browser-compat: api.HTMLMediaElement.onwaitingforkey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('EME','#dom-htmlmediaelement-onwaitingforkey','onwaitingforkey')}}
-            </td>
-            <td>{{Spec2('EME')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/pause/index.html
+++ b/files/en-us/web/api/htmlmediaelement/pause/index.html
@@ -34,27 +34,7 @@ browser-compat: api.HTMLMediaElement.pause
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-media-pause', 'pause()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition; living specification.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','embedded-content-0.html#dom-media-pause','pause()')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/pause_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/pause_event/index.html
@@ -82,24 +82,7 @@ video.onpause = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-pause", "pause media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-pause", "pause media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/paused/index.html
+++ b/files/en-us/web/api/htmlmediaelement/paused/index.html
@@ -32,26 +32,7 @@ console.log(obj.paused); // true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-paused", "HTMLMediaElement.paused")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.paused")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/play/index.html
+++ b/files/en-us/web/api/htmlmediaelement/play/index.html
@@ -135,26 +135,7 @@ function handlePlayButton() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-media-play', 'play()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition; living specification.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','embedded-content-0.html#dom-media-play','play()')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
   <p><strong>Note:</strong> The WHATWG and W3C versions of the specification differ (as of

--- a/files/en-us/web/api/htmlmediaelement/play_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/play_event/index.html
@@ -70,22 +70,7 @@ video.onplay = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-play", "play media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-play", "play media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/playbackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/playbackrate/index.html
@@ -37,27 +37,7 @@ console.log(obj.playbackRate); // Expected Output: 1</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#dom-media-playbackrate", "HTMLMediaElement.playbackRate")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement", "HTMLMediaElement.playbackRate")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/playing_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/playing_event/index.html
@@ -67,24 +67,7 @@ video.onplaying = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-playing", "playing media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-playing", "playing media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/progress_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/progress_event/index.html
@@ -127,22 +127,7 @@ loadVideo.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-progress", "progress media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-progress", "progress media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
@@ -69,22 +69,7 @@ video.onratechange = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-ratechange", "ratechange media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-ratechange", "ratechange media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/readystate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/readystate/index.html
@@ -91,27 +91,7 @@ obj.addEventListener('loadeddata', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-readystate",
-        "HTMLMediaElement.readyState")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.readyState")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/seekable/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.html
@@ -41,26 +41,7 @@ for (let count = 0; count &lt; timeRangesObject.length; count ++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "the-video-element.html#dom-media-seekable", "seekable")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions','#htmlmediaelement-extensions')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Specifies a new algorithm for returning the seekable time ranges of a media
-        element whose source is a {{domxref("MediaSource")}} object.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/seeked_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seeked_event/index.html
@@ -69,22 +69,7 @@ video.onseeked = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-seeked", "seeked media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-seeked", "seeked media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/seeking_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seeking_event/index.html
@@ -69,22 +69,7 @@ video.onseeking = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-seeking", "seeking media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-seeking", "seeking media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/setsinkid/index.html
+++ b/files/en-us/web/api/htmlmediaelement/setsinkid/index.html
@@ -64,21 +64,7 @@ console.log('Audio is being played on ' + audio.sinkId);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Audio Output','#dom-htmlmediaelement-setsinkid','sinkId')}}</td>
-      <td>{{Spec2('Audio Output')}}</td>
-      <td>Initial definition. Older versions of this spec were called "Media Capture
-        Output".</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/sinkid/index.html
+++ b/files/en-us/web/api/htmlmediaelement/sinkid/index.html
@@ -28,21 +28,7 @@ browser-compat: api.HTMLMediaElement.sinkId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Audio Output','#dom-htmlmediaelement-sinkid','sinkId')}}</td>
-      <td>{{Spec2('Audio Output')}}</td>
-      <td>Initial definition. Older versions of this spec were called "Media Capture
-        Output".</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/src/index.html
+++ b/files/en-us/web/api/htmlmediaelement/src/index.html
@@ -44,27 +44,7 @@ console.log(obj.src); // ""
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "embedded-content.html#dom-media-src",
-        "HTMLMediaElement.src")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-media-src",
-        "HTMLMediaElement.src")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.html
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.html
@@ -110,21 +110,7 @@ if ('srcObject' in video) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'embedded-content.html#dom-media-srcobject',
-        'srcObject')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/stalled_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/stalled_event/index.html
@@ -69,22 +69,7 @@ video.onstalled = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-stalled", "stalled media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-stalled", "stalled media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/suspend_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/suspend_event/index.html
@@ -69,22 +69,7 @@ video.onsuspend = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-suspend", "suspend media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-suspend", "suspend media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.html
@@ -118,27 +118,7 @@ for (var i = 0, L = tracks.length; i &lt; L; i++) { /* tracks.length == 10 */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-texttracks",
-        "HTMLMediaElement.textTracks")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.textTracks")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.html
@@ -70,24 +70,7 @@ video.ontimeupdate = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-timeupdate", "timeupdate media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-timeupdate", "timeupdate media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/videotracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/videotracks/index.html
@@ -45,21 +45,7 @@ browser-compat: api.HTMLMediaElement.videoTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-media-videotracks",
-        "HTMLMediaElement.videoTracks")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/volume/index.html
+++ b/files/en-us/web/api/htmlmediaelement/volume/index.html
@@ -33,26 +33,7 @@ obj.volume = 0.75;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-media-volume", "HTMLMediaElement.volume")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#htmlmediaelement",
-        "HTMLMediaElement.volume")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.html
@@ -70,24 +70,7 @@ video.onvolumechange = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-volumechange", "volumechange media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-volumechange", "volumechange media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/waiting_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/waiting_event/index.html
@@ -69,24 +69,7 @@ video.onwaiting = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#event-media-waiting", "waiting media event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#event-media-waiting", "waiting media event")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -20,34 +20,7 @@ browser-compat: api.HTMLMenuElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "grouping-content.html#htmlmenuelement", "HTMLMenuElement")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>No change from latest snapshot, {{SpecName("HTML5.3")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "grouping-content.html#htmlmenuelement", "HTMLMenuElement")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>Snapshot of the {{SpecName("HTML WHATWG")}}.<br>
-    Removed the <code>context</code> type.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "interactive-elements.html#htmlmenuelement-htmlmenuelement", "HTMLMenuElement")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Snapshot of the {{SpecName("HTML WHATWG")}}.<br>
-    Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmenuitemelement/index.html
+++ b/files/en-us/web/api/htmlmenuitemelement/index.html
@@ -20,23 +20,7 @@ browser-compat: api.HTMLMenuItemElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML5.1", "interactive-elements.html#htmlmenuitemelement-htmlmenuitemelement", "HTMLMenuItemElement")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Snapshot of the {{SpecName("HTML WHATWG")}}.<br>
-    Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmetaelement/index.html
+++ b/files/en-us/web/api/htmlmetaelement/index.html
@@ -56,35 +56,7 @@ browser-compat: api.HTMLMetaElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlmetaelement", "HTMLMetaElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-meta-element", "HTMLMetaElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property is now obsolete: <code>scheme</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-37041454', 'HTMLMetaElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-37041454', 'HTMLMetaElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmeterelement/index.html
+++ b/files/en-us/web/api/htmlmeterelement/index.html
@@ -42,30 +42,7 @@ browser-compat: api.HTMLMeterElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlmeterelement", "HTMLMeterElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "forms.html#the-meter-element", "HTMLMeterElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-meter-element", "HTMLMeterElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmeterelement/labels/index.html
+++ b/files/en-us/web/api/htmlmeterelement/labels/index.html
@@ -47,27 +47,7 @@ browser-compat: api.HTMLMeterElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmodelement/index.html
+++ b/files/en-us/web/api/htmlmodelement/index.html
@@ -27,35 +27,7 @@ browser-compat: api.HTMLModElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "edits.html#htmlmodelement", "HTMLAnchorElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "edits.html#htmlmodelement", "HTMLAnchorElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-79359609', 'HTMLModElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-79359609', 'HTMLModElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/checkvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/checkvalidity/index.html
@@ -36,22 +36,7 @@ browser-compat: api.HTMLObjectElement.checkValidity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-cva-checkvalidity','checkValidity')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/contentdocument/index.html
+++ b/files/en-us/web/api/htmlobjectelement/contentdocument/index.html
@@ -29,20 +29,7 @@ browser-compat: api.HTMLObjectElement.contentDocument
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-contentwindow','contentDocument')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.html
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.html
@@ -29,20 +29,7 @@ browser-compat: api.HTMLObjectElement.contentWindow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-contentwindow','contentWindow')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/data/index.html
+++ b/files/en-us/web/api/htmlobjectelement/data/index.html
@@ -30,20 +30,7 @@ HTMLObjectElement.data;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-data','data')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/form/index.html
+++ b/files/en-us/web/api/htmlobjectelement/form/index.html
@@ -28,20 +28,7 @@ browser-compat: api.HTMLObjectElement.form
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-fae-form','form')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/height/index.html
+++ b/files/en-us/web/api/htmlobjectelement/height/index.html
@@ -29,20 +29,7 @@ HTMLObjectElement.height = String;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-dim-height','height')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/index.html
+++ b/files/en-us/web/api/htmlobjectelement/index.html
@@ -80,30 +80,7 @@ browser-compat: api.HTMLObjectElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlobjectelement", "HTMLObjectElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-9893177', 'HTMLObjectElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>contentDocument</code> property has been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-9893177', 'HTMLObjectElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/name/index.html
+++ b/files/en-us/web/api/htmlobjectelement/name/index.html
@@ -29,20 +29,7 @@ HTMLObjectElement.name = String;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-name','name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
@@ -77,20 +77,7 @@ browser-compat: api.HTMLObjectElement.setCustomValidity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG','#dom-cva-setcustomvalidity','setCustomValidity')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/type/index.html
+++ b/files/en-us/web/api/htmlobjectelement/type/index.html
@@ -29,20 +29,7 @@ HTMLObjectElement.type = String;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-type','type')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/usemap/index.html
+++ b/files/en-us/web/api/htmlobjectelement/usemap/index.html
@@ -30,20 +30,7 @@ HTMLObjectElement.useMap = String;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-object-usemap','useMap')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/validationmessage/index.html
+++ b/files/en-us/web/api/htmlobjectelement/validationmessage/index.html
@@ -31,21 +31,7 @@ browser-compat: api.HTMLObjectElement.validationMessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-cva-validationmessage','validationMessage')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/validity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/validity/index.html
@@ -28,20 +28,7 @@ browser-compat: api.HTMLObjectElement.validity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-cva-validity','validity')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/width/index.html
+++ b/files/en-us/web/api/htmlobjectelement/width/index.html
@@ -29,20 +29,7 @@ HTMLObjectElement.width = String;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-dim-width','width')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlobjectelement/willvalidate/index.html
+++ b/files/en-us/web/api/htmlobjectelement/willvalidate/index.html
@@ -29,20 +29,7 @@ browser-compat: api.HTMLObjectElement.willValidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-cva-willvalidate','willValidate')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlolistelement/index.html
+++ b/files/en-us/web/api/htmlolistelement/index.html
@@ -45,35 +45,7 @@ browser-compat: api.HTMLOListElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlolistelement", "HTMLOListElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-ol-element", "HTMLOListElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Added the <code>reversed</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-58056027', 'HTMLOListElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-58056027', 'HTMLOListElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloptgroupelement/index.html
+++ b/files/en-us/web/api/htmloptgroupelement/index.html
@@ -33,35 +33,7 @@ browser-compat: api.HTMLOptGroupElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmloptgroupelement", "HTMLOptgroupElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-optgroup-element", "HTMLOptGroupElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-ID-38450247', 'HTMLOptGroupElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-38450247', 'HTMLOptGroupElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloptionelement/index.html
+++ b/files/en-us/web/api/htmloptionelement/index.html
@@ -54,37 +54,7 @@ browser-compat: api.HTMLOptionElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmloptionelement", "HTMLOptionElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-option-element", "HTMLOptionElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>A constructor, <code>Option()</code>, has been added.<br>
-    The <code>form</code> property can be the <code>null</code> value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-70901257', 'HTMLOptionElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>selected</code> property changed its meaning: it now indicates if the option is currently selected and no longer if it was initially selected.<br>
-    The <code>defaultSelected</code> property is no longer read-only.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-70901257', 'HTMLOptionElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloptionelement/option/index.html
+++ b/files/en-us/web/api/htmloptionelement/option/index.html
@@ -101,16 +101,7 @@ options.forEach(function(element, key) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-option','Option()')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloptionscollection/index.html
+++ b/files/en-us/web/api/htmloptionscollection/index.html
@@ -44,22 +44,7 @@ browser-compat: api.HTMLOptionsCollection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#the-htmloptionscollection-interface', 'HTMLOptionsCollection')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlorforeignelement/index.html
+++ b/files/en-us/web/api/htmlorforeignelement/index.html
@@ -27,22 +27,7 @@ browser-compat: api.HTMLOrForeignElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "dom.html#htmlorsvgelement", '<code>HTMLOrForeignElement</code>')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloutputelement/index.html
+++ b/files/en-us/web/api/htmloutputelement/index.html
@@ -73,32 +73,7 @@ browser-compat: api.HTMLOutputElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmloutputelement", "HTMLOutputElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "forms.html#the-output-element", "HTMLOutputElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-output-element", "HTMLOutputElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmloutputelement/labels/index.html
+++ b/files/en-us/web/api/htmloutputelement/labels/index.html
@@ -47,27 +47,7 @@ browser-compat: api.HTMLOutputElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlparagraphelement/index.html
+++ b/files/en-us/web/api/htmlparagraphelement/index.html
@@ -31,35 +31,7 @@ browser-compat: api.HTMLParagraphElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlparagraphelement", "HTMLParagraphElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-p-element", "HTMLParagraphElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property is now obsolete: <code>align</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-84675076', 'HTMLParagraphElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-84675076', 'HTMLParagraphElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlparamelement/index.html
+++ b/files/en-us/web/api/htmlparamelement/index.html
@@ -37,35 +37,7 @@ browser-compat: api.HTMLParamElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlparamelement", "HTMLParamElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-param-element", "HTMLParamElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties are now obsolete: <code>type</code>, and <code>valueType</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-64077273', 'HTMLParamElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-64077273', 'HTMLParamElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlpictureelement/index.html
+++ b/files/en-us/web/api/htmlpictureelement/index.html
@@ -25,20 +25,7 @@ browser-compat: api.HTMLPictureElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlpictureelement", "HTMLPictureElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlpreelement/index.html
+++ b/files/en-us/web/api/htmlpreelement/index.html
@@ -31,35 +31,7 @@ browser-compat: api.HTMLPreElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlpreelement", "HTMLPreElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-pre-element", "HTMLLIElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property is now obsolete: <code>width</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-11383425', 'HTMLPreElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-11383425', 'HTMLPreElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlprogresselement/index.html
+++ b/files/en-us/web/api/htmlprogresselement/index.html
@@ -35,30 +35,7 @@ browser-compat: api.HTMLProgressElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlprogresselement", "HTMLProgressElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "forms.html#the-progress-element", "HTMLProgressElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-progress-element", "HTMLProgressElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlprogresselement/labels/index.html
+++ b/files/en-us/web/api/htmlprogresselement/labels/index.html
@@ -47,27 +47,7 @@ browser-compat: api.HTMLProgressElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlquoteelement/index.html
+++ b/files/en-us/web/api/htmlquoteelement/index.html
@@ -29,35 +29,7 @@ browser-compat: api.HTMLQuoteElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlquoteelement", "HTMLQuoteElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-blockquote-element", "HTMLQuoteElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-70319763', 'HTMLQuoteElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-70319763', 'HTMLQuoteElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlscriptelement/index.html
+++ b/files/en-us/web/api/htmlscriptelement/index.html
@@ -111,40 +111,7 @@ affixScriptToHead("myScript2.js", function () { alert("The script \"myScript2.js
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlscriptelement", "HTMLScriptElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "scripting-1.html#the-script-element", "HTMLScriptElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "scripting-1.html#the-script-element", "HTMLScriptElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties are now obsolete: <code>htmlFor,</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-81598695', 'HTMLScriptElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-81598695', 'HTMLScriptElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
@@ -79,27 +79,7 @@ document.body.appendChild(scriptElem);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute', 'referrerpolicy attribute')}}</td>
-      <td>{{Spec2('Referrer Policy')}}</td>
-      <td>Added the <code>referrerPolicy</code> attribute.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-script-referrerpolicy', 'HTMLScriptElement: referrerPolicy')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/add/index.html
+++ b/files/en-us/web/api/htmlselectelement/add/index.html
@@ -137,43 +137,7 @@ sel.add(opt, sel.options[1]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-select-add', 'HTMLSelectElement.add()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-add',
-        'HTMLSelectElement.add()')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Is a snapshot of {{SpecName("HTML WHATWG")}}.<br>
-        The value of <code>before</code> can now be a long and is optional. It throws a
-        {{domxref("DOMError")}} of the type <code>HierarchyRequestError</code> if the
-        passed <code>item</code> is an ancestor of the {{domxref("HTMLSelectElement")}}
-        and no longer throws if the <code>before</code> parameter is not found.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-14493106', 'HTMLSelectElement.add()')}}
-      </td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>The method now throws an NOT_FOUND_ERR exception if the item of the
-        <code>before</code> parameter is not a child of this element.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-14493106',
-        'HTMLSelectElement.add()')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/autofocus/index.html
+++ b/files/en-us/web/api/htmlselectelement/autofocus/index.html
@@ -50,27 +50,7 @@ var hasAutofocus = document.getElementById('mySelect').autofocus;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fe-autofocus', 'autofocus')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.2',
-        'sec-forms.html#autofocusing-a-form-control-the-autofocus-attribute',
-        'autofocus')}}</td>
-      <td>{{Spec2('HTML5.2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.html
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.html
@@ -24,27 +24,7 @@ browser-compat: api.HTMLSelectElement.checkValidity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-cva-checkvalidity',
-        'HTMLSelectElement.checkValidity()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-cva-checkvalidity',
-        'HTMLSelectElement.checkValidity()')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName('HTML WHATWG')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/disabled/index.html
+++ b/files/en-us/web/api/htmlselectelement/disabled/index.html
@@ -60,26 +60,7 @@ allowDrinksCheckbox.addEventListener("change", function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fe-disabled', 'disabled')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-disabled', 'HTMLSelectElement')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName("HTML WHATWG")}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/form/index.html
+++ b/files/en-us/web/api/htmlselectelement/form/index.html
@@ -52,26 +52,7 @@ else
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-fae-form', 'form')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-form', 'HTMLSelectElement')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName("HTML WHATWG")}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/index.html
+++ b/files/en-us/web/api/htmlselectelement/index.html
@@ -115,41 +115,7 @@ console.log(select.options[select.selectedIndex].value) // Second
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#htmlselectelement', 'HTMLSelectElement')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Since the latest snapshot, {{SpecName('HTML5 W3C')}}, it adds the <code>autocomplete</code> property and the <code>reportValidity()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#htmlselectelement', 'HTMLSelectElement')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Is a snapshot of {{SpecName("HTML WHATWG")}}.<br>
-    It adds the <code>autofocus</code>, <code>form</code>, <code>required</code>, <code>labels</code>, <code>selectedOptions</code>, <code>willValidate</code>, <code>validity</code> and <code>validationMessage</code> properties.<br>
-    The <code>tabindex</code> property and the <code>blur()</code> and <code>focus()</code> methods have been moved to {{domxref("HTMLElement")}}.<br>
-    The methods <code>item()</code>, <code>namedItem()</code>, <code>checkValidity()</code> and <code>setCustomValidity()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-94282980', 'HTMLSelectElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td><code>options</code> now returns an {{domxref("HTMLOptionsCollection")}}.<br>
-    <code>length</code> now returns an <code>unsigned long</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-94282980', 'HTMLSelectElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/item/index.html
+++ b/files/en-us/web/api/htmlselectelement/item/index.html
@@ -58,26 +58,7 @@ elem1 = document.forms[0]['myFormControl'][1];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-select-item", "HTMLSelectElement.item()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "forms.html#dom-select-item",
-        "HTMLSelectElement.item()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName('HTML WHATWG')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/labels/index.html
+++ b/files/en-us/web/api/htmlselectelement/labels/index.html
@@ -50,27 +50,7 @@ browser-compat: api.HTMLSelectElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/nameditem/index.html
+++ b/files/en-us/web/api/htmlselectelement/nameditem/index.html
@@ -57,27 +57,7 @@ var <em>item </em>=<em> collection</em>[<em>str</em>];
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-select-nameditem",
-        "HTMLSelectElement.namedItem()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "forms.html#dom-select-nameditem",
-        "HTMLSelectElement.namedItem()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName('HTML WHATWG')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/options/index.html
+++ b/files/en-us/web/api/htmlselectelement/options/index.html
@@ -50,27 +50,7 @@ browser-compat: api.HTMLSelectElement.options
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-select-options", "options")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#htmlselectelement", "options")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/remove/index.html
+++ b/files/en-us/web/api/htmlselectelement/remove/index.html
@@ -52,39 +52,7 @@ sel.remove(1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-select-remove', 'HTMLSelectElement.remove()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-remove',
-        'HTMLSelectElement.remove()')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Is a snapshot of {{SpecName("HTML WHATWG")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-33404570', 'HTMLSelectElement.remove()')}}
-      </td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-33404570',
-        'HTMLSelectElement.remove()')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.html
@@ -54,27 +54,7 @@ selectElem.addEventListener('change', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-select-selectedindex', 'HTMLSelectElement')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-selectedindex',
-        'HTMLSelectElement')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName("HTML WHATWG")}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
@@ -122,27 +122,7 @@ orderButton.addEventListener("click", function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "form-elements.html#dom-select-selectedoptions",
-        "HTMLSelectElement.selectedOptions")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "forms.html#dom-select-selectedoptions",
-        "HTMLSelectElement.selectedOptions")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.html
@@ -31,27 +31,7 @@ browser-compat: api.HTMLSelectElement.setCustomValidity
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-cva-setcustomvalidity',
-        'HTMLSelectElement.setCustomValidity()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change since the latest snapshot, {{SpecName('HTML5 W3C')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-cva-setcustomvalidity',
-        'HTMLSelectElement.setCustomValidity()')}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition, snapshot of {{SpecName('HTML WHATWG')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlselectelement/type/index.html
+++ b/files/en-us/web/api/htmlselectelement/type/index.html
@@ -43,38 +43,7 @@ browser-compat: api.HTMLSelectElement.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-select-type', 'HTMLSelectElement')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}, the latest snapshot.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', 'forms.html#dom-select-type', 'HTMLSelectElement')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Is a snapshot of {{SpecName("HTML WHATWG")}}. No change from {{SpecName("DOM2
-        HTML")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-58783172', 'HTMLSelectElement')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-58783172', 'HTMLSelectElement')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.html
@@ -51,23 +51,7 @@ let elements = slots.assignedElements({flatten: true});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-slot-assignedelements','assignedElements()')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.html
@@ -63,22 +63,7 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','scripting.html#dom-slot-assignednodes','assignedNodes')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlslotelement/index.html
+++ b/files/en-us/web/api/htmlslotelement/index.html
@@ -52,22 +52,7 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','scripting.html#htmlslotelement','HTMLSlotElement')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlslotelement/name/index.html
+++ b/files/en-us/web/api/htmlslotelement/name/index.html
@@ -48,20 +48,7 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-slot-name','name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlslotelement/slotchange_event/index.html
+++ b/files/en-us/web/api/htmlslotelement/slotchange_event/index.html
@@ -63,22 +63,7 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#mutation-observers", '"Mutation observers" and slotchange event')}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlsourceelement/index.html
+++ b/files/en-us/web/api/htmlsourceelement/index.html
@@ -39,20 +39,7 @@ browser-compat: api.HTMLSourceElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlsourceelement", "HTMLSourceElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlspanelement/index.html
+++ b/files/en-us/web/api/htmlspanelement/index.html
@@ -24,37 +24,7 @@ browser-compat: api.HTMLSpanElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "text-level-semantics.html#htmlspanelement", "HTMLSpanElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.2', "textlevel-semantics.html#htmlspanelement", "HTMLSpanElement")}}</td>
-   <td>{{Spec2('HTML5.2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "textlevel-semantics.html#htmlspanelement", "HTMLSpanElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "text-level-semantics.html#htmlspanelement", "HTMLSpanElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition, as {{HTMLElement("span")}} was associated with an {{DOMxRef("HTMLElement")}} before that.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlstyleelement/index.html
+++ b/files/en-us/web/api/htmlstyleelement/index.html
@@ -42,40 +42,7 @@ browser-compat: api.HTMLStyleElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlstyleelement", "HTMLStyleElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "document-metadata.html#the-style-element", "HTMLStyleElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-style-element", "HTMLStyleElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following property has been added: <code>scoped</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-16428977', 'HTMLStyleElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>Added a second inheritence, the <code>LinkStyle</code> interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-16428977', 'HTMLStyleElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlstyleelement/media/index.html
+++ b/files/en-us/web/api/htmlstyleelement/media/index.html
@@ -52,47 +52,7 @@ alert('InlineStyle: ' + document.getElementById('InlineStyle').media); // 'scree
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "semantics.html#attr-style-media",
-				"HTMLStyleElement")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5.1', "semantics.html#attr-style-media",
-				"HTMLStyleElement")}}</td>
-			<td>{{Spec2('HTML5.1')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5 W3C', "semantics.html#attr-style-media",
-				"HTMLStyleElement")}}</td>
-			<td>{{Spec2('HTML5 W3C')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 HTML', 'html.html#ID-16428977', 'HTMLStyleElement')}}
-			</td>
-			<td>{{Spec2('DOM2 HTML')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM1', 'level-one-html.html#ID-16428977',
-				'HTMLStyleElement')}}</td>
-			<td>{{Spec2('DOM1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablecaptionelement/index.html
+++ b/files/en-us/web/api/htmltablecaptionelement/index.html
@@ -31,35 +31,7 @@ browser-compat: api.HTMLTableCaptionElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "tabular-data.html#htmltablecaptionelement", "HTMLTableCaptionElement")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>No change from {{SpecName("HTML5 W3C")}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5 W3C', "tabular-data.html#the-caption-element", "HTMLTableCaptionElement")}}</td>
-			<td>{{Spec2('HTML5 W3C')}}</td>
-			<td>No change from {{SpecName("DOM2 HTML")}}, though <code>align</code> was formerly obsoleted.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 HTML', 'html.html#ID-12035137', 'HTMLTableCaptionElement')}}</td>
-			<td>{{Spec2('DOM2 HTML')}}</td>
-			<td>No change from {{SpecName("DOM1")}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM1', 'level-one-html.html#ID-12035137', 'HTMLTableCaptionElement')}}</td>
-			<td>{{Spec2('DOM1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablecellelement/index.html
+++ b/files/en-us/web/api/htmltablecellelement/index.html
@@ -85,39 +85,7 @@ browser-compat: api.HTMLTableCellElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "tabular-data.html#htmltablecellelement", "HTMLTableCellElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "tabular-data.html#htmltablecellelement", "HTMLTableCellElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The following properties have been obsoleted: <code>align</code>, <code>axis</code>, <code>bgColor</code>, <code>height</code>, <code>width</code>, <code>ch</code>, <code>chOff</code>, <code>noWrap</code>, and <code>vAlign</code>.<br>
-    The <code>headers</code> property is now read-only and contains a {{domxref("DOMSettableTokenList")}} rather than a mere {{domxref("DOMString")}}.<br>
-    The <code>colspan</code> and <code>rowspan</code> properties are now <code>unsigned long</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-82915075', 'HTMLTableCellElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>cellIndex</code> property is now read-only.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-82915075', 'HTMLTableCellElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablecolelement/index.html
+++ b/files/en-us/web/api/htmltablecolelement/index.html
@@ -45,35 +45,7 @@ browser-compat: api.HTMLTableColElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "tabular-data.html#htmltablecolelement", "HTMLTableColElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "tabular-data.html#htmltablecolelement", "HTMLTableColElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The <code>span</code> property is now an <code>unsigned long</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-84150186', 'HTMLTableColElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-84150186', 'HTMLTableColElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/caption/index.html
+++ b/files/en-us/web/api/htmltableelement/caption/index.html
@@ -27,39 +27,7 @@ browser-compat: api.HTMLTableElement.caption
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "tabular-data.html#dom-table-caption",
-        "HTMLTableElement.caption")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "tabular-data.html#dom-table-caption",
-        "HTMLTableElement.caption")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>No change from {{SpecName("DOM2 HTML")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-14594520', 'HTMLTableElement.caption')}}
-      </td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-14594520',
-        'HTMLTableElement.caption')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/createcaption/index.html
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.html
@@ -56,22 +56,7 @@ caption.textContent = 'This caption was created by JavaScript!';</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-table-createcaption', 'HTMLTableElement: createCaption')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/createtbody/index.html
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.html
@@ -40,22 +40,7 @@ browser-compat: api.HTMLTableElement.createTBody
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createtbody', 'HTMLTableElement: createTBody')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.html
@@ -39,22 +39,7 @@ browser-compat: api.HTMLTableElement.createTFoot
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createtfoot', 'HTMLTableElement: createTFoot')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/createthead/index.html
+++ b/files/en-us/web/api/htmltableelement/createthead/index.html
@@ -39,22 +39,7 @@ browser-compat: api.HTMLTableElement.createTHead
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createthead', 'HTMLTableElement: createTHead')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.html
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.html
@@ -44,22 +44,7 @@ table.deleteCaption();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletecaption', 'HTMLTableElement: deleteCaption')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/deleterow/index.html
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.html
@@ -65,22 +65,7 @@ table.deleteRow(1);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deleterow', 'HTMLTableElement: deleteRow')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.html
@@ -43,22 +43,7 @@ table.deleteTFoot();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletetfoot', 'HTMLTableElement: deleteTFoot')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/deletethead/index.html
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.html
@@ -42,22 +42,7 @@ table.deleteTHead();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletethead', 'HTMLTableElement: deleteTHead')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/index.html
+++ b/files/en-us/web/api/htmltableelement/index.html
@@ -85,37 +85,7 @@ browser-compat: api.HTMLTableElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltableelement", "HTMLTableElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Added the <code>sortable</code> property and the <code>stopSorting()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "tabular-data.html#the-table-element", "HTMLTableElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Added the <code>createTBody()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-64060425', 'HTMLTableElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>Defined when <code>caption</code>, <code>tHead</code>, <code>tFoot</code>, <code>insertRow()</code>, and <code>deleteRow()</code> raise exceptions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-64060425', 'HTMLTableElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.html
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.html
@@ -97,33 +97,7 @@ addRow('my-table');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "tables.html#dom-table-insertrow",
-        "HTMLTableElement.insertRow()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-93995626",
-        "HTMLTableElement.insertRow()")}}</td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td>Specifies in more detail where the row is inserted.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM1", "level-one-html.html#ID-39872903",
-        "HTMLTableElement.insertRow()")}}</td>
-      <td>{{Spec2("DOM1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/rows/index.html
+++ b/files/en-us/web/api/htmltableelement/rows/index.html
@@ -53,22 +53,7 @@ lastRow = mytable.rows.item(mytable.rows.length-1);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-rows', 'HTMLTableElement: rows')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/tbodies/index.html
+++ b/files/en-us/web/api/htmltableelement/tbodies/index.html
@@ -44,23 +44,7 @@ browser-compat: api.HTMLTableElement.tBodies
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-tbodies', 'HTMLTableElement: tBodies')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/tfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.html
@@ -29,39 +29,7 @@ browser-compat: api.HTMLTableElement.tFoot
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "tabular-data.html#dom-table-tfoot",
-        "HTMLTableElement.tFoot")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "tabular-data.html#dom-table-tfoot",
-        "HTMLTableElement.tFoot")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>No change from {{SpecName("DOM2 HTML")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-64197097', 'HTMLTableElement.tFoot')}}
-      </td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-64197097',
-        'HTMLTableElement.tFoot')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltableelement/thead/index.html
+++ b/files/en-us/web/api/htmltableelement/thead/index.html
@@ -36,38 +36,7 @@ browser-compat: api.HTMLTableElement.tHead
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "tabular-data.html#dom-table-thead",
-        "HTMLTableElement.tHead")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "tabular-data.html#dom-table-thead",
-        "HTMLTableElement.tHead")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>No change from {{SpecName("DOM2 HTML")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 HTML', 'html.html#ID-9530944', 'HTMLTableElement.tHead')}}</td>
-      <td>{{Spec2('DOM2 HTML')}}</td>
-      <td>No change from {{SpecName("DOM1")}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-html.html#ID-9530944', 'HTMLTableElement.tHead')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablerowelement/index.html
+++ b/files/en-us/web/api/htmltablerowelement/index.html
@@ -59,36 +59,7 @@ browser-compat: api.HTMLTableRowElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltablerowelement", "HTMLTableRowElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "tabular-data.html#the-tr-element", "HTMLTableRowElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The parameter of <code>insertCell</code> is now optional and default to <code>-1</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-6986576', 'HTMLTableRowElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The <code>cells</code>, <code>rowIndex</code>, and <code>selectionRowIndex</code> properties are now read-only.<br>
-    The methods <code>insertCell</code> and <code>deleteCell</code> can raise exceptions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-6986576', 'HTMLTableRowElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.html
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.html
@@ -94,29 +94,7 @@ addRow('my-table');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "tables.html#dom-tr-insertcell",
-        "HTMLTableRowElement.insertCell()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 HTML", "html.html#ID-68927016",
-        "HTMLTableRowElement.insertCell()")}}</td>
-      <td>{{Spec2("DOM2 HTML")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltablesectionelement/index.html
+++ b/files/en-us/web/api/htmltablesectionelement/index.html
@@ -44,35 +44,7 @@ browser-compat: api.HTMLTableSectionElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "tabular-data.html#htmltablesectionelement", "HTMLTableSectionElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "tabular-data.html#htmltablesectionelement", "HTMLTableSectionElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The parameter of <code>insertCell</code> is now optional.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-67417573', 'HTMLTableSectionElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The methods <code>insertRow</code> and <code>deleteRow</code> can raise exceptions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-67417573', 'HTMLTableSectionElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltemplateelement/content/index.html
+++ b/files/en-us/web/api/htmltemplateelement/content/index.html
@@ -28,27 +28,7 @@ var documentFragment = templateElement.content.cloneNode(true);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','scripting.html#dom-template-content','HTMLTemplateElement interface')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C','scripting-1.html#dom-template-content','HTMLTemplateElement interface')}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltemplateelement/index.html
+++ b/files/en-us/web/api/htmltemplateelement/index.html
@@ -31,25 +31,7 @@ browser-compat: api.HTMLTemplateElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','scripting.html#htmltemplateelement','HTMLTemplateElement interface')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C','scripting-1.html#htmltemplateelement','HTMLTemplateElement interface')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltextareaelement/index.html
+++ b/files/en-us/web/api/htmltextareaelement/index.html
@@ -300,39 +300,7 @@ browser-compat: api.HTMLTextAreaElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltextareaelement", "HTMLTextAreaElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "forms.html#the-textarea-element", "HTMLTextAreaElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The attributes <code>tabindex</code> and <code>accesskey</code>, as well as the methods <code>blur()</code> and <code>focus()</code> are now defined on {{domxref("HTMLElement")}}.<br>
-    The following attributes have been added: <code>autofocus</code>, <code>placeholder</code>, <code>dirName</code>, <code>wrap</code>, <code>maxLength</code>, <code>required</code>, <code>textLength</code>, <code>labels</code>, <code>selectionStart</code>, <code>selectionEnd</code>, <code>selectionDirection</code>, <code>validity</code>, <code>validationMessage</code>, and <code>willValidate</code>.<br>
-    The following methods have been added: <code>checkValidity()</code>, <code>setCustomValidity()</code>, and <code>setSelectionRange()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-ID-24874179', 'HTMLTextAreaElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>The property <code>defaultValue</code> doesn't contain the initial value of the <code>value</code> attribute, but the initial value of the content of the {{HTMLElement("textarea")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-24874179', 'HTMLTextAreaElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltextareaelement/labels/index.html
+++ b/files/en-us/web/api/htmltextareaelement/labels/index.html
@@ -47,27 +47,7 @@ browser-compat: api.HTMLTextAreaElement.labels
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML5 W3C", "forms.html#dom-lfe-labels", "labels")}}</td>
-      <td>{{Spec2("HTML5 W3C")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltimeelement/datetime/index.html
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.html
@@ -148,33 +148,7 @@ t.dateTime = "6w 5h 34m 5s";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "text-level-semantics.html#dom-time-datetime",
-        "HTMLTimeElement")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5.1")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5.1', "text-level-semantics.html#dom-time-datetime",
-        "HTMLTimeElement")}}</td>
-      <td>{{Spec2('HTML5.1')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "text-level-semantics.html#dom-time-datetime",
-        "HTMLTimeElement")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltimeelement/index.html
+++ b/files/en-us/web/api/htmltimeelement/index.html
@@ -29,30 +29,7 @@ browser-compat: api.HTMLTimeElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltimeelement", "HTMLTimeElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "text-level-semantics.html#the-time-element", "HTMLTimeElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "text-level-semantics.html#the-time-element", "HTMLTimeElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltitleelement/index.html
+++ b/files/en-us/web/api/htmltitleelement/index.html
@@ -29,40 +29,7 @@ browser-compat: api.HTMLTitleElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltitleelement", "HTMLTitleElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "document-metadata.html#the-title-element", "HTMLTitleElement")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from {{SpecName("HTML5 W3C")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "document-metadata.html#the-title-element", "HTMLTitleElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>No change from {{SpecName("DOM2 HTML")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-79243169', 'HTMLTitleElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-79243169', 'HTMLTitleElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltrackelement/index.html
+++ b/files/en-us/web/api/htmltrackelement/index.html
@@ -89,25 +89,7 @@ browser-compat: api.HTMLTrackElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmltrackelement", "HTMLTrackElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#the-track-element", "HTMLTrackElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmltrackelement/src/index.html
+++ b/files/en-us/web/api/htmltrackelement/src/index.html
@@ -34,27 +34,7 @@ browser-compat: api.HTMLTrackElement.src
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "embedded-content.html#dom-track-src",
-        "HTMLTrackElement.src")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName('HTML5 W3C')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-track-src",
-        "HTMLTrackElement.src")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlulistelement/index.html
+++ b/files/en-us/web/api/htmlulistelement/index.html
@@ -33,35 +33,7 @@ browser-compat: api.HTMLUListElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlulistelement", "HTMLUListElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "grouping-content.html#the-ul-element", "HTMLUListElement")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>The <code>compact</code> and <code>type</code> properties have been obsoleted.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML', 'html.html#ID-86834457', 'HTMLUListElement')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td>No change from {{SpecName("DOM1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-html.html#ID-86834457', 'HTMLUListElement')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlunknownelement/index.html
+++ b/files/en-us/web/api/htmlunknownelement/index.html
@@ -24,25 +24,7 @@ browser-compat: api.HTMLUnknownElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("HTML WHATWG", "elements.html#htmlunknownelement", "HTMLUnknownElement")}}</td>
-			<td>{{Spec2("HTML WHATWG")}}</td>
-			<td>No change from {{SpecName("HTML5 W3C")}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("HTML5 W3C", "dom.html#htmlunknownelement", "HTMLUnknownElement")}}</td>
-			<td>{{Spec2("HTML5 W3C")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.html
@@ -34,21 +34,7 @@ browser-compat: api.HTMLVideoElement.autoPictureInPicture
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture', "#auto-pip",
-        "HTMLVideoElement.autoPictureInPicture")}}</td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.html
@@ -34,21 +34,7 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture', "#disable-pip",
-        "HTMLVideoElement.autoPictureInPicture")}}</td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.html
+++ b/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.html
@@ -81,18 +81,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', "#eventdef-htmlvideoelement-enterpictureinpicture", "enterpictureinpicture event")}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.html
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.html
@@ -53,22 +53,7 @@ counterElem.innerText = quality.totalVideoFrames;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Playback Quality',
-        '#dom-htmlvideoelement-getvideoplaybackquality',
-        'HTMLVideoElement.getVideoPlaybackQuality()')}}</td>
-      <td>{{Spec2('Media Playback Quality')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/index.html
+++ b/files/en-us/web/api/htmlvideoelement/index.html
@@ -97,20 +97,7 @@ browser-compat: api.HTMLVideoElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#htmlvideoelement", "HTMLVideoElement")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.html
+++ b/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.html
@@ -85,18 +85,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', "#eventdef-htmlvideoelement-leavepictureinpicture", "leavepictureinpicture event")}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
@@ -60,22 +60,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Picture-in-Picture','#dom-htmlvideoelement-onenterpictureinpicture','HTMLVideoElement.onenterpictureinpicture')}}
-      </td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
@@ -62,22 +62,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Picture-in-Picture','#dom-htmlvideoelement-onleavepictureinpicture','HTMLVideoElement.onleavepictureinpicture')}}
-      </td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.html
@@ -50,21 +50,7 @@ browser-compat: api.HTMLVideoElement.requestPictureInPicture
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture', '#request-pip',
-        'HTMLVideoElement.requestPictureInPicture()')}}</td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/videoheight/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videoheight/index.html
@@ -91,28 +91,7 @@ v.addEventListener("resize", ev =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-video-videoheight",
-        "HTMLVideoElement.videoHeight")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C',
-        "semantics-embedded-content.html#dom-htmlvideoelement-videoheight",
-        "HTMLVideoElement.videoHeight")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.html
@@ -40,28 +40,7 @@ browser-compat: api.HTMLVideoElement.videoWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-video-videowidth",
-        "HTMLVideoElement.videoWidth")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C',
-        "semantics-embedded-content.html#dom-htmlvideoelement-videowidth",
-        "HTMLVideoElement.videoWidth")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/h* to the {{Specifications}} macros. 

Note that:
- `HTMLMediaElement.controlsList` displays "Unknown specification" in the table (but link is ok). I have opened mdn/yari#4015 about this issue.
- `HTMLMediaElement.mediaGroup` and `HTMLMediaElement.mediaGroup` have no more table, but it was semi-bogus, pointing to HTML 5.2 for a feature no more considered on the standard track. I'll leave it that way.
- `HTMLMenuItemElement`, completely outdated (but still in Firefox) also lost its table. I'll leave it that way
- `HTMLOrForeignElement` has the weird "If you're able to see this, something went wrong on this page.", but is a mixin, so I'll leave it there (I guess the page will get deleted very soon)

All other pages look fine.