### PR TITLE
Clarify why slice() w/ typed arrays returns shallow copy

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -62,8 +62,7 @@ slice(start, end)
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>slice</code> method does not alter. It returns a shallow copy of elements
-  from the original typed array.</p>
+<p>The <code>slice</code> method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the <code>slice</code> method returns is always a shallow copy.</p>
 
 <p>If a new element is added to either typed array, the other typed array is not affected.
 </p>

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -2,13 +2,13 @@
 title: TypedArray.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/slice
 tags:
-- ECMAScript 2015
-- JavaScript
-- Method
-- Prototype
-- TypedArray
-- TypedArrays
-- Polyfill
+  - ECMAScript 2015
+  - JavaScript
+  - Method
+  - Prototype
+  - TypedArray
+  - TypedArrays
+  - Polyfill
 browser-compat: javascript.builtins.TypedArray.slice
 ---
 <div>{{JSRef}}</div>
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.TypedArray.slice
   underlying buffer), that contains a copy of a portion of the original typed array. This
   method has the same algorithm as {{jsxref("Array.prototype.slice()")}}.
   <em>TypedArray</em> is one of the <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects">typed
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects">typed
     array types</a> here.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-slice.html","shorter")}}</div>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/5035