### PR TITLE
Trailing commas page update

### DIFF
--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -20,8 +20,8 @@ browser-compat: javascript.grammar.trailing_commas
   code might be less troublesome.</p>
 
 <p>JavaScript has allowed trailing commas in array literals since the beginning, and later
-  added them to object literals (ECMAScript 5) and most recently (ECMAScript 2017 and ECMA-262) to
-  function parameters and Named Imports, Named Exports respectively.</p>
+  added them to object literals, and more recently, to
+  function parameters and to named imports and named exports.</p>
 
 <p><a href="/en-US/docs/Glossary/JSON">JSON</a>, however, disallows trailing commas.</p>
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -166,7 +166,7 @@ JSON.parse('{"foo" : 1 }');</pre>
 
 <h3 id="Trailing_commas_in_named_imports_and_named_exports">Trailing commas in named imports and named exports</h3>
 
-<p>As per ECMA-262 trailing commas are vaild in named imports and named exports</p>
+<p>Trailing commas are valid in named imports and named exports.</p>
 
 <h4 id="named_imports">named imports</h4>
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -164,9 +164,11 @@ JSON.parse('{"foo" : 1, }');
 <pre class="brush: js example-good">JSON.parse('[1, 2, 3, 4 ]');
 JSON.parse('{"foo" : 1 }');</pre>
 
-<h3 id="Trailing_commas_in_named_imports">Trailing commas in Named Imports</h3>
+<h3 id="Trailing_commas_in_named_imports_and_named_exports">Trailing commas in named imports and named exports</h3>
 
-<p>As per ECMA-262 trailing commas are vaild in Named Imports</p>
+<p>As per ECMA-262 trailing commas are vaild in named imports and named exports</p>
+
+<h4 id="named_imports">named imports</h4>
 
 <pre class="brush: js">
   import {
@@ -176,6 +178,22 @@ JSON.parse('{"foo" : 1 }');</pre>
   } from 'D'
 
   import { X, Y, Z } from 'W'
+
+  import { A as B, C as D, E as F } from 'Z'; //Renaming imports
+</pre>
+
+<h4 id="named_exports">named exports</h4>
+
+<pre class="brush: js">
+  export {
+    A,
+    B,
+    C
+  }
+
+  export { A, B, C };
+
+  export { A as B, C as D, E as F }; // Renaming exports
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -20,8 +20,8 @@ browser-compat: javascript.grammar.trailing_commas
   code might be less troublesome.</p>
 
 <p>JavaScript has allowed trailing commas in array literals since the beginning, and later
-  added them to object literals (ECMAScript 5) and most recently (ECMAScript 2017) to
-  function parameters.</p>
+  added them to object literals (ECMAScript 5) and most recently (ECMAScript 2017 and ECMA-262) to
+  function parameters and Named Imports, Named Exports respectively.</p>
 
 <p><a href="/en-US/docs/Glossary/JSON">JSON</a>, however, disallows trailing commas.</p>
 
@@ -163,6 +163,20 @@ JSON.parse('{"foo" : 1, }');
 
 <pre class="brush: js example-good">JSON.parse('[1, 2, 3, 4 ]');
 JSON.parse('{"foo" : 1 }');</pre>
+
+<h3 id="Trailing_commas_in_named_imports">Trailing commas in Named Imports</h3>
+
+<p>As per ECMA-262 trailing commas are vaild in Named Imports</p>
+
+<pre class="brush: js">
+  import {
+    A,
+    B,
+    C,
+  } from 'D'
+
+  import { X, Y, Z } from 'W'
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -196,6 +196,15 @@ JSON.parse('{"foo" : 1 }');</pre>
   export { A as B, C as D, E as F }; // Renaming exports
 </pre>
 
+<h3 id="Quantifier_prefix">Quantifier prefix</h3>
+
+<pre class="brush: js">
+  //{ DecimalDigits[~Sep], DecimalDigits[~Sep] }
+  x{n,}
+  x{n,m}
+  x{n,m}?
+</pre>
+
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->
This PR adds cases for named imports, named exports and quantifier prefix to <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas">Trailing commas</a>.

Issue number (if there is an associated issue)
Fixes #4719 

