### PR TITLE
Improve code sample for setCustomValidity

### DIFF
--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
@@ -44,31 +44,21 @@ browser-compat: api.HTMLObjectElement.setCustomValidity
 		href="/en-US/docs/Web/API/HTMLFormElement/reportValidity">reportValidity</a>
 	method on the same element or nothing will happen.</p>
 
-<pre class="brush: js">function validate(inputID)
-{
- var input = document.getElementById(inputID);
- var validityState_object = input.validity;
+<pre class="brush: js">function validate(inputID) {
+  const input = document.getElementById(inputID);
+  const validityState = input.validity;
 
- if (validityState_object.valueMissing)
- {
-  input.setCustomValidity('You gotta fill this out, yo!');
+  if (validityState.valueMissing) {
+    input.setCustomValidity('You gotta fill this out, yo!');
+  } else if (validityState.rangeUnderflow) {
+    input.setCustomValidity('We need a higher number!');
+  } else if (validityState.rangeOverflow) {
+    input.setCustomValidity('Thats too high!');
+  } else {
+    input.setCustomValidity('');
+  }
+  
   input.reportValidity();
- }
- else if (validityState_object.rangeUnderflow)
- {
-  input.setCustomValidity('We need a higher number!');
-  input.reportValidity();
- }
- else if (validityState_object.rangeOverflow)
- {
-  input.setCustomValidity('Thats too high!');
-  input.reportValidity();
- }
- else
- {
-  input.setCustomValidity('');
-  input.reportValidity();
- }
 }</pre>
 
 <p>It's vital to set the message to an empty string if there are no errors. As long as the


### PR DESCRIPTION
The main two changes are the use of const instead of var since it's
widely accepted today to favor const/let and calling reportValidity
only once at the end instead of in every block because the end result
is the same.

I also updated the formatting to match what you'd most commonly
see in a JavaScript project.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The code sample looks like it was written a while ago, and it had some unnecessary lines.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it

I am open to suggestions on how to further improve the code sample.