### PR TITLE
Reword the value of pathname when there is no path.

### DIFF
--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -11,9 +11,11 @@ browser-compat: api.Location.pathname
 <p>{{ApiRef("Location")}}</p>
 
 <p>The <strong><code>pathname</code></strong> property of the {{domxref("Location")}}
-  interface is a {{domxref("USVString")}} containing an initial <code>'/'</code> followed
-  by the path of the URL, or just <code>'/'</code> if there is no path.</p>
-
+  interface is a {{domxref("USVString")}} containing the path of the URL. 
+  The path usually starts with a <code>/</code>, since requests to URLs without a path
+  (such as <code>GET "https://mozilla.org"</code>) are by default fetched with a path
+  of <code>/</code>.
+  
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js"><em>string</em> = <em>object</em>.pathname;

--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Location.pathname
 
 <p>The <strong><code>pathname</code></strong> property of the {{domxref("Location")}}
   interface is a {{domxref("USVString")}} containing an initial <code>'/'</code> followed
-  by the path of the URL (or the empty string if there is no path).</p>
+  by the path of the URL, or just <code>'/'</code> if there is no path.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -11,10 +11,7 @@ browser-compat: api.Location.pathname
 <p>{{ApiRef("Location")}}</p>
 
 <p>The <strong><code>pathname</code></strong> property of the {{domxref("Location")}}
-  interface is a {{domxref("USVString")}} containing the path of the URL. 
-  The path usually starts with a <code>/</code>, since requests to URLs without a path
-  (such as a link to "https://mozilla.org") are by default fetched with a path
-  of <code>/</code>.
+interface is a {{domxref("USVString")}} containing the path of the URL for the location, which will be the empty string if there is no path.</p>
   
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Location.pathname
 <p>The <strong><code>pathname</code></strong> property of the {{domxref("Location")}}
   interface is a {{domxref("USVString")}} containing the path of the URL. 
   The path usually starts with a <code>/</code>, since requests to URLs without a path
-  (such as <code>GET "https://mozilla.org"</code>) are by default fetched with a path
+  (such as a link to "https://mozilla.org") are by default fetched with a path
   of <code>/</code>.
   
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The parenthetical "or the empty string if there is no path" was ambiguous. It could either mean the pathname is "/" or "".

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname
