### PR TITLE
Correct embedded example in Date.prototype.setUTCFullYear() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.html
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Date.setUTCFullYear
 <p>The <strong><code>setUTCFullYear()</code></strong> method sets the full year for a
   specified date according to universal time.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/date-setutcmonth.html")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/date-setutcfullyear.html")}}</div>
 
 
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The example was pointing to setUTCmonth instead of setUTCFullYear

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear

> Issue number (if there is an associated issue)
Fixes #5996 

