### PR TITLE
Page macro: Remove example inclusion in pannernode methods

### DIFF
--- a/files/en-us/web/api/pannernode/distancemodel/index.html
+++ b/files/en-us/web/api/pannernode/distancemodel/index.html
@@ -41,9 +41,11 @@ panner.distanceModel = 'inverse';</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <table class="standard-table">
  <tbody>

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -105,24 +105,11 @@ browser-compat: api.PannerNode
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#pannernode', 'PannerNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/maxdistance/index.html
+++ b/files/en-us/web/api/pannernode/maxdistance/index.html
@@ -37,24 +37,11 @@ panner.maxDistance = 10000;</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-maxdistance', 'maxDistance')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/panningmodel/index.html
+++ b/files/en-us/web/api/pannernode/panningmodel/index.html
@@ -35,24 +35,11 @@ panner.panningModel = 'HRTF';</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-panningmodel', 'panningModel')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/setorientation/index.html
+++ b/files/en-us/web/api/pannernode/setorientation/index.html
@@ -32,7 +32,7 @@ panner.setOrientation(1,0,0);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Parameters">Parameters</h2>
 
@@ -47,20 +47,7 @@ panner.setOrientation(1,0,0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-setorientation', 'setOrientation()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/setposition/index.html
+++ b/files/en-us/web/api/pannernode/setposition/index.html
@@ -30,7 +30,7 @@ panner.setPosition(0,0,0);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Parameters">Parameters</h2>
 
@@ -45,20 +45,7 @@ panner.setPosition(0,0,0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-setposition', 'setPosition()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/setvelocity/index.html
+++ b/files/en-us/web/api/pannernode/setvelocity/index.html
@@ -37,7 +37,7 @@ panner.setVelocity(0,0,17);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Parameters">Parameters</h2>
 
@@ -49,6 +49,10 @@ panner.setVelocity(0,0,17);</pre>
  <dt><code>z</code></dt>
  <dd>The z value of the panner's velocity vector.</dd>
 </dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

This is same as #4401. A bunch of example code now links rather than imports `BaseAudioContext.createPanner`
