### PR TITLE
Replace spec table with {{specifications}} for api/m[f-z]*

### DIFF
--- a/files/en-us/web/api/midiaccess/index.html
+++ b/files/en-us/web/api/midiaccess/index.html
@@ -48,20 +48,7 @@ browser-compat: api.MIDIAccess
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midiaccess-interface')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.MIDIConnectionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midiconnectionevent-interface')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midiinput/index.html
+++ b/files/en-us/web/api/midiinput/index.html
@@ -28,20 +28,7 @@ browser-compat: api.MIDIInput
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midiinput-interface')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midiinputmap/index.html
+++ b/files/en-us/web/api/midiinputmap/index.html
@@ -11,20 +11,7 @@ browser-compat: api.MIDIInputMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midiinputmap-interface')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midimessageevent/index.html
+++ b/files/en-us/web/api/midimessageevent/index.html
@@ -43,20 +43,7 @@ navigator.requestMIDIAccess().then(midiAccess =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midimessageevent-interface', 'MIDIMessageEvent')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutputmap/index.html
+++ b/files/en-us/web/api/midioutputmap/index.html
@@ -11,20 +11,7 @@ browser-compat: api.MIDIOutputMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebMIDI API','#midiinputmap-interface')}}</td>
-   <td>{{Spec2('WebMIDI API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mimetype/index.html
+++ b/files/en-us/web/api/mimetype/index.html
@@ -27,20 +27,7 @@ browser-compat: api.MimeType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','#mimetype','MimeType')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mimetypearray/index.html
+++ b/files/en-us/web/api/mimetypearray/index.html
@@ -45,20 +45,7 @@ if (typeof flashPlugin === "undefined") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','#mimetypearray','MimeTypeArray')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/altkey/index.html
+++ b/files/en-us/web/api/mouseevent/altkey/index.html
@@ -61,25 +61,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-altKey','MouseEvent.altkey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.altkey')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/button/index.html
+++ b/files/en-us/web/api/mouseevent/button/index.html
@@ -94,25 +94,7 @@ function logMouseButton(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-button','MouseEvent.button')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Compared to {{SpecName('DOM2 Events')}}, the return value can be negative.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.button')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/buttons/index.html
+++ b/files/en-us/web/api/mouseevent/buttons/index.html
@@ -83,26 +83,7 @@ document.querySelector('#log').appendChild(log)</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('UI Events','#dom-mouseevent-buttons','MouseEvent.buttons')}}
-			</td>
-			<td>{{Spec2('UI Events')}}</td>
-			<td>Current working draft</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM3 Events','#widl-MouseEvent-buttons','MouseEvent.buttons')}}</td>
-			<td>{{Spec2('DOM3 Events')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/clientx/index.html
+++ b/files/en-us/web/api/mouseevent/clientx/index.html
@@ -61,31 +61,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-mouseevent-clientx', 'clientX')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines {{domxref("MouseEvent")}} from <code>long</code> to
-        <code>double</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-clientX','MouseEvent.clientX')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.clientX')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/clienty/index.html
+++ b/files/en-us/web/api/mouseevent/clienty/index.html
@@ -60,31 +60,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-mouseevent-clienty', 'clientY')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines {{domxref("MouseEvent")}} from <code>long</code> to
-        <code>double</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-clientY','MouseEvent.clientY')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.clientY')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.html
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.html
@@ -57,25 +57,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-ctrlKey','MouseEvent.ctrlKey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.ctrlKey')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.html
@@ -41,21 +41,7 @@ browser-compat: api.MouseEvent.getModifierState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-MouseEvent-getModifierState',
-        'getModifierState()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/index.html
@@ -141,47 +141,7 @@ document.getElementById("button").addEventListener('click', simulateClick);</pre
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM View','#extensions-to-the-mouseevent-interface', 'MouseEvent')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>Redefines <code>MouseEvent</code> from long to double. This means that a <code>PointerEvent</code> whose <code>pointerType</code> is mouse will be a double.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Lock','#extensions-to-the-mouseevent-interface','MouseEvent')}}</td>
-   <td>{{Spec2('Pointer Lock')}}</td>
-   <td>From {{SpecName('DOM3 Events')}}, added <code>movementX</code> and <code>movementY</code> properties.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#extensions-to-the-mouseevent-interface', 'MouseEvent')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>From {{SpecName('DOM3 Events')}}, added <code>offsetX</code> and <code>offsetY</code>, <code>pageX</code> and <code>pageY</code>, <code>x</code>, and <code>y</code> properties. Redefined screen, page, client, and coordinate (x and y) properties as <code>double</code> from <code>long</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('UI Events', '#interface-mouseevent', 'MouseEvent')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events','#events-mouseevents','MouseEvent')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>From {{SpecName('DOM2 Events')}}, added the <code>MouseEvent()</code> constructor, the <code>getModifierState()</code> method and the <code>buttons</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent')}}</td>
-   <td>{{Spec2('DOM2 Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.html
@@ -120,27 +120,7 @@ simulateClick();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#idl-interface-MouseEvent-initializers',
-        'MouseEvent.initMouseEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>From {{SpecName('DOM2 Events')}}, deprecated.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-Event-initMouseEvent',
-        'MouseEvent.initMouseEvent()')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/metakey/index.html
+++ b/files/en-us/web/api/mouseevent/metakey/index.html
@@ -61,25 +61,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-metaKey','MouseEvent.metaKey')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.metaKey')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.html
@@ -134,28 +134,7 @@ browser-compat: api.MouseEvent.MouseEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#extensions-to-the-mouseevent-interface',
-        'MouseEvent')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines screen and client fields long to double.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#interface-MouseEvent','MouseEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/movementx/index.html
+++ b/files/en-us/web/api/mouseevent/movementx/index.html
@@ -56,21 +56,7 @@ document.addEventListener('mousemove', logMovement);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Lock','#dom-mouseevent-movementx','MouseEvent.movementX')}}
-      </td>
-      <td>{{Spec2('Pointer Lock')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/movementy/index.html
+++ b/files/en-us/web/api/mouseevent/movementy/index.html
@@ -55,21 +55,7 @@ document.addEventListener('mousemove', logMovement);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Lock','#dom-mouseevent-movementy','MouseEvent.movementY')}}
-      </td>
-      <td>{{Spec2('Pointer Lock')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/offsetx/index.html
+++ b/files/en-us/web/api/mouseevent/offsetx/index.html
@@ -28,20 +28,7 @@ browser-compat: api.MouseEvent.offsetX
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-mouseevent-offsetx', 'MouseEvent')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/offsety/index.html
+++ b/files/en-us/web/api/mouseevent/offsety/index.html
@@ -28,20 +28,7 @@ browser-compat: api.MouseEvent.offsetY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-mouseevent-offsety', 'MouseEvent')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/pagex/index.html
+++ b/files/en-us/web/api/mouseevent/pagex/index.html
@@ -136,25 +136,7 @@ box.addEventListener("mouseleave", updateDisplay, false);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-mouseevent-pagex', 'pageX')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefined from <code>long</code> to <code>double</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-pageX', 'pageX')}}</td>
-      <td>{{Spec2('TouchEvents')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p>Prior to being added to the CSSOM View specification, <code>pageX</code> and
   <code>pageY</code> were available on the {{domxref("UIEvent")}} interface in a limited

--- a/files/en-us/web/api/mouseevent/pagey/index.html
+++ b/files/en-us/web/api/mouseevent/pagey/index.html
@@ -30,25 +30,7 @@ browser-compat: api.MouseEvent.pageY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-mouseevent-pagey', 'pageY')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefined from <code>long</code> to <code>double</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-pageY', 'pageY')}}</td>
-      <td>{{Spec2('TouchEvents')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -137,30 +137,7 @@ function overListener(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('UI Events', '#dom-mouseevent-relatedtarget', 'MouseEvent.relatedTarget')}}</td>
-      <td>{{Spec2('UI Events')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-relatedTarget','MouseEvent.relatedTarget')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.altkey')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/screenx/index.html
+++ b/files/en-us/web/api/mouseevent/screenx/index.html
@@ -68,30 +68,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-mouseevent-screenx', 'screenX')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines {{domxref("MouseEvent")}} from long to double.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-screenX','MouseEvent.screenX')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.sceenX')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/screeny/index.html
+++ b/files/en-us/web/api/mouseevent/screeny/index.html
@@ -54,30 +54,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#dom-mouseevent-screeny', 'screenY')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines {{domxref("MouseEvent")}} from long to double.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-screenY','MouseEvent.screenY')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.sceenY')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/shiftkey/index.html
+++ b/files/en-us/web/api/mouseevent/shiftkey/index.html
@@ -52,26 +52,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-shiftKey','MouseEvent.shiftKey')}}
-      </td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>No change from {{SpecName('DOM2 Events')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events','#Events-MouseEvent','MouseEvent.shiftKey')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/x/index.html
+++ b/files/en-us/web/api/mouseevent/x/index.html
@@ -15,20 +15,7 @@ browser-compat: api.MouseEvent.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSSOM View', '#dom-mouseevent-x', 'MouseEvent.x')}}</td>
-			<td>{{Spec2('CSSOM View')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mouseevent/y/index.html
+++ b/files/en-us/web/api/mouseevent/y/index.html
@@ -15,20 +15,7 @@ browser-compat: api.MouseEvent.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#dom-mouseevent-y', 'MouseEvent.y')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserver/disconnect/index.html
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.html
@@ -71,23 +71,7 @@ observer.disconnect();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserver-disconnect',
-        'MutationObserver.disconnect()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserver/index.html
+++ b/files/en-us/web/api/mutationobserver/index.html
@@ -75,22 +75,7 @@ observer.disconnect();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#interface-mutationobserver', 'MutationObserver')}}</td>
-			<td>{{ Spec2('DOM WHATWG') }}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserver/mutationobserver/index.html
+++ b/files/en-us/web/api/mutationobserver/mutationobserver/index.html
@@ -126,23 +126,7 @@ observer.observe(targetNode, observerOptions);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserver-mutationobserver',
-        'MutationObserver()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserver/observe/index.html
+++ b/files/en-us/web/api/mutationobserver/observe/index.html
@@ -182,23 +182,7 @@ observer.observe(elementToObserve, {subtree: true, childList: true});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserver-observe',
-        'MutationObserver.observe()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserver/takerecords/index.html
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.html
@@ -82,23 +82,7 @@ if (mutations) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserver-takerecords',
-        'MutationObserver.takeRecords()')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/attributefilter/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributefilter/index.html
@@ -103,23 +103,7 @@ observer.observe(userListElement, {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-attributefilter',
-        'MutationObserverInit: attributeFilter')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
@@ -47,23 +47,7 @@ browser-compat: api.MutationObserverInit.attributeOldValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-attributeoldvalue',
-        'MutationObserverInit.attributeOldValue')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/attributes/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributes/index.html
@@ -104,23 +104,7 @@ observer.observe(targetNode, {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-attributes',
-        'MutationObserverInit.attributes')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/characterdata/index.html
+++ b/files/en-us/web/api/mutationobserverinit/characterdata/index.html
@@ -72,23 +72,7 @@ browser-compat: api.MutationObserverInit.characterData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-characterdata',
-        'MutationObserverInit.characterData')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/characterdataoldvalue/index.html
+++ b/files/en-us/web/api/mutationobserverinit/characterdataoldvalue/index.html
@@ -60,23 +60,7 @@ browser-compat: api.MutationObserverInit.characterDataOldValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-characterdataoldvalue',
-        'MutationObserverInit.characterDataOldValue')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/childlist/index.html
+++ b/files/en-us/web/api/mutationobserverinit/childlist/index.html
@@ -49,23 +49,7 @@ browser-compat: api.MutationObserverInit.childList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-childlist',
-        'MutationObserverInit.childList')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/index.html
+++ b/files/en-us/web/api/mutationobserverinit/index.html
@@ -43,22 +43,7 @@ browser-compat: api.MutationObserverInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dictdef-mutationobserverinit', 'MutationObserverInit')}}</td>
-			<td>{{ Spec2('DOM WHATWG') }}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationobserverinit/subtree/index.html
+++ b/files/en-us/web/api/mutationobserverinit/subtree/index.html
@@ -68,23 +68,7 @@ browser-compat: api.MutationObserverInit.subtree
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-mutationobserverinit-subtree',
-        'MutationObserverInit.subtree')}}</td>
-      <td>{{ Spec2('DOM WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/mutationrecord/index.html
+++ b/files/en-us/web/api/mutationrecord/index.html
@@ -87,22 +87,7 @@ browser-compat: api.MutationRecord
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#mutationrecord', 'MutationRecord')}}</td>
-   <td>{{ Spec2('DOM WHATWG') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of the remaining api/m* to the {{Specifications}} macros. 

Note that:
- `MouseEvent.initMouseEvent` lose its table as it is no more on the standard track. I'm adding it to the list of deprecated page to improve the message in a second phase.

All other pages look fine.