### PR TITLE
Fix broken image links on the img page

### DIFF
--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -248,7 +248,7 @@ browser-compat: html.elements.img
 
 <p>The following example embeds an image into the page and includes alternative text for accessibility.</p>
 
-<pre class="brush: html">&lt;img src="https://developer.mozilla.org/static/img/favicon144.png"
+<pre class="brush: html">&lt;img src="https://developer.mozilla.org/favicon144.png"
      alt="MDN logo"&gt;
 </pre>
 
@@ -259,7 +259,7 @@ browser-compat: html.elements.img
 <p>This example builds upon the previous one, showing how to turn the image into a link. To do so, nest the <code>&lt;img&gt;</code> tag inside the {{HTMLElement("a")}}. You should made the alternative text describe the resource the link is pointing to, as if you were using a text link instead.</p>
 
 <pre class="brush: html">&lt;a href="https://developer.mozilla.org"&gt;
-  &lt;img src="https://developer.mozilla.org/static/img/favicon144.png"
+  &lt;img src="https://developer.mozilla.org/favicon144.png"
        alt="Visit the MDN site"&gt;
 &lt;/a&gt;</pre>
 
@@ -269,9 +269,9 @@ browser-compat: html.elements.img
 
 <p>In this example we include a <code>srcset</code> attribute with a reference to a high-resolution version of the logo; this will be loaded instead of the <code>src</code> image on high-resolution devices. The image referenced in the <code>src</code> attribute is counted as a <code>1x</code> candidate in {{glossary("User agent", "user agents")}} that support <code>srcset</code>.</p>
 
-<pre class="brush: html"> &lt;img src="https://developer.mozilla.org/static/img/favicon72.png"
+<pre class="brush: html"> &lt;img src="https://developer.mozilla.org/favicon72.png"
       alt="MDN logo"
-      srcset="https://developer.mozilla.org/static/img/favicon144.png 2x"&gt;</pre>
+      srcset="https://developer.mozilla.org/favicon144.png 2x"&gt;</pre>
 
 <p>{{EmbedLiveSample("Using_the_srcset_attribute", "100%", "160")}}</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Images used as examples in the `img` page were pointing to broken URLs
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img