### PR TITLE
FF90 JavaScript Class private features release note/exp features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -585,46 +585,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Private_class_fields">Private class fields</h3>
-
-<p>See <a href="/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields">Private class fields</a> for more details.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference names</th>
-   <th colspan="2"><code>javascript.options.experimental.private_fields<br>
-    javascript.options.experimental.private_methods</code></th>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="APIs">APIs</h2>
 

--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -34,6 +34,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields">Private class fields and methods</a> are now supported by default ({{bug(1708235)}} and {{bug(1708236)}}).</li>
   <li>Custom date/time formats specified as options to the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat"><code>Intl.DateTimeFormat()</code> constructor</a> can now include <code>dayPeriod</code> — a value indicating that the approximate time of day (e.g. "in the morning", "at night", etc.) should be included as a <code>narrow</code>, <code>short</code>, or <code>long</code> string ({{bug(1645115)}}).</li>
  </ul>
 


### PR DESCRIPTION
Private class features (methods and fields) are supported by default. This just removes the preference from Experimental features and adds a Release note. 

Note that the release note has a link to an the current [class private fields doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields). That's OK because [following the update in this PR](https://github.com/mdn/content/pull/5690) it will cover both methods and fields. If that doc ends up being split up into fields/methods the release note will need an update.

If you're happy with this nothing to stop it going in now. 

> Issue number (if there is an associated issue)

#5386

