### PR TITLE
Drop ad-hoc compat note with outdated/broken link

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
@@ -34,11 +34,6 @@ browser-compat: http.headers.csp.Content-Security-Policy.worker-src
           {{CSP("child-src")}} directive, then the {{CSP("script-src")}} directive, then
           finally for the {{CSP("default-src")}} directive, when governing worker
           execution.</p>
-
-        <p>Chrome 59 and higher skips the {{CSP("child-src")}} directive.</p>
-
-        <p>Edge 17 skips the {{CSP("script-src")}} directive (<a
-            href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17415478/">bug</a>).
         </p>
       </td>
     </tr>


### PR DESCRIPTION
This change removes a redundant mention about CSP `child`-src support in Chrome that’s already in BCD and so doesn’t need repeating. The change also removes a mention about lack of `script`-src support in Edge 17 which referenced an issue-tracker URL that no longer works, because it’s from an issue tracker that Microsoft no longer maintains.

Fixes https://github.com/mdn/content/issues/5941