### PR TITLE
Page macro: Replace macro with links to VRDisplay.getframedata()

### DIFF
--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -97,8 +97,8 @@ function drawVRScene() {
   vrDisplay.submitFrame();
 }</pre>
 
-<div class="note">
-<p><strong>Note</strong>: You can see this complete code at <a href="https://github.com/mdn/webvr-tests/blob/master/raw-webgl-example/webgl-demo.js">raw-webgl-example</a>.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> You can see this complete code at <a href="https://github.com/mdn/webvr-tests/blob/master/raw-webgl-example/webgl-demo.js">raw-webgl-example</a>.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -85,8 +85,8 @@ browser-compat: api.VRDisplay
   });
 }</pre>
 
-<div class="note">
-<p><strong>Note</strong>: You can see this complete code at <a href="https://github.com/mdn/webvr-tests/blob/master/raw-webgl-example/webgl-demo.js">raw-webgl-example</a>.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> You can see this complete code at <a href="https://github.com/mdn/webvr-tests/blob/master/raw-webgl-example/webgl-demo.js">raw-webgl-example</a>.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -42,7 +42,7 @@ browser-compat: api.VRFrameData
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.leftViewMatrix
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -27,7 +27,7 @@ browser-compat: api.VRFrameData.pose
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.rightViewMatrix
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -26,7 +26,7 @@ browser-compat: api.VRFrameData.VRFrameData
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -44,7 +44,7 @@ browser-compat: api.VRPose
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -38,7 +38,7 @@ browser-compat: api.VRPose.orientation
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <div class="note">
 <p><strong>Note</strong>: An orientation of <code>{ x: 0, y: 0, z: 0, w: 1 }</code> is considered to be "forward".</p>

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -45,7 +45,7 @@ browser-compat: api.VRPose.position
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay/getFrameData", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay/getFrameData#examples"><code>VRDisplay.getFrameData()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

This is same as #4401. A bunch of example code now links rather than imports `VRDisplay.getFrameData()`

Note, I did consider moving the example up to `VRDisplay` and linking to that, but that object already has a different example. 