### PR TITLE
Replace spec table with {{specifications}} for api/n*

### DIFF
--- a/files/en-us/web/api/namednodemap/index.html
+++ b/files/en-us/web/api/namednodemap/index.html
@@ -50,35 +50,7 @@ browser-compat: api.NamedNodeMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-namednodemap', 'NamedNodeMap')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Deals with {{domxref("Attr")}} instead of {{domxref("Node")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-1780488922', 'NamedNodeMap')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>No change from {{SpecName('DOM2 Core')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-1780488922', 'NamedNodeMap')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>Added <code>getNamedItemNS()</code>, <code>setNamedItemNS()</code> and <code>removeNamedItemNS()</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'core.html#ID-1780488922', 'NamedNodeMap')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.html
+++ b/files/en-us/web/api/navigationpreloadmanager/index.html
@@ -63,20 +63,7 @@ browser-compat: api.NavigationPreloadManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers','#navigation-preload-manager','NavigationPreloadManager')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/activevrdisplays/index.html
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.html
@@ -42,23 +42,7 @@ browser-compat: api.Navigator.activeVRDisplays
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebVR 1.1", '#navigator-activevrdisplays-attribute',
-        'activeVRDisplays')}}</td>
-      <td>{{Spec2("WebVR 1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/clearappbadge/index.html
+++ b/files/en-us/web/api/navigator/clearappbadge/index.html
@@ -41,20 +41,7 @@ browser-compat: api.Navigator.clearAppBadge
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Badging API','#clearappbadge-method','clearAppBadge')}}</td>
-    <td>{{Spec2('Badging API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/clipboard/index.html
+++ b/files/en-us/web/api/navigator/clipboard/index.html
@@ -56,22 +56,7 @@ browser-compat: api.Navigator.clipboard
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Clipboard API','#navigator-clipboard','navigator.clipboard')}}</td>
-      <td>{{Spec2('Clipboard API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/connection/index.html
+++ b/files/en-us/web/api/navigator/connection/index.html
@@ -30,23 +30,7 @@ browser-compat: api.Navigator.connection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Network Information', '#connection-attribute',
-        'Navigator.connection')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial specification</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/contacts/index.html
+++ b/files/en-us/web/api/navigator/contacts/index.html
@@ -36,20 +36,7 @@ browser-compat: api.Navigator.contacts
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Contact Picker API','#extensions-to-navigator','Navigator.contacts')}}</td>
-      <td>{{Spec2('Contact Picker API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/cookieenabled/index.html
+++ b/files/en-us/web/api/navigator/cookieenabled/index.html
@@ -34,22 +34,7 @@ browser-compat: api.Navigator.cookieEnabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "webappapis.html#dom-navigator-cookieenabled", "Navigator.cookieEnabled")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/credentials/index.html
+++ b/files/en-us/web/api/navigator/credentials/index.html
@@ -40,22 +40,7 @@ browser-compat: api.Navigator.credentials
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/devicememory/index.html
+++ b/files/en-us/web/api/navigator/devicememory/index.html
@@ -39,22 +39,7 @@ console.log (`This device has at least ${memory}GiB of RAM.`)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Device Memory","#sec-device-memory-js-api","deviceMemory")}}</td>
-      <td>{{Spec2("Device Memory")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/donottrack/index.html
+++ b/files/en-us/web/api/navigator/donottrack/index.html
@@ -24,22 +24,7 @@ browser-compat: api.Navigator.doNotTrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Tracking", "#dom-navigator-donottrack", "Navigator.doNotTrack")}}</td>
-   <td>{{Spec2("Tracking")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/geolocation/index.html
+++ b/files/en-us/web/api/navigator/geolocation/index.html
@@ -30,23 +30,7 @@ browser-compat: api.Navigator.geolocation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Geolocation', '#dom-navigator-geolocation',
-        'Navigator.geolocation')}}</td>
-      <td>{{Spec2('Geolocation')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/getbattery/index.html
+++ b/files/en-us/web/api/navigator/getbattery/index.html
@@ -79,23 +79,7 @@ navigator.getBattery().then(function(battery) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Battery API", "#dom-navigator-getbattery",
-        "Navigator.getBattery()")}}</td>
-      <td>{{Spec2("Battery API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/getgamepads/index.html
+++ b/files/en-us/web/api/navigator/getgamepads/index.html
@@ -35,20 +35,7 @@ browser-compat: api.Navigator.getGamepads
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Gamepad', '', 'The Gamepad API specification')}}</td>
-      <td>{{Spec2('Gamepad')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/getvrdisplays/index.html
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.html
@@ -42,23 +42,7 @@ browser-compat: api.Navigator.getVRDisplays
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebVR 1.1", '#navigator-getvrdisplays-attribute',
-        'getVRDisplays()')}}</td>
-      <td>{{Spec2("WebVR 1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/hid/index.html
+++ b/files/en-us/web/api/navigator/hid/index.html
@@ -29,23 +29,7 @@ browser-compat: api.Navigator.hid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebHID', '#dom-navigator-hid',
-        'Navigator.hid')}}</td>
-      <td>{{Spec2('WebHID')}}</td>
-      <td>Initial specification</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -166,22 +166,7 @@ browser-compat: api.Navigator
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#the-navigator-object', 'the Navigator object')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/keyboard/index.html
+++ b/files/en-us/web/api/navigator/keyboard/index.html
@@ -29,22 +29,7 @@ browser-compat: api.Navigator.keyboard
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#navigator-interface','keyboard')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/locks/index.html
+++ b/files/en-us/web/api/navigator/locks/index.html
@@ -29,20 +29,7 @@ browser-compat: api.Navigator.locks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Locks','#navigator-mixins','locks')}}</td>
-      <td>{{Spec2('Web Locks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/maxtouchpoints/index.html
+++ b/files/en-us/web/api/navigator/maxtouchpoints/index.html
@@ -29,29 +29,7 @@ browser-compat: api.Navigator.maxTouchPoints
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#extensions-to-the-navigator-interface',
-        'maxTouchPoints')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#extensions-to-the-navigator-interface',
-        'maxTouchPoints')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/mediacapabilities/index.html
+++ b/files/en-us/web/api/navigator/mediacapabilities/index.html
@@ -47,22 +47,7 @@ browser-compat: api.Navigator.mediaCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capabilities')}}</td>
-      <td>{{Spec2('Media Capabilities')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/mediadevices/index.html
+++ b/files/en-us/web/api/navigator/mediadevices/index.html
@@ -32,23 +32,7 @@ browser-compat: api.Navigator.mediaDevices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Capture', '#mediadevices',
-        'NavigatorUserMedia.mediaDevices')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/mediasession/index.html
+++ b/files/en-us/web/api/navigator/mediasession/index.html
@@ -65,22 +65,7 @@ browser-compat: api.Navigator.mediaSession
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Session','#dom-navigator-mediasession','navigator.mediaSession')}}</td>
-      <td>{{Spec2('Media Session')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/oscpu/index.html
+++ b/files/en-us/web/api/navigator/oscpu/index.html
@@ -86,22 +86,7 @@ osInfo(); // alerts "Windows NT 6.0" for example
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-navigator-oscpu', 'NavigatorID: oscpu')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/permissions/index.html
+++ b/files/en-us/web/api/navigator/permissions/index.html
@@ -40,20 +40,7 @@ browser-compat: api.Navigator.permissions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Permissions API')}}</td>
-			<td>{{Spec2('Permissions API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/presentation/index.html
+++ b/files/en-us/web/api/navigator/presentation/index.html
@@ -20,21 +20,7 @@ browser-compat: api.Navigator.presentation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName("Presentation","#dom-navigator-presentation","Navigator.presentation")}}
-            </td>
-            <td>{{Spec2('Presentation')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/productsub/index.html
+++ b/files/en-us/web/api/navigator/productsub/index.html
@@ -44,22 +44,7 @@ function prodsub() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-productsub', 'NavigatorID: productSub')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/registercontenthandler/index.html
+++ b/files/en-us/web/api/navigator/registercontenthandler/index.html
@@ -56,24 +56,7 @@ browser-compat: api.Navigator.registerContentHandler
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML5.2', 'webappapis.html#dom-navigator-registercontenthandler',
-        'registerContentHandler()')}}</td>
-      <td>{{Spec2('HTML5.2')}}</td>
-      <td>This feature is present in HTML 5.2, but has since been removed from the WHATWG
-        HTML Living Standard.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.html
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.html
@@ -153,23 +153,7 @@ browser-compat: api.Navigator.registerProtocolHandler
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'system-state.html#custom-handlers',
-        'registerProtocolHandler()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
@@ -81,21 +81,7 @@ browser-compat: api.Navigator.requestMediaKeySystemAccess
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME', '#navigator-extension-requestmediakeysystemaccess',
-        'requestMediaKeySystemAccess()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.html
+++ b/files/en-us/web/api/navigator/sendbeacon/index.html
@@ -127,22 +127,7 @@ navigator.sendBeacon(<var>url</var>, <var>data</var>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Beacon', '#sendbeacon-method', 'sendBeacon()')}}</td>
-      <td>{{Spec2('Beacon')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -33,20 +33,7 @@ browser-compat: api.Navigator.serial
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Web Serial API','#extensions-to-the-navigator-interface','Extensions to the Navigator Interface')}}</td>
-    <td>{{Spec2('Web Serial API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/serviceworker/index.html
+++ b/files/en-us/web/api/navigator/serviceworker/index.html
@@ -41,23 +41,7 @@ browser-compat: api.Navigator.serviceWorker
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Service Workers', '#navigator-serviceworker',
-        'navigator.serviceWorker')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/setappbadge/index.html
+++ b/files/en-us/web/api/navigator/setappbadge/index.html
@@ -45,20 +45,7 @@ navigator.setAppBadge(unread);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Badging API','#setappbadge-method','setAppBadge')}}</td>
-   <td>{{Spec2('Badging API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -93,22 +93,7 @@ btn.addEventListener('click', async () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Share API','#share-method','share()')}}</td>
-      <td>{{Spec2('Web Share API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/vendor/index.html
+++ b/files/en-us/web/api/navigator/vendor/index.html
@@ -25,22 +25,7 @@ browser-compat: api.Navigator.vendor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-navigator-vendor', 'NavigatorID: vendor')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/vendorsub/index.html
+++ b/files/en-us/web/api/navigator/vendorsub/index.html
@@ -27,22 +27,7 @@ browser-compat: api.Navigator.vendorSub
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-vendorsub', 'NavigatorID: vendorSub')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/vibrate/index.html
+++ b/files/en-us/web/api/navigator/vibrate/index.html
@@ -46,22 +46,7 @@ window.navigator.vibrate([100,30,100,30,100,30,200,30,200,30,200,30,100,30,100,3
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Vibration API')}}</td>
-      <td>{{Spec2('Vibration API')}}</td>
-      <td>Linked to spec is the latest editor's draft; W3C version is a REC.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/wakelock/index.html
+++ b/files/en-us/web/api/navigator/wakelock/index.html
@@ -21,24 +21,7 @@ browser-compat: api.Navigator.wakeLock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a
-          href="https://w3c.github.io/screen-wake-lock/#extensions-to-the-navigator-interface">Screen
-          Wake Lock API</a></td>
-      <td>Editor's Draft</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/webdriver/index.html
+++ b/files/en-us/web/api/navigator/webdriver/index.html
@@ -42,24 +42,7 @@ browser-compat: api.Navigator.webdriver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebDriver","#dom-navigatorautomationinformation-webdriver","webdriver")}}
-      </td>
-      <td>{{Spec2("WebDriver")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/xr/index.html
+++ b/files/en-us/web/api/navigator/xr/index.html
@@ -55,22 +55,7 @@ browser-compat: api.Navigator.xr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#navigator-xr-attribute","Navigator.xr")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.html
+++ b/files/en-us/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.html
@@ -62,21 +62,7 @@ for (let i = 0; i &lt; window.navigator.hardwareConcurrency; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-hardwareconcurrency',
-        'navigator.hardwareConcurrency')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorconcurrenthardware/index.html
+++ b/files/en-us/web/api/navigatorconcurrenthardware/index.html
@@ -38,22 +38,7 @@ browser-compat: api.NavigatorConcurrentHardware
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigator.hardwareconcurrency', 'NavigatorConcurrentHardware')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/appcodename/index.html
+++ b/files/en-us/web/api/navigatorid/appcodename/index.html
@@ -31,23 +31,7 @@ browser-compat: api.NavigatorID.appCodeName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-appcodename',
-        'NavigatorID.appCodeName')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/appname/index.html
+++ b/files/en-us/web/api/navigatorid/appname/index.html
@@ -32,23 +32,7 @@ browser-compat: api.NavigatorID.appName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-appname', 'NavigatorID.appName')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/appversion/index.html
+++ b/files/en-us/web/api/navigatorid/appversion/index.html
@@ -52,23 +52,7 @@ browser-compat: api.NavigatorID.appVersion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-appversion',
-        'NavigatorID.appVersion')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/index.html
+++ b/files/en-us/web/api/navigatorid/index.html
@@ -46,27 +46,7 @@ browser-compat: api.NavigatorID
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigatorid', 'NavigatorID')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Added the <code>appCodeName</code> property and the <code>taintEnabled()</code> method,  for compatibility purpose.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', '#navigatorid', 'NavigatorID')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/platform/index.html
+++ b/files/en-us/web/api/navigatorid/platform/index.html
@@ -44,23 +44,7 @@ browser-compat: api.NavigatorID.platform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-platform', 'NavigatorID.platform')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/product/index.html
+++ b/files/en-us/web/api/navigatorid/product/index.html
@@ -31,23 +31,7 @@ browser-compat: api.NavigatorID.product
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-product', 'NavigatorID.product')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/taintenabled/index.html
+++ b/files/en-us/web/api/navigatorid/taintenabled/index.html
@@ -25,23 +25,7 @@ browser-compat: api.NavigatorID.taintEnabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-taintenabled',
-        'NavigatorID.taintEnabled')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorid/useragent/index.html
+++ b/files/en-us/web/api/navigatorid/useragent/index.html
@@ -71,23 +71,7 @@ Application-Name Application-Name-version
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-useragent', 'NavigatorID.userAgent')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/index.html
+++ b/files/en-us/web/api/navigatorlanguage/index.html
@@ -30,27 +30,7 @@ browser-compat: api.NavigatorLanguage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigatorlanguage', 'NavigatorLanguage')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Since the {{SpecName('HTML5 W3C')}} snapshot, the <code>languages</code> property has been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', '#navigatorlanguage', 'NavigatorLanguage')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial specification; snapshot of an early version {{SpecName('HTML WHATWG')}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/language/index.html
+++ b/files/en-us/web/api/navigatorlanguage/language/index.html
@@ -40,22 +40,7 @@ browser-compat: api.NavigatorLanguage.language
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-language', 'NavigatorLanguage: language')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/languages/index.html
+++ b/files/en-us/web/api/navigatorlanguage/languages/index.html
@@ -43,22 +43,7 @@ navigator.languages  //["en-US", "zh-CN", "ja-JP"]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-languages', 'NavigatorLanguage: languages')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatoronline/index.html
+++ b/files/en-us/web/api/navigatoronline/index.html
@@ -27,19 +27,7 @@ browser-compat: api.NavigatorOnLine
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#browser-state', 'NavigatorOnLine')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatoronline/online/index.html
+++ b/files/en-us/web/api/navigatoronline/online/index.html
@@ -81,23 +81,7 @@ window.addEventListener('online', function(e) { console.log('online'); });
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "browsers.html#dom-navigator-online",
-        "navigator.onLine")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorplugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/index.html
@@ -37,22 +37,7 @@ browser-compat: api.NavigatorPlugins
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigatorplugins', 'NavigatorPlugins')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorplugins/javaenabled/index.html
+++ b/files/en-us/web/api/navigatorplugins/javaenabled/index.html
@@ -25,22 +25,7 @@ browser-compat: api.NavigatorPlugins.javaEnabled
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-navigator-javaenabled', 'NavigatorPlugins.javaEnabled')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorplugins/mimetypes/index.html
+++ b/files/en-us/web/api/navigatorplugins/mimetypes/index.html
@@ -45,23 +45,7 @@ function getJavaPluginDescription() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-navigator-mimetypes',
-				'NavigatorPlugins.mimeTypes')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorplugins/plugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/plugins/index.html
@@ -86,23 +86,7 @@ for(var i = 0; i &lt; pluginsLength; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-plugins',
-        'NavigatorPlugins.plugins')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorstorage/index.html
+++ b/files/en-us/web/api/navigatorstorage/index.html
@@ -35,22 +35,7 @@ browser-compat: api.NavigatorStorage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Storage')}}</td>
-   <td>{{Spec2('Storage')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigatorstorage/storage/index.html
+++ b/files/en-us/web/api/navigatorstorage/storage/index.html
@@ -33,20 +33,7 @@ browser-compat: api.NavigatorStorage.storage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Storage', '#navigatorstorage', 'navigator.storage')}}</td>
-      <td>{{Spec2('Storage')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefmessage/index.html
+++ b/files/en-us/web/api/ndefmessage/index.html
@@ -27,20 +27,7 @@ browser-compat: api.NDEFMessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefmessage">Web NFC, NDEFMessage</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefmessage/records/index.html
+++ b/files/en-us/web/api/ndefmessage/records/index.html
@@ -25,21 +25,7 @@ browser-compat: api.NDEFMessage.records
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefmessage-records">Web NFC,
-          NDEFMessage.records</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/index.html
@@ -42,20 +42,7 @@ browser-compat: api.NDEFReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader">Web NFC, NDEFReader</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/ndefreader/index.html
@@ -30,21 +30,7 @@ browser-compat: api.NDEFReader.NDEFReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader">Web NFC, NDEFReader</a>
-      </td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/onreading/index.html
+++ b/files/en-us/web/api/ndefreader/onreading/index.html
@@ -13,20 +13,7 @@ browser-compat: api.NDEFReader.onreading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader">Web NFC, NDEFReader.onreading</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/onreadingerror/index.html
+++ b/files/en-us/web/api/ndefreader/onreadingerror/index.html
@@ -13,16 +13,7 @@ browser-compat: api.NDEFReader.onreadingerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader-onreadingerror">Web NFC</a></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/scan/index.html
+++ b/files/en-us/web/api/ndefreader/scan/index.html
@@ -56,21 +56,7 @@ browser-compat: api.NDEFReader.scan
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader-scan">Web NFC, scan()</a>
-      </td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -65,21 +65,7 @@ browser-compat: api.NDEFReader.write
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreader-write">Web NFC,
-          write()</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefreadingevent/index.html
+++ b/files/en-us/web/api/ndefreadingevent/index.html
@@ -35,22 +35,7 @@ browser-compat: api.NDEFReadingEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefreadingevent">Web NFC, NDEFReadingEvent</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/data/index.html
+++ b/files/en-us/web/api/ndefrecord/data/index.html
@@ -26,21 +26,7 @@ browser-compat: api.NDEFRecord.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-data">Web NFC,
-          NDEFRecord.data</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/encoding/index.html
+++ b/files/en-us/web/api/ndefrecord/encoding/index.html
@@ -26,21 +26,7 @@ browser-compat: api.NDEFRecord.encoding
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-encoding">Web NFC,
-          NDEFRecord.encoding</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/id/index.html
+++ b/files/en-us/web/api/ndefrecord/id/index.html
@@ -29,21 +29,7 @@ browser-compat: api.NDEFRecord.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-id">Web NFC,
-          NDEFRecord</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/index.html
@@ -45,20 +45,7 @@ browser-compat: api.NDEFRecord
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord">Web NFC, NDEFRecord</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/lang/index.html
+++ b/files/en-us/web/api/ndefrecord/lang/index.html
@@ -27,21 +27,7 @@ browser-compat: api.NDEFRecord.lang
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-lang">Web NFC,
-          NDEFRecord.lang</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/mediatype/index.html
+++ b/files/en-us/web/api/ndefrecord/mediatype/index.html
@@ -24,21 +24,7 @@ browser-compat: api.NDEFRecord.mediaType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-mediatype">Web NFC,
-          NDEFRecord.mediaType</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.html
@@ -33,21 +33,7 @@ browser-compat: api.NDEFRecord.NDEFRecord
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord">Web NFC, NDEFRecord</a>
-      </td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/recordtype/index.html
+++ b/files/en-us/web/api/ndefrecord/recordtype/index.html
@@ -46,21 +46,7 @@ browser-compat: api.NDEFRecord.recordType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-recordtype">Web NFC,
-          NDEFRecord.recordType</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ndefrecord/torecords/index.html
+++ b/files/en-us/web/api/ndefrecord/torecords/index.html
@@ -41,21 +41,7 @@ browser-compat: api.NDEFRecord.toRecords
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td><a href="https://w3c.github.io/web-nfc/#dom-ndefrecord-torecords">Web NFC,
-          NDEFRecord.toRecords()</a></td>
-      <td>Draft</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/downlink/index.html
+++ b/files/en-us/web/api/networkinformation/downlink/index.html
@@ -37,20 +37,7 @@ browser-compat: api.NetworkInformation.downlink
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Network Information','#dom-networkinformation-downlink','downlink')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/downlinkmax/index.html
+++ b/files/en-us/web/api/networkinformation/downlinkmax/index.html
@@ -57,23 +57,7 @@ navigator.connection.addEventListener('change', logConnectionType);</code></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Network Information', '#dom-networkinformation-downlinkmax',
-        'downlinkMax')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/effectivetype/index.html
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.html
@@ -28,20 +28,7 @@ browser-compat: api.NetworkInformation.effectiveType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Network Information','#dom-networkinformation-effectivetype','effectiveType')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/index.html
+++ b/files/en-us/web/api/networkinformation/index.html
@@ -59,22 +59,7 @@ browser-compat: api.NetworkInformation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Network Information', '#networkinformation-interface', 'NetworkInformation')}}</td>
-   <td>{{Spec2('Network Information')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/onchange/index.html
+++ b/files/en-us/web/api/networkinformation/onchange/index.html
@@ -38,22 +38,7 @@ navigator.connection.onchange = changeHandler;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Network Information','#dom-networkinformation-onchange','onchange')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/rtt/index.html
+++ b/files/en-us/web/api/networkinformation/rtt/index.html
@@ -33,22 +33,7 @@ browser-compat: api.NetworkInformation.rtt
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Network Information', '#dom-networkinformation-rtt', 'rtt')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/savedata/index.html
+++ b/files/en-us/web/api/networkinformation/savedata/index.html
@@ -29,16 +29,7 @@ browser-compat: api.NetworkInformation.saveData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td><a href="https://wicg.github.io/savedata/#dfn-savedata">Save Data API</a></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/networkinformation/type/index.html
+++ b/files/en-us/web/api/networkinformation/type/index.html
@@ -39,22 +39,7 @@ browser-compat: api.NetworkInformation.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Network Information', '#dom-networkinformation-type', 'type')}}</td>
-      <td>{{Spec2('Network Information')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/appendchild/index.html
+++ b/files/en-us/web/api/node/appendchild/index.html
@@ -69,38 +69,7 @@ document.body.appendChild(p);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-appendchild', 'Node.appendChild()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName("DOM3 Core")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-184E7107', 'Node.appendChild()')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName("DOM2 Core")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-184E7107', 'Node.appendChild()')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change from {{SpecName("DOM1")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-184E7107', 'Node.appendChild()')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/baseuri/index.html
+++ b/files/en-us/web/api/node/baseuri/index.html
@@ -70,22 +70,7 @@ browser-compat: api.Node.baseURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-baseuri', 'Node: baseURI')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/childnodes/index.html
+++ b/files/en-us/web/api/node/childnodes/index.html
@@ -65,38 +65,7 @@ while (box.firstChild) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-childnodes', 'Node.childNodes')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-1451460987', 'Node.childNodes')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-1451460987', 'Node.childNodes')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-1451460987', 'Node.childNodes')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/clonenode/index.html
+++ b/files/en-us/web/api/node/clonenode/index.html
@@ -99,32 +99,7 @@ let p_prime = p.cloneNode(true)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-clonenode", "Node.cloneNode()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 Core", "core.html#ID-3A0ED0A4", "Node.cloneNode()")}}</td>
-      <td>{{Spec2("DOM3 Core")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Core", "core.html#ID-3A0ED0A4", "Node.cloneNode()")}}</td>
-      <td>{{Spec2("DOM2 Core")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/comparedocumentposition/index.html
+++ b/files/en-us/web/api/node/comparedocumentposition/index.html
@@ -104,27 +104,7 @@ if (head.compareDocumentPosition(body) &amp; Node.DOCUMENT_POSITION_FOLLOWING) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-node-comparedocumentposition','Node.compareDocumentPosition()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core','core.html#Node3-compareDocumentPosition','Node.compareDocumentPosition()')}}
-      </td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/contains/index.html
+++ b/files/en-us/web/api/node/contains/index.html
@@ -32,22 +32,7 @@ browser-compat: api.Node.contains
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-contains", "Node.contains()")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/firstchild/index.html
+++ b/files/en-us/web/api/node/firstchild/index.html
@@ -65,37 +65,7 @@ browser-compat: api.Node.firstChild
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-firstchild', 'Node.firstChild')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-169727388', 'Node.firstChild')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-169727388', 'Node.firstChild')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-169727388', 'Node.firstChild')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/getrootnode/index.html
+++ b/files/en-us/web/api/node/getrootnode/index.html
@@ -86,22 +86,7 @@ browser-compat: api.Node.getRootNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-node-getrootnode','getRootNode()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/getuserdata/index.html
+++ b/files/en-us/web/api/node/getuserdata/index.html
@@ -43,23 +43,7 @@ console.log(document.getUserData('key')); // 15</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Node3-getUserData', 'Node.getUserData()')}}
-      </td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/haschildnodes/index.html
+++ b/files/en-us/web/api/node/haschildnodes/index.html
@@ -57,23 +57,7 @@ if (foo.hasChildNodes()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-haschildnodes", "Node: hasChildNodes")}}
-      </td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/index.html
+++ b/files/en-us/web/api/node/index.html
@@ -387,64 +387,7 @@ console.log(mistakes)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#interface-node", "Node")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Added the following methods: <code>getRootNode()</code></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM4", "#interface-node", "Node")}}</td>
-      <td>{{Spec2("DOM4")}}</td>
-      <td>Removed the following properties: <code>attributes</code>,
-        <code>namespaceURI</code>, <code>prefix</code>, and <code>localName</code>.<br>
-        Removed the following methods: <code>isSupported()</code>,
-        <code>hasAttributes()</code>, <code>getFeature()</code>,
-        <code>setUserData()</code>, and <code>getUserData()</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 Core", "core.html#ID-1950641247", "Node")}}</td>
-      <td>{{Spec2("DOM3 Core")}}</td>
-      <td>The methods <code>insertBefore()</code>, <code>replaceChild()</code>,
-        <code>removeChild()</code>, and <code>appendChild()</code> returns one more kind
-        of error (<code>NOT_SUPPORTED_ERR</code>) if called on a
-        {{DOMxRef("Document")}}.<br>
-        The <code>normalize()</code> method has been modified so that {{DOMxRef("Text")}}
-        node can also be normalized if the proper {{DOMxRef("DOMConfiguration")}} flag is
-        set.<br>
-        Added the following methods: <code>compareDocumentPosition()</code>,
-        <code>isSameNode()</code>, <code>lookupPrefix()</code>,
-        <code>isDefaultNamespace()</code>, <code>lookupNamespaceURI()</code>,
-        <code>isEqualNode()</code>, <code>getFeature()</code>, <code>setUserData()</code>,
-        and <code>getUserData().</code><br>
-        Added the following properties: <code>baseURI</code> and <code>textContent</code>.
-      </td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Core", "core.html#ID-1950641247", "Node")}}</td>
-      <td>{{Spec2("DOM2 Core")}}</td>
-      <td>The <code>ownerDocument</code> property was slightly modified so that
-        {{DOMxRef("DocumentFragment")}} also returns <code>null</code>.<br>
-        Added the following properties: <code>namespaceURI</code>, <code>prefix</code>,
-        and <code>localName</code>.<br>
-        Added the following methods: <code>normalize()</code>, <code>isSupported()</code>
-        and <code>hasAttributes()</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM1", "level-one-core.html#ID-1950641247", "Node")}}</td>
-      <td>{{Spec2("DOM1")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/insertbefore/index.html
+++ b/files/en-us/web/api/node/insertbefore/index.html
@@ -157,44 +157,7 @@ parentElement.insertBefore(newElement, theFirstChild)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-node-insertbefore','Node.insertBefore')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Fixes errors in the insertion algorithm</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM4','#dom-node-insertbefore','Node.insertBefore')}}</td>
-      <td>{{Spec2('DOM4')}}</td>
-      <td>Describes the algorithm in more detail</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core','core.html#ID-952280727','Node.insertBefore')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No notable changes</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core','core.html#ID-952280727','Node.insertBefore')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No notable changes</td>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('DOM1','level-one-core.html#method-insertBefore','Node.insertBefore')}}
-      </td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Introduced</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/isconnected/index.html
+++ b/files/en-us/web/api/node/isconnected/index.html
@@ -78,20 +78,7 @@ console.log(style.isConnected); // Returns true</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-node-isconnected','isConnected')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/isdefaultnamespace/index.html
+++ b/files/en-us/web/api/node/isdefaultnamespace/index.html
@@ -41,23 +41,7 @@ alert(el.isDefaultNamespace(XULNS)); // true</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-isdefaultnamespace", "Node:
-        isDefaultNamespace")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/isequalnode/index.html
+++ b/files/en-us/web/api/node/isequalnode/index.html
@@ -72,22 +72,7 @@ output.innerHTML += "div 0 equals div 2: " + divList[0].isEqualNode(divList[2]) 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-isequalnode', 'Node.isEqualNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/issamenode/index.html
+++ b/files/en-us/web/api/node/issamenode/index.html
@@ -70,28 +70,7 @@ output.innerHTML += "div 0 same as div 2: " + divList[0].isSameNode(divList[2]) 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-issamenode', 'Node: isSameNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change (was for a long time removed from it).</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Node3-isSameNode', 'Node.isSameNode()')}}
-      </td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/issupported/index.html
+++ b/files/en-us/web/api/node/issupported/index.html
@@ -54,29 +54,7 @@ browser-compat: api.Node.isSupported
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Level-2-Core-Node-supports',
-        'Node.isSupported()')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName('DOM2 Core')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#Level-2-Core-Node-supports',
-        'Node.isSupported()')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/lastchild/index.html
+++ b/files/en-us/web/api/node/lastchild/index.html
@@ -28,37 +28,7 @@ var corner_td = tr.lastChild;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-lastchild', 'Node.lastChild')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-61AD09FB', 'Node.lastChild')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-61AD09FB', 'Node.lastChild')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-61AD09FB', 'Node.lastChild')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/lookupnamespaceuri/index.html
+++ b/files/en-us/web/api/node/lookupnamespaceuri/index.html
@@ -36,23 +36,7 @@ browser-compat: api.Node.lookupNamespaceURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-lookupnamespaceuri", "Node:
-        lookupNamespaceURI")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/nextsibling/index.html
+++ b/files/en-us/web/api/node/nextsibling/index.html
@@ -84,35 +84,7 @@ console.groupEnd();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-node-nextsibling', 'Node.nextSibling')}}
-			</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Core', 'core.html#ID-6AC54C2F', 'Node.nextSibling')}}
-			</td>
-			<td>{{Spec2('DOM2 Core')}}</td>
-			<td>No change</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM1', 'level-one-core.html#attribute-nextSibling',
-				'Node.nextSibling')}}</td>
-			<td>{{Spec2('DOM1')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/nodename/index.html
+++ b/files/en-us/web/api/node/nodename/index.html
@@ -112,20 +112,7 @@ text_field.value = div1.nodeName;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-node-nodename','nodeName')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/nodetype/index.html
+++ b/files/en-us/web/api/node/nodetype/index.html
@@ -151,38 +151,7 @@ if (node.nodeType !== Node.COMMENT_NODE) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-nodetype', 'Node.nodeType')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Deprecated <code>ATTRIBUTE_NODE</code>, <code>ENTITY_REFERENCE_NODE</code> and
-        <code>NOTATION_NODE</code> types.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-1950641247', 'Node.nodeType')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-111237558', 'Node.nodeType')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-111237558', 'Node.nodeType')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/nodevalue/index.html
+++ b/files/en-us/web/api/node/nodevalue/index.html
@@ -92,22 +92,7 @@ browser-compat: api.Node.nodeValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-nodevalue", "Node: nodeValue")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/normalize/index.html
+++ b/files/en-us/web/api/node/normalize/index.html
@@ -37,22 +37,7 @@ wrapper.normalize();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#dom-node-normalize", "Node: normalize")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/ownerdocument/index.html
+++ b/files/en-us/web/api/node/ownerdocument/index.html
@@ -36,21 +36,7 @@ var html = d.documentElement;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-ownerdocument', 'Node: ownerDocument')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/parentelement/index.html
+++ b/files/en-us/web/api/node/parentelement/index.html
@@ -34,23 +34,7 @@ browser-compat: api.Node.parentElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-parentelement",
-        "<code>parentElement</code>")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/parentnode/index.html
+++ b/files/en-us/web/api/node/parentnode/index.html
@@ -43,22 +43,7 @@ browser-compat: api.Node.parentNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-parentnode", "Node: parentNode")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -77,39 +77,7 @@ document.getElementById("b2").previousSibling.id;              // undefined
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-node-previoussibling', 'Node.previousSibling')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-640FB3C8', 'Node.previousSibling')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-640FB3C8', 'Node.previousSibling')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#attribute-previousSibling',
-        'Node.previousSibling')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/removechild/index.html
+++ b/files/en-us/web/api/node/removechild/index.html
@@ -143,22 +143,7 @@ while (element.firstChild) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-node-removechild", "Node: removeChild")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/replacechild/index.html
+++ b/files/en-us/web/api/node/replacechild/index.html
@@ -73,23 +73,7 @@ parentDiv.replaceChild(sp1, sp2);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("DOM WHATWG", "#dom-node-replacechild", "Node: replaceChild")}}
-			</td>
-			<td>{{Spec2("DOM WHATWG")}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/setuserdata/index.html
+++ b/files/en-us/web/api/node/setuserdata/index.html
@@ -66,23 +66,7 @@ console.log(e.getUserData('key')); // null since user data is not copied
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#Node3-setUserData', 'Node.setUserData()')}}
-      </td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/node/textcontent/index.html
+++ b/files/en-us/web/api/node/textcontent/index.html
@@ -116,22 +116,7 @@ browser-compat: api.Node.textContent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG','#dom-node-textcontent','Node.textContent')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodefilter/acceptnode/index.html
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.html
@@ -99,27 +99,7 @@ while ((node = iterator.nextNode())) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-nodefilter-acceptnode',
-        'NodeFilter.acceptNode()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Traversal-NodeFilter',
-        'NodeFilter.acceptNode()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodefilter/index.html
+++ b/files/en-us/web/api/nodefilter/index.html
@@ -97,27 +97,7 @@ while ((node = nodeIterator.nextNode())) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#interface-nodefilter', 'NodeFilter')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Traversal-NodeFilter', 'NodeFilter')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/detach/index.html
+++ b/files/en-us/web/api/nodeiterator/detach/index.html
@@ -40,28 +40,7 @@ nodeIterator.nextNode(); // throws an INVALID_STATE_ERR exception
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-detach',
-				'NodeIterator.detach')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Transformed in a no-op</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-detach', 'NodeIterator.detach')}}
-			</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -36,22 +36,7 @@ expand = nodeIterator.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-NodeIterator-expandEntityReferences',
-        'NodeIterator.expandEntityReferences')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/filter/index.html
+++ b/files/en-us/web/api/nodeiterator/filter/index.html
@@ -38,30 +38,7 @@ nodeFilter = nodeIterator.filter;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-filter',
-				'NodeIterator.filter')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change from {{SpecName('DOM2 Traversal_Range')}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-filter', 'NodeIterator.filter')}}
-			</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/index.html
+++ b/files/en-us/web/api/nodeiterator/index.html
@@ -171,33 +171,7 @@ browser-compat: api.NodeIterator
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#nodeiterator', 'NodeIterator')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Added the <code>referenceNode</code> and
-				<code>pointerBeforeReferenceNode</code> properties.<br>
-				Removed the <code>expandEntityReferences</code> property.<br>
-				The method <code>detach()</code> has been changed to be a no-op.<br>
-				The methods <code>previousNode()</code> and <code>nextNode()</code> don't
-				raise an exception any more.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Iterator-overview',
-				'NodeIterator')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/nextnode/index.html
+++ b/files/en-us/web/api/nodeiterator/nextnode/index.html
@@ -40,29 +40,7 @@ currentNode = nodeIterator.nextNode(); // returns the next node
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-nextnode',
-				'NodeIterator.nextNode')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>As <code>detach()</code> is now a no-op method, this method cannot throw
-				anymore.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-nextNode',
-				'NodeIterator.nextNode')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
@@ -34,21 +34,7 @@ flag = nodeIterator.pointerBeforeReferenceNode;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-pointerbeforereferencenode',
-				'NodeIterator.pointerBeforeReferenceNode')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/previousnode/index.html
+++ b/files/en-us/web/api/nodeiterator/previousnode/index.html
@@ -41,29 +41,7 @@ previousNode = nodeIterator.previousNode(); // same result, since we backtracked
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-previousnode',
-				'NodeIterator.previousNode')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>As <code>detach()</code> is now a no-op method, this method cannot throw
-				anymore.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-previousNode',
-				'NodeIterator.previousNode')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/referencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/referencenode/index.html
@@ -33,21 +33,7 @@ node = nodeIterator.referenceNode;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-referencenode',
-				'NodeIterator.referenceNode')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/root/index.html
+++ b/files/en-us/web/api/nodeiterator/root/index.html
@@ -32,27 +32,7 @@ root = nodeIterator.root; // document.body in this case
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-root', 'NodeIterator.root')}}
-			</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change from {{SpecName('DOM2 Traversal_Range')}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-root', 'NodeIterator.root')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.html
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.html
@@ -127,28 +127,7 @@ if( (nodeIterator.whatToShow == NodeFilter.SHOW_ALL) ||
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG', '#dom-nodeiterator-whattoshow',
-				'NodeIterator.whatToShow')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td>No change from {{SpecName('DOM2 Traversal_Range')}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM2 Traversal_Range',
-				'traversal.html#Traversal-NodeIterator-whatToShow',
-				'NodeIterator.whatToShow')}}</td>
-			<td>{{Spec2('DOM2 Traversal_Range')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodelist/foreach/index.html
+++ b/files/en-us/web/api/nodelist/foreach/index.html
@@ -103,22 +103,7 @@ list.forEach(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebIDL", "#es-forEach", "forEach")}}</td>
-      <td>{{Spec2("WebIDL")}}</td>
-      <td>Defines <code>forEach</code> on <code>iterable</code> declarations</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodelist/index.html
+++ b/files/en-us/web/api/nodelist/index.html
@@ -93,37 +93,7 @@ Array.prototype.forEach.call(list, function (checkbox) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-nodelist', 'NodeList')}}</td>
-   <td>{{ Spec2('DOM WHATWG') }}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-536297177', 'NodeList')}}</td>
-   <td>{{ Spec2('DOM3 Core') }}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-536297177', 'NodeList')}}</td>
-   <td>{{ Spec2('DOM2 Core') }}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-536297177', 'NodeList')}}</td>
-   <td>{{ Spec2('DOM1') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodelist/item/index.html
+++ b/files/en-us/web/api/nodelist/item/index.html
@@ -48,22 +48,7 @@ var firstTable = tables.item(1); // or tables[1] - returns the <strong>second</s
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-nodelist-item", "NodeList: item")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodelist/length/index.html
+++ b/files/en-us/web/api/nodelist/length/index.html
@@ -47,22 +47,7 @@ for (let i = 0; i &lt; items.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("DOM WHATWG", "#dom-nodelist-length", "NodeList: length")}}</td>
-      <td>{{Spec2("DOM WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/actions/index.html
+++ b/files/en-us/web/api/notification/actions/index.html
@@ -39,20 +39,7 @@ browser-compat: api.Notification.actions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-actions','actions')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/badge/index.html
+++ b/files/en-us/web/api/notification/badge/index.html
@@ -28,20 +28,7 @@ browser-compat: api.Notification.badge
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-badge','badge')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/body/index.html
+++ b/files/en-us/web/api/notification/body/index.html
@@ -41,20 +41,7 @@ browser-compat: api.Notification.body
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-body','body')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/close/index.html
+++ b/files/en-us/web/api/notification/close/index.html
@@ -64,20 +64,7 @@ browser-compat: api.Notification.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/data/index.html
+++ b/files/en-us/web/api/notification/data/index.html
@@ -47,20 +47,7 @@ console.log(n.data) // should return 'I like peas.'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-data','data')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/dir/index.html
+++ b/files/en-us/web/api/notification/dir/index.html
@@ -50,20 +50,7 @@ console.log(n.dir) // should return 'rtl'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-notification-dir','dir')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/icon/index.html
+++ b/files/en-us/web/api/notification/icon/index.html
@@ -44,20 +44,7 @@ browser-compat: api.Notification.icon
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-icon','icon')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/image/index.html
+++ b/files/en-us/web/api/notification/image/index.html
@@ -29,20 +29,7 @@ browser-compat: api.Notification.image
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#image-resource','image')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/index.html
+++ b/files/en-us/web/api/notification/index.html
@@ -151,20 +151,7 @@ browser-compat: api.Notification
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/lang/index.html
+++ b/files/en-us/web/api/notification/lang/index.html
@@ -49,20 +49,7 @@ console.log(n.lang) // should return 'en-US'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-lang','lang')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/maxactions/index.html
+++ b/files/en-us/web/api/notification/maxactions/index.html
@@ -38,22 +38,7 @@ console.log('This device can display at most ' + maxActions + ' actions on each 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Web Notifications")}}</td>
-      <td>{{Spec2("Web Notifications")}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/notification/index.html
+++ b/files/en-us/web/api/notification/notification/index.html
@@ -95,23 +95,7 @@ browser-compat: api.Notification.Notification
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Web Notifications","#dom-notification-notification","Notification()
-        constructor")}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/onclick/index.html
+++ b/files/en-us/web/api/notification/onclick/index.html
@@ -40,22 +40,7 @@ browser-compat: api.Notification.onclick
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-onclick','onclick')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/onerror/index.html
+++ b/files/en-us/web/api/notification/onerror/index.html
@@ -26,22 +26,7 @@ browser-compat: api.Notification.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-onerror','onerror')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/permission/index.html
+++ b/files/en-us/web/api/notification/permission/index.html
@@ -69,21 +69,7 @@ browser-compat: api.Notification.permission
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Notifications","#dom-notification-permission","permission")}}
-      </td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/renotify/index.html
+++ b/files/en-us/web/api/notification/renotify/index.html
@@ -44,22 +44,7 @@ console.log(n.renotify) // should log true</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-renotify','renotify')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/requestpermission/index.html
+++ b/files/en-us/web/api/notification/requestpermission/index.html
@@ -91,20 +91,7 @@ browser-compat: api.Notification.requestPermission
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/requireinteraction/index.html
+++ b/files/en-us/web/api/notification/requireinteraction/index.html
@@ -36,20 +36,7 @@ browser-compat: api.Notification.requireInteraction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-notification-requireinteraction','requireInteraction')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/silent/index.html
+++ b/files/en-us/web/api/notification/silent/index.html
@@ -46,20 +46,7 @@ console.log(n.silent) // should log true</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-silent','silent')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/tag/index.html
+++ b/files/en-us/web/api/notification/tag/index.html
@@ -40,20 +40,7 @@ browser-compat: api.Notification.tag
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-tag','tag')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/timestamp/index.html
+++ b/files/en-us/web/api/notification/timestamp/index.html
@@ -52,20 +52,7 @@ console.log(n.timestamp) // should log original timestamp</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-timestamp','timestamp')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/title/index.html
+++ b/files/en-us/web/api/notification/title/index.html
@@ -42,20 +42,7 @@ browser-compat: api.Notification.title
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-title','title')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notification/vibrate/index.html
+++ b/files/en-us/web/api/notification/vibrate/index.html
@@ -49,20 +49,7 @@ console.log(n.vibrate) // should log [200,100,200]</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notification-vibrate','vibrate')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notificationaction/index.html
+++ b/files/en-us/web/api/notificationaction/index.html
@@ -51,20 +51,7 @@ self.addEventListener('notificationclick', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notificationevent/action/index.html
+++ b/files/en-us/web/api/notificationevent/action/index.html
@@ -38,22 +38,7 @@ self.addEventListener('notificationclick', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-notification-actions','action')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/index.html
@@ -71,22 +71,7 @@ browser-compat: api.NotificationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Web Notifications','#notificationevent','NotificationEvent')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p><strong>Note</strong>: This interface is specified in the <a href="/en-US/docs/Web/API/Notifications_API">Notifications API</a>, but accessed through {{domxref("ServiceWorkerGlobalScope")}}.</p>

--- a/files/en-us/web/api/notificationevent/notification/index.html
+++ b/files/en-us/web/api/notificationevent/notification/index.html
@@ -49,22 +49,7 @@ browser-compat: api.NotificationEvent.notification
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-notificationevent-notification','notification')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/notificationevent/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.html
@@ -41,23 +41,7 @@ var myNotificationEvent = new NotificationEvent(type, init);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-notificationevent-notificationevent','NotificationEvent()
-        constructor')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Living standard.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/n* to the {{Specifications}} macros. 

A few notes:
- Like always, there are a few deprecated features that lose their (outdated) table. This time it is `Navigator.getVRDisplays()`, `Navigator.activeVRDisplays`, `Navigator.registerContentHandler`, `NodeIterator.expandEntityReferences`, `Node.getUserData()`, `Node.isSupported()`, and `Node.setUserData()`.
- `Navigator.clearAppBadge` & `Navigator.setAppBadge`: I'm adding the spec info on bcd in mdn/browser-compat-data#11024
- `NotificationAction` has no bcd: the spec will be added there at the same time as it.

All other pages look fine.