### PR TITLE
Add media attribute support for meta[name=theme-color]

### DIFF
--- a/files/en-us/web/html/element/meta/name/theme-color/index.html
+++ b/files/en-us/web/html/element/meta/name/theme-color/index.html
@@ -23,6 +23,11 @@ browser-compat: html.elements.meta.name.theme-color
 <figcaption><small>Image credit: from <a href="https://developers.google.com/web/fundamentals/design-and-ux/browser-customization">Icons &amp; Browser Colors</a>, created and <a href="https://developers.google.com/readme/policies">shared by Google</a> and used according to terms described in the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons 4.0 Attribution License</a>.</small></figcaption>
 </figure>
 
+<p>You can provide a media type or query inside the {{htmlattrxref("media", "meta")}} attribute; the color will then only be set if the media condition is true. For example:</p>
+
+<pre class="brush: html">&lt;meta name="theme-color" media="(prefers-color-scheme: light)" content="white"&gt;
+&lt;meta name="theme-color" media="(prefers-color-scheme: dark)" content="black"&gt;</pre>
+
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>


### PR DESCRIPTION
https://github.com/whatwg/html/pull/6569 is about to add media attribute support for meta[name=theme-color]. This PR reflects this to the https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color page.