### PR TITLE
HTMLMediaElement playing event- sidebar

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/playing_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/playing_event/index.html
@@ -6,11 +6,12 @@ tags:
   - HTMLMediaElement
   - Reference
   - playing
+  - Event
 browser-compat: api.HTMLMediaElement.playing_event
 ---
 <div>{{APIRef("HTMLMediaElement")}}</div>
 
-<p><span class="seoSummary">The <code>playing</code> event is fired when playback is ready to start after having been paused or delayed due to lack of data.</span></p>
+<p><span class="seoSummary">The <code>playing</code> event is fired after playback is first started, and whenever it is restarted. For example it is fired when playback resumes after having been paused or delayed due to lack of data.</span></p>
 
 <table class="properties">
  <tbody>


### PR DESCRIPTION
Fixes errors in [HTMLMediaElement/playing_even](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playing_event)
- Not automatically added to sidebar for media events
- Ambiguity about playing on start and restart

Fixes #5932