### PR TITLE
Replace spec table with {{specifications}} for api/p[o-z]*

### DIFF
--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
@@ -32,20 +32,7 @@ browser-compat: api.PointerEvent.getCoalescedEvents
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 3','#dom-pointerevent-getcoalescedevents','getCoalescedEvents()')}}</td>
-      <td>{{Spec2('Pointer Events 3')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/height/index.html
+++ b/files/en-us/web/api/pointerevent/height/index.html
@@ -41,25 +41,7 @@ browser-compat: api.PointerEvent.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-height', 'height')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEvent-height', 'height')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/index.html
@@ -120,32 +120,7 @@ browser-compat: api.PointerEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Pointer Events 3','#pointerevent-interface', 'PointerEvent')}}</td>
-   <td>{{Spec2('Pointer Events 3')}}</td>
-   <td>Added the {{DOMxRef('PointerEvent.getCoalescedEvents()', 'getCoalescedEvents()')}} and {{DOMxRef('PointerEvent.getPredictedEvents()', 'getPredictedEvents()')}} methods and {{Event('pointerrawupdate')}} event.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2','#pointerevent-interface', 'PointerEvent')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-   <td>Added the {{DOMxRef('PointerEvent.twist', 'twist')}} and {{DOMxRef('PointerEvent.tangentialPressure', 'tangentialPressure')}} properties.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#pointerevent-interface', 'PointerEvent')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/isprimary/index.html
+++ b/files/en-us/web/api/pointerevent/isprimary/index.html
@@ -67,25 +67,7 @@ browser-compat: api.PointerEvent.isPrimary
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-isprimary', 'isPrimary')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEvent-isPrimary', 'isPrimary')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/pointerid/index.html
+++ b/files/en-us/web/api/pointerevent/pointerid/index.html
@@ -46,26 +46,7 @@ target.addEventListener('pointerdown', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-pointerid', 'pointerId')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEventInit-pointerId', 'pointerId')}}
-      </td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/pointertype/index.html
+++ b/files/en-us/web/api/pointerevent/pointertype/index.html
@@ -68,35 +68,7 @@ browser-compat: api.PointerEvent.pointerType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEventInit-pointerType',
-        'pointerType')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-pointertype', 'pointerType')}}
-      </td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View','#extensions-to-the-mouseevent-interface',
-        'MouseEvent')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Redefines {{domxref("MouseEvent")}} from <code>long</code> to
-        <code>double</code>. This means that a {{domxref("PointerEvent")}} whose
-        <code>pointerType</code> is mouse will be a <code>double</code>.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/pressure/index.html
+++ b/files/en-us/web/api/pointerevent/pressure/index.html
@@ -54,26 +54,7 @@ browser-compat: api.PointerEvent.pressure
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-pressure', 'pressure')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEventInit-pressure', 'pressure')}}
-      </td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/tangentialpressure/index.html
+++ b/files/en-us/web/api/pointerevent/tangentialpressure/index.html
@@ -55,21 +55,7 @@ browser-compat: api.PointerEvent.tangentialPressure
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-tangentialpressure',
-        'tangentialPressure')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/tiltx/index.html
+++ b/files/en-us/web/api/pointerevent/tiltx/index.html
@@ -48,25 +48,7 @@ browser-compat: api.PointerEvent.tiltX
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-tiltx', 'tiltX')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEventInit-tiltX', 'tiltX')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/tilty/index.html
+++ b/files/en-us/web/api/pointerevent/tilty/index.html
@@ -47,25 +47,7 @@ browser-compat: api.PointerEvent.tiltY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-tilty', 'tiltY')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEventInit-tiltY', 'tiltY')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/twist/index.html
+++ b/files/en-us/web/api/pointerevent/twist/index.html
@@ -47,20 +47,7 @@ browser-compat: api.PointerEvent.twist
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-twist', 'twist')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pointerevent/width/index.html
+++ b/files/en-us/web/api/pointerevent/width/index.html
@@ -48,25 +48,7 @@ browser-compat: api.PointerEvent.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events 2','#dom-pointerevent-width', 'width')}}</td>
-      <td>{{Spec2('Pointer Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Pointer Events', '#widl-PointerEvent-width', 'width')}}</td>
-      <td>{{Spec2('Pointer Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/popstateevent/index.html
+++ b/files/en-us/web/api/popstateevent/index.html
@@ -68,21 +68,7 @@ history.go(2);  // alerts "location: http://example.com/example.html?page=3, sta
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "browsing-the-web.html#popstateevent",
-        "PopStateEvent")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/positionoptions/enablehighaccuracy/index.html
+++ b/files/en-us/web/api/positionoptions/enablehighaccuracy/index.html
@@ -28,23 +28,7 @@ browser-compat: api.PositionOptions.enableHighAccuracy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Geolocation', '#dom-positionoptions-enablehighaccuracy',
-				'PositionOptions.enableHighAccuracy')}}</td>
-			<td>{{Spec2('Geolocation')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/positionoptions/index.html
+++ b/files/en-us/web/api/positionoptions/index.html
@@ -27,22 +27,7 @@ browser-compat: api.PositionOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#position_options_interface', 'PositionOptions')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/positionoptions/maximumage/index.html
+++ b/files/en-us/web/api/positionoptions/maximumage/index.html
@@ -27,23 +27,7 @@ browser-compat: api.PositionOptions.maximumAge
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Geolocation', '#dom-positionoptions-maximumage',
-				'PositionOptions.maximumAge')}}</td>
-			<td>{{Spec2('Geolocation')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/positionoptions/timeout/index.html
+++ b/files/en-us/web/api/positionoptions/timeout/index.html
@@ -27,23 +27,7 @@ browser-compat: api.PositionOptions.timeout
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Geolocation', '#dom-positionoptions-timeout',
-				'PositionOptions.timeout')}}</td>
-			<td>{{Spec2('Geolocation')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentation/defaultrequest/index.html
+++ b/files/en-us/web/api/presentation/defaultrequest/index.html
@@ -27,20 +27,7 @@ browser-compat: api.Presentation.defaultRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Presentation","#dom-presentation-defaultrequest","defaultRequest")}}</td>
-   <td>{{Spec2("Presentation")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentation/index.html
+++ b/files/en-us/web/api/presentation/index.html
@@ -31,20 +31,7 @@ browser-compat: api.Presentation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentation','Presentation interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentation/receiver/index.html
+++ b/files/en-us/web/api/presentation/receiver/index.html
@@ -84,20 +84,7 @@ navigator.presentation.receiver.connectionList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Presentation', '#dom-presentation-receiver', 'receiver')}}</td>
-      <td>{{Spec2('Presentation')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationavailability/index.html
+++ b/files/en-us/web/api/presentationavailability/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PresentationAvailability
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationavailability','PresentationAvailability interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnection/index.html
+++ b/files/en-us/web/api/presentationconnection/index.html
@@ -53,20 +53,7 @@ browser-compat: api.PresentationConnection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationconnection','PresentationConnection interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnection/send/index.html
+++ b/files/en-us/web/api/presentationconnection/send/index.html
@@ -42,20 +42,7 @@ browser-compat: api.PresentationConnection.send
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Presentation', '#dom-presentationconnection-send', 'send()')}}</td>
-      <td>{{Spec2('Presentation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnection/url/index.html
+++ b/files/en-us/web/api/presentationconnection/url/index.html
@@ -28,20 +28,7 @@ browser-compat: api.PresentationConnection.url
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Presentation','#dom-presentationconnection-url','url')}}</td>
-      <td>{{Spec2('Presentation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnectionavailableevent/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.PresentationConnectionAvailableEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationconnectionavailableevent','PresentationConnectionAvailableEvent interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.html
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.PresentationConnectionCloseEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationconnectioncloseevent','PresentationConnectionCloseEvent interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationconnectionlist/index.html
+++ b/files/en-us/web/api/presentationconnectionlist/index.html
@@ -31,20 +31,7 @@ browser-compat: api.PresentationConnectionList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationconnectionlist','PresentationConnectionList')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationreceiver/index.html
+++ b/files/en-us/web/api/presentationreceiver/index.html
@@ -24,20 +24,7 @@ browser-compat: api.PresentationReceiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationreceiver','PresentationReceiver')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/index.html
@@ -47,20 +47,7 @@ browser-compat: api.PresentationRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#interface-presentationrequest','PresentationRequest interface')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationrequest/onconnectionavailable/index.html
+++ b/files/en-us/web/api/presentationrequest/onconnectionavailable/index.html
@@ -22,20 +22,7 @@ browser-compat: api.PresentationRequest.onconnectionavailable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Presentation','#dom-presentationrequest-onconnectionavailable','PresentationRequest.onconnectionavailable')}}</td>
-   <td>{{Spec2('Presentation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.html
@@ -31,22 +31,7 @@ browser-compat: api.PresentationRequest.PresentationRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Presentation','#constructing-a-presentationrequest','PresentationRequest')}}
-      </td>
-      <td>{{Spec2('Presentation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/presentationrequest/start/index.html
+++ b/files/en-us/web/api/presentationrequest/start/index.html
@@ -35,20 +35,7 @@ promise.then(function(PresentationConnection) { ... })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Presentation','#dom-presentationrequest-start','start()')}}</td>
-      <td>{{Spec2('Presentation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/processinginstruction/index.html
+++ b/files/en-us/web/api/processinginstruction/index.html
@@ -29,25 +29,7 @@ browser-compat: api.ProcessingInstruction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#processinginstruction', 'ProcessingInstruction')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td><a href="https://www.w3.org/TR/xml/#sec-pi">XML specification</a></td>
-   <td></td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/index.html
@@ -64,20 +64,7 @@ client.send()</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#interface-progressevent', 'ProgressEvent')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/progressevent/lengthcomputable/index.html
+++ b/files/en-us/web/api/progressevent/lengthcomputable/index.html
@@ -23,21 +23,7 @@ browser-compat: api.ProgressEvent.lengthComputable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#dom-progressevent-lengthcomputable',
-        'ProgressEvent.lengthComputable')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/progressevent/loaded/index.html
+++ b/files/en-us/web/api/progressevent/loaded/index.html
@@ -23,21 +23,7 @@ browser-compat: api.ProgressEvent.loaded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#dom-progressevent-loaded',
-        'ProgressEvent.loaded')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/progressevent/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/progressevent/index.html
@@ -46,21 +46,7 @@ browser-compat: api.ProgressEvent.ProgressEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#dom-progressevent-progressevent',
-        'ProgressEvent()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/progressevent/total/index.html
+++ b/files/en-us/web/api/progressevent/total/index.html
@@ -27,21 +27,7 @@ browser-compat: api.ProgressEvent.total
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#dom-progressevent-total',
-        'ProgressEvent.lengthComputable')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/index.html
+++ b/files/en-us/web/api/promiserejectionevent/index.html
@@ -61,22 +61,7 @@ browser-compat: api.PromiseRejectionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'webappapis.html#promiserejectionevent', 'PromiseRejectionEvent')}}</td>
-   <td>{{ Spec2('HTML WHATWG') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/promise/index.html
+++ b/files/en-us/web/api/promiserejectionevent/promise/index.html
@@ -54,23 +54,7 @@ browser-compat: api.PromiseRejectionEvent.promise
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webappapis.html#dom-promiserejectionevent-promise',
-        'PromiseRejectionEvent.promise')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
+++ b/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
@@ -77,22 +77,7 @@ browser-compat: api.PromiseRejectionEvent.PromiseRejectionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#the-promiserejectionevent-interface', 'the PromiseRejectionEvent interface')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/reason/index.html
+++ b/files/en-us/web/api/promiserejectionevent/reason/index.html
@@ -39,23 +39,7 @@ browser-compat: api.PromiseRejectionEvent.reason
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webappapis.html#dom-promiserejectionevent-reason',
-        'PromiseRejectionEvent.reason')}}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/getclientextensionresults/index.html
+++ b/files/en-us/web/api/publickeycredential/getclientextensionresults/index.html
@@ -98,24 +98,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredential-getclientextensionresults','getClientExtensionResults()')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/id/index.html
+++ b/files/en-us/web/api/publickeycredential/id/index.html
@@ -74,28 +74,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#iface-pkcredential','id')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Specified in the context of <code>PublicKeyCredential</code>. Overrides the
-        getter defined in <code>Credential</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Credential Management','#dom-credential-id','id')}}</td>
-      <td>{{Spec2('Credential Management')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/index.html
+++ b/files/en-us/web/api/publickeycredential/index.html
@@ -94,22 +94,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebAuthn','#iface-pkcredential','PublicKeyCredential interface')}}</td>
-   <td>{{Spec2('WebAuthn')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
@@ -75,24 +75,7 @@ browser-compat: api.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvai
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredential-isuserverifyingplatformauthenticatoravailable','isUserVerifyingPlatformAuthenticatorAvailable')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/rawid/index.html
+++ b/files/en-us/web/api/publickeycredential/rawid/index.html
@@ -69,22 +69,7 @@ navigator.credentials.create({  publickey: options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#dom-publickeycredential-rawid','rawId')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredential/response/index.html
+++ b/files/en-us/web/api/publickeycredential/response/index.html
@@ -97,22 +97,7 @@ navigator.credentials.create({  publickey: options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#dom-publickeycredential-response','response')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/attestation/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/attestation/index.html
@@ -78,24 +78,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-attestation','attestation')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/authenticatorselection/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/authenticatorselection/index.html
@@ -98,24 +98,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-authenticatorselection','authenticatorSelection')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/challenge/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/challenge/index.html
@@ -77,24 +77,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-challenge','challenge')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/excludecredentials/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/excludecredentials/index.html
@@ -98,24 +98,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-excludecredentials','excludeCredentials')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
@@ -158,24 +158,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-extensions','extensions')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/index.html
@@ -117,22 +117,7 @@ navigator.credentials.create(createCredentialOptions)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebAuthn','#dictdef-publickeycredentialcreationoptions', 'PublicKeyCredentialCreationOptions dictionary')}}</td>
-   <td>{{Spec2('WebAuthn')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/pubkeycredparams/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/pubkeycredparams/index.html
@@ -85,24 +85,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-pubkeycredparams','pubKeyCredParams')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/rp/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/rp/index.html
@@ -71,22 +71,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-rp','rp')}}</td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/timeout/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/timeout/index.html
@@ -69,24 +69,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-timeout','timeout')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/user/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/user/index.html
@@ -78,23 +78,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#dom-publickeycredentialcreationoptions-user','user')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/allowcredentials/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/allowcredentials/index.html
@@ -93,23 +93,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-allowcredentials','allowCredentials')}}
-			</td>
-			<td>{{Spec2('WebAuthn')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/challenge/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/challenge/index.html
@@ -64,24 +64,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-challenge','challenge')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/extensions/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/extensions/index.html
@@ -151,24 +151,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-extensions','extensions')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.html
@@ -74,22 +74,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebAuthn','#dictdef-publickeycredentialrequestoptions', 'PublicKeyCredentialRequestOptions dictionary')}}</td>
-   <td>{{Spec2('WebAuthn')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/rpid/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/rpid/index.html
@@ -59,23 +59,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-rpid','rpId')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/timeout/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/timeout/index.html
@@ -55,24 +55,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-timeout','timeout')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/userverification/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/userverification/index.html
@@ -65,24 +65,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebAuthn','#dom-publickeycredentialrequestoptions-userverification','userVerification')}}
-      </td>
-      <td>{{Spec2('WebAuthn')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushevent/data/index.html
+++ b/files/en-us/web/api/pushevent/data/index.html
@@ -56,20 +56,7 @@ browser-compat: api.PushEvent.data
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API','#dom-pushevent-data','data')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/index.html
@@ -70,20 +70,7 @@ browser-compat: api.PushEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API','#pushevent-interface','PushEvent')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/getsubscription/index.html
+++ b/files/en-us/web/api/pushmanager/getsubscription/index.html
@@ -66,20 +66,7 @@ browser-compat: api.PushManager.getSubscription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-pushmanager-getsubscription', 'getSubscription()')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/haspermission/index.html
+++ b/files/en-us/web/api/pushmanager/haspermission/index.html
@@ -23,20 +23,7 @@ browser-compat: api.PushManager.hasPermission
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Defines the <code>PushManager</code> interface.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/index.html
+++ b/files/en-us/web/api/pushmanager/index.html
@@ -80,20 +80,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API','#pushmanager-interface','PushManager')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/permissionstate/index.html
+++ b/files/en-us/web/api/pushmanager/permissionstate/index.html
@@ -55,21 +55,7 @@ browser-compat: api.PushManager.permissionState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushmanager-permissionstate','permissionState()')}}
-      </td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/register/index.html
+++ b/files/en-us/web/api/pushmanager/register/index.html
@@ -48,22 +48,7 @@ req.onerror = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Push API')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Defines the <code>PushManager</code> interface.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/registrations/index.html
+++ b/files/en-us/web/api/pushmanager/registrations/index.html
@@ -60,22 +60,7 @@ req.onsuccess = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Push API')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Defines the <code>PushManager</code> interface.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/subscribe/index.html
+++ b/files/en-us/web/api/pushmanager/subscribe/index.html
@@ -111,20 +111,7 @@ navigator.serviceWorker.ready.then(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API', '#dom-pushmanager-subscribe', 'subscribe()')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
@@ -28,21 +28,7 @@ browser-compat: api.PushManager.supportedContentEncodings
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushmanager-supportedcontentencodings','supportedContentEncodings')}}
-      </td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmanager/unregister/index.html
+++ b/files/en-us/web/api/pushmanager/unregister/index.html
@@ -63,22 +63,7 @@ req.onerror = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Push API')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Defines the <code>PushManager</code> interface.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PushMessageData.arrayBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-pushmessagedata-arraybuffer', 'arrayBuffer()')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmessagedata/blob/index.html
+++ b/files/en-us/web/api/pushmessagedata/blob/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PushMessageData.blob
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-pushmessagedata-blob', 'blob()')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmessagedata/index.html
+++ b/files/en-us/web/api/pushmessagedata/index.html
@@ -52,20 +52,7 @@ browser-compat: api.PushMessageData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#pushmessagedata-interface', 'PushMessageData')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmessagedata/json/index.html
+++ b/files/en-us/web/api/pushmessagedata/json/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PushMessageData.json
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-pushmessagedata-json', 'json()')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushmessagedata/text/index.html
+++ b/files/en-us/web/api/pushmessagedata/text/index.html
@@ -39,20 +39,7 @@ browser-compat: api.PushMessageData.text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-pushmessagedata-text', 'text()')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/endpoint/index.html
+++ b/files/en-us/web/api/pushsubscription/endpoint/index.html
@@ -48,20 +48,7 @@ browser-compat: api.PushSubscription.endpoint
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-endpoint','endPoint')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.html
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.html
@@ -30,21 +30,7 @@ browser-compat: api.PushSubscription.expirationTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-expirationtime','expirationTime')}}
-      </td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/getkey/index.html
+++ b/files/en-us/web/api/pushsubscription/getkey/index.html
@@ -78,21 +78,7 @@ browser-compat: api.PushSubscription.getKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>This is the Push API spec, but note that <code>getKey()</code> is not currently
-        specified in here. It is currently Firefox-only experimental.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/index.html
+++ b/files/en-us/web/api/pushsubscription/index.html
@@ -56,20 +56,7 @@ browser-compat: api.PushSubscription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Push API", "#pushsubscription-interface", "PushSubscription")}}</td>
-   <td>{{Spec2("Push API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/options/index.html
+++ b/files/en-us/web/api/pushsubscription/options/index.html
@@ -37,20 +37,7 @@ browser-compat: api.PushSubscription.options
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-options','options')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.html
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.html
@@ -27,20 +27,7 @@ browser-compat: api.PushSubscription.subscriptionId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Push API")}}</td>
-      <td>{{Spec2("Push API")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/tojson/index.html
+++ b/files/en-us/web/api/pushsubscription/tojson/index.html
@@ -44,20 +44,7 @@ browser-compat: api.PushSubscription.toJSON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-tojson','PushSubscription: toJSON')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscription/unsubscribe/index.html
+++ b/files/en-us/web/api/pushsubscription/unsubscribe/index.html
@@ -47,21 +47,7 @@ browser-compat: api.PushSubscription.unsubscribe
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-unsubscribe','unsubscribe()')}}
-      </td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
@@ -33,20 +33,7 @@ browser-compat: api.PushSubscriptionOptions.applicationServerKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscriptionoptionsinit-applicationserverkey','PushSubscriptionOptions.applicationServerKey')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.html
@@ -38,20 +38,7 @@ browser-compat: api.PushSubscriptionOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscriptionoptions','PushSubscriptionOptions')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
@@ -33,20 +33,7 @@ browser-compat: api.PushSubscriptionOptions.userVisibleOnly
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscriptionoptions-uservisibleonly','PushSubscriptionOptions.userVisibleOnly')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/p[o-z]* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `PushManager.register`, `PushManager.registrations`, `PushManager.hasPermission`, `PushManager.unregister`, all deprecated (I'll improve them in a 2nd phase).
- `PushSubscription.subscriptionId` also deprecated (and dealt with in a 2nd phase)
- `PublicKeyCredential.id` that is not existing (`id` on `PublicKeyCredential` is inherited from `Credential.id`). 
- 
All other pages look fine.