### PR TITLE
Drag Operations - Case of letter 'h'

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>When a user begins to drag, the {{event("dragstart")}} event is fired.</p>
 
-<p>In this example the {{event("dragstart")}} listener is added to the draggable element itself. however, you could listen to a higher ancestor as drag events bubble up as most other events do.</p>
+<p>In this example the {{event("dragstart")}} listener is added to the draggable element itself. However, you could listen to a higher ancestor as drag events bubble up as most other events do.</p>
 
 <p>Within the {{event("dragstart")}} event, you can specify the <strong>drag data</strong>, the <strong>feedback image</strong>, and the <strong>drag effects</strong>, all of which are described below. However, only the <strong>drag data</strong> is required. (The default image and drag effects are suitable in most situations.)</p>
 


### PR DESCRIPTION
Capital letter "h" at the beginning of a sentence in article "Drag Operations"
https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations