### PR TITLE
Replace spec table with {{specifications}} for api/o* and api/pa*

### DIFF
--- a/files/en-us/web/api/oes_element_index_uint/index.html
+++ b/files/en-us/web/api/oes_element_index_uint/index.html
@@ -35,20 +35,7 @@ gl.drawElements(gl.POINTS, 8, gl.UNSIGNED_INT, 0);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('OES_element_index_uint', '', 'OES_element_index_uint')}}</td>
-   <td>{{Spec2('OES_element_index_uint')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_fbo_render_mipmap/index.html
+++ b/files/en-us/web/api/oes_fbo_render_mipmap/index.html
@@ -26,18 +26,7 @@ browser-compat: api.OES_fbo_render_mipmap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td><a href="https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/">OES_fbo_render_mipmap</a></td>
-   <td>Draft</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_standard_derivatives/index.html
+++ b/files/en-us/web/api/oes_standard_derivatives/index.html
@@ -60,20 +60,7 @@ void main(){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('OES_standard_derivatives', '', 'OES_standard_derivatives')}}</td>
-   <td>{{Spec2('OES_standard_derivatives')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_texture_float/index.html
+++ b/files/en-us/web/api/oes_texture_float/index.html
@@ -49,20 +49,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('OES_texture_float', "", "OES_texture_float")}}</td>
-			<td>{{Spec2('OES_texture_float')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_texture_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_float_linear/index.html
@@ -38,20 +38,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('OES_texture_float_linear', "", "OES_texture_float_linear")}}</td>
-   <td>{{Spec2('OES_texture_float')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_texture_half_float/index.html
+++ b/files/en-us/web/api/oes_texture_half_float/index.html
@@ -55,20 +55,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, ext.HALF_FLOAT_OES, image);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('OES_texture_half_float', "", "OES_texture_half_float")}}</td>
-   <td>{{Spec2('OES_texture_half_float')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.html
@@ -38,20 +38,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, halfFloat.HALF_FLOAT_OES, imag
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('OES_texture_half_float_linear', "", "OES_texture_half_float_linear")}}</td>
-   <td>{{Spec2('OES_texture_half_float')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
@@ -46,20 +46,7 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('OES_vertex_array_object', '', 'OES_vertex_array_object')}}</td>
-      <td>{{Spec2('OES_vertex_array_object')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
@@ -46,20 +46,7 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('OES_vertex_array_object', '', 'OES_vertex_array_object')}}</td>
-      <td>{{Spec2('OES_vertex_array_object')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
@@ -45,20 +45,7 @@ ext.deleteVertexArrayOES(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('OES_vertex_array_object', '', 'OES_vertex_array_object')}}</td>
-      <td>{{Spec2('OES_vertex_array_object')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/index.html
@@ -64,20 +64,7 @@ oes_vao_ext.bindVertexArrayOES(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('OES_vertex_array_object', '', 'OES_vertex_array_object')}}</td>
-			<td>{{Spec2('OES_vertex_array_object')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
@@ -47,20 +47,7 @@ ext.isVertexArrayOES(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('OES_vertex_array_object', '', 'OES_vertex_array_object')}}</td>
-      <td>{{Spec2('OES_vertex_array_object')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.html
@@ -39,20 +39,7 @@ browser-compat: api.OfflineAudioCompletionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#OfflineAudioCompletionEvent', 'OfflineAudioCompletionEvent')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
@@ -47,21 +47,7 @@ browser-compat: api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API','#dom-offlineaudiocompletionevent-offlineaudiocompletionevent','OfflineAudioCompletionEvent()')}}
-			</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
@@ -27,20 +27,7 @@ browser-compat: api.OfflineAudioCompletionEvent.renderedBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-offlineaudiocompletionevent-renderedbuffer','renderedBuffer')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.html
@@ -63,20 +63,7 @@ offlineAudioCtx.oncomplete = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#OfflineAudioCompletionEvent', 'OfflineAudioCompletionEvent')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/index.html
@@ -135,20 +135,7 @@ getData();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#OfflineAudioContext', 'OfflineAudioContext')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/length/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/length/index.html
@@ -26,20 +26,7 @@ browser-compat: api.OfflineAudioContext.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-offlineaudiocontext-length','length')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
@@ -89,21 +89,7 @@ const source = offlineCtx.createBufferSource();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-offlineaudiocontext-offlineaudiocontext','OfflineAudioContext()')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
@@ -33,20 +33,7 @@ offlineAudioCtx.oncomplete = function() { ... }</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-offlineaudiocontext-oncomplete', 'oncomplete')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.html
@@ -44,21 +44,7 @@ browser-compat: api.OfflineAudioContext.resume
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web Audio API", "#dom-offlineaudiocontext-resume", "resume()")}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.html
@@ -129,21 +129,7 @@ getData();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-offlineaudiocontext-startrendering',
-        'startRendering()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.html
@@ -57,21 +57,7 @@ browser-compat: api.OfflineAudioContext.suspend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-offlineaudiocontext-suspend', 'suspend()')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.html
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.html
@@ -58,22 +58,7 @@ offscreen.convertToBlob().then(function(blob) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-offscreencanvas-converttoblob', 'OffscreenCanvas: convertToBlob')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.html
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.html
@@ -141,21 +141,7 @@ gl.canvas; // OffscreenCanvas</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-offscreencanvas-getcontext",
-        "OffscreenCanvas.getContext()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/height/index.html
+++ b/files/en-us/web/api/offscreencanvas/height/index.html
@@ -32,21 +32,7 @@ offscreen.height = 512;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-offscreencanvas-height",
-        "OffscreenCanvas.height")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/index.html
+++ b/files/en-us/web/api/offscreencanvas/index.html
@@ -114,20 +114,7 @@ worker.postMessage({canvas: offscreen}, [offscreen]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#the-offscreencanvas-interface", "OffscreenCanvas")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/offscreencanvas/index.html
+++ b/files/en-us/web/api/offscreencanvas/offscreencanvas/index.html
@@ -43,20 +43,7 @@ let gl = offscreen.getContext('webgl');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-offscreencanvas", "OffscreenCanvas()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.html
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.html
@@ -37,21 +37,7 @@ offscreen.transferToImageBitmap();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-offscreencanvas-transfertoimagebitmap",
-        "OffscreenCanvas.transferToImageBitmap()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/offscreencanvas/width/index.html
+++ b/files/en-us/web/api/offscreencanvas/width/index.html
@@ -32,21 +32,7 @@ offscreen.width = 512;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-offscreencanvas-width",
-        "OffscreenCanvas.width")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/orientationsensor/index.html
+++ b/files/en-us/web/api/orientationsensor/index.html
@@ -83,20 +83,7 @@ Promise.all([navigator.permissions.query({ name: "accelerometer" }),
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Orientation Sensor','#orientationsensor-interface','OrientationSensor')}}</td>
-   <td>{{Spec2('Orientation Sensor')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.html
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.html
@@ -62,20 +62,7 @@ browser-compat: api.OrientationSensor.populateMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Orientation Sensor','#orientationsensor-populatematrix','populateMatrix')}}</td>
-      <td>{{Spec2('Orientation Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/orientationsensor/quaternion/index.html
+++ b/files/en-us/web/api/orientationsensor/quaternion/index.html
@@ -39,21 +39,7 @@ browser-compat: api.OrientationSensor.quaternion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Orientation Sensor','#orientationsensor-quaternion','quaternion')}}
-      </td>
-      <td>{{Spec2('Orientation Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/detune/index.html
+++ b/files/en-us/web/api/oscillatornode/detune/index.html
@@ -46,20 +46,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-oscillatornode-detune', 'detune')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/frequency/index.html
+++ b/files/en-us/web/api/oscillatornode/frequency/index.html
@@ -45,20 +45,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-oscillatornode-frequency', 'frequency')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -99,20 +99,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#oscillatornode', 'OscillatorNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/onended/index.html
+++ b/files/en-us/web/api/oscillatornode/onended/index.html
@@ -46,20 +46,7 @@ oscillator.onended = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-audioscheduledsourcenode-onended', 'onended')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -63,20 +63,7 @@ browser-compat: api.OscillatorNode.OscillatorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API','#dom-oscillatornode-oscillatornode','OscillatorNode()')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
+++ b/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
@@ -75,21 +75,7 @@ osc.stop(2);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-oscillatornode-setperiodicwave',
-        'setPeriodicWave')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/start/index.html
+++ b/files/en-us/web/api/oscillatornode/start/index.html
@@ -53,21 +53,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-audioscheduledsourcenode-start', 'start')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/stop/index.html
+++ b/files/en-us/web/api/oscillatornode/stop/index.html
@@ -56,20 +56,7 @@ oscillator.stop(audioCtx.currentTime + 2); // stop 2 seconds after the current t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-audioscheduledsourcenode-stop', 'stop')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/oscillatornode/type/index.html
+++ b/files/en-us/web/api/oscillatornode/type/index.html
@@ -76,20 +76,7 @@ oscillator.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-oscillatornode-type', 'type')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/overconstrainederror/constraint/index.html
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.html
@@ -32,20 +32,7 @@ browser-compat: api.OverconstrainedError.constraint
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-overconstrainederror-constraint','constraint')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/index.html
@@ -41,20 +41,7 @@ browser-compat: api.OverconstrainedError
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture','#overconstrainederror-interface','OverconstrainedError')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
@@ -39,20 +39,7 @@ browser-compat: api.OverconstrainedError.OverconstrainedError
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Capture','#dom-overconstrainederror-constructor','OverconstrainedError()')}}</td>
-      <td>{{Spec2('Media Capture')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
+++ b/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
@@ -138,20 +138,7 @@ browser-compat: api.OVR_multiview2.framebufferTextureMultiviewOVR
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-    </tr>
-    <tr>
-      <td><a class="external"
-          href="https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/"
-          rel="noopener">OVR_multiview2</a></td>
-      <td>Community Approved</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ovr_multiview2/index.html
+++ b/files/en-us/web/api/ovr_multiview2/index.html
@@ -88,18 +88,7 @@ void main() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-		</tr>
-		<tr>
-			<td><a href="https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/">OVR_multiview2</a></td>
-			<td>Community Approved</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pagetransitionevent/index.html
+++ b/files/en-us/web/api/pagetransitionevent/index.html
@@ -48,22 +48,7 @@ function myFunction(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#the-pagetransitionevent-interface', 'PageTransitionEvent')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pagetransitionevent/persisted/index.html
+++ b/files/en-us/web/api/pagetransitionevent/persisted/index.html
@@ -27,22 +27,7 @@ browser-compat: api.PageTransitionEvent.persisted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-pagetransitionevent-persisted', 'PageTransitionEvent: persisted')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.html
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PaintWorkletGlobalScope.devicePixelRatio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Painting API','#dom-paintworkletglobalscope-devicepixelratio','PaintWorkletGlobalScope.devicePixelRatio')}}</td>
-   <td>{{Spec2('CSS Painting API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paintworklet/index.html
+++ b/files/en-us/web/api/paintworklet/index.html
@@ -97,20 +97,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Painting API','#paintworkletglobalscope','PaintWorkletGlobalScope')}}</td>
-   <td>{{Spec2('CSS Painting API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paintworklet/registerpaint/index.html
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.html
@@ -94,21 +94,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Painting API','#dom-paintworkletglobalscope-registerpaint','PaintWorkletGlobalScope.registerPaint')}}
-      </td>
-      <td>{{Spec2('CSS Painting API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/coneinnerangle/index.html
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.html
@@ -34,20 +34,7 @@ panner.coneInnerAngle = 360;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-coneinnerangle', 'coneInnerAngle')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/coneouterangle/index.html
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.html
@@ -34,20 +34,7 @@ panner.coneOuterAngle = 0;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-coneouterangle', 'coneOuterAngle')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/coneoutergain/index.html
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.html
@@ -41,20 +41,7 @@ panner.coneOuterGain = 0;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-coneoutergain', 'coneOuterGain')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/distancemodel/index.html
+++ b/files/en-us/web/api/pannernode/distancemodel/index.html
@@ -47,21 +47,6 @@ panner.distanceModel = 'inverse';</pre>
 
 {{Specifications}}
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-distancemodel', 'distanceModel')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/pannernode/orientationx/index.html
+++ b/files/en-us/web/api/pannernode/orientationx/index.html
@@ -146,21 +146,7 @@ osc.start(0);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-orientationx', 'orientationX')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/orientationy/index.html
+++ b/files/en-us/web/api/pannernode/orientationy/index.html
@@ -56,21 +56,7 @@ browser-compat: api.PannerNode.orientationY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-orientationy', 'orientationY')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/orientationz/index.html
+++ b/files/en-us/web/api/pannernode/orientationz/index.html
@@ -54,21 +54,7 @@ browser-compat: api.PannerNode.orientationZ
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-orientationz', 'orientationZ')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/pannernode/index.html
@@ -72,20 +72,7 @@ var myPanner = new PannerNode(ctx, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API','#dom-pannernode-pannernode','PannerNode()')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/positionx/index.html
+++ b/files/en-us/web/api/pannernode/positionx/index.html
@@ -73,20 +73,7 @@ osc.start(0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-positionx', 'positionX')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/positiony/index.html
+++ b/files/en-us/web/api/pannernode/positiony/index.html
@@ -75,20 +75,7 @@ osc.start(0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-positiony', 'positionY')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/positionz/index.html
+++ b/files/en-us/web/api/pannernode/positionz/index.html
@@ -75,20 +75,7 @@ osc.start(0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-pannernode-positionz', 'positionZ')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/refdistance/index.html
+++ b/files/en-us/web/api/pannernode/refdistance/index.html
@@ -78,20 +78,7 @@ scheduleTestTone(7, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-refdistance', 'refDistance')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pannernode/rollofffactor/index.html
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.html
@@ -91,20 +91,7 @@ scheduleTestTone(0.1, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-pannernode-rollofffactor', 'rolloffFactor')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/passwordcredential/iconurl/index.html
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PasswordCredential.iconURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credentialuserdata-iconurl','iconURL')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/index.html
@@ -63,20 +63,7 @@ navigator.credentials.store(cred)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Credential Management')}}</td>
-   <td>{{Spec2('Credential Management')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/passwordcredential/name/index.html
+++ b/files/en-us/web/api/passwordcredential/name/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PasswordCredential.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credentialuserdata-name','name')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/passwordcredential/password/index.html
+++ b/files/en-us/web/api/passwordcredential/password/index.html
@@ -28,20 +28,7 @@ browser-compat: api.PasswordCredential.password
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-passwordcredential-password','password')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.html
@@ -69,20 +69,7 @@ navigator.credentials.store(creds)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/path2d/addpath/index.html
+++ b/files/en-us/web/api/path2d/addpath/index.html
@@ -81,21 +81,7 @@ ctx.fill(p1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "scripting.html#dom-path2d-addpath",
-        "Path2D.addPath()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/path2d/index.html
+++ b/files/en-us/web/api/path2d/index.html
@@ -47,22 +47,7 @@ browser-compat: api.Path2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#path2d-objects", "Path2D")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/path2d/path2d/index.html
+++ b/files/en-us/web/api/path2d/path2d/index.html
@@ -86,20 +86,7 @@ ctx.fill(p);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-path2d', 'Path2D()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/currency/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currency/index.html
@@ -47,22 +47,7 @@ browser-compat: api.PaymentCurrencyAmount.currency
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentcurrencyamount-currency','PaymentCurrencyAmount.currency')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
@@ -51,32 +51,7 @@ browser-compat: api.PaymentCurrencyAmount.currencySystem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentcurrencyamount','PaymentCurrencyAmount')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>No longer part of the specification</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentcurrencyamount')}}<br>
-        <small><a
-            href="https://www.w3.org/TR/2018/CR-payment-request-20180320/#dom-paymentcurrencyamount-currencysystem">The
-            definition of 'PaymentCurrencyAmount.currencySystem' in that
-            specification.</a></small>
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>The March 20, 2018 version of the specification; the last one to include this
-        property</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/index.html
@@ -43,20 +43,7 @@ browser-compat: api.PaymentCurrencyAmount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dom-paymentcurrencyamount','PaymentCurrencyAmount')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/value/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/value/index.html
@@ -99,22 +99,7 @@ browser-compat: api.PaymentCurrencyAmount.value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentcurrencyamount-value','PaymentCurrencyAmount.value')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentdetailsbase/index.html
+++ b/files/en-us/web/api/paymentdetailsbase/index.html
@@ -42,20 +42,7 @@ browser-compat: api.PaymentDetailsBase
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dom-paymentdetailsbase','PaymentDetailsBase')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentdetailsupdate/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/index.html
@@ -40,20 +40,7 @@ browser-compat: api.PaymentDetailsUpdate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dom-paymentdetailsupdate','PaymentDetailsUpdate')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentitem/index.html
+++ b/files/en-us/web/api/paymentitem/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PaymentItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dom-paymentitem','PaymentItem')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.html
@@ -41,20 +41,7 @@ browser-compat: api.PaymentMethodChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#paymentmethodchangeevent-interface','PaymentMethodChangeEvent')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.html
@@ -69,22 +69,7 @@ const response = await request.show();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentmethodchangeevent-methoddetails','PaymentMethodChangeEvent.methodDetails')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/methodname/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/methodname/index.html
@@ -66,22 +66,7 @@ const response = await request.show();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentmethodchangeevent-methodname','PaymentMethodChangeEvent.methodName')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.html
@@ -60,22 +60,7 @@ browser-compat: api.PaymentMethodChangeEvent.PaymentMethodChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#paymentmethodchangeevent-interface','PaymentMethodChangeEvent()')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/abort/index.html
+++ b/files/en-us/web/api/paymentrequest/abort/index.html
@@ -49,20 +49,7 @@ var paymentTimeout = window.setTimeout(() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentrequest-abort','abort()')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.html
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.html
@@ -102,20 +102,7 @@ async function initPaymentRquest() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#canmakepayment-method','canMakePayment()')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/id/index.html
+++ b/files/en-us/web/api/paymentrequest/id/index.html
@@ -61,20 +61,7 @@ console.log(json.requestId,response.requestId, request.id);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentrequest-id','id')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/index.html
@@ -69,20 +69,7 @@ browser-compat: api.PaymentRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#paymentrequest-interface','PaymentRequest')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.html
+++ b/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.html
@@ -68,21 +68,7 @@ const response = await request.show();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment', '#onpaymentmethodchange-attribute',
-        'onpaymentmethodchange')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
@@ -83,20 +83,7 @@ paymentRequest.show()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment', '#dfn-paymentmethodchange', 'paymentmethodchange')}}</td>
-   <td>{{Spec2("Payment")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentrequest/index.html
@@ -171,20 +171,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#constructor','PaymentRequest() constructor')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/show/index.html
+++ b/files/en-us/web/api/paymentrequest/show/index.html
@@ -279,20 +279,7 @@ document.getElementById("buyButton").onclick = requestPayment;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#show-method','show(optional detailsPromise)')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/index.html
+++ b/files/en-us/web/api/paymentrequestevent/index.html
@@ -52,20 +52,7 @@ browser-compat: api.PaymentRequestEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Payment Handler","#the-paymentrequestevent","PaymentRequestEvent")}}</td>
-   <td>{{Spec2("Payment Handler")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
+++ b/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
@@ -22,21 +22,7 @@ browser-compat: api.PaymentRequestEvent.instrumentKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Payment Handler','#instrumentkey-attribute','instrumentKey')}}
-            </td>
-            <td>{{Spec2('Payment Handler')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/methoddata/index.html
+++ b/files/en-us/web/api/paymentrequestevent/methoddata/index.html
@@ -22,20 +22,7 @@ browser-compat: api.PaymentRequestEvent.methodData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Payment Handler','#methoddata-attribute','methodData')}}</td>
-            <td>{{Spec2('Payment Handler')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/modifiers/index.html
+++ b/files/en-us/web/api/paymentrequestevent/modifiers/index.html
@@ -20,20 +20,7 @@ browser-compat: api.PaymentRequestEvent.modifiers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Payment Handler','#modifiers-attribute','modifiers')}}</td>
-            <td>{{Spec2('Payment Handler')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.html
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.html
@@ -39,20 +39,7 @@ browser-compat: api.PaymentRequestEvent.openWindow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment Handler','#openwindow-method','openWindow')}}</td>
-      <td>{{Spec2('Payment Handler')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.html
@@ -28,21 +28,7 @@ browser-compat: api.PaymentRequestEvent.paymentRequestId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment Handler','#paymentrequestid-attribute','paymentRequestId')}}
-      </td>
-      <td>{{Spec2('Payment Handler')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
@@ -28,20 +28,7 @@ browser-compat: api.PaymentRequestEvent.paymentRequestOrigin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment Handler','#paymentrequestorigin-attribute','paymentRequestOrigin')}}</td>
-      <td>{{Spec2('Payment Handler')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.html
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PaymentRequestEvent.respondWith
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment Handler','','respondWith')}}</td>
-      <td>{{Spec2('Payment Handler')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.html
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.html
@@ -28,20 +28,7 @@ browser-compat: api.PaymentRequestEvent.topOrigin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Payment Handler","#toporigin-attribute","topOrigin")}}</td>
-      <td>{{Spec2("Payment Handler")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/total/index.html
+++ b/files/en-us/web/api/paymentrequestevent/total/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PaymentRequestEvent.total
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment Handler','#total-attribute','total')}}</td>
-      <td>{{Spec2('Payment Handler')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/index.html
@@ -47,20 +47,7 @@ browser-compat: api.PaymentRequestUpdateEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#paymentrequestupdateevent-interface','PaymentRequestUpdateEvent')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
@@ -37,20 +37,7 @@ browser-compat: api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#constructor-0','PaymentRequestUpdateEvent()')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
@@ -44,22 +44,7 @@ browser-compat: api.PaymentRequestUpdateEvent.updateWith
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#updatewith-method','PaymentRequestUpdateEvent.updateWith()')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/complete/index.html
+++ b/files/en-us/web/api/paymentresponse/complete/index.html
@@ -109,20 +109,7 @@ payment.show().then(function(paymentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentresponse-complete','PaymentResponse: complete')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/details/index.html
+++ b/files/en-us/web/api/paymentresponse/details/index.html
@@ -48,20 +48,7 @@ browser-compat: api.PaymentResponse.details
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/index.html
+++ b/files/en-us/web/api/paymentresponse/index.html
@@ -57,20 +57,7 @@ browser-compat: api.PaymentResponse
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Payment','#paymentresponse-interface','PaymentResponse')}}</td>
-			<td>{{Spec2('Payment')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/methodname/index.html
+++ b/files/en-us/web/api/paymentresponse/methodname/index.html
@@ -55,20 +55,7 @@ browser-compat: api.PaymentResponse.methodName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/requestid/index.html
+++ b/files/en-us/web/api/paymentresponse/requestid/index.html
@@ -29,20 +29,7 @@ browser-compat: api.PaymentResponse.requestId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentresponse-requestid','requestId')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/retry/index.html
+++ b/files/en-us/web/api/paymentresponse/retry/index.html
@@ -149,20 +149,7 @@ doPaymentRequest();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentresponse-retry','retry()')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentvalidationerrors/index.html
+++ b/files/en-us/web/api/paymentvalidationerrors/index.html
@@ -36,25 +36,7 @@ browser-compat: api.PaymentValidationErrors
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Basic Card Payment')}}</td>
-   <td>{{Spec2('Basic Card Payment')}}</td>
-   <td>Defines {{domxref("BasicCardErrors")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/o* and api/pa* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `PaymentValidationErrors` :a dictionary (will be dealt with all the other dictionaries)
- `OscillatorNode.start`,`OscillatorNode.end` and `OscillatorNode.onended`: these pages should be redirected to their `AudioScheduleSourceNode.start`, `AudioScheduleSourceNode.end`, and `AudioScheduleSourceNode.onended`. Meanwhile I'm leaving them as is.
- One deprecated items (will be handled in a second phase): `PaymentCurrencyAmount.currencySystem`.
- `PaymentMethodChangeEvent`: missing in bcd, adding it in mdn/browser-compat-data#11033



All other pages look fine.