### PR TITLE
Increase height of iframe examples in <input type="file"> doc

### DIFF
--- a/files/en-us/web/html/element/input/file/index.html
+++ b/files/en-us/web/html/element/input/file/index.html
@@ -195,7 +195,7 @@ browser-compat: html.elements.input.input-file
 
 <p>This produces the following output:</p>
 
-<p>{{EmbedLiveSample('A_basic_example', 650, 60)}}</p>
+<p>{{EmbedLiveSample('A_basic_example', 650, 90)}}</p>
 
 <div class="note">
 <p><strong>Note</strong>: You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/simple-file.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/simple-file.html">see it running live</a>.</p>
@@ -264,7 +264,7 @@ browser-compat: html.elements.input.input-file
 
 <p>This produces a similar-looking output to the previous example:</p>
 
-<p>{{EmbedLiveSample('Limiting_accepted_file_types', 650, 60)}}</p>
+<p>{{EmbedLiveSample('Limiting_accepted_file_types', 650, 90)}}</p>
 
 <div class="note">
 <p><strong>Note</strong>: You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/file-with-accept.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/file-with-accept.html">see it running live</a>.</p>


### PR DESCRIPTION
Example iframes not fully visible.

Changed iframe height from 60px to 90px. Whole iframe is visible now.


[https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file)

![image](https://user-images.githubusercontent.com/6934044/121804933-2fb4f780-cc49-11eb-83bf-44f19c2d60e6.png)
![image](https://user-images.githubusercontent.com/6934044/121804938-3c395000-cc49-11eb-8fc9-d444629507b2.png)
