### PR TITLE
Fix description of status code 405

### DIFF
--- a/files/en-us/web/http/status/index.html
+++ b/files/en-us/web/http/status/index.html
@@ -109,7 +109,7 @@ tags:
  <dt>{{HTTPStatus(404, "404 Not Found")}}</dt>
  <dd>The server can not find the requested resource. In the browser, this means the URL is not recognized. In an API, this can also mean that the endpoint is valid but the resource itself does not exist. Servers may also send this response instead of 403 to hide the existence of a resource from an unauthorized client. This response code is probably the most famous one due to its frequent occurrence on the web.</dd>
  <dt>{{HTTPStatus(405, "405 Method Not Allowed")}}</dt>
- <dd>The request method is known by the server but has been disabled and cannot be used. For example, an API may forbid DELETE-ing a resource. The two mandatory methods, <code>GET</code> and <code>HEAD</code>, must never be disabled and should not return this error code.</dd>
+ <dd>The request method is known by the server but not supported by the target resource. For example, an API may forbid DELETE-ing a resource.</dd>
  <dt>{{HTTPStatus(406, "406 Not Acceptable")}}</dt>
  <dd>This response is sent when the web server, after performing <a href="/en-US/docs/Web/HTTP/Content_negotiation#server-driven_negotiation">server-driven content negotiation</a>, doesn't find any content that conforms to the criteria given by the user agent.</dd>
  <dt>{{HTTPStatus(407, "407 Proxy Authentication Required")}}</dt>

--- a/files/en-us/web/http/status/index.html
+++ b/files/en-us/web/http/status/index.html
@@ -109,7 +109,7 @@ tags:
  <dt>{{HTTPStatus(404, "404 Not Found")}}</dt>
  <dd>The server can not find the requested resource. In the browser, this means the URL is not recognized. In an API, this can also mean that the endpoint is valid but the resource itself does not exist. Servers may also send this response instead of 403 to hide the existence of a resource from an unauthorized client. This response code is probably the most famous one due to its frequent occurrence on the web.</dd>
  <dt>{{HTTPStatus(405, "405 Method Not Allowed")}}</dt>
- <dd>The request method is known by the server but not supported by the target resource. For example, an API may forbid DELETE-ing a resource.</dd>
+ <dd>The request method is known by the server but is not supported by the target resource. For example, an API may forbid DELETE-ing a resource.</dd>
  <dt>{{HTTPStatus(406, "406 Not Acceptable")}}</dt>
  <dd>This response is sent when the web server, after performing <a href="/en-US/docs/Web/HTTP/Content_negotiation#server-driven_negotiation">server-driven content negotiation</a>, doesn't find any content that conforms to the criteria given by the user agent.</dd>
  <dt>{{HTTPStatus(407, "407 Proxy Authentication Required")}}</dt>


### PR DESCRIPTION
It is totally allowed to return status 405 when the method is GET: the standards do not require that all *resources* support any particular methods.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The page said "The two mandatory methods, <code>GET</code> and <code>HEAD</code>, must never be disabled and should not return this error code."

This is not true. No methods are mandatory for all resources.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status