### PR TITLE
Add `filter` and `offset-path` to list with URLs

### DIFF
--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -59,7 +59,9 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 
 <p>Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).</p>
 
-<p class="task-list-item">The <code><strong>url()</strong></code> function can be included as a value for {{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('border')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, <a href="/en-US/docs/Web/CSS/@font-face/src">src</a> as part of a <a href="/en-US/docs/Web/CSS/@font-face">@font-face</a> block, and <a href="/en-US/docs/Web/CSS/@counter-style/symbols">@counter-style/symbol</a></p>
+<p class="task-list-item">The <code><strong>url()</strong></code> function can be included as a value for 
+  {{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('border')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('filter')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, {{cssxref('offset-path')}},
+  <a href="/en-US/docs/Web/CSS/@font-face/src">src</a> as part of a <a href="/en-US/docs/Web/CSS/@font-face">@font-face</a> block, and <a href="/en-US/docs/Web/CSS/@counter-style/symbols">@counter-style/symbol</a></p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Add `filter` and `offset-path` to list with URLS

Also alphabetizes.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Missing some items, and hard to parse when not alphabetical.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/url()

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
