### PR TITLE
FF90 WheelEvent - add WheelDelta properties and release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -59,6 +59,10 @@ tags:
 
 <h4 id="DOM">DOM</h4>
 
+<ul>
+  <li>Support was added for the deprecated {{DOMxref("WheelEvent")}} properties: <code>WheelEvent.wheelDelta</code>, <code>WheelEvent.wheelDeltaX</code>, and <code>WheelEvent.wheelDeltaY</code>. This allows Firefox to work with a small subset of pages that were broken by recent compatibility improvements to <code>WheelEvent</code> ({{bug(1708829)}}).</li>
+</ul>
+
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
 
 <h4 id="removals_media">Removals</h4>

--- a/files/en-us/web/api/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/index.html
@@ -34,7 +34,7 @@ browser-compat: api.WheelEvent
 
 <p><em>This interface inherits properties from its ancestors, {{DOMxRef("MouseEvent")}}, {{DOMxRef("UIEvent")}}, and {{DOMxRef("Event")}}.</em></p>
 
-<dl id="raw_prop">
+<dl>
  <dt>{{DOMxRef("WheelEvent.deltaX")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a <code>double</code> representing the horizontal scroll amount.</dd>
  <dt>{{DOMxRef("WheelEvent.deltaY")}}{{ReadOnlyInline}}</dt>
@@ -60,17 +60,16 @@ browser-compat: api.WheelEvent
    <tr>
     <td><code>WheelEvent.DOM_DELTA_LINE</code></td>
     <td><code>0x01</code></td>
-    <td>The <code>delta*</code> values are specified in lines.</td>
+    <td>The <code>delta*</code> values are specified in lines. Each mouse click scrolls a line of content, where the method used to calculate line height is browser dependent.</td>
    </tr>
    <tr>
     <td><code>WheelEvent.DOM_DELTA_PAGE</code></td>
     <td><code>0x02</code></td>
-    <td>The <code>delta*</code> values are specified in pages.</td>
+    <td>The <code>delta*</code> values are specified in pages. Each mouse click scrolls a page of content.</td>
    </tr>
   </tbody>
  </table>
  </dd>
-
 
  <dt>{{DOMxRef("WheelEvent.wheelDelta")}}{{ReadOnlyInline}} {{deprecated_inline}}</dt>
  <dd>Returns an integer (32-bit) representing the distance in pixels.</dd>

--- a/files/en-us/web/api/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/index.html
@@ -70,7 +70,21 @@ browser-compat: api.WheelEvent
   </tbody>
  </table>
  </dd>
+
+
+ <dt>{{DOMxRef("WheelEvent.wheelDelta")}}{{ReadOnlyInline}} {{deprecated_inline}}</dt>
+ <dd>Returns an integer (32-bit) representing the distance in pixels.</dd>
+ <dt>{{DOMxRef("WheelEvent.wheelDeltaX")}}{{ReadOnlyInline}} {{deprecated_inline}}</dt>
+ <dd>Returns an integer representing the horizontal scroll amount.</dd>
+ <dt>{{DOMxRef("WheelEvent.wheelDeltaY")}}{{ReadOnlyInline}} {{deprecated_inline}}</dt>
+ <dd>Returns an integer representing the vertical scroll amount.</dd>
 </dl>
+
+
+<div class="notecard note">
+  <p><strong>Note:</strong> <a href="/en-US/docs/Web/API/Element/mousewheel_event">Element: mousewheel event</a> has additional documentation about the deprecated properties <code>wheelDelta</code>, <code>wheelDeltaX</code>, <code>wheelDeltaY</code>.
+  </p>
+</div>
 
 <h2 id="Methods">Methods</h2>
 


### PR DESCRIPTION
This adds docs and release note to address #5385 (FF90 bug https://bugzilla.mozilla.org/show_bug.cgi?id=1708829)

The bug story is quite confusing. Essentially in FF88 "ish" we made [WheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent) return delta values in pixels rather than "lines" for consistency with other major browsers. This broke some sites which did not test the code path. The fix was to add some legacy/deprecated properties to `WheelEvent` (`.WheelEvent`, `.WheelEventX`, `.WheelEventY`, because these are supported by the broken sites. Discussion of this in https://bugzilla.mozilla.org/show_bug.cgi?id=1708829#c16 and next couple of comments.

I was tempted to say we simply don't document this at all, since the additional properties should not be used, and this fixes a small subset of sites. But decided to go ahead.

PS 
- I also added a brief note about the difference between WheelEvent returning pixels, lines or pages as that was missing (well, specifically the fact that "lines" result in unpredictable behaviour because they are implementation dependent.)
- I didn't add specific sub pages for the new/deprecated properties. IMO not worth effort.