### PR TITLE
Replace spec table with {{specifications}} for api/[kl]*

### DIFF
--- a/files/en-us/web/api/keyboard/getlayoutmap/index.html
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.html
@@ -49,20 +49,7 @@ keyboard.getLayoutMap()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#h-keyboard-getlayoutmap','getLayoutMap()')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboard/index.html
+++ b/files/en-us/web/api/keyboard/index.html
@@ -50,25 +50,7 @@ browser-compat: api.Keyboard
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Keyboard Map','#keyboard-interface','Keyboard')}}</td>
-   <td>{{Spec2('Keyboard Map')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Keyboard Lock','#keyboard-interface','Keyboard')}}</td>
-   <td>{{Spec2('Keyboard Lock')}}</td>
-   <td>Adds <code>lock()</code> and <code>unlock()</code>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboard/lock/index.html
+++ b/files/en-us/web/api/keyboard/lock/index.html
@@ -59,20 +59,7 @@ browser-compat: api.Keyboard.lock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{experimental_inline}} {{SpecName('Keyboard Lock','#h-keyboard-lock','lock()')}}</td>
-      <td>{{Spec2('Keyboard Lock')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboard/unlock/index.html
+++ b/files/en-us/web/api/keyboard/unlock/index.html
@@ -31,25 +31,7 @@ browser-compat: api.Keyboard.unlock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboard-interface','Keyboard')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Defines the <code>Keyboard</code> interface.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Lock','#h-keyboard-unlock','unlock()')}}</td>
-      <td>{{Spec2('Keyboard Lock')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/altkey/index.html
+++ b/files/en-us/web/api/keyboardevent/altkey/index.html
@@ -56,21 +56,7 @@ You can also use the SHIFT key together with the ALT key.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-altKey','KeyboardEvent.altkey')}}
-      </td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.html
+++ b/files/en-us/web/api/keyboardevent/charcode/index.html
@@ -83,22 +83,7 @@ input.addEventListener('keypress', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-charCode','KeyboardEvent.charCode')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition; specified as deprecated</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/code/index.html
+++ b/files/en-us/web/api/keyboardevent/code/index.html
@@ -191,22 +191,7 @@ let spaceship = document.getElementById("spaceship");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#dom-keyboardevent-code', 'KeyboardEvent.code')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td>Initial definition, included <a href="https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3Events-code.html">code values</a>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/ctrlkey/index.html
+++ b/files/en-us/web/api/keyboardevent/ctrlkey/index.html
@@ -52,20 +52,7 @@ You can also use the SHIFT key together with the CTRL key.&lt;/p&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-ctrlKey','KeyboardEvent.ctrlKey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
@@ -277,23 +277,7 @@ if ((event.getModifierState("ScrollLock") ||
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-KeyboardEvent-getModifierState',
-        'getModifierState()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition (<a
-          href="https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3Events-key.html#keys-modifier">Modifier
-          Keys spec</a>)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/index.html
@@ -293,22 +293,7 @@ document.addEventListener('keyup', (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#interface-keyboardevent', 'KeyboardEvent')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <p>The <code>KeyboardEvent</code> interface specification went through numerous draft versions, first under DOM Events Level 2 where it was dropped as no consensus arose, then under DOM Events Level 3. This led to the implementation of non-standard initialization methods, the early DOM Events Level 2 version, {{domxref("KeyboardEvent.initKeyEvent()")}} by Gecko browsers and the early DOM Events Level 3 version, {{domxref("KeyboardEvent.initKeyboardEvent()")}} by others. Both have been superseded by the modern usage of a constructor: {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}}.</p>
 

--- a/files/en-us/web/api/keyboardevent/iscomposing/index.html
+++ b/files/en-us/web/api/keyboardevent/iscomposing/index.html
@@ -30,28 +30,7 @@ console.log(kbdEvent.isComposing); // return false
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('UI Events', '#dom-keyboardevent-iscomposing', 'KeyboardEvent.prototype.isComposing')}}</td>
-      <td>{{Spec2('UI Events')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-isComposing','KeyboardEvent.prototype.isComposing')}}
-      </td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/key/index.html
+++ b/files/en-us/web/api/keyboardevent/key/index.html
@@ -205,27 +205,7 @@ btnReset.addEventListener('click', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#dom-keyboardevent-key', 'KeyboardEvent.key')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events', '#widl-KeyboardEvent-key', 'KeyboardEvent.key')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>Initial definition, included key values.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.html
@@ -76,28 +76,7 @@ browser-compat: api.KeyboardEvent.KeyboardEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('UI Events','#dom-keyboardevent-keyboardevent','KeyboardEvent()')}}</td>
-			<td>{{Spec2('UI Events')}}</td>
-			<td>Current definition.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Events','#interface-KeyboardEvent','KeyboardEvent()')}}
-			</td>
-			<td>{{Spec2('DOM3 Events')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -46,22 +46,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-keyCode','KeyboardEvent.keyCode')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>Initial definition; specified as deprecated</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/location/index.html
+++ b/files/en-us/web/api/keyboardevent/location/index.html
@@ -111,21 +111,7 @@ browser-compat: api.KeyboardEvent.location
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-KeyboardEvent-location',
-        'KeyboardEvent.location')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/metakey/index.html
+++ b/files/en-us/web/api/keyboardevent/metakey/index.html
@@ -51,20 +51,7 @@ browser-compat: api.KeyboardEvent.metaKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-metaKey','KeyboardEvent.metaKey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/repeat/index.html
+++ b/files/en-us/web/api/keyboardevent/repeat/index.html
@@ -28,21 +28,7 @@ browser-compat: api.KeyboardEvent.repeat
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-KeyboardEvent-repeat',
-        'KeyboardEvent.repeat')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/shiftkey/index.html
+++ b/files/en-us/web/api/keyboardevent/shiftkey/index.html
@@ -55,20 +55,7 @@ You can also use the SHIFT key together with the ALT key.&lt;/p&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-shiftKey','KeyboardEvent.shiftKey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/which/index.html
+++ b/files/en-us/web/api/keyboardevent/which/index.html
@@ -73,22 +73,7 @@ alert("onkeydown handler: \n"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#legacy-interface-KeyboardEvent','KeyboardEvent.which')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition; specified as deprecated</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/entries/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/entries/index.html
@@ -32,20 +32,7 @@ browser-compat: api.KeyboardLayoutMap.entries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','entries')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/foreach/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/foreach/index.html
@@ -52,21 +52,7 @@ browser-compat: api.KeyboardLayoutMap.forEach
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','forEach()')}}
-			</td>
-			<td>{{Spec2('Keyboard Map')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/get/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/get/index.html
@@ -52,20 +52,7 @@ keyboard.getLayoutMap()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','get()')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/index.html
@@ -53,20 +53,7 @@ keyboard.getLayoutMap()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','KeyboardLayoutMap')}}</td>
-			<td>{{Spec2('Keyboard Map')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/keys/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/keys/index.html
@@ -31,20 +31,7 @@ browser-compat: api.KeyboardLayoutMap.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','keys')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/size/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/size/index.html
@@ -30,20 +30,7 @@ browser-compat: api.KeyboardLayoutMap.size
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','size')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/values/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/values/index.html
@@ -31,20 +31,7 @@ browser-compat: api.KeyboardLayoutMap.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','values')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/composite/index.html
+++ b/files/en-us/web/api/keyframeeffect/composite/index.html
@@ -40,20 +40,7 @@ keyframeEffect.composite = 'accumulate';</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-keyframeeffect-composite', 'KeyframeEffect.composite' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/getkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/getkeyframes/index.html
@@ -64,20 +64,7 @@ redQueen_alice.effect.getKeyframes();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-keyframeeffect-getkeyframes', 'KeyframeEffect.getKeyframes()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/index.html
@@ -70,20 +70,7 @@ browser-compat: api.KeyframeEffect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#the-keyframeeffect-interface', 'KeyframeEffect' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/iterationcomposite/index.html
+++ b/files/en-us/web/api/keyframeeffect/iterationcomposite/index.html
@@ -37,20 +37,7 @@ keyframeEffect.<em>iterationComposite</em> = 'replace';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations 2', '#dom-keyframeeffect-iterationcomposite', 'iterationComposite')}}</td>
-   <td>{{Spec2('Web Animations 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
@@ -68,25 +68,7 @@ var keyframes = new KeyframeEffect(<em>sourceKeyFrames</em>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations 2', '#dom-keyframeeffect-iterationcomposite', 'KeyframeEffectOptions.iterationComposite' )}}</td>
-   <td>{{Spec2('Web Animations 2')}}</td>
-   <td>Added the <code>iterationComposite</code> option.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-keyframeeffect-keyframeeffect', 'keyframeEffect()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
@@ -82,20 +82,7 @@ existingKeyframeEffect.setKeyframes(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-keyframeeffect-setkeyframes', 'KeyframeEffect.setKeyframes()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffect/target/index.html
+++ b/files/en-us/web/api/keyframeeffect/target/index.html
@@ -54,20 +54,7 @@ rabbitDownKeyframes.target;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-keyframeeffect-target', 'keyframeEffect' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyframeeffectoptions/index.html
+++ b/files/en-us/web/api/keyframeeffectoptions/index.html
@@ -40,27 +40,7 @@ browser-compat: api.KeyframeEffectOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Web Animations 2', '#the-keyframeeffectoptions-dictionary', 'KeyframeEffectOptions' )}}</td>
-   <td>{{Spec2('Web Animations 2')}}</td>
-   <td>Added the <code>iterationComposite</code> option.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#the-keyframeeffectoptions-dictionary', 'KeyframeEffectOptions' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/khr_parallel_shader_compile/index.html
+++ b/files/en-us/web/api/khr_parallel_shader_compile/index.html
@@ -61,20 +61,7 @@ function* linkingProgress(programs) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('KHR_parallel_shader_compile', "", "KHR_parallel_shader_compile")}}</td>
-   <td>{{Spec2('KHR_parallel_shader_compile')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/index.html
@@ -78,20 +78,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Largest Contentful Paint','#sec-largest-contentful-paint-interface','LargestContentfulPaint')}}</td>
-   <td>{{Spec2('Largest Contentful Paint')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/layoutshift/index.html
+++ b/files/en-us/web/api/layoutshift/index.html
@@ -71,20 +71,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Layout Instability','#layoutshift','LayoutShift')}}</td>
-   <td>{{Spec2('Layout Instability')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/index.html
@@ -27,20 +27,7 @@ browser-compat: api.LayoutShiftAttribution
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Layout Instability','#layoutshiftattribution','LayoutShiftAttribution')}}</td>
-   <td>{{Spec2('Layout Instability')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/index.html
@@ -48,25 +48,7 @@ laSensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Generic Sensor')}}</td>
-			<td>{{Spec2('Generic Sensor')}}</td>
-			<td>Defines sensors in general.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('Accelerometer','#linearaccelerationsensor-interface','LinearAccelerationSensor')}}</td>
-			<td>{{Spec2('Accelerometer')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
@@ -48,27 +48,7 @@ browser-compat: api.LinearAccelerationSensor.LinearAccelerationSensor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Accelerometer','#dom-linearaccelerationsensor-linearaccelerationsensor','LinearAccelerationSensor')}}
-      </td>
-      <td>{{Spec2('Accelerometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
@@ -72,22 +72,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="http://dev.w3.org/2009/dap/file-system/pub/FileSystem/">File API: Directories and System Specification</a></td>
-   <td>Working Draft</td>
-   <td>Initial specification, abandoned.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/ancestororigins/index.html
+++ b/files/en-us/web/api/location/ancestororigins/index.html
@@ -28,21 +28,7 @@ browser-compat: api.Location.ancestorOrigins
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-ancestororigins', 'ancestorOrigins ')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/assign/index.html
+++ b/files/en-us/web/api/location/assign/index.html
@@ -45,27 +45,7 @@ window.location.assign('https://developer.mozilla.org/en-US/docs/Web/API/Locatio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#dom-location-assign",
-        "Location.assign()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "browsers.html#dom-location-assign",
-        "Location.assign()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/hash/index.html
+++ b/files/en-us/web/api/location/hash/index.html
@@ -35,20 +35,7 @@ browser-compat: api.Location.hash
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-hash', 'hash')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/host/index.html
+++ b/files/en-us/web/api/location/host/index.html
@@ -38,20 +38,7 @@ anchor.host == "developer.mozilla.org:4097"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-host', 'host')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/hostname/index.html
+++ b/files/en-us/web/api/location/hostname/index.html
@@ -27,20 +27,7 @@ var result = anchor.hostname; // Returns:'developer.mozilla.org'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-hostname', 'hostname')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/href/index.html
+++ b/files/en-us/web/api/location/href/index.html
@@ -32,20 +32,7 @@ var result = anchor.href; // Returns: 'https://developer.mozilla.org/en-US/Locat
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-href', 'href')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/index.html
+++ b/files/en-us/web/api/location/index.html
@@ -112,22 +112,7 @@ console.log(url.origin);    // https://developer.mozilla.org:8080
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "browsers.html#the-location-interface", "Location")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/origin/index.html
+++ b/files/en-us/web/api/location/origin/index.html
@@ -40,20 +40,7 @@ var result = window.location.origin; // Returns:'https://developer.mozilla.org'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-origin', 'origin')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -29,20 +29,7 @@ var result = anchor.pathname; // Returns:'/en-US/docs/Location.pathname'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-pathname', 'pathname')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/port/index.html
+++ b/files/en-us/web/api/location/port/index.html
@@ -29,20 +29,7 @@ var result = anchor.port; // Returns:'443'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-port', 'Location.port')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/protocol/index.html
+++ b/files/en-us/web/api/location/protocol/index.html
@@ -29,20 +29,7 @@ var result = anchor.protocol; // Returns:'https:'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-protocol', 'protocol')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/reload/index.html
+++ b/files/en-us/web/api/location/reload/index.html
@@ -28,29 +28,7 @@ browser-compat: api.Location.reload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#dom-location-reload",
-        "Location.reload()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "browsers.html#dom-location-reload",
-        "Location.reload()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/replace/index.html
+++ b/files/en-us/web/api/location/replace/index.html
@@ -47,27 +47,7 @@ window.location.replace('https://developer.mozilla.org/en-US/docs/Web/API/Locati
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "history.html#dom-location-replace",
-        "Location.replace()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>No change from {{SpecName("HTML5 W3C")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "browsers.html#dom-location-replace",
-        "Location.replace()")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/search/index.html
+++ b/files/en-us/web/api/location/search/index.html
@@ -39,20 +39,7 @@ let q = parseInt(params.get("q")); // is the number 123
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-location-search', 'search')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/location/tostring/index.html
+++ b/files/en-us/web/api/location/tostring/index.html
@@ -28,20 +28,7 @@ var result = anchor.toString(); // Returns: 'https://developer.mozilla.org/en-US
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-location-href")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lock/index.html
+++ b/files/en-us/web/api/lock/index.html
@@ -37,20 +37,7 @@ function show_lock_properties(lock) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Locks','#api-lock','Lock')}}</td>
-   <td>{{Spec2('Web Locks')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lock/mode/index.html
+++ b/files/en-us/web/api/lock/mode/index.html
@@ -50,20 +50,7 @@ function show_lock_properties(lock) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Locks','#dom-lock-mode','mode')}}</td>
-      <td>{{Spec2('Web Locks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lock/name/index.html
+++ b/files/en-us/web/api/lock/name/index.html
@@ -49,20 +49,7 @@ function show_lock_properties(lock) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Locks','#dom-lock-name','name')}}</td>
-      <td>{{Spec2('Web Locks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lockmanager/index.html
+++ b/files/en-us/web/api/lockmanager/index.html
@@ -26,20 +26,7 @@ browser-compat: api.LockManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Locks','#api-lock-manager','LockManager')}}</td>
-   <td>{{Spec2('Web Locks')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lockmanager/query/index.html
+++ b/files/en-us/web/api/lockmanager/query/index.html
@@ -50,20 +50,7 @@ for (const request of state.pending) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Locks','#dom-lockmanager-query','query()')}}</td>
-      <td>{{Spec2('Web Locks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/lockmanager/request/index.html
+++ b/files/en-us/web/api/lockmanager/request/index.html
@@ -157,20 +157,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Locks','#dom-lockmanager-request','request()')}}</td>
-      <td>{{Spec2('Web Locks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the api/[kl]* to the {{Specifications}} macros. 

Note that:
- `KeyboardEvent.which` is no more on a standard track (deprecated) for almost a decade. I will keep it without spec and the message will be improved in mdn/yari#4012
- `LocalFileSystemSync.requestFileSystemSync`is no more on a standard track for a long time; the spec is now a note. I will keep it without spec and the message will be improved in mdn/yari#4012
- `KeyframeEffectOptions` is a dictionary and has no bcd. We need to discuss what to do with dictionaries and this will be dealt with at that time.

All other pages look fine.