### PR TITLE
Remove capital in slug of FetchEvent.preloadResponse

### DIFF
--- a/files/en-us/web/api/fetchevent/preloadresponse/index.html
+++ b/files/en-us/web/api/fetchevent/preloadresponse/index.html
@@ -1,6 +1,6 @@
 ---
 title: FetchEvent.preloadResponse
-slug: Web/API/FetchEvent/PreloadResponse
+slug: Web/API/FetchEvent/preloadResponse
 tags:
 - API
 - Experimental


### PR DESCRIPTION
Attributes, properties and methods mustn't start with a capital letter (in the general case).

This was the case, so I'm updating the case.

No redirect is needed, so only 1 file is touched.

This was detected by @foolip in mdn/browser-compat-data#10983