### PR TITLE
Fix “samples” link in File and Directory Entries API intro doc

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -40,7 +40,7 @@ tags:
  <li>It provides a storage API that is already familiar to your users, who are used to working with file systems. </li>
 </ul>
 
-<p>For examples of features you can create with this app, see the <a href="#samples" title="#samples">Sample use cases</a> section.  </p>
+<p>For examples of features you can create with this app, see the <a href="#sample" title="#samples">Sample use cases</a> section.  </p>
 
 <h3 id="The_File_and_Directory_Entries_API_and_other_storage_APIs">The File and Directory Entries API and other storage APIs</h3>
 

--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -40,7 +40,7 @@ tags:
  <li>It provides a storage API that is already familiar to your users, who are used to working with file systems. </li>
 </ul>
 
-<p>For examples of features you can create with this app, see the <a href="/#samples" title="#samples">Sample use cases</a> section.  </p>
+<p>For examples of features you can create with this app, see the <a href="#samples" title="#samples">Sample use cases</a> section.  </p>
 
 <h3 id="The_File_and_Directory_Entries_API_and_other_storage_APIs">The File and Directory Entries API and other storage APIs</h3>
 


### PR DESCRIPTION
Remove / (slash) from Sample href

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The link navigate to the project home page instead to the Sample section 

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction