### PR TITLE
Replace spec table with {{specifications}} for api/p[b-n]*

### DIFF
--- a/files/en-us/web/api/performance/clearmarks/index.html
+++ b/files/en-us/web/api/performance/clearmarks/index.html
@@ -73,26 +73,7 @@ logMarkCount() // "Found this many entries: 0"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmarks',
-        'clearMarks()')}}</td>
-      <td>{{Spec2('User Timing Level 2')}}</td>
-      <td>Clarifies <code>clearMarks()</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing', '#dom-performance-clearmarks', 'clearMarks()')}}</td>
-      <td>{{Spec2('User Timing')}}</td>
-      <td>Basic definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/clearmeasures/index.html
+++ b/files/en-us/web/api/performance/clearmeasures/index.html
@@ -74,27 +74,7 @@ logMeasureCount() // "Found this many entries: 0"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmeasures',
-        'clearMeasures()')}}</td>
-      <td>{{Spec2('User Timing Level 2')}}</td>
-      <td>Clarifies <code>clearMeasures()</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing', '#dom-performance-clearmeasures', 'clearMeasures()')}}
-      </td>
-      <td>{{Spec2('User Timing')}}</td>
-      <td>Basic definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/clearresourcetimings/index.html
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.html
@@ -71,21 +71,7 @@ function clear_performance_timings() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performance-clearresourcetimings',
-        'clearResourceTimings()')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/getentries/index.html
+++ b/files/en-us/web/api/performance/getentries/index.html
@@ -84,27 +84,7 @@ browser-compat: api.Performance.getEntries
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentries',
-        'getEntries()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performance-getentries',
-        'getEntries()')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/getentriesbyname/index.html
+++ b/files/en-us/web/api/performance/getentriesbyname/index.html
@@ -99,27 +99,7 @@ browser-compat: api.Performance.getEntriesByName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbyname',
-        'getEntriesByName()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performance-getentriesbyname',
-        'getEntriesByName()')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/getentriesbytype/index.html
+++ b/files/en-us/web/api/performance/getentriesbytype/index.html
@@ -96,27 +96,7 @@ browser-compat: api.Performance.getEntriesByType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbytype',
-        'getEntriesByType()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performance-getentriesbytype',
-        'getEntriesByType()')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/index.html
+++ b/files/en-us/web/api/performance/index.html
@@ -84,50 +84,7 @@ browser-compat: api.Performance
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time Level 2', '#sec-performance', 'Performance')}}</td>
-   <td>{{Spec2('Highres Time Level 2')}}</td>
-   <td>Defines <code>toJson()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time', '#performance', 'Performance')}}</td>
-   <td>{{Spec2('Highres Time')}}</td>
-   <td>Defines <code>now()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline Level 2', '#extensions-to-the-performance-interface', 'Performance extensions')}}</td>
-   <td>{{Spec2('Performance Timeline Level 2')}}</td>
-   <td>Changes <code>getEntries()</code> interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline', '#extensions-to-the-performance-interface', 'Performance extensions')}}</td>
-   <td>{{Spec2('Performance Timeline')}}</td>
-   <td>Defines <code>getEntries()</code>, <code>getEntriesByType()</code> and <code>getEntriesByName()</code> methods.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing', '#extensions-performance-interface', 'Performance extensions')}}</td>
-   <td>{{Spec2('Resource Timing')}}</td>
-   <td>Defines <code>clearResourceTimings()</code> and <code>setResourceTimingBufferSize()</code> methods and the <code>onresourcetimingbufferfull</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing Level 2', '#extensions-performance-interface', 'Performance extensions')}}</td>
-   <td>{{Spec2('User Timing Level 2')}}</td>
-   <td>Clarifies <code>mark()</code>, <code>clearMark()</code>, <code>measure()</code> and <code>clearMeasure()</code> methods.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing', '#extensions-performance-interface', 'Performance extensions')}}</td>
-   <td>{{Spec2('User Timing')}}</td>
-   <td>Defines <code>mark()</code>, <code>clearMark()</code>, <code>measure()</code> and <code>clearMeasure()</code> methods.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/mark/index.html
+++ b/files/en-us/web/api/performance/mark/index.html
@@ -76,25 +76,7 @@ performance.clearMarks();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing Level 2', '#dom-performance-mark', 'mark()')}}</td>
-      <td>{{Spec2('User Timing Level 2')}}</td>
-      <td>Clarifies <code>mark()</code> processing model.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing', '#dom-performance-mark', 'mark()')}}</td>
-      <td>{{Spec2('User Timing')}}</td>
-      <td>Basic definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/measure/index.html
+++ b/files/en-us/web/api/performance/measure/index.html
@@ -102,26 +102,7 @@ setTimeout(function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing Level 2', '#dom-performance-measure', 'measure()')}}
-      </td>
-      <td>{{Spec2('User Timing Level 2')}}</td>
-      <td>Clarifies <code>measure()</code> processing model.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('User Timing', '#dom-performance-measure', 'measure()')}}</td>
-      <td>{{Spec2('User Timing')}}</td>
-      <td>Basic definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/navigation/index.html
+++ b/files/en-us/web/api/performance/navigation/index.html
@@ -36,21 +36,7 @@ browser-compat: api.Performance.navigation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#sec-window.performance-attribute',
-        'Performance.navigation')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/now/index.html
+++ b/files/en-us/web/api/performance/now/index.html
@@ -106,26 +106,7 @@ Cross-Origin-Embedder-Policy: require-corp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Highres Time Level 2', '#dom-performance-now',
-        'performance.now()')}}</td>
-      <td>{{Spec2('Highres Time Level 2')}}</td>
-      <td>Stricter definitions of interfaces and types.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Highres Time', '#dom-performance-now', 'performance.now()')}}</td>
-      <td>{{Spec2('Highres Time')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
@@ -48,21 +48,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull',
-        'onresourcetimingbufferfull')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -57,20 +57,7 @@ function init() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull', 'onresourcetimingbufferfull')}}</td>
-   <td>{{Spec2('Resource Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.html
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.html
@@ -60,21 +60,7 @@ browser-compat: api.Performance.setResourceTimingBufferSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performance-setresourcetimingbuffersize',
-        'setResourceTimingBufferSize()')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/timeorigin/index.html
+++ b/files/en-us/web/api/performance/timeorigin/index.html
@@ -30,18 +30,7 @@ browser-compat: api.Performance.timeOrigin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Highres Time Level 2','#dom-performance-timeorigin','timeOrigin')}}</td>
-			<td>{{Spec2('Highres Time Level 2')}}</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/timing/index.html
+++ b/files/en-us/web/api/performance/timing/index.html
@@ -35,20 +35,7 @@ browser-compat: api.Performance.timing
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2', '#obsolete')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/tojson/index.html
+++ b/files/en-us/web/api/performance/tojson/index.html
@@ -45,21 +45,7 @@ console.log("json = " + JSON.stringify(js));
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Highres Time Level 2', '#dom-performance-tojson', 'toJSON()
-        serializer')}}</td>
-      <td>{{Spec2('Highres Time Level 2')}}</td>
-      <td>Defines <code>toJson()</code>.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/element/index.html
+++ b/files/en-us/web/api/performanceelementtiming/element/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-element','PerformanceElementTiming.element')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/id/index.html
+++ b/files/en-us/web/api/performanceelementtiming/id/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-id','PerformanceElementTiming.id')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.html
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-identifier','PerformanceElementTiming.identifier')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/index.html
+++ b/files/en-us/web/api/performanceelementtiming/index.html
@@ -60,20 +60,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Element Timing API','#sec-performance-element-timing','PerformanceElementTiming')}}</td>
-   <td>{{Spec2('Element Timing API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
@@ -41,20 +41,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-intersectionrect','PerformanceElementTiming.intersectionRect')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-loadtime','PerformanceElementTiming.loadTime')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-naturalheight','PerformanceElementTiming.naturalHeight')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
@@ -38,20 +38,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-naturalwidth','PerformanceElementTiming.naturalWidth')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.html
@@ -43,20 +43,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-rendertime','PerformanceElementTiming.renderTime')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.html
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.html
@@ -43,20 +43,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-tojson','PerformanceElementTiming.toJson()')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/url/index.html
+++ b/files/en-us/web/api/performanceelementtiming/url/index.html
@@ -39,20 +39,7 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-url','PerformanceElementTiming.url')}}</td>
-    <td>{{Spec2('Element Timing API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/duration/index.html
+++ b/files/en-us/web/api/performanceentry/duration/index.html
@@ -108,27 +108,7 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry-duration',
-        'duration')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performanceentry-duration',
-        'duration')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/entrytype/index.html
+++ b/files/en-us/web/api/performanceentry/entrytype/index.html
@@ -119,27 +119,7 @@ browser-compat: api.PerformanceEntry.entryType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry-entrytype',
-        'entryType')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performanceentry-entrytype',
-        'entryType')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/index.html
+++ b/files/en-us/web/api/performanceentry/index.html
@@ -80,65 +80,7 @@ function print_PerformanceEntry(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing 3')}}</td>
-   <td>{{Spec2('Resource Timing 3')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing 2')}}</td>
-   <td>{{Spec2('Resource Timing 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing')}}</td>
-   <td>{{Spec2('Resource Timing')}}</td>
-   <td>Adds the {{domxref("PerformanceResourceTiming")}} interface and the <code>resource</code> value for <code>entryType</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Navigation Timing Level 2')}}</td>
-   <td>{{Spec2('Navigation Timing Level 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Navigation Timing')}}</td>
-   <td>{{Spec2('Navigation Timing')}}</td>
-   <td>Adds the {{domxref("PerformanceNavigationTiming")}} interface and the <code>navigation</code> value for <code>entryType</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing Level 2')}}</td>
-   <td>{{Spec2('User Timing Level 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing')}}</td>
-   <td>{{Spec2('User Timing')}}</td>
-   <td>Adds the {{domxref("PerformanceMark")}} and {{domxref("PerformanceMeasure")}} interfaces as well as the <code>mark</code> and <code>measure</code> values for <code>entryType</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Frame Timing')}}</td>
-   <td>{{Spec2('Frame Timing')}}</td>
-   <td>Adds the {{domxref('PerformanceFrameTiming')}} interface and the <code>frame</code> value for <code>entryType</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry', 'PerformanceEntry')}}</td>
-   <td>{{Spec2('Performance Timeline Level 2')}}</td>
-   <td>Added <code>toJSON()</code> serializer method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline', '#dom-performanceentry', 'PerformanceEntry')}}</td>
-   <td>{{Spec2('Performance Timeline')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/name/index.html
+++ b/files/en-us/web/api/performanceentry/name/index.html
@@ -125,26 +125,7 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry-name',
-        'name')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performanceentry-name', 'name')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/starttime/index.html
+++ b/files/en-us/web/api/performanceentry/starttime/index.html
@@ -103,27 +103,7 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry-starttime',
-        'startTime')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline', '#dom-performanceentry-starttime',
-        'startTime')}}</td>
-      <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceentry/tojson/index.html
+++ b/files/en-us/web/api/performanceentry/tojson/index.html
@@ -87,21 +87,7 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceentry-tojson',
-        'toJSON')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>toJSON()</code> method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceeventtiming/index.html
+++ b/files/en-us/web/api/performanceeventtiming/index.html
@@ -146,20 +146,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Event Timing API','#sec-performance-event-timing','PerformanceEventTiming')}}</td>
-   <td>{{Spec2('Event Timing API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceframetiming/index.html
+++ b/files/en-us/web/api/performanceframetiming/index.html
@@ -44,20 +44,7 @@ browser-compat: api.PerformanceFrameTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Frame Timing', '#performanceframetiming-interface', 'PerformanceFrameTiming')}}</td>
-   <td>{{Spec2('Frame Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancelongtasktiming/attribution/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/attribution/index.html
@@ -20,20 +20,7 @@ browser-compat: api.PerformanceLongTaskTiming.attribution
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Long Tasks','#dom-performancelongtasktiming-attribution','attribution')}}</td>
-            <td>{{Spec2('Long Tasks')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancelongtasktiming/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/index.html
@@ -24,20 +24,7 @@ browser-compat: api.PerformanceLongTaskTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Long Tasks','#sec-PerformanceLongTaskTiming','PerformanceLongTaskTiming')}}</td>
-			<td>{{Spec2('Long Tasks')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancemark/index.html
+++ b/files/en-us/web/api/performancemark/index.html
@@ -42,25 +42,7 @@ browser-compat: api.PerformanceMark
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing Level 2', '#performancemark', 'PerformanceMark')}}</td>
-   <td>{{Spec2('User Timing Level 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing', '#performancemark', 'PerformanceMark')}}</td>
-   <td>{{Spec2('User Timing')}}</td>
-   <td>Basic definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancemeasure/index.html
+++ b/files/en-us/web/api/performancemeasure/index.html
@@ -42,25 +42,7 @@ browser-compat: api.PerformanceMeasure
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing Level 2', '#dom-performance-measure', 'PerformanceMeasure')}}</td>
-   <td>{{Spec2('User Timing Level 2')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('User Timing', '#performancemeasure', 'PerformanceMeasure')}}</td>
-   <td>{{Spec2('User Timing')}}</td>
-   <td>Basic definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/index.html
+++ b/files/en-us/web/api/performancenavigation/index.html
@@ -59,20 +59,7 @@ browser-compat: api.PerformanceNavigation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Navigation Timing', '#performancenavigation', 'PerformanceNavigation')}}</td>
-   <td>{{Spec2('Navigation Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.html
@@ -33,21 +33,7 @@ browser-compat: api.PerformanceNavigation.redirectCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancenavigation-redirectcount',
-        'PerformanceNavigation.redirectCount')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/type/index.html
+++ b/files/en-us/web/api/performancenavigation/type/index.html
@@ -66,21 +66,7 @@ browser-compat: api.PerformanceNavigation.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancenavigation-type',
-        'PerformanceNavigation.type')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.html
@@ -59,21 +59,7 @@ browser-compat: api.PerformanceNavigationTiming.domComplete
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-domcomplete', 'domComplete')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.html
@@ -57,22 +57,7 @@ browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-domcontentloadedeventend',
-        'domContentLoadedEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.html
@@ -57,22 +57,7 @@ browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-domcontentloadedeventstart',
-        'domContentLoadedEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.html
@@ -57,21 +57,7 @@ browser-compat: api.PerformanceNavigationTiming.domInteractive
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-dominteractive', 'domInteractive')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/index.html
@@ -77,22 +77,7 @@ browser-compat: api.PerformanceNavigationTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Navigation Timing Level 2', '#sec-PerformanceNavigationTiming', 'PerformanceNavigationTiming')}}</td>
-   <td>{{Spec2('Navigation Timing Level 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.html
@@ -53,21 +53,7 @@ browser-compat: api.PerformanceNavigationTiming.loadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-loadeventend', 'loadEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.html
@@ -53,21 +53,7 @@ browser-compat: api.PerformanceNavigationTiming.loadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-loadeventstart', 'loadEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.html
@@ -55,21 +55,7 @@ browser-compat: api.PerformanceNavigationTiming.redirectCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-redirectcount', 'redirectCount')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.html
@@ -46,21 +46,7 @@ console.log("PerformanceNavigationTiming.toJSON() = " + s);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-tojson', 'toJSON()')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/type/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.html
@@ -69,21 +69,7 @@ browser-compat: api.PerformanceNavigationTiming.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2', '#dom-performancenavigationtiming-type',
-        'type')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.html
@@ -55,21 +55,7 @@ browser-compat: api.PerformanceNavigationTiming.unloadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-unloadeventend', 'unloadEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.html
@@ -55,21 +55,7 @@ browser-compat: api.PerformanceNavigationTiming.unloadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing Level 2',
-        '#dom-performancenavigationtiming-unloadeventstart', 'unloadEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/disconnect/index.html
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.html
@@ -46,21 +46,7 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2',
-        '#dom-performanceobserver-disconnect', 'disconnect()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>disconnect()</code> method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -52,20 +52,7 @@ observer.observe({entryTypes: ["measure"]});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceobserver', 'PerformanceObserver')}}</td>
-   <td>{{Spec2('Performance Timeline Level 2')}}</td>
-   <td>Initial definition of <code>PerformanceObserver</code> interface.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/observe/index.html
+++ b/files/en-us/web/api/performanceobserver/observe/index.html
@@ -76,21 +76,7 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceobserver-observe',
-        'observe()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>observe()</code> method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.html
@@ -58,21 +58,7 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2',
-        '#idl-def-performanceobservercallback', 'PerformanceObserver()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>PerformanceObserver()</code> constructor.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
@@ -53,20 +53,7 @@ detectSupport(["resource", "mark", "frame"]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Performance Timeline Level 2', '#supportedentrytypes-attribute', 'PerformanceObserver.supportedEntryTypes')}}</td>
-    <td>{{Spec2('Performance Timeline Level 2')}}</td>
-    <td>Initial definition of <code>PerformanceObserver</code> interface.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserver/takerecords/index.html
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.html
@@ -48,21 +48,7 @@ console.log(records[0].duration);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2',
-        '#dom-performanceobserver-takerecords', 'takeRecords()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>takeRecords()</code> method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
@@ -110,21 +110,7 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2',
-        '#dom-performanceobserverentrylist-getentries', 'getEntries()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
@@ -97,21 +97,7 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Performance Timeline Level 2',
-        '#dom-performanceobserverentrylist-getentriesbyname', 'getEntriesByName()')}}</td>
-      <td>{{Spec2('Performance Timeline Level 2')}}</td>
-      <td>Initial definition of <code>getEntriesByName()</code> method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
@@ -78,20 +78,7 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Performance Timeline Level 2', '#dom-performanceobserverentrylist-getentriesbytype', 'getEntriesByType()')}}</td>
-   <td>{{Spec2('Performance Timeline Level 2')}}</td>
-   <td>Initial definition of <code>getEntriesByType()</code> method.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/index.html
@@ -39,20 +39,7 @@ var observe_all = new PerformanceObserver(function(list, obs) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Performance Timeline Level 2', '#idl-def-performanceobserverentrylist', 'PerformanceObserverEntryList')}}</td>
-			<td>{{Spec2('Performance Timeline Level 2')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancepainttiming/index.html
+++ b/files/en-us/web/api/performancepainttiming/index.html
@@ -59,20 +59,7 @@ The time to first-contentful-paint was 2787.460 milliseconds.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Paint Timing','#sec-PerformancePaintTiming','PerformancePaintTiming')}}</td>
-   <td>{{Spec2('Paint Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.html
@@ -66,21 +66,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-connectend',
-        'connectEnd')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.html
@@ -64,21 +64,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-connectstart',
-        'connectStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.html
@@ -62,21 +62,7 @@ function check_PerformanceEntries() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2',
-        '#dom-performanceresourcetiming-decodedbodysize', 'decodedBodySize')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.html
@@ -69,21 +69,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-domainlookupend',
-        'domainLookupEnd')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.html
@@ -64,21 +64,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing',
-        '#dom-performanceresourcetiming-domainlookupstart', 'domainLookupStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.html
@@ -64,21 +64,7 @@ function check_PerformanceEntries() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2',
-        '#dom-performanceresourcetiming-encodedbodysize', 'encodedBodySize')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.html
@@ -67,21 +67,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-fetchstart',
-        'fetchStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/index.html
@@ -87,20 +87,7 @@ browser-compat: api.PerformanceResourceTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resource Timing', '#performanceresourcetiming', 'PerformanceResourceTiming')}}</td>
-   <td>{{Spec2('Resource Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.html
@@ -60,21 +60,7 @@ function print_initiatorType(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Resource Timing',
-				'#dom-performanceresourcetiming-initiatortype', 'initiatorType')}}</td>
-			<td>{{Spec2('Resource Timing')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.html
@@ -56,21 +56,7 @@ function print_nextHopProtocol(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2',
-        '#dom-performanceresourcetiming-nexthopprotocol', 'nextHopProtocol')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.html
@@ -70,21 +70,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-redirectend',
-        'redirectEnd')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.html
@@ -69,21 +69,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-redirectstart',
-        'redirectStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.html
@@ -68,21 +68,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-requeststart',
-        'requestStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.html
@@ -66,21 +66,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-responseend',
-        'responseEnd')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.html
@@ -64,21 +64,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing', '#dom-performanceresourcetiming-responsestart',
-        'responseStart')}}</td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.html
@@ -67,22 +67,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing',
-        '#dom-performanceresourcetiming-secureconnectionstart', 'secureConnectionStart')}}
-      </td>
-      <td>{{Spec2('Resource Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/servertiming/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/servertiming/index.html
@@ -22,20 +22,7 @@ browser-compat: api.PerformanceResourceTiming.serverTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Server Timing','#servertiming-attribute', 'serverTiming')}}</td>
-      <td>{{Spec2('Server Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.html
@@ -45,21 +45,7 @@ console.log("PerformanceEntry.toJSON = " + s);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2', '#dom-performanceresourcetiming-tojson',
-        'toJSON')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.html
@@ -66,21 +66,7 @@ function check_PerformanceEntries() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2', '#dom-performanceresourcetiming-transfersize',
-        'transferSize')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.html
@@ -69,21 +69,7 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resource Timing 2', '#dom-performanceresourcetiming-workerstart',
-        'workerStart')}}</td>
-      <td>{{Spec2('Resource Timing 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceservertiming/description/index.html
+++ b/files/en-us/web/api/performanceservertiming/description/index.html
@@ -21,21 +21,7 @@ browser-compat: api.PerformanceServerTiming.description
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Server Timing','#dom-performanceservertiming-description',
-        'description')}}</td>
-      <td>{{Spec2('Server Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceservertiming/duration/index.html
+++ b/files/en-us/web/api/performanceservertiming/duration/index.html
@@ -20,21 +20,7 @@ browser-compat: api.PerformanceServerTiming.duration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Server Timing','#dom-performanceservertiming-duration',
-        'duration')}}</td>
-      <td>{{Spec2('Server Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceservertiming/index.html
+++ b/files/en-us/web/api/performanceservertiming/index.html
@@ -66,20 +66,7 @@ console.log(entries[0].serverTiming);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Server Timing','#the-performanceservertiming-interface', 'PerformanceServerTiming')}}</td>
-   <td>{{Spec2('Server Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceservertiming/name/index.html
+++ b/files/en-us/web/api/performanceservertiming/name/index.html
@@ -20,20 +20,7 @@ browser-compat: api.PerformanceServerTiming.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Server Timing','#dom-performanceservertiming-name', 'name')}}</td>
-      <td>{{Spec2('Server Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performanceservertiming/tojson/index.html
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceServerTiming.toJSON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Server Timing','#dom-performanceservertiming-tojson','toJSON')}}
-      </td>
-      <td>{{Spec2('Server Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/connectend/index.html
+++ b/files/en-us/web/api/performancetiming/connectend/index.html
@@ -37,21 +37,7 @@ browser-compat: api.PerformanceTiming.connectEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-connectend',
-        'PerformanceTiming.connectEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.html
+++ b/files/en-us/web/api/performancetiming/connectstart/index.html
@@ -37,21 +37,7 @@ browser-compat: api.PerformanceTiming.connectStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-connectstart',
-        'PerformanceTiming.connectStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.domainLookupEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-domainlookupend',
-        'PerformanceTiming.domainLookupEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.domainLookupStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-domainlookupstart',
-        'PerformanceTiming.domainLookupStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.html
@@ -36,21 +36,7 @@ browser-compat: api.PerformanceTiming.domComplete
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-domcomplete',
-        'PerformanceTiming.domComplete')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
@@ -34,22 +34,7 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing',
-        '#dom-performancetiming-domcontentloadedeventend',
-        'PerformanceTiming.domContentLoadedEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
@@ -35,22 +35,7 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing',
-        '#dom-performancetiming-domcontentloadedeventstart',
-        'PerformanceTiming.domContentLoadedEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.html
@@ -43,21 +43,7 @@ browser-compat: api.PerformanceTiming.domInteractive
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-dominteractive',
-        'PerformanceTiming.domInteractive')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domloading/index.html
+++ b/files/en-us/web/api/performancetiming/domloading/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.domLoading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-domloading',
-        'PerformanceTiming.domLoading')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.fetchStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-fetchstart',
-        'PerformanceTiming.fetchStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/index.html
+++ b/files/en-us/web/api/performancetiming/index.html
@@ -90,20 +90,7 @@ browser-compat: api.PerformanceTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Navigation Timing', '#performancetiming', 'PerformanceTiming')}}</td>
-   <td>{{Spec2('Navigation Timing')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.html
@@ -36,21 +36,7 @@ browser-compat: api.PerformanceTiming.loadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-loadedeventend',
-        'PerformanceTiming.loadEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.html
@@ -34,21 +34,7 @@ browser-compat: api.PerformanceTiming.loadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-loadeventstart',
-        'PerformanceTiming.loadEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/navigationstart/index.html
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.html
@@ -36,21 +36,7 @@ browser-compat: api.PerformanceTiming.navigationStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-navigationstart',
-        'PerformanceTiming.navigationStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectend/index.html
+++ b/files/en-us/web/api/performancetiming/redirectend/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.redirectEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-redirectend',
-        'PerformanceTiming.redirectEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.redirectStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-redirectstart',
-        'PerformanceTiming.redirectStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/requeststart/index.html
+++ b/files/en-us/web/api/performancetiming/requeststart/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.requestStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-requeststart',
-        'PerformanceTiming.requestStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/responseend/index.html
+++ b/files/en-us/web/api/performancetiming/responseend/index.html
@@ -35,21 +35,7 @@ browser-compat: api.PerformanceTiming.responseEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-responseEnd',
-        'PerformanceTiming.responseEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/responsestart/index.html
+++ b/files/en-us/web/api/performancetiming/responsestart/index.html
@@ -34,21 +34,7 @@ browser-compat: api.PerformanceTiming.responseStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-responsestart',
-        'PerformanceTiming.responseStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
@@ -33,21 +33,7 @@ browser-compat: api.PerformanceTiming.secureConnectionStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-secureconnectionstart',
-        'PerformanceTiming.secureConnectionStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.html
@@ -34,21 +34,7 @@ browser-compat: api.PerformanceTiming.unloadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-unloadeventend',
-        'PerformanceTiming.unloadEventEnd')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.html
@@ -34,21 +34,7 @@ browser-compat: api.PerformanceTiming.unloadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Navigation Timing', '#dom-performancetiming-unloadeventstart',
-        'PerformanceTiming.unloadEventStart')}}</td>
-      <td>{{Spec2('Navigation Timing')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/index.html
@@ -53,20 +53,7 @@ browser-compat: api.PeriodicSyncEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Periodic Background Sync','#periodicsync-event','PeriodicSyncEvent')}}</td>
-   <td>{{Spec2('Periodic Background Sync')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
@@ -58,20 +58,7 @@ psEvent.tag; // should return 'unique-tag'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#periodicsync-event','PeriodicSyncEvent')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/tag/index.html
+++ b/files/en-us/web/api/periodicsyncevent/tag/index.html
@@ -40,20 +40,7 @@ browser-compat: api.PeriodicSyncEvent.tag
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncevent-tag','tag')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.html
@@ -54,20 +54,7 @@ browser-compat: api.PeriodicSyncManager.getTags
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-gettags','getTags')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/index.html
@@ -74,20 +74,7 @@ browser-compat: api.PeriodicSyncManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Periodic Background Sync','#periodicsyncmanager','PeriodicSyncManager')}}</td>
-   <td>{{Spec2('Periodic Background Sync')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/register/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.html
@@ -72,20 +72,7 @@ browser-compat: api.PeriodicSyncManager.register
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-register','register')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.html
@@ -50,20 +50,7 @@ browser-compat: api.PeriodicSyncManager.unregister
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-unregister','unregister')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/index.html
@@ -42,20 +42,7 @@ browser-compat: api.PeriodicWave
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API', '#periodicwave', 'PeriodicWave')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/periodicwave/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.html
@@ -72,20 +72,7 @@ var wave = new PeriodicWave(ac, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#periodicwave','PeriodicWave')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/permissions/index.html
+++ b/files/en-us/web/api/permissions/index.html
@@ -40,20 +40,7 @@ browser-compat: api.Permissions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Permissions API","#permissions-interface", "Permissions")}}</td>
-   <td>{{Spec2("Permissions API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_Support">Browser Support</h2>
 

--- a/files/en-us/web/api/permissions/query/index.html
+++ b/files/en-us/web/api/permissions/query/index.html
@@ -72,20 +72,7 @@ browser-compat: api.Permissions.query
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Permissions API','#dom-permissions-query','query()')}}</td>
-   <td>{{Spec2('Permissions API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/permissionstatus/index.html
+++ b/files/en-us/web/api/permissionstatus/index.html
@@ -42,20 +42,7 @@ browser-compat: api.PermissionStatus
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Permissions API', '#status-of-a-permission', 'PermissionStatus')}}</td>
-   <td>{{Spec2('Permissions API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/permissionstatus/onchange/index.html
+++ b/files/en-us/web/api/permissionstatus/onchange/index.html
@@ -32,20 +32,7 @@ PermissionStatus.addEventListener('change', function() { ... })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Permissions API','#dom-permissionstatus-onchange','onchange')}}</td>
-   <td>{{Spec2('Permissions API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/permissionstatus/state/index.html
+++ b/files/en-us/web/api/permissionstatus/state/index.html
@@ -36,20 +36,7 @@ browser-compat: api.PermissionStatus.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Permissions API','#dom-permissionstatus-state','state')}}</td>
-      <td>{{Spec2('Permissions API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/photocapabilities/filllightmode/index.html
+++ b/files/en-us/web/api/photocapabilities/filllightmode/index.html
@@ -41,20 +41,7 @@ browser-compat: api.PhotoCapabilities.fillLightMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('MediaStream Image','#dom-photocapabilities-filllightmode','fillLightMode')}}</td>
-			<td>{{Spec2('MediaStream Image')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/photocapabilities/imageheight/index.html
+++ b/files/en-us/web/api/photocapabilities/imageheight/index.html
@@ -30,20 +30,7 @@ browser-compat: api.PhotoCapabilities.imageHeight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-imageheight','imageHeight')}}</td>
-      <td>{{Spec2('MediaStream Image')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/photocapabilities/imagewidth/index.html
+++ b/files/en-us/web/api/photocapabilities/imagewidth/index.html
@@ -30,20 +30,7 @@ browser-compat: api.PhotoCapabilities.imageWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-imagewidth','imageWidth')}}</td>
-      <td>{{Spec2('MediaStream Image')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/photocapabilities/index.html
+++ b/files/en-us/web/api/photocapabilities/index.html
@@ -63,20 +63,7 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('MediaStream Image','#photocapabilities-section','PhotoCapabilities')}}</td>
-   <td>{{Spec2('MediaStream Image')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/photocapabilities/redeyereduction/index.html
+++ b/files/en-us/web/api/photocapabilities/redeyereduction/index.html
@@ -41,20 +41,7 @@ browser-compat: api.PhotoCapabilities.redEyeReduction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-redeyereduction','redEyeReduction')}}</td>
-      <td>{{Spec2('MediaStream Image')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpictureevent/index.html
+++ b/files/en-us/web/api/pictureinpictureevent/index.html
@@ -32,22 +32,7 @@ browser-compat: api.PictureInPictureEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', '#pictureinpictureevent', 'PictureInPictureEvent')}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.html
+++ b/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.html
@@ -35,22 +35,7 @@ browser-compat: api.PictureInPictureEvent.PictureInPictureEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('Picture-in-Picture',
-                '#dom-pictureinpictureevent-pictureinpictureevent',
-                'PictureInPictureEvent()')}}</td>
-            <td>{{Spec2('Picture-in-Picture')}}</td>
-            <td>Initial definition</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/height/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/height/index.html
@@ -28,23 +28,7 @@ browser-compat: api.PictureInPictureWindow.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture', '#dom-pictureinpicturewindow-height',
-        'PictureInPicture.height')}}</td>
-      <td>{{Spec2('PictureInPicture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/index.html
@@ -65,22 +65,7 @@ button.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', '#pictureinpicturewindow')}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
@@ -60,22 +60,7 @@ video.requestPictureInPicture()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Picture-in-Picture','#dom-pictureinpicturewindow-onresize','PictureInPictureWindow.onresize')}}
-      </td>
-      <td>{{Spec2('Picture-in-Picture')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.html
@@ -68,18 +68,7 @@ video.requestPictureInPicture()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', '#eventdef-pictureinpicturewindow-resize', 'resize')}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/width/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/width/index.html
@@ -28,23 +28,7 @@ browser-compat: api.PictureInPictureWindow.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture', '#dom-pictureinpicturewindow-width',
-        'PictureInPicture.width')}}</td>
-      <td>{{Spec2('PictureInPicture')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/plugin/index.html
+++ b/files/en-us/web/api/plugin/index.html
@@ -42,20 +42,7 @@ browser-compat: api.Plugin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','#dom-plugin','Plugin')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pluginarray/index.html
+++ b/files/en-us/web/api/pluginarray/index.html
@@ -81,22 +81,7 @@ for(var i = 0; i &lt; pluginsLength; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#pluginarray", "PluginArray")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/p[b-n]* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `PerformanceTiming.*` (24 pages) are deprecated in favor of `PerformanceNavigationTiming`. I keep them like this for this phase.
- `PerformanceNavigation.*` (3 pages) are deprecated in favor of `PerformanceNavigationTiming`. I keep them like this for this phase.

All other pages look fine.