### PR TITLE
Page macro: Replace VRDisplayCapilities example include

### DIFF
--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -27,7 +27,7 @@ browser-compat: api.VRDisplay.capabilities
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -27,7 +27,7 @@ browser-compat: api.VRDisplay.displayId
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRDisplay.displayName
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>hasExternalDisplay</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display is separate from the device's primary display.</p>
+<p>The <strong><code>hasExternalDisplay</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display is separate from the device's primary display.</p>
 
 <div class="note">
 <p><strong>Note</strong>: If presenting VR content would obscure other content on the device, this will return <code>false</code>, in which case the application should not attempt to mirror VR content or update non-VR UI because that content will not be visible.</p>
@@ -31,7 +31,7 @@ browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -16,7 +16,7 @@ browser-compat: api.VRDisplayCapabilities.hasOrientation
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_header}}</div>
 
-<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display can track and return orientation information.</p>
+<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display can track and return orientation information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -28,7 +28,7 @@ browser-compat: api.VRDisplayCapabilities.hasOrientation
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplayCapabilities.hasPosition
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display can track and return position information.</p>
+<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display can track and return position information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -27,7 +27,7 @@ browser-compat: api.VRDisplayCapabilities.hasPosition
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -27,7 +27,7 @@ browser-compat: api.VRDisplayCapabilities.maxLayers
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayCapabilities", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplayCapabilities#examples"><code>VRDisplayCapabilities</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

This is same as #4401. A bunch of example code sections now link rather than import example code in [VRDisplayCapabilities](https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities#examples)