### PR TITLE
list JPEG XL under experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1367,6 +1367,46 @@ tags:
  </tbody>
 </table>
 
+<h4 id="JPEG_XL_support">JPEG XL support</h4>
+
+<p>With this feature enabled, Firefox supports <a href="https://jpeg.org/jpegxl/">JPEG XL</a> images, see {{bug(1539075)}} for more details. This feature is available in nightly builds effective in Firefox 90 or later.</p>
+
+<table class="standard-table">
+  <thead>
+   <tr>
+    <th scope="col" style="vertical-align: bottom;">Release channel</th>
+    <th scope="col" style="vertical-align: bottom;">Version added</th>
+    <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <th scope="row">Nightly</th>
+    <td>90</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Developer Edition</th>
+    <td>90</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Beta</th>
+    <td>90</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Release</th>
+    <td>—</td>
+    <td>—</td>
+   </tr>
+   <tr>
+    <th scope="row">Preference name</th>
+    <th colspan="2">image.jxl.enabled</th>
+   </tr>
+  </tbody>
+ </table>
+
 <h2 id="Security_and_privacy">Security and privacy</h2>
 
 <h4 id="Block_plain_text_requests_from_Flash_on_encrypted_pages">Block plain text requests from Flash on encrypted pages</h4>


### PR DESCRIPTION
This adds the information about the JPEG XL image format to page
listing experimental features in Firefox.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

So far the new feature was not mentioned on the page

> MDN URL of the main page changed

en-US/docs/Mozilla/Firefox/Experimental_features

> Anything else that could help us review it

Tracking but for JPEG XL: https://bugzilla.mozilla.org/show_bug.cgi?id=1539075