### PR TITLE
Replace spec table with {{specifications}} for api/r[a-s]*

### DIFF
--- a/files/en-us/web/api/radionodelist/index.html
+++ b/files/en-us/web/api/radionodelist/index.html
@@ -29,22 +29,7 @@ browser-compat: api.RadioNodeList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comments</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#radionodelist", "RadioNodeList")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/radionodelist/value/index.html
+++ b/files/en-us/web/api/radionodelist/value/index.html
@@ -52,23 +52,7 @@ radios.value = 'red';</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comments</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-radionodelist-value', 'RadioNodeList.value')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/clonecontents/index.html
+++ b/files/en-us/web/api/range/clonecontents/index.html
@@ -36,27 +36,7 @@ document.body.appendChild(documentFragment);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-clonecontents', 'Range.cloneContents()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-cloneContents', 'Range.cloneContents()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/clonerange/index.html
+++ b/files/en-us/web/api/range/clonerange/index.html
@@ -31,26 +31,7 @@ clone = range.cloneRange();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-clonerange', 'Range.cloneRange()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-clone',
-        'Range.cloneRange()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/collapse/index.html
+++ b/files/en-us/web/api/range/collapse/index.html
@@ -42,26 +42,7 @@ range.collapse(true);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-collapse', 'Range.collapse()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>The parameter is now optional and default to <code>false</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-collapse',
-        'Range.collapse()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/collapsed/index.html
+++ b/files/en-us/web/api/range/collapsed/index.html
@@ -38,26 +38,7 @@ isCollapsed = range.collapsed;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-collapsed', 'Range.collapsed')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-attr-collapsed',
-        'Range.collapsed')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/commonancestorcontainer/index.html
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.html
@@ -110,28 +110,7 @@ function playAnimation(el) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-commonancestorcontainer',
-        'Range.commonAncestorContainer')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level-2-Range-attr-commonParent', 'Range.commonAncestorContainer')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/compareboundarypoints/index.html
+++ b/files/en-us/web/api/range/compareboundarypoints/index.html
@@ -63,28 +63,7 @@ compare = range.compareBoundaryPoints(Range.START_TO_END, sourceRange);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-compareboundarypoints',
-        'Range.compareBoundaryPoints()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-compareBoundaryPoints',
-        'Range.compareBoundaryPoints()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/comparepoint/index.html
+++ b/files/en-us/web/api/range/comparepoint/index.html
@@ -47,21 +47,7 @@ returnValue = range.comparePoint(document.getElementsByTagName('p').item(0), 1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-comparepoint', 'Range.comparePoint()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/createcontextualfragment/index.html
+++ b/files/en-us/web/api/range/createcontextualfragment/index.html
@@ -45,21 +45,7 @@ document.body.appendChild(documentFragment);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM Parsing', '#dom-range-createcontextualfragment',
-        'Range.createContextualFragment()')}}</td>
-      <td>{{Spec2('DOM Parsing')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/deletecontents/index.html
+++ b/files/en-us/web/api/range/deletecontents/index.html
@@ -30,27 +30,7 @@ range.deleteContents();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-deletecontents',
-        'Range.deleteContents()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-deleteContents', 'Range.deleteContents()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/detach/index.html
+++ b/files/en-us/web/api/range/detach/index.html
@@ -29,26 +29,7 @@ range.detach();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-detach', 'Range.detach()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-detach',
-        'Range.detach()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/endcontainer/index.html
+++ b/files/en-us/web/api/range/endcontainer/index.html
@@ -31,26 +31,7 @@ endRangeNode = range.endContainer;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-endcontainer', 'Range.endContainer')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-attr-endParent',
-        'Range.endContainer')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/endoffset/index.html
+++ b/files/en-us/web/api/range/endoffset/index.html
@@ -38,26 +38,7 @@ endRangeOffset = range.endOffset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-endoffset', 'Range.endOffset')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-attr-endOffset',
-        'Range.endOffset')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/extractcontents/index.html
+++ b/files/en-us/web/api/range/extractcontents/index.html
@@ -97,28 +97,7 @@ button.addEventListener('click', e =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-extractcontents',
-        'Range.extractContents()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-extractContents', 'Range.extractContents()')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/getboundingclientrect/index.html
+++ b/files/en-us/web/api/range/getboundingclientrect/index.html
@@ -64,21 +64,7 @@ highlight.style.height = `${clientRect.height}px`;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-range-getboundingclientrect',
-        'Range.getBoundingClientRect()')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/getclientrects/index.html
+++ b/files/en-us/web/api/range/getclientrects/index.html
@@ -31,21 +31,7 @@ rectList = range.getClientRects();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-range-getclientrects',
-        'Range.getClientRects()')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/index.html
+++ b/files/en-us/web/api/range/index.html
@@ -99,40 +99,7 @@ browser-compat: api.Range
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-range', 'Range')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Do not use <code>RangeException</code> anymore, use <code>DOMException</code> instead.<br>
-    Made the second parameter of <code>collapse()</code> optional.<br>
-    Added the methods <code>isPointInRange()</code>, <code>comparePoint()</code>, and <code>intersectsNode()</code>.<br>
-    Added the constructor <code>Range()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM Parsing', '#extensions-to-the-range-interface', 'Extensions to Range')}}</td>
-   <td>{{Spec2('DOM Parsing')}}</td>
-   <td>Added the method <code>createContextualFragment()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#extensions-to-the-range-interface', 'Extensions to Range')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td>Added the methods <code>getClientRects()</code> and <code>getBoundingClientRect()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-Interface', 'Range')}}</td>
-   <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/insertnode/index.html
+++ b/files/en-us/web/api/range/insertnode/index.html
@@ -43,26 +43,7 @@ range.insertNode(newNode);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-insertnode', 'Range.insertNode()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-insertNode',
-        'Range.insertNode()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/intersectsnode/index.html
+++ b/files/en-us/web/api/range/intersectsnode/index.html
@@ -37,21 +37,7 @@ var bool = range.intersectsNode(document.getElementsByTagName("p").item(0));</pr
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-intersectsnode', 'Range.intersectNode()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/ispointinrange/index.html
+++ b/files/en-us/web/api/range/ispointinrange/index.html
@@ -41,21 +41,7 @@ bool = range.isPointInRange(document.getElementsByTagName("p").item(0),1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-ispointinrange',
-        'Range.isPointInRange()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/range/index.html
+++ b/files/en-us/web/api/range/range/index.html
@@ -60,20 +60,7 @@ selection.addRange(range);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-range', 'Range.Range()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/selectnode/index.html
+++ b/files/en-us/web/api/range/selectnode/index.html
@@ -36,26 +36,7 @@ range.selectNode(referenceNode);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-selectnode', 'Range.selectNode()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-selectNode',
-        'Range.selectNode()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/selectnodecontents/index.html
+++ b/files/en-us/web/api/range/selectnodecontents/index.html
@@ -82,28 +82,7 @@ deselectButton.addEventListener('click', e =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-selectnodecontents',
-        'Range.selectNodeContents()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-selectNodeContents',
-        'Range.selectNodeContents()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setend/index.html
+++ b/files/en-us/web/api/range/setend/index.html
@@ -76,26 +76,7 @@ range.setEnd(endNode, endOffset);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setend', 'Range.setEnd()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-setEnd',
-        'Range.setEnd()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setendafter/index.html
+++ b/files/en-us/web/api/range/setendafter/index.html
@@ -36,26 +36,7 @@ range.setEndAfter(referenceNode);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setendafter', 'Range.setEndAfter()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-setEndAfter', 'Range.setEndAfter()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setendbefore/index.html
+++ b/files/en-us/web/api/range/setendbefore/index.html
@@ -37,27 +37,7 @@ range.setEndBefore(referenceNode);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setendbefore', 'Range.setEndBefore()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-setEndBefore', 'Range.setEndBefore()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setstart/index.html
+++ b/files/en-us/web/api/range/setstart/index.html
@@ -113,26 +113,7 @@ document.getElementById('log').textContent = range;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setstart', 'Range.setStart()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-setStart',
-        'Range.setStart()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setstartafter/index.html
+++ b/files/en-us/web/api/range/setstartafter/index.html
@@ -37,27 +37,7 @@ range.setStartAfter(referenceNode);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setstartafter', 'Range.setStartAfter()')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-setStartAfter', 'Range.setStartAfter()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/setstartbefore/index.html
+++ b/files/en-us/web/api/range/setstartbefore/index.html
@@ -37,27 +37,7 @@ range.setStartBefore(referenceNode);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-setstartbefore',
-        'Range.setStartBefore()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-setStartBefore',
-        'Range.setStartBefore()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/startcontainer/index.html
+++ b/files/en-us/web/api/range/startcontainer/index.html
@@ -29,27 +29,7 @@ startRangeNode = range.startContainer;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-startcontainer', 'Range.endContainer')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-attr-startParent',
-        'Range.startContainer')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/startoffset/index.html
+++ b/files/en-us/web/api/range/startoffset/index.html
@@ -38,26 +38,7 @@ var startRangeOffset = range.startOffset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-startoffset', 'Range.startOffset')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level-2-Range-attr-startOffset',
-        'Range.startOffset')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/surroundcontents/index.html
+++ b/files/en-us/web/api/range/surroundcontents/index.html
@@ -57,28 +57,7 @@ range.surroundContents(newParent);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-surroundcontents',
-        'Range.surroundContents()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'ranges.html#Level2-Range-method-surroundContents', 'Range.surroundContents()')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/range/tostring/index.html
+++ b/files/en-us/web/api/range/tostring/index.html
@@ -44,26 +44,7 @@ document.getElementById('log').textContent = range.toString();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-stringifier', 'Range.toString()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'ranges.html#Level2-Range-method-toString',
-        'Range.toString()')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
@@ -33,20 +33,7 @@ browser-compat: api.ReadableByteStreamController.byobRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rbs-controller-byob-request","byobRequest")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.html
@@ -48,20 +48,7 @@ browser-compat: api.ReadableByteStreamController.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rbs-controller-close","close()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
@@ -32,20 +32,7 @@ browser-compat: api.ReadableByteStreamController.desiredSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rbs-controller-desired-size","desiredSize")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
@@ -48,20 +48,7 @@ browser-compat: api.ReadableByteStreamController.enqueue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rbs-controller-enqueue","enqueue()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.html
@@ -47,20 +47,7 @@ browser-compat: api.ReadableByteStreamController.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rbs-controller-error","error()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.html
@@ -45,20 +45,7 @@ browser-compat: api.ReadableByteStreamController
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#rbs-controller-class','ReadableByteStreamController')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/cancel/index.html
+++ b/files/en-us/web/api/readablestream/cancel/index.html
@@ -120,20 +120,7 @@ fetch(url).then(response =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-cancel","cancel()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/getreader/index.html
+++ b/files/en-us/web/api/readablestream/getreader/index.html
@@ -96,20 +96,7 @@ browser-compat: api.ReadableStream.getReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-get-reader","getReader()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -118,20 +118,7 @@ browser-compat: api.ReadableStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Streams','#rs-class','ReadableStream')}}</td>
-			<td>{{Spec2('Streams')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/locked/index.html
+++ b/files/en-us/web/api/readablestream/locked/index.html
@@ -39,20 +39,7 @@ stream.locked
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-locked","locked")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/pipethrough/index.html
+++ b/files/en-us/web/api/readablestream/pipethrough/index.html
@@ -102,20 +102,7 @@ fetch('png-logo.png')
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-pipe-through","pipeThrough()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/pipeto/index.html
+++ b/files/en-us/web/api/readablestream/pipeto/index.html
@@ -86,20 +86,7 @@ fetch('png-logo.png')
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-pipe-to","pipeTo()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -147,20 +147,7 @@ browser-compat: api.ReadableStream.ReadableStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-constructor","ReadableStream()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestream/tee/index.html
+++ b/files/en-us/web/api/readablestream/tee/index.html
@@ -92,20 +92,7 @@ function fetchStream(stream, list) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-tee","tee()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.html
@@ -54,20 +54,7 @@ browser-compat: api.ReadableStreamBYOBReader.cancel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#byob-reader-cancel","cancel()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.html
@@ -34,20 +34,7 @@ browser-compat: api.ReadableStreamBYOBReader.closed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#byob-reader-closed","closed")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/index.html
@@ -46,20 +46,7 @@ browser-compat: api.ReadableStreamBYOBReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#byob-reader-class','ReadableStreamBYOBReader')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/read/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.html
@@ -57,20 +57,7 @@ browser-compat: api.ReadableStreamBYOBReader.read
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#byob-reader-read","read()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
@@ -52,21 +52,7 @@ browser-compat: api.ReadableStreamBYOBReader.ReadableStreamBYOBReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#byob-reader-constructor","ReadableStreamBYOBReader()")}}
-      </td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
@@ -51,20 +51,7 @@ browser-compat: api.ReadableStreamBYOBReader.releaseLock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#byob-reader-release-lock","releaseLock()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobrequest/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/index.html
@@ -43,20 +43,7 @@ browser-compat: api.ReadableStreamBYOBRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#rs-byob-request-class','ReadableStreamBYOBRequest')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobrequest/respond/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respond/index.html
@@ -46,20 +46,7 @@ browser-compat: api.ReadableStreamBYOBRequest.respond
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-byob-request-respond","respond()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
@@ -47,22 +47,7 @@ browser-compat: api.ReadableStreamBYOBRequest.respondWithNewView
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName("Streams","#rs-byob-request-respond-with-new-view","respondWithNewView()")}}
-      </td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreambyobrequest/view/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.html
@@ -32,20 +32,7 @@ browser-compat: api.ReadableStreamBYOBRequest.view
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-byob-request-view","view")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
@@ -90,20 +90,7 @@ browser-compat: api.ReadableStreamDefaultController.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-default-controller-close","close()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
@@ -36,20 +36,7 @@ browser-compat: api.ReadableStreamDefaultController.desiredSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-default-controller-desired-size","desiredSize")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
@@ -86,20 +86,7 @@ browser-compat: api.ReadableStreamDefaultController.enqueue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-default-controller-enqueue","enqueue()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
@@ -56,20 +56,7 @@ browser-compat: api.ReadableStreamDefaultController.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#rs-default-controller-error","error()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.html
@@ -76,20 +76,7 @@ browser-compat: api.ReadableStreamDefaultController
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#rs-default-controller-class','ReadableStreamDefaultController')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
@@ -97,20 +97,7 @@ browser-compat: api.ReadableStreamDefaultReader.cancel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#default-reader-cancel","cancel()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
@@ -39,20 +39,7 @@ browser-compat: api.ReadableStreamDefaultReader.closed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#default-reader-closed","closed")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.html
@@ -76,20 +76,7 @@ browser-compat: api.ReadableStreamDefaultReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#default-reader-class','ReadableStreamDefaultReader')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.html
@@ -138,20 +138,7 @@ for await (let line of makeTextFileLineIterator(urlOfFile)) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#default-reader-read","read()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
@@ -86,22 +86,7 @@ browser-compat: api.ReadableStreamDefaultReader.ReadableStreamDefaultReader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName("Streams","#default-reader-constructor","ReadableStreamDefaultReader()")}}
-      </td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
@@ -58,20 +58,7 @@ browser-compat: api.ReadableStreamDefaultReader.releaseLock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Streams","#default-reader-release-lock","releaseLock()")}}</td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/index.html
@@ -83,20 +83,7 @@ Promise.all([navigator.permissions.query({ name: "accelerometer" }),
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Orientation Sensor','#relativeorientationsensor-interface','RelativeOrientationSensor')}}</td>
-   <td>{{Spec2('Orientation Sensor')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
@@ -48,21 +48,7 @@ browser-compat: api.RelativeOrientationSensor.RelativeOrientationSensor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Orientation Sensor','#dom-relativeorientationsensor-relativeorientationsensor','RelativeOrientationSensor()')}}
-			</td>
-			<td>{{Spec2('Orientation Sensor')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/report/body/index.html
+++ b/files/en-us/web/api/report/body/index.html
@@ -48,20 +48,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-report-body','Report.body')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/report/index.html
+++ b/files/en-us/web/api/report/index.html
@@ -90,20 +90,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Reporting API","#dom-report","Report")}}</td>
-   <td>{{Spec2("Reporting API")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/report/type/index.html
+++ b/files/en-us/web/api/report/type/index.html
@@ -43,20 +43,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-report-body','Report.body')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/report/url/index.html
+++ b/files/en-us/web/api/report/url/index.html
@@ -42,20 +42,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-report-url','Report.url')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserver/disconnect/index.html
+++ b/files/en-us/web/api/reportingobserver/disconnect/index.html
@@ -47,20 +47,7 @@ observer.disconnect()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-reportingobserver-disconnect','ReportingObserver.disconnect()')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/index.html
@@ -81,20 +81,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Reporting API","#interface-reporting-observer","ReportingObserver")}}</td>
-   <td>{{Spec2("Reporting API")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserver/observe/index.html
+++ b/files/en-us/web/api/reportingobserver/observe/index.html
@@ -38,20 +38,7 @@ observer.observe()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-reportingobserver-observe','ReportingObserver.observe()')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserver/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/reportingobserver/index.html
@@ -65,20 +65,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-reportingobserver-reportingobserver','ReportingObserver()')}}</td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserver/takerecords/index.html
+++ b/files/en-us/web/api/reportingobserver/takerecords/index.html
@@ -47,21 +47,7 @@ console.log(records);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Reporting API','#dom-reportingobserver-takerecords','ReportingObserver.takeRecords()')}}
-      </td>
-      <td>{{Spec2('Reporting API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/reportingobserveroptions/index.html
+++ b/files/en-us/web/api/reportingobserveroptions/index.html
@@ -36,20 +36,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Reporting API","#dictdef-reportingobserveroptions","ReportingObserverOptions")}}</td>
-   <td>{{Spec2("Reporting API")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/cache/index.html
+++ b/files/en-us/web/api/request/cache/index.html
@@ -113,20 +113,7 @@ fetch("some.json", {cache: "only-if-cached", mode: "same-origin", signal: contro
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#dom-request-cache','cache')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/clone/index.html
+++ b/files/en-us/web/api/request/clone/index.html
@@ -40,20 +40,7 @@ var newRequest = myRequest.clone(); // a copy of the request is now stored in ne
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#dom-request-clone','clone')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/credentials/index.html
+++ b/files/en-us/web/api/request/credentials/index.html
@@ -42,20 +42,7 @@ var myCred = myRequest.credentials; // returns "same-origin" by default</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#dom-request-credentials','credentials')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/destination/index.html
+++ b/files/en-us/web/api/request/destination/index.html
@@ -62,20 +62,7 @@ var myDestination = myRequest.destination; // returns the empty string by defaul
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-destination','destination')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/headers/index.html
+++ b/files/en-us/web/api/request/headers/index.html
@@ -55,20 +55,7 @@ myContentType = myRequest.headers.get('Content-Type'); // returns 'image/jpeg'</
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-headers','headers')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -138,22 +138,7 @@ const bodyUsed = request.bodyUsed;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#request-class','Request')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/integrity/index.html
+++ b/files/en-us/web/api/request/integrity/index.html
@@ -34,20 +34,7 @@ var myIntegrity = myRequest.integrity;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#dom-request-integrity','integrity')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/method/index.html
+++ b/files/en-us/web/api/request/method/index.html
@@ -36,20 +36,7 @@ var myMethod = myRequest.method; // GET</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-method','method')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/mode/index.html
+++ b/files/en-us/web/api/request/mode/index.html
@@ -89,20 +89,7 @@ var myMode = myRequest.mode; // returns "cors" by default</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-mode', 'mode')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/redirect/index.html
+++ b/files/en-us/web/api/request/redirect/index.html
@@ -40,20 +40,7 @@ var myCred = myRequest.redirect;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Fetch','#dom-request-redirect','redirect')}}</td>
-			<td>{{Spec2('Fetch')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/referrer/index.html
+++ b/files/en-us/web/api/request/referrer/index.html
@@ -42,20 +42,7 @@ var myReferrer = myRequest.referrer; // returns "about:client" by default</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-referrer','referrer')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/referrerpolicy/index.html
+++ b/files/en-us/web/api/request/referrerpolicy/index.html
@@ -40,20 +40,7 @@ var myReferrer = myRequest.referrerPolicy; // returns "" by default</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-referrerpolicy','referrerPolicy')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/request/url/index.html
+++ b/files/en-us/web/api/request/url/index.html
@@ -37,20 +37,7 @@ var myURL = myRequest.url; // "https://mdn.github.io/fetch-examples/fetch-reques
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-request-url','url')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/requestdestination/index.html
+++ b/files/en-us/web/api/requestdestination/index.html
@@ -62,20 +62,7 @@ browser-compat: api.RequestDestination
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#requestdestination','RequestDestination')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserver/disconnect/index.html
+++ b/files/en-us/web/api/resizeobserver/disconnect/index.html
@@ -41,21 +41,7 @@ browser-compat: api.ResizeObserver.disconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserver-disconnect','disconnect()')}}
-      </td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/index.html
@@ -95,20 +95,7 @@ checkbox.addEventListener('change', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resize Observer','#resize-observer-interface','ResizeObserver')}}</td>
-   <td>{{Spec2('Resize Observer')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserver/observe/index.html
+++ b/files/en-us/web/api/resizeobserver/observe/index.html
@@ -84,20 +84,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserver-observe','observe()')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.html
@@ -81,22 +81,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserver-resizeobserver','ResizeObserver')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserver/unobserve/index.html
+++ b/files/en-us/web/api/resizeobserver/unobserve/index.html
@@ -77,21 +77,7 @@ checkbox.addEventListener('change', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserver-unobserve','unobserve()')}}
-      </td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
@@ -66,20 +66,7 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-borderboxsize','borderBoxSize')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
@@ -76,20 +76,7 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-contentboxsize','contentBoxSize')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.html
@@ -65,22 +65,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-contentrect','contentRect')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/index.html
+++ b/files/en-us/web/api/resizeobserverentry/index.html
@@ -60,20 +60,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Resize Observer','#resize-observer-entry-interface','ResizeObserverEntry')}}</td>
-   <td>{{Spec2('Resize Observer')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/target/index.html
+++ b/files/en-us/web/api/resizeobserverentry/target/index.html
@@ -65,20 +65,7 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-target','target')}}</td>
-      <td>{{Spec2('Resize Observer')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.html
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.html
@@ -40,20 +40,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Resize Observer','#dom-resizeobserversize-blocksize','ResizeObserverEntry.blockSize')}}</td>
-    <td>{{Spec2('Resize Observer')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserversize/index.html
+++ b/files/en-us/web/api/resizeobserversize/index.html
@@ -47,20 +47,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Resize Observer','#resizeobserversize','ResizeObserverSize')}}</td>
-    <td>{{Spec2('Resize Observer')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.html
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.html
@@ -40,20 +40,7 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Resize Observer','#dom-resizeobserversize-inlinesize','ResizeObserverEntry.inlineSize')}}</td>
-    <td>{{Spec2('Resize Observer')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/clone/index.html
+++ b/files/en-us/web/api/response/clone/index.html
@@ -70,20 +70,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-clone','clone()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/error/index.html
+++ b/files/en-us/web/api/response/error/index.html
@@ -49,20 +49,7 @@ browser-compat: api.Response.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-error','error()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/headers/index.html
+++ b/files/en-us/web/api/response/headers/index.html
@@ -54,20 +54,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-headers','headers')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -125,22 +125,7 @@ doAjax().then(console.log).catch(console.log);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#response-class','Response')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/ok/index.html
+++ b/files/en-us/web/api/response/ok/index.html
@@ -56,20 +56,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-ok','ok')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/redirect/index.html
+++ b/files/en-us/web/api/response/redirect/index.html
@@ -69,20 +69,7 @@ browser-compat: api.Response.redirect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-redirect','redirect()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/redirected/index.html
+++ b/files/en-us/web/api/response/redirected/index.html
@@ -75,20 +75,7 @@ browser-compat: api.Response.redirected
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-redirected','redirected')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/response/index.html
+++ b/files/en-us/web/api/response/response/index.html
@@ -66,20 +66,7 @@ var myResponse = new Response(myBlob,init);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response','Response()')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/status/index.html
+++ b/files/en-us/web/api/response/status/index.html
@@ -54,20 +54,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-status','status')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/statustext/index.html
+++ b/files/en-us/web/api/response/statustext/index.html
@@ -59,20 +59,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Fetch','#dom-response-statustext','statusText')}}</td>
-			<td>{{Spec2('Fetch')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/type/index.html
+++ b/files/en-us/web/api/response/type/index.html
@@ -55,20 +55,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Fetch", "#dom-response-type", "type")}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/response/url/index.html
+++ b/files/en-us/web/api/response/url/index.html
@@ -55,20 +55,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#dom-response-url','url')}}</td>
-      <td>{{Spec2('Fetch')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/r[a-s]* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `ReportingObserverOptions` is a dictionary, so should be gone soon.
- `Report`, `Report.type`, `Report.body`, `Report.url` are in progress to be added in mdn/browser-compat-data#10925

All other pages look fine.