### PR TITLE
Replace spec table with {{specifications}} for api/m[a-e]*

### DIFF
--- a/files/en-us/web/api/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/index.html
@@ -53,25 +53,7 @@ magSensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Generic Sensor')}}</td>
-   <td>{{Spec2('Generic Sensor')}}</td>
-   <td>Defines sensors in general.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Magnetometer','#magnetometer-interface','Magnetometer')}}</td>
-   <td>{{Spec2('Magnetometer')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/magnetometer/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/magnetometer/index.html
@@ -46,26 +46,7 @@ browser-compat: api.Magnetometer.Magnetometer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Magnetometer','#dom-magnetometer-magnetometer','Magnetometer')}}
-      </td>
-      <td>{{Spec2('Magnetometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/magnetometer/x/index.html
+++ b/files/en-us/web/api/magnetometer/x/index.html
@@ -47,25 +47,7 @@ magSensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Magnetometer','#magnetometer-x','x')}}</td>
-      <td>{{Spec2('Magnetometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/magnetometer/y/index.html
+++ b/files/en-us/web/api/magnetometer/y/index.html
@@ -47,25 +47,7 @@ magSensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Magnetometer','#magnetometer-y','y')}}</td>
-      <td>{{Spec2('Magnetometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/magnetometer/z/index.html
+++ b/files/en-us/web/api/magnetometer/z/index.html
@@ -48,25 +48,7 @@ magSensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Defines sensors in general.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Magnetometer','#magnetometer-z','z')}}</td>
-      <td>{{Spec2('Magnetometer')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mathmlelement/index.html
+++ b/files/en-us/web/api/mathmlelement/index.html
@@ -44,22 +44,7 @@ browser-compat: api.MathMLElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://mathml-refresh.github.io/mathml-core/#dom-mathmlelement">MathMLElement interface</a></td>
-   <td></td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
@@ -65,22 +65,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities', '#dom-mediacapabilities-decodinginfo-configuration-configuration', 'decodingInfo()')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.html
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.html
@@ -82,24 +82,7 @@ navigator.mediaCapabilities.encodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capabilities',
-        '#dom-mediacapabilities-encodinginfo-configuration-configuration',
-        'encodingInfo()')}}</td>
-      <td>{{Spec2('Media Capabilities')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediacapabilities/index.html
+++ b/files/en-us/web/api/mediacapabilities/index.html
@@ -29,22 +29,7 @@ browser-compat: api.MediaCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities', '#mediacapabilities', 'MediaCapabilities')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediacapabilitiesinfo/index.html
+++ b/files/en-us/web/api/mediacapabilitiesinfo/index.html
@@ -51,22 +51,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; { // res
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities','#media-capabilities-info','MediaCapabilitiesInfo')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaconfiguration/index.html
+++ b/files/en-us/web/api/mediaconfiguration/index.html
@@ -83,22 +83,7 @@ const audioEncoderConfig = {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities', '#mediaconfiguration', 'MediaConfiguration')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadecodingconfiguration/index.html
+++ b/files/en-us/web/api/mediadecodingconfiguration/index.html
@@ -50,22 +50,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities', '#mediaconfiguration','MediaDecodingConfiguration')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
@@ -29,20 +29,7 @@ browser-compat: api.MediaDeviceInfo.deviceId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediadeviceinfo-deviceid','deviceId')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/groupid/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/groupid/index.html
@@ -32,20 +32,7 @@ browser-compat: api.MediaDeviceInfo.groupId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediadeviceinfo-groupid','groupId')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/index.html
@@ -78,20 +78,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-mediadeviceinfo', 'MediaDevicesInfo')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.html
@@ -26,20 +26,7 @@ browser-compat: api.MediaDeviceInfo.kind
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediadeviceinfo-kind','kind')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/label/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/label/index.html
@@ -35,20 +35,7 @@ browser-compat: api.MediaDeviceInfo.label
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediadeviceinfo-label','label')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.html
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.html
@@ -54,20 +54,7 @@ browser-compat: api.MediaDevices.devicechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('Media Capture', '#event-mediadevices-devicechange', 'devicechange') }}</td>
-   <td>{{ Spec2('Media Capture') }}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.html
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.html
@@ -73,20 +73,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediadevices-enumeratedevices', 'mediaDevices: enumerateDevices')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
@@ -143,21 +143,7 @@ browser-compat: api.MediaDevices.getDisplayMedia
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-mediadevices-getdisplaymedia',
-        'MediaDevices.getDisplayMedia()')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
@@ -77,21 +77,7 @@ for (let constraint in supportedConstraints) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediadevices-getsupportedconstraints',
-        'getSupportedConstraints()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.html
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.html
@@ -467,23 +467,7 @@ var constraints = { video: { facingMode: (front? "user" : "environment") } };
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediadevices-getusermedia',
-        'MediaDevices.getUserMedia()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/index.html
+++ b/files/en-us/web/api/mediadevices/index.html
@@ -94,22 +94,7 @@ function errorMsg(msg, error) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Media Capture', '#mediadevices', 'MediaDevices')}}</td>
-			<td>{{Spec2('Media Capture')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediadevices/ondevicechange/index.html
+++ b/files/en-us/web/api/mediadevices/ondevicechange/index.html
@@ -231,23 +231,7 @@ let videoList = document.getElementById("videoList");</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediadevices-ondevicechange',
-        'ondevicechange') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.html
@@ -62,20 +62,7 @@ browser-compat: api.MediaElementAudioSourceNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#mediaelementaudiosourcenode', 'MediaElementAudioSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
@@ -44,21 +44,7 @@ console.log(source.mediaElement);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediaelementaudiosourcenode-mediaelement','MediaElementAudioSourceNode.mediaElement')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.html
@@ -50,20 +50,7 @@ var myAudioSource = new MediaElementAudioSourceNode(ac, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#mediaelementaudiosourcenode','MediaElementAudioSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaencodingconfiguration/index.html
+++ b/files/en-us/web/api/mediaencodingconfiguration/index.html
@@ -50,22 +50,7 @@ navigator.mediaCapabilities.encodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities', '#mediaconfiguration','MediaEncodingConfiguration')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaerror/code/index.html
+++ b/files/en-us/web/api/mediaerror/code/index.html
@@ -81,20 +81,7 @@ obj.src="https://example.com/blahblah.mp4";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-mediaerror-code", "MediaError.code")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaerror/index.html
+++ b/files/en-us/web/api/mediaerror/index.html
@@ -36,20 +36,7 @@ browser-compat: api.MediaError
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "embedded-content.html#mediaerror", "MediaError")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaerror/message/index.html
+++ b/files/en-us/web/api/mediaerror/message/index.html
@@ -101,21 +101,7 @@ browser-compat: api.MediaError.message
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "embedded-content.html#dom-mediaerror-message",
-        "MediaError.message")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaimage/index.html
+++ b/files/en-us/web/api/mediaimage/index.html
@@ -20,22 +20,7 @@ browser-compat: api.MediaImage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Session','#dictdef-mediaimage','MediaImage')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeymessageevent/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/index.html
@@ -44,20 +44,7 @@ browser-compat: api.MediaKeyMessageEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('EME', '#mediakeymessageevent', 'MediaKeyMessageEvent')}}</td>
-			<td>{{Spec2('EME')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeymessageevent/message/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/message/index.html
@@ -24,20 +24,7 @@ browser-compat: api.MediaKeyMessageEvent.message
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeymessageevent-message', 'message')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeymessageevent/messagetype/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/messagetype/index.html
@@ -25,20 +25,7 @@ browser-compat: api.MediaKeyMessageEvent.messageType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeymessageevent-messagetype', 'messageType')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeys/createsession/index.html
+++ b/files/en-us/web/api/mediakeys/createsession/index.html
@@ -25,20 +25,7 @@ browser-compat: api.MediaKeys.createSession
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeys-createsession', 'createSession()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeys/index.html
+++ b/files/en-us/web/api/mediakeys/index.html
@@ -36,20 +36,7 @@ browser-compat: api.MediaKeys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#mediakeys-interface', 'MediaKeys')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.html
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.html
@@ -24,21 +24,7 @@ browser-compat: api.MediaKeys.setServerCertificate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('EME', '#dom-mediakeys-setservercertificate',
-				'setServerCertificate()')}}</td>
-			<td>{{Spec2('EME')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/close/index.html
+++ b/files/en-us/web/api/mediakeysession/close/index.html
@@ -29,20 +29,7 @@ browser-compat: api.MediaKeySession.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-close', 'close()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/closed/index.html
+++ b/files/en-us/web/api/mediakeysession/closed/index.html
@@ -30,20 +30,7 @@ browser-compat: api.MediaKeySession.closed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-closed', 'closed')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/expiration/index.html
+++ b/files/en-us/web/api/mediakeysession/expiration/index.html
@@ -27,20 +27,7 @@ browser-compat: api.MediaKeySession.expiration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-expiration', 'expiration')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.html
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.html
@@ -24,21 +24,7 @@ browser-compat: api.MediaKeySession.generateRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-generaterequest', 'generateRequest()')}}
-      </td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/index.html
+++ b/files/en-us/web/api/mediakeysession/index.html
@@ -62,20 +62,7 @@ browser-compat: api.MediaKeySession
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#mediakeysession-interface', 'MediaKeySession')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/keystatuses/index.html
+++ b/files/en-us/web/api/mediakeysession/keystatuses/index.html
@@ -25,20 +25,7 @@ browser-compat: api.MediaKeySession.keyStatuses
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-keystatuses', 'keyStatuses')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/load/index.html
+++ b/files/en-us/web/api/mediakeysession/load/index.html
@@ -37,20 +37,7 @@ browser-compat: api.MediaKeySession.load
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-load', 'load()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
+++ b/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
@@ -17,20 +17,7 @@ browser-compat: api.MediaKeySession.onkeystatuseschange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME','#dom-evt-keystatuseschange','onkeystatuseschange')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/onmessage/index.html
+++ b/files/en-us/web/api/mediakeysession/onmessage/index.html
@@ -21,20 +21,7 @@ browser-compat: api.MediaKeySession.onmessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('EME','#dom-mediakeysession-onmessage','onmessage')}}</td>
-            <td>{{Spec2('EME')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/remove/index.html
+++ b/files/en-us/web/api/mediakeysession/remove/index.html
@@ -22,20 +22,7 @@ browser-compat: api.MediaKeySession.remove
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#dom-mediakeysession-sessionid', 'remove()')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/sessionid/index.html
+++ b/files/en-us/web/api/mediakeysession/sessionid/index.html
@@ -25,20 +25,7 @@ browser-compat: api.MediaKeySession.sessionId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-sessionid', 'sessionId')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysession/update/index.html
+++ b/files/en-us/web/api/mediakeysession/update/index.html
@@ -35,20 +35,7 @@ browser-compat: api.MediaKeySession.update
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysession-update', 'update()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.html
@@ -31,20 +31,7 @@ browser-compat: api.MediaKeyStatusMap.entries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/foreach/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/foreach/index.html
@@ -46,20 +46,7 @@ browser-compat: api.MediaKeyStatusMap.forEach
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/get/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.html
@@ -34,20 +34,7 @@ browser-compat: api.MediaKeyStatusMap.get
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/has/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.html
@@ -34,20 +34,7 @@ browser-compat: api.MediaKeyStatusMap.has
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/index.html
@@ -41,20 +41,7 @@ browser-compat: api.MediaKeyStatusMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#mediakeystatusmap-interface', 'MediaKeyStatusMap')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.html
@@ -33,20 +33,7 @@ browser-compat: api.MediaKeyStatusMap.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/size/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.html
@@ -27,20 +27,7 @@ browser-compat: api.MediaKeyStatusMap.size
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME','#dom-mediakeystatusmap-size','size')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeystatusmap/values/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.html
@@ -30,20 +30,7 @@ browser-compat: api.MediaKeyStatusMap.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.html
@@ -26,21 +26,7 @@ browser-compat: api.MediaKeySystemAccess.createMediaKeys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemaccess-createmediakeys',
-        'createMediaKeys()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.html
@@ -27,21 +27,7 @@ browser-compat: api.MediaKeySystemAccess.getConfiguration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemaccess-getconfiguration',
-        'getConfiguration()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemaccess/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/index.html
@@ -35,20 +35,7 @@ browser-compat: api.MediaKeySystemAccess
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#mediakeysystemaccess-interface', 'MediaKeySystemAccess')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemaccess/keysystem/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/keysystem/index.html
@@ -24,20 +24,7 @@ browser-compat: api.MediaKeySystemAccess.keySystem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemaccess-keysystem', 'keySystem')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/audiocapabilities/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/audiocapabilities/index.html
@@ -25,21 +25,7 @@ browser-compat: api.MediaKeySystemConfiguration.audioCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemconfiguration-audiocapabilities',
-        'audioCapabilities')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/distinctiveidentifier/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/distinctiveidentifier/index.html
@@ -25,21 +25,7 @@ browser-compat: api.MediaKeySystemConfiguration.distinctiveIdentifier
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemconfiguration-distinctiveidentifier',
-        'distinctiveIdentifier')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/index.html
@@ -35,20 +35,7 @@ browser-compat: api.MediaKeySystemConfiguration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('EME', '#mediakeysystemconfiguration-dictionary', 'MediaKeySystemConfiguration')}}</td>
-   <td>{{Spec2('EME')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/initdatatypes/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/initdatatypes/index.html
@@ -27,21 +27,7 @@ browser-compat: api.MediaKeySystemConfiguration.initDataTypes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemconfiguration-initdatatypes',
-        'initDataTypes')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/persistentstate/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/persistentstate/index.html
@@ -25,21 +25,7 @@ browser-compat: api.MediaKeySystemConfiguration.persistentState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemconfiguration-persistentstate',
-        'persistentState')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediakeysystemconfiguration/videocapabilities/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/videocapabilities/index.html
@@ -25,21 +25,7 @@ browser-compat: api.MediaKeySystemConfiguration.videoCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#dom-mediakeysystemconfiguration-videocapabilities',
-        'videoCapabilities')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/medialist/index.html
+++ b/files/en-us/web/api/medialist/index.html
@@ -47,20 +47,7 @@ console.log(stylesheet.media.mediaText);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM', '#the-medialist-interface', 'MediaList')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/medialist/mediatext/index.html
+++ b/files/en-us/web/api/medialist/mediatext/index.html
@@ -51,20 +51,7 @@ console.log(stylesheet.media.mediaText);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-medialist-mediatext', 'mediaText')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/album/index.html
+++ b/files/en-us/web/api/mediametadata/album/index.html
@@ -46,20 +46,7 @@ mediaMetaData.album = album</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediametadata-album','album')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/artist/index.html
+++ b/files/en-us/web/api/mediametadata/artist/index.html
@@ -50,20 +50,7 @@ mediaMetadata.artist = artist</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediametadata-artist','artist')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/artwork/index.html
+++ b/files/en-us/web/api/mediametadata/artwork/index.html
@@ -52,20 +52,7 @@ mediaMetadata.artwork = artwork[]</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediametadata-artwork','artwork')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -58,20 +58,7 @@ browser-compat: api.MediaMetadata
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Session','#the-mediametadata-interface','MediaMetaData')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.html
@@ -61,20 +61,7 @@ browser-compat: api.MediaMetadata.MediaMetadata
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediametadata-mediametadata','MediaMetadata()')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediametadata/title/index.html
+++ b/files/en-us/web/api/mediametadata/title/index.html
@@ -51,20 +51,7 @@ mediaMetaData.title = title</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediametadata-title','title')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediapositionstate/duration/index.html
+++ b/files/en-us/web/api/mediapositionstate/duration/index.html
@@ -68,22 +68,7 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediapositionstate-duration','MediaPositionState.duration')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediapositionstate/index.html
+++ b/files/en-us/web/api/mediapositionstate/index.html
@@ -35,22 +35,7 @@ browser-compat: api.MediaPositionState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Session','#dictdef-mediapositionstate','MediaPositionState')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediapositionstate/playbackrate/index.html
+++ b/files/en-us/web/api/mediapositionstate/playbackrate/index.html
@@ -77,23 +77,7 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediapositionstate-playbackrate','MediaPositionState.playbackRate')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediapositionstate/position/index.html
+++ b/files/en-us/web/api/mediapositionstate/position/index.html
@@ -72,22 +72,7 @@ let <em>duration</em> = <em>positionState</em>.duration;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediapositionstate-position','MediaPositionState.position')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/addlistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.html
@@ -60,21 +60,7 @@ mediaQueryList.addListener(screenTest);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylist-addlistener", "addListener")}}
-      </td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/index.html
+++ b/files/en-us/web/api/mediaquerylist/index.html
@@ -80,22 +80,7 @@ mql.addEventListener('change', screenTest);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM View", "#the-mediaquerylist-interface", "MediaQueryList")}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/matches/index.html
+++ b/files/en-us/web/api/mediaquerylist/matches/index.html
@@ -62,22 +62,7 @@ addMQListener(window.matchMedia("(orientation:landscape)"),
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylist-matches", "matches")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/media/index.html
+++ b/files/en-us/web/api/mediaquerylist/media/index.html
@@ -69,22 +69,7 @@ document.querySelector(".mq-value").innerText = mql.media;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylist-media", "media")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/onchange/index.html
+++ b/files/en-us/web/api/mediaquerylist/onchange/index.html
@@ -44,22 +44,7 @@ mql.addEventListener( "change", (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylist-onchange", "onchange")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.html
@@ -62,21 +62,7 @@ mediaQueryList.removeListener(screenTest);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylist-removelistener",
-        "removeListener")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/index.html
@@ -56,20 +56,7 @@ mql.addListener(screenTest);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM View", "#mediaquerylistevent", "MediaQueryListEvent")}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/matches/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/matches/index.html
@@ -49,20 +49,7 @@ mql.addListener(screenTest);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylistevent-matches", "matches")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/media/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/media/index.html
@@ -49,20 +49,7 @@ mql.addListener(screenTest);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylistevent-media", "media")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
@@ -48,21 +48,7 @@ var myMediaQueryListEvent = new MediaQueryListEvent({media, matches});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-mediaquerylistevent-mediaquerylistevent",
-        "MediaQueryListEvent()")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
@@ -28,20 +28,7 @@ browser-compat: api.MediaRecorder.audioBitsPerSecond
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording','#dom-mediarecorder-audiobitspersecond','audioBitsPerSecond')}}</td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/error_event/index.html
+++ b/files/en-us/web/api/mediarecorder/error_event/index.html
@@ -62,18 +62,7 @@ record();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('MediaStream Recording', '#errorevent-section')}}</td>
-   <td>{{Spec2('MediaStream Recording')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -179,20 +179,7 @@ browser-compat: api.MediaRecorder
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("MediaStream Recording", "#mediarecorder-api")}}</td>
-   <td>{{Spec2("MediaStream Recording")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/istypesupported/index.html
+++ b/files/en-us/web/api/mediarecorder/istypesupported/index.html
@@ -58,21 +58,7 @@ for (var i in types) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording', '#dom-mediarecorder-istypesupported',
-        'isTypeSupported()')}}</td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.html
@@ -110,20 +110,7 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/mimetype/index.html
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.html
@@ -94,21 +94,7 @@ if (navigator.mediaDevices) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-mimetype",
-        "MediaRecorder.mimeType")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/ondataavailable/index.html
+++ b/files/en-us/web/api/mediarecorder/ondataavailable/index.html
@@ -84,21 +84,7 @@ browser-compat: api.MediaRecorder.ondataavailable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-ondataavailable",
-        "MediaRecorder.ondataavailable")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/onerror/index.html
+++ b/files/en-us/web/api/mediarecorder/onerror/index.html
@@ -117,21 +117,7 @@ browser-compat: api.MediaRecorder.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-onerror",
-        "MediaRecorder.onerror")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/onpause/index.html
+++ b/files/en-us/web/api/mediarecorder/onpause/index.html
@@ -61,21 +61,7 @@ MediaRecorder.addEventListener('pause', function(event) { ... })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-onpause",
-        "MediaRecorder.onpause")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/onresume/index.html
+++ b/files/en-us/web/api/mediarecorder/onresume/index.html
@@ -61,21 +61,7 @@ MediaRecorder.addEventListener('resume', function(event) { ... })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-onresume",
-        "MediaRecorder.onresume")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/onstart/index.html
+++ b/files/en-us/web/api/mediarecorder/onstart/index.html
@@ -51,21 +51,7 @@ MediaRecorder.addEventListener('start', function(event) { ... })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-onstart",
-        "MediaRecorder.onstart")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/onstop/index.html
+++ b/files/en-us/web/api/mediarecorder/onstop/index.html
@@ -54,21 +54,7 @@ MediaRecorder.addEventListener('stop', function(event) { ... })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-onstop",
-        "MediaRecorder.onstop")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/pause/index.html
+++ b/files/en-us/web/api/mediarecorder/pause/index.html
@@ -60,21 +60,7 @@ browser-compat: api.MediaRecorder.pause
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-pause",
-        "MediaRecorder.pause()")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/requestdata/index.html
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.html
@@ -62,21 +62,7 @@ browser-compat: api.MediaRecorder.requestData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-requestdata",
-        "MediaRecorder.requestData()")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/resume/index.html
+++ b/files/en-us/web/api/mediarecorder/resume/index.html
@@ -61,21 +61,7 @@ browser-compat: api.MediaRecorder.resume
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-resume",
-        "MediaRecorder.resume()")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/start/index.html
+++ b/files/en-us/web/api/mediarecorder/start/index.html
@@ -111,21 +111,7 @@ browser-compat: api.MediaRecorder.start
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-start",
-        "MediaRecorder.start()")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/state/index.html
+++ b/files/en-us/web/api/mediarecorder/state/index.html
@@ -65,21 +65,7 @@ browser-compat: api.MediaRecorder.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-state",
-        "MediaRecorder.state")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/stop/index.html
+++ b/files/en-us/web/api/mediarecorder/stop/index.html
@@ -56,21 +56,7 @@ browser-compat: api.MediaRecorder.stop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-stop",
-        "MediaRecorder.stop()")}}</td>
-      <td>{{Spec2("MediaStream Recording")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/stream/index.html
+++ b/files/en-us/web/api/mediarecorder/stream/index.html
@@ -47,21 +47,7 @@ browser-compat: api.MediaRecorder.stream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-   <tbody>
-      <tr>
-         <th scope="col">Specification</th>
-         <th scope="col">Status</th>
-         <th scope="col">Comment</th>
-      </tr>
-      <tr>
-         <td>{{SpecName("MediaStream Recording", "#dom-mediarecorder-stream",
-            "MediaRecorder.stream")}}</td>
-         <td>{{Spec2("MediaStream Recording")}}</td>
-         <td>Initial definition</td>
-      </tr>
-   </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
@@ -25,21 +25,7 @@ browser-compat: api.MediaRecorder.videoBitsPerSecond
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('MediaStream Recording','#dom-mediarecorder-videobitspersecond','videoBitsPerSecond')}}
-            </td>
-            <td>{{Spec2('MediaStream Recording')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecordererrorevent/error/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/error/index.html
@@ -93,23 +93,7 @@ browser-compat: api.MediaRecorderErrorEvent.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('MediaStream Recording', '#errorevent-section',
-        'MediaRecorderErrorEvent.error') }}</td>
-      <td>{{ Spec2('MediaStream Recording') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/index.html
@@ -45,22 +45,7 @@ browser-compat: api.MediaRecorderErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('MediaStream Recording', '#errorevent-section', 'MediaRecorderErrorEvent') }}</td>
-   <td>{{ Spec2('MediaStream Recording') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
@@ -59,21 +59,7 @@ browser-compat: api.MediaRecorderErrorEvent.MediaRecorderErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Recording','#dom-mediarecordererrorevent-mediarecordererrorevent','MediaRecorderErrorEvent()')}}
-      </td>
-      <td>{{Spec2('MediaStream Recording')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasession/index.html
+++ b/files/en-us/web/api/mediasession/index.html
@@ -104,22 +104,7 @@ for (const [action, handler] of actionHandlers) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Session','#the-mediasession-interface','MediaSession')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasession/metadata/index.html
+++ b/files/en-us/web/api/mediasession/metadata/index.html
@@ -54,20 +54,7 @@ navigator.mediaSession.metadata = <em>mediaMetadata</em>;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasession-metadata','MediaSession.metadata')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasession/playbackstate/index.html
+++ b/files/en-us/web/api/mediasession/playbackstate/index.html
@@ -81,21 +81,7 @@ for (const [action, handler] of actionHandlers) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasession-playbackstate','playbackState')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasession/setactionhandler/index.html
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.html
@@ -174,21 +174,7 @@ function handleSeek(details) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasession-setactionhandler','MediaSession.setActionHandler()')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasession/setpositionstate/index.html
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.html
@@ -98,23 +98,7 @@ browser-compat: api.MediaSession.setPositionState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasession-setpositionstate','MediaSession.setPositionState()')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasessionaction/index.html
+++ b/files/en-us/web/api/mediasessionaction/index.html
@@ -118,20 +118,7 @@ function handleSeek(details) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Session','#enumdef-mediasessionaction','Media Session action types')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasessionactiondetails/action/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/action/index.html
@@ -37,21 +37,7 @@ let <em>actionType</em> = <em>mediaSessionActionDetails</em>.action;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-action','MediaSessionActionDetails.action')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
@@ -45,21 +45,7 @@ let <em>shouldFastSeek</em> = <em>mediaSessionActionDetails</em>.fastSeek;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-fastseek','MediaSessionActionDetails.fastSeek')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/index.html
@@ -72,20 +72,7 @@ browser-compat: api.MediaSessionActionDetails
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Session','#dictdef-mediasessionactiondetails','MediaSessionActionDetails')}}</td>
-   <td>{{Spec2('Media Session')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
@@ -46,21 +46,7 @@ let <em>deltaTime</em> = <em>mediaSessionActionDetails</em>.seekOffset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-seekoffset','MediaSessionActionDetails.seekOffset')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
@@ -60,21 +60,7 @@ let <em>absTime</em> = <em>mediaSessionActionDetails</em>.seekTime;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-seektime','MediaSessionActionDetails.seekTime')}}
-      </td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasettingsrange/index.html
+++ b/files/en-us/web/api/mediasettingsrange/index.html
@@ -60,20 +60,7 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('MediaStream Image','#mediasettingsrange-section','MediaSettingsRange')}}</td>
-			<td>{{Spec2('MediaStream Image')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasettingsrange/max/index.html
+++ b/files/en-us/web/api/mediasettingsrange/max/index.html
@@ -29,20 +29,7 @@ browser-compat: api.MediaSettingsRange.max
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('MediaStream Image','#dom-mediasettingsrange-max','max')}}</td>
-			<td>{{Spec2('MediaStream Image')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasettingsrange/min/index.html
+++ b/files/en-us/web/api/mediasettingsrange/min/index.html
@@ -29,20 +29,7 @@ browser-compat: api.MediaSettingsRange.min
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('MediaStream Image','#dom-mediasettingsrange-min','min')}}</td>
-			<td>{{Spec2('MediaStream Image')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasettingsrange/step/index.html
+++ b/files/en-us/web/api/mediasettingsrange/step/index.html
@@ -29,21 +29,7 @@ browser-compat: api.MediaSettingsRange.step
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('MediaStream Image','#dom-mediasettingsrange-step','step')}}
-			</td>
-			<td>{{Spec2('MediaStream Image')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/activesourcebuffers/index.html
+++ b/files/en-us/web/api/mediasource/activesourcebuffers/index.html
@@ -62,21 +62,7 @@ browser-compat: api.MediaSource.activeSourceBuffers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions',
-        '#idl-def-mediasource-activesourcebuffers', 'activeSourceBuffers')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.html
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.html
@@ -101,21 +101,7 @@ function sourceOpen (_) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-mediasource-addsourcebuffer',
-        'addSourceBuffer()')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
@@ -35,21 +35,7 @@ browser-compat: api.MediaSource.clearLiveSeekableRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions','#dom-mediasource-clearliveseekablerange','clearLiveSeekableRange()')}}
-      </td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/duration/index.html
+++ b/files/en-us/web/api/mediasource/duration/index.html
@@ -83,21 +83,7 @@ var <em>myDuration</em> = <em>mediaSource</em>.duration;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-mediasource-duration',
-        'duration')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/endofstream/index.html
+++ b/files/en-us/web/api/mediasource/endofstream/index.html
@@ -111,21 +111,7 @@ function sourceOpen (_) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-mediasource-endofstream',
-        'endOfStream()')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/index.html
@@ -123,20 +123,7 @@ function fetchAB (url, cb) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Source Extensions', '#mediasource', 'MediaSource')}}</td>
-   <td>{{Spec2('Media Source Extensions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/istypesupported/index.html
+++ b/files/en-us/web/api/mediasource/istypesupported/index.html
@@ -92,21 +92,7 @@ function sourceOpen (_) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-mediasource-istypesupported',
-        'isTypeSupported()')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/readystate/index.html
+++ b/files/en-us/web/api/mediasource/readystate/index.html
@@ -71,21 +71,7 @@ function sourceOpen (_) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-mediasource-readystate',
-        'readyState')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/removesourcebuffer/index.html
+++ b/files/en-us/web/api/mediasource/removesourcebuffer/index.html
@@ -66,21 +66,7 @@ mediaSource.removeSourceBuffer(mediaSource.sourceBuffers[0]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-mediasource-removesourcebuffer',
-        'removeSourceBuffer()')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.html
@@ -52,21 +52,7 @@ browser-compat: api.MediaSource.setLiveSeekableRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions','#dom-mediasource-setliveseekablerange','setLiveSeekableRange()')}}
-      </td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediasource/sourcebuffers/index.html
+++ b/files/en-us/web/api/mediasource/sourcebuffers/index.html
@@ -57,21 +57,7 @@ browser-compat: api.MediaSource.sourceBuffers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-mediasource-sourcebuffers',
-        'sourceBuffers')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/active/index.html
+++ b/files/en-us/web/api/mediastream/active/index.html
@@ -51,20 +51,7 @@ promise.then((stream) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastream-active', 'active')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/addtrack/index.html
+++ b/files/en-us/web/api/mediastream/addtrack/index.html
@@ -42,22 +42,7 @@ browser-compat: api.MediaStream.addTrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture','#dom-mediastream-addtrack','addTrack()') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/addtrack_event/index.html
+++ b/files/en-us/web/api/mediastream/addtrack_event/index.html
@@ -50,18 +50,7 @@ stream.onaddtrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#event-mediastream-addtrack', 'addtrack')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/clone/index.html
+++ b/files/en-us/web/api/mediastream/clone/index.html
@@ -36,21 +36,7 @@ browser-compat: api.MediaStream.clone
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastream-clone', 'MediaStream.clone()')}}
-      </td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.html
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.html
@@ -70,22 +70,7 @@ browser-compat: api.MediaStream.getAudioTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediastream-getaudiotracks','getAudioTracks()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/gettrackbyid/index.html
+++ b/files/en-us/web/api/mediastream/gettrackbyid/index.html
@@ -46,23 +46,7 @@ stream.getTrackById("commentary-track").enabled = true;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture','#dom-mediastream-gettrackbyid','getTrackById()') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/gettracks/index.html
+++ b/files/en-us/web/api/mediastream/gettracks/index.html
@@ -48,22 +48,7 @@ browser-compat: api.MediaStream.getTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediastream-gettracks','getTracks()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/getvideotracks/index.html
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.html
@@ -71,20 +71,7 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-mediastream-getvideotracks','getVideoTracks()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/id/index.html
+++ b/files/en-us/web/api/mediastream/id/index.html
@@ -31,21 +31,7 @@ p.then(function(stream) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Media Capture', '#dom-mediastream-id', 'MediaStream.id')}}
-			</td>
-			<td>{{Spec2('Media Capture')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/index.html
@@ -107,22 +107,7 @@ browser-compat: api.MediaStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-mediastream', 'MediaStream')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/mediastream/index.html
@@ -51,22 +51,7 @@ browser-compat: api.MediaStream.MediaStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture', '#mediastream', 'MediaStream')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/onaddtrack/index.html
+++ b/files/en-us/web/api/mediastream/onaddtrack/index.html
@@ -55,23 +55,7 @@ browser-compat: api.MediaStream.onaddtrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#event-mediastream-addtrack',
-        'MediaStream.onaddtrack') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/onremovetrack/index.html
+++ b/files/en-us/web/api/mediastream/onremovetrack/index.html
@@ -55,23 +55,7 @@ browser-compat: api.MediaStream.onremovetrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastream-onremovetrack',
-        'MediaStream.onremovetrack') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastream/removetrack_event/index.html
+++ b/files/en-us/web/api/mediastream/removetrack_event/index.html
@@ -50,18 +50,7 @@ stream.onremovetrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#event-mediastream-removetrack', 'removetrack')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
@@ -68,20 +68,7 @@ browser-compat: api.MediaStreamAudioDestinationNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#mediastreamaudiodestinationnode', 'MediaStreamAudioDestinationNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
@@ -41,20 +41,7 @@ var myDestination = new MediaStreamAudioDestinationNode(<em>ac</em>);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#mediastreamaudiodestinationnode','MediaStreamAudioDestinationNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
@@ -36,20 +36,7 @@ var myStream = destination.stream;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-mediastreamaudiodestinationnode-stream', 'stream')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.html
@@ -91,20 +91,7 @@ browser-compat: api.MediaStreamAudioSourceNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#mediastreamaudiosourcenode', 'MediaStreamAudioSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
@@ -52,21 +52,7 @@ console.log(source.mediaStream);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourcenode-mediastream','MediaStreamAudioSourceNode.mediaStream')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
@@ -89,21 +89,7 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode','MediaStreamAudioSourceNode()')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourceoptions/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourceoptions/index.html
@@ -30,20 +30,7 @@ browser-compat: api.MediaStreamAudioSourceOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#dictdef-mediastreamaudiosourceoptions','MediaStreamAudioSourceOptions')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
@@ -45,21 +45,7 @@ browser-compat: api.MediaStreamAudioSourceOptions.mediaStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourceoptions-mediastream','MediaStreamAudioSourceOptions.mediaStream')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/audio/index.html
@@ -200,23 +200,7 @@ function log(msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamconstraints-audio',
-        'MediaStreamConstraints.audio') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/video/index.html
@@ -193,23 +193,7 @@ function log(msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamconstraints-video',
-        'MediaStreamConstraints.video') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
+++ b/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
@@ -89,27 +89,7 @@ navigator.mediaDevices.getUserMedia({ video: true })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediatrackconstraints',
-        'applyConstraints()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Image',
-        '#mediatrackconstraintset-section','applyConstraints()')}}</td>
-      <td>{{Spec2('MediaStream Image')}}</td>
-      <td>Adds image constraints.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/clone/index.html
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.html
@@ -31,20 +31,7 @@ browser-compat: api.MediaStreamTrack.clone
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastreamtrack-clone', 'clone()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/enabled/index.html
+++ b/files/en-us/web/api/mediastreamtrack/enabled/index.html
@@ -84,22 +84,7 @@ browser-compat: api.MediaStreamTrack.enabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-enabled', 'enabled') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.html
@@ -69,22 +69,7 @@ browser-compat: api.MediaStreamTrack.ended_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('Media Capture', '#event-mediastreamtrack-ended', 'ended') }}</td>
-   <td>{{ Spec2('Media Capture') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.html
@@ -38,21 +38,7 @@ browser-compat: api.MediaStreamTrack.getCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastreamtrack-getcapabilities',
-        'getCapabilities()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.html
@@ -66,21 +66,7 @@ browser-compat: api.MediaStreamTrack.getConstraints
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastreamtrack-getconstraints',
-        'getConstraints()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.html
@@ -41,21 +41,7 @@ browser-compat: api.MediaStreamTrack.getSettings
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastreamtrack-getsettings',
-        'getSettings()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/id/index.html
+++ b/files/en-us/web/api/mediastreamtrack/id/index.html
@@ -22,23 +22,7 @@ browser-compat: api.MediaStreamTrack.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-id', 'MediaStreamTrack.id')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/index.html
+++ b/files/en-us/web/api/mediastreamtrack/index.html
@@ -88,27 +88,7 @@ browser-compat: api.MediaStreamTrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebRTC Identity", "#isolated-track", "Isolated tracks")}}</td>
-   <td>{{Spec2("WebRTC Identity")}}</td>
-   <td>Additional properties for isolated track support</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#mediastreamtrack', 'MediaStreamTrack')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/kind/index.html
+++ b/files/en-us/web/api/mediastreamtrack/kind/index.html
@@ -33,23 +33,7 @@ browser-compat: api.MediaStreamTrack.kind
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-kind',
-        'MediaStreamTrack.kind') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/label/index.html
+++ b/files/en-us/web/api/mediastreamtrack/label/index.html
@@ -27,23 +27,7 @@ browser-compat: api.MediaStreamTrack.label
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-label',
-        'MediaStreamTrack.label') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.html
@@ -72,22 +72,7 @@ musicTrack.onunmute = event = &gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capture', '#event-mediastreamtrack-mute', 'mute')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/muted/index.html
+++ b/files/en-us/web/api/mediastreamtrack/muted/index.html
@@ -56,20 +56,7 @@ trackList.forEach((track) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediastreamtrack-muted', 'muted')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onended/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onended/index.html
@@ -47,23 +47,7 @@ browser-compat: api.MediaStreamTrack.onended
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-onended',
-        'MediaStreamTrack.onended') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onmute/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onmute/index.html
@@ -43,23 +43,7 @@ browser-compat: api.MediaStreamTrack.onmute
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-onmute',
-        'MediaStreamTrack.onmute') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onunmute/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onunmute/index.html
@@ -48,23 +48,7 @@ browser-compat: api.MediaStreamTrack.onunmute
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-onunmute',
-        'MediaStreamTrack.onunmute') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/readystate/index.html
+++ b/files/en-us/web/api/mediastreamtrack/readystate/index.html
@@ -35,23 +35,7 @@ browser-compat: api.MediaStreamTrack.readyState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-readystate',
-        'MediaStreamTrack.readyState') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/stop/index.html
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.html
@@ -67,23 +67,7 @@ browser-compat: api.MediaStreamTrack.stop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrack-stop',
-        'MediaStreamTrack.stop()') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.html
@@ -70,22 +70,7 @@ musicTrack.mute = event = &gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capture', '#event-mediastreamtrack-unmute', 'unmute')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
@@ -47,20 +47,7 @@ browser-compat: api.MediaStreamTrackAudioSourceNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#mediastreamtrackaudiosourcenode', 'MediaStreamTrackAudioSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
@@ -96,21 +96,7 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode','MediaStreamTrackAudioSourceNode()')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourceoptions/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourceoptions/index.html
@@ -29,20 +29,7 @@ browser-compat: api.MediaStreamTrackAudioSourceOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#dictdef-mediastreamtrackaudiosourceoptions','MediaStreamTrackAudioSourceOptions')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
@@ -49,21 +49,7 @@ browser-compat: api.MediaStreamTrackAudioSourceOptions.mediaStreamTrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack','MediaStreamTrackAudioSourceOptions.mediaStream')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackevent/index.html
+++ b/files/en-us/web/api/mediastreamtrackevent/index.html
@@ -43,20 +43,7 @@ browser-compat: api.MediaStreamTrackEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('Media Capture', '#mediastreamtrackevent', 'MediaStreamTrackEvent') }}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.html
+++ b/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.html
@@ -43,21 +43,7 @@ browser-compat: api.MediaStreamTrackEvent.MediaStreamTrackEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediastreamtrackevent',
-        'MediaStreamTrackEvent()') }}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.html
@@ -56,23 +56,7 @@ browser-compat: api.MediaTrackConstraints.aspectRatio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-aspectratio',
-        'aspectRatio') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.html
@@ -53,23 +53,7 @@ browser-compat: api.MediaTrackConstraints.autoGainControl
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-autogaincontrol',
-        'autoGainControl') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.html
@@ -53,23 +53,7 @@ browser-compat: api.MediaTrackConstraints.channelCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-channelcount',
-        'channelCount') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/cursor/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/cursor/index.html
@@ -114,23 +114,7 @@ if (displayStream.getVideoTracks()[0].getSettings().cursor === "never") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Screen Capture', '#dom-mediatrackconstraintset-cursor',
-        'MediaTrackConstraints.cursor') }}</td>
-      <td>{{ Spec2('Screen Capture API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.html
@@ -70,23 +70,7 @@ browser-compat: api.MediaTrackConstraints.deviceId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-deviceid',
-        'deviceId') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.html
@@ -90,23 +90,7 @@ if (displaySurface === "monitor" || displaySurface ==="application") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Screen Capture', '#dom-mediatrackconstraintset-displaysurface',
-        'MediaTrackConstraints.displaySurface') }}</td>
-      <td>{{ Spec2('Screen Capture API') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.html
@@ -55,23 +55,7 @@ browser-compat: api.MediaTrackConstraints.echoCancellation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-echocancellation',
-        'echoCancellation') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.html
@@ -65,23 +65,7 @@ browser-compat: api.MediaTrackConstraints.facingMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-facingmode',
-        'facingMode') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.html
@@ -53,23 +53,7 @@ browser-compat: api.MediaTrackConstraints.frameRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-framerate',
-        'frameRate') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.html
@@ -66,23 +66,7 @@ browser-compat: api.MediaTrackConstraints.groupId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-groupid', 'groupId')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/height/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.html
@@ -49,23 +49,7 @@ browser-compat: api.MediaTrackConstraints.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-height', 'height') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/index.html
@@ -149,25 +149,7 @@ browser-compat: api.MediaTrackConstraints
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-mediatrackconstraints')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('MediaStream Image', '#mediatrackconstraintset-section')}}</td>
-   <td>{{Spec2('MediaStream Image')}}</td>
-   <td>Adds image constraints.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.html
@@ -69,23 +69,7 @@ browser-compat: api.MediaTrackConstraints.latency
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-latency', 'latency')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.html
@@ -73,23 +73,7 @@ browser-compat: api.MediaTrackConstraints.logicalSurface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Screen Capture', '#dom-mediatrackconstraintset-logicalsurface',
-        'MediaTrackConstraints.logicalSurface') }}</td>
-      <td>{{ Spec2('Screen Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.html
@@ -53,23 +53,7 @@ browser-compat: api.MediaTrackConstraints.noiseSuppression
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-noisesuppression',
-        'noiseSuppression') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.html
@@ -51,23 +51,7 @@ browser-compat: api.MediaTrackConstraints.sampleRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-samplerate',
-        'sampleRate') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.html
@@ -55,23 +55,7 @@ browser-compat: api.MediaTrackConstraints.sampleSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-samplesize',
-        'sampleSize') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/width/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.html
@@ -49,23 +49,7 @@ browser-compat: api.MediaTrackConstraints.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatrackconstraintset-width', 'width') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.html
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.html
@@ -50,23 +50,7 @@ browser-compat: api.MediaTrackSettings.aspectRatio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-aspectratio',
-        'aspectRatio') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.html
@@ -52,23 +52,7 @@ browser-compat: api.MediaTrackSettings.autoGainControl
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-autogaincontrol',
-        'autoGainControl') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.html
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.html
@@ -48,23 +48,7 @@ browser-compat: api.MediaTrackSettings.channelCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-channelcount',
-        'channelCount') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/cursor/index.html
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.html
@@ -51,21 +51,7 @@ browser-compat: api.MediaTrackSettings.cursor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-mediatracksettings-cursor',
-        'MediaTrackSettings.cursor')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.html
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.html
@@ -68,23 +68,7 @@ browser-compat: api.MediaTrackSettings.deviceId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-deviceid', 'deviceId') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.html
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.html
@@ -61,21 +61,7 @@ browser-compat: api.MediaTrackSettings.displaySurface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-mediatrackconstraintset-displaysurface',
-        'MediaTrackSettings.displaySurface')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.html
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.html
@@ -58,23 +58,7 @@ browser-compat: api.MediaTrackSettings.echoCancellation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-echocancellation',
-        'echoCancellation') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.html
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.html
@@ -73,23 +73,7 @@ browser-compat: api.MediaTrackSettings.facingMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-facingmode', 'facingMode')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/framerate/index.html
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.html
@@ -48,23 +48,7 @@ browser-compat: api.MediaTrackSettings.frameRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-framerate', 'frameRate')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/groupid/index.html
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.html
@@ -69,23 +69,7 @@ browser-compat: api.MediaTrackSettings.groupId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-groupid', 'groupId') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/height/index.html
+++ b/files/en-us/web/api/mediatracksettings/height/index.html
@@ -47,22 +47,7 @@ browser-compat: api.MediaTrackSettings.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-height', 'height') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/index.html
+++ b/files/en-us/web/api/mediatracksettings/index.html
@@ -130,25 +130,7 @@ browser-compat: api.MediaTrackSettings
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#media-track-settings', 'MediaTrackSettings')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Screen Capture', '#extensions-to-mediatracksettings', 'MediaTrackSettings extensions')}}</td>
-   <td>{{Spec2('Screen Capture')}}</td>
-   <td>Defines the <code>displaySurface</code>, <code>logicalSurface</code>, and <code>cursor</code> members</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/latency/index.html
+++ b/files/en-us/web/api/mediatracksettings/latency/index.html
@@ -55,23 +55,7 @@ browser-compat: api.MediaTrackSettings.latency
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-latency', 'latency') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.html
@@ -56,21 +56,7 @@ browser-compat: api.MediaTrackSettings.logicalSurface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-mediatrackconstraintset-logicalsurface',
-        'MediaTrackSettings.logicalSurface')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.html
@@ -52,23 +52,7 @@ browser-compat: api.MediaTrackSettings.noiseSuppression
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-noisesuppression',
-        'noiseSuppression') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.html
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.html
@@ -53,23 +53,7 @@ browser-compat: api.MediaTrackSettings.sampleRate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-samplerate', 'sampleRate')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.html
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.html
@@ -56,23 +56,7 @@ browser-compat: api.MediaTrackSettings.sampleSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-samplesize', 'sampleSize')
-        }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksettings/width/index.html
+++ b/files/en-us/web/api/mediatracksettings/width/index.html
@@ -47,22 +47,7 @@ browser-compat: api.MediaTrackSettings.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksettings-width', 'width') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.html
@@ -71,23 +71,7 @@ if (navigator.mediaDevices.getSupportedConstraints().aspectRatio) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-aspectratio',
-        'aspectRatio') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.html
@@ -81,23 +81,7 @@ if (navigator.mediaDevices.getSupportedConstraints().autoGainControl) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture',
-        '#dom-mediatracksupportedconstraints-autogaincontrol', 'autoGainControl') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.html
@@ -71,23 +71,7 @@ if (navigator.mediaDevices.getSupportedConstraints().channelCount) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-channelcount',
-        'channelCount') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.html
@@ -74,21 +74,7 @@ browser-compat: api.MediaTrackSupportedConstraints.cursor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture', '#dom-mediatracksupportedconstraints-cursor',
-        'MediaTrackSupportedConstraints.cursor')}}</td>
-      <td>{{Spec2('Screen Capture API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.html
@@ -71,23 +71,7 @@ if (navigator.mediaDevices.getSupportedConstraints().deviceId) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-deviceid',
-        'deviceId') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.html
@@ -74,22 +74,7 @@ browser-compat: api.MediaTrackSupportedConstraints.displaySurface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture',
-        '#dom-mediatracksupportedconstraints-displaysurface',
-        'MediaTrackSupportedConstraints.displaySurface')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.html
@@ -70,24 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().echoCancellation) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture',
-        '#dom-mediatracksupportedconstraints-echocancellation', 'echoCancellation') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.html
@@ -70,23 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().facingMode) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-facingmode',
-        'facingMode') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
@@ -94,23 +94,7 @@ if (navigator.mediaDevices.getSupportedConstraints().frameRate) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-framerate',
-        'frameRate') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.html
@@ -70,23 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().groupId) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-groupid',
-        'groupId') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.html
@@ -70,23 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().height) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-height',
-        'height') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.html
@@ -71,23 +71,7 @@ if (navigator.mediaDevices.getSupportedConstraints().latency) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-latency',
-        'latency') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.html
@@ -73,22 +73,7 @@ browser-compat: api.MediaTrackSupportedConstraints.logicalSurface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Capture',
-        '#dom-mediatracksupportedconstraints-logicalsurface',
-        'MediaTrackSupportedConstraints.logicalSurface')}}</td>
-      <td>{{Spec2('Screen Capture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.html
@@ -79,24 +79,7 @@ if (navigator.mediaDevices.getSupportedConstraints().noiseSuppression) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture',
-        '#dom-mediatracksupportedconstraints-noisesuppression', 'noiseSuppression') }}
-      </td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.html
@@ -70,23 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().sampleRate) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-samplerate',
-        'sampleRate') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.html
@@ -70,23 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().sampleSize) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-samplesize',
-        'sampleSize') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.html
@@ -59,23 +59,7 @@ if (navigator.mediaDevices.getSupportedConstraints().width) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('Media Capture', '#dom-mediatracksupportedconstraints-width',
-        'width') }}</td>
-      <td>{{ Spec2('Media Capture') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messagechannel/index.html
+++ b/files/en-us/web/api/messagechannel/index.html
@@ -67,20 +67,7 @@ function onMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', 'web-messaging.html#message-channels','Message channels')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messagechannel/messagechannel/index.html
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.html
@@ -61,21 +61,7 @@ function handleMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messagechannel',
-        'MessageChannel()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messagechannel/port1/index.html
+++ b/files/en-us/web/api/messagechannel/port1/index.html
@@ -59,23 +59,7 @@ function handleMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messagechannel-port1',
-        'port1')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messagechannel/port2/index.html
+++ b/files/en-us/web/api/messagechannel/port2/index.html
@@ -65,21 +65,7 @@ function handleMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messagechannel-port2',
-        'port2')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/data/index.html
+++ b/files/en-us/web/api/messageevent/data/index.html
@@ -35,20 +35,7 @@ browser-compat: api.MessageEvent.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-messageevent-data", "MessageEvent: data")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/index.html
@@ -111,20 +111,7 @@ myWorker.port.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#messageevent", "MessageEvent")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/lasteventid/index.html
+++ b/files/en-us/web/api/messageevent/lasteventid/index.html
@@ -36,21 +36,7 @@ browser-compat: api.MessageEvent.lastEventId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-messageevent-lasteventid", "MessageEvent:
-        lastEventId")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/messageevent/index.html
@@ -60,20 +60,7 @@ browser-compat: api.MessageEvent.MessageEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-event-constructor", "MessageEvent()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/origin/index.html
+++ b/files/en-us/web/api/messageevent/origin/index.html
@@ -36,21 +36,7 @@ browser-compat: api.MessageEvent.origin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-messageevent-origin", "MessageEvent: origin")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/ports/index.html
+++ b/files/en-us/web/api/messageevent/ports/index.html
@@ -42,20 +42,7 @@ browser-compat: api.MessageEvent.ports
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-messageevent-ports", "ports")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageevent/source/index.html
+++ b/files/en-us/web/api/messageevent/source/index.html
@@ -40,21 +40,7 @@ browser-compat: api.MessageEvent.source
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-messageevent-source", " MessageEvent: source")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/close/index.html
+++ b/files/en-us/web/api/messageport/close/index.html
@@ -51,21 +51,7 @@ channel.port1.start();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messageport-close',
-        'close()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/index.html
+++ b/files/en-us/web/api/messageport/index.html
@@ -84,20 +84,7 @@ function onMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'web-messaging.html#message-ports','Message ports')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/message_event/index.html
+++ b/files/en-us/web/api/messageport/message_event/index.html
@@ -72,18 +72,7 @@ targetFrame.postMessage('init', targetOrigin, [channel.port2]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-message')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/messageerror_event/index.html
+++ b/files/en-us/web/api/messageport/messageerror_event/index.html
@@ -81,18 +81,7 @@ targetFrame.postMessage('init', targetOrigin, [channel.port2]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'indices.html#event-messageerror')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/onmessage/index.html
+++ b/files/en-us/web/api/messageport/onmessage/index.html
@@ -58,21 +58,7 @@ function handleMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#handler-messageport-onmessage',
-        'onmessage')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/onmessageerror/index.html
+++ b/files/en-us/web/api/messageport/onmessageerror/index.html
@@ -27,21 +27,7 @@ browser-compat: api.MessagePort.onmessageerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        'web-messaging.html#handler-messageport-onmessageerror', 'onmessageerror')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/postmessage/index.html
+++ b/files/en-us/web/api/messageport/postmessage/index.html
@@ -74,21 +74,7 @@ function handleMessage(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messageport-postmessage',
-        'postMessage()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/messageport/start/index.html
+++ b/files/en-us/web/api/messageport/start/index.html
@@ -55,21 +55,7 @@ channel.port1.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'web-messaging.html#dom-messageport-start',
-        'start()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/metadata/index.html
+++ b/files/en-us/web/api/metadata/index.html
@@ -32,22 +32,7 @@ browser-compat: api.Metadata
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File System API')}}</td>
-   <td>{{Spec2('File System API')}}</td>
-   <td>Draft of proposed API</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods in api/m[a-e]* to the {{Specifications}} macros. 

Note that the following pages lose their table
- `MediaImage`, `MediaEncodingConfiguration`, `MediaPositionState`, `MediaConfiguration`, and `MediaDecodingConfiguration` as they have no bcd entry. These are dictionaries. I keep it that way; it will be dealt with when we deal with dictionaries.
- `MediaPositionState.duration`, `MediaPositionState.position`, `MediaPositionState.playbackRate` as they have no bcd entry. These are fields of dictionaries. I keep it that way; it will be dealt with when we deal with dictionaries. 
- `MetaData`. Missing spec_url in bcd; the previous link was to a spec without this info. The few browsers that implement it, do so with a prefix. I think I will keep the error message there.

All other pages look fine.