### PR TITLE
 Replace spec table with {{specifications}} for api/rtc[a-i]*

### DIFF
--- a/files/en-us/web/api/rtcansweroptions/index.html
+++ b/files/en-us/web/api/rtcansweroptions/index.html
@@ -29,20 +29,7 @@ browser-compat: api.RTCAnswerOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcansweroptions', 'RTCAnswerOptions')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtccertificate/index.html
+++ b/files/en-us/web/api/rtccertificate/index.html
@@ -23,20 +23,7 @@ browser-compat: api.RTCCertificate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtccertificate')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
@@ -117,20 +117,7 @@ let pc = new RTCPeerConnection(config);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-bundlepolicy','RTCConfiguration.bundlePolicy')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/certificates/index.html
+++ b/files/en-us/web/api/rtcconfiguration/certificates/index.html
@@ -101,20 +101,7 @@ let <em>certificates</em> = <em>rtcConfiguration</em>.certificates;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-certificates','RTCConfiguration.certificates')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/certificates/index.html
+++ b/files/en-us/web/api/rtcconfiguration/certificates/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC Device API
 - certificates
 - parameters
+browser-compat: api.RTCConfiguration.certificates
 ---
 <p>{{APIRef("WebRTC API")}}</p>
 
@@ -81,8 +82,7 @@ let <em>certificates</em> = <em>rtcConfiguration</em>.certificates;
   for subsequent calls, the remote peer can tell you're the same caller. This also avoids
   the cost of generating new keys.</p>
 
-<p><strong>&lt;&lt;&lt;--- add link to information about identity browser-compat: api.RTCConfiguration.certificates
----&gt;&gt;&gt;</strong>
+<p><strong>&lt;&lt;&lt;--- add link to information about identity ---&gt;&gt;&gt;</strong>
 </p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/rtcconfiguration/iceservers/index.html
+++ b/files/en-us/web/api/rtcconfiguration/iceservers/index.html
@@ -87,20 +87,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
   <h2 id="Specifications">Specifications</h2>
 
-  <table class="standard-table">
-    <tbody>
-      <tr>
-        <th scope="col">Specification</th>
-        <th scope="col">Status</th>
-        <th scope="col">Comment</th>
-      </tr>
-      <tr>
-        <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-iceservers','RTCConfiguration.iceServers')}}</td>
-        <td>{{Spec2('WebRTC 1.0')}}</td>
-        <td>Initial definition.</td>
-      </tr>
-    </tbody>
-  </table>
+{{Specifications}}
 
   <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
@@ -81,21 +81,7 @@ let pc = new RTCPeerConnection(config);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-icetransportpolicy','RTCCandidate.iceTransportPolicy')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/index.html
+++ b/files/en-us/web/api/rtcconfiguration/index.html
@@ -67,20 +67,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration','RTCConfiguration')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/binarytype/index.html
+++ b/files/en-us/web/api/rtcdatachannel/binarytype/index.html
@@ -67,23 +67,7 @@ dc.onmessage = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-binarytype',
-        'RTCDataChannel.binaryType') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
@@ -66,23 +66,7 @@ function showBufferedAmount(channel) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-bufferedamount',
-        'RTCDataChannel.bufferedAmount') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
@@ -72,20 +72,7 @@ pc.addEventListener("bufferedamountlow", ev =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-datachannel-bufferedamountlow', 'bufferedamountlow') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
@@ -62,23 +62,7 @@ dc.onbufferedamountlow = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-bufferedamountlowthreshold',
-        'RTCDataChannel.bufferedAmountLowThreshold') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/close/index.html
+++ b/files/en-us/web/api/rtcdatachannel/close/index.html
@@ -82,23 +82,7 @@ dc.onclose = function (
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-close', 'RTCDataChannel.close()')
-        }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/close_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/close_event/index.html
@@ -66,22 +66,7 @@ browser-compat: api.RTCDataChannel.close_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcdatachannel-close', 'close')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/closing_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/closing_event/index.html
@@ -67,20 +67,7 @@ browser-compat: api.RTCDataChannel.closing_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dfn-closing', 'RTCDataChannel: closing event') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/error_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/error_event/index.html
@@ -127,22 +127,7 @@ dc.addEventListener("error", ev =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#event-datachannel-error', 'error event')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/id/index.html
+++ b/files/en-us/web/api/rtcdatachannel/id/index.html
@@ -56,22 +56,7 @@ console.log("Channel id: " + dc.id);</code></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-id', 'RTCDataChannel.id') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/index.html
+++ b/files/en-us/web/api/rtcdatachannel/index.html
@@ -62,22 +62,7 @@ dc.onclose = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#rtcdatachannel', 'RTCDataChannel') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/label/index.html
+++ b/files/en-us/web/api/rtcdatachannel/label/index.html
@@ -56,23 +56,7 @@ document.getElementById(&quot;channel-name&quot;).innerHTML =
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-label', 'RTCDataChannel.label') }}
-      </td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.html
+++ b/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.html
@@ -40,23 +40,7 @@ browser-compat: api.RTCDataChannel.maxPacketLifeTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-maxpacketlifetime',
-        'RTCDataChannel.maxPacketLifeTime') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/maxretransmits/index.html
+++ b/files/en-us/web/api/rtcdatachannel/maxretransmits/index.html
@@ -41,23 +41,7 @@ browser-compat: api.RTCDataChannel.maxRetransmits
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-maxretransmits',
-        'RTCDataChannel.maxRetransmits') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/message_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/message_event/index.html
@@ -74,20 +74,7 @@ browser-compat: api.RTCDataChannel.message_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-datachannel-message', 'the &lt;code&gt;message&lt;/code&gt; event') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/negotiated/index.html
+++ b/files/en-us/web/api/rtcdatachannel/negotiated/index.html
@@ -51,23 +51,7 @@ browser-compat: api.RTCDataChannel.negotiated
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-negotiated',
-        'RTCDataChannel.negotiated') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
@@ -57,23 +57,7 @@ dc.onbufferedamountlow = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-onbufferedamountlow',
-        'RTCDataChannel.onbufferedamountlow') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onclose/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclose/index.html
@@ -54,23 +54,7 @@ dc.onclose = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-onclose',
-        'RTCDataChannel.onclose') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onclosing/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclosing/index.html
@@ -34,23 +34,7 @@ browser-compat: api.RTCDataChannel.onclosing
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcdatachannel-onclosing",
-        "RTCDataChannel.onclosing")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onerror/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onerror/index.html
@@ -56,23 +56,7 @@ dc.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-onerror',
-        'RTCDataChannel.onerror') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onmessage/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onmessage/index.html
@@ -51,23 +51,7 @@ dc.onmessage = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-onmessage',
-        'RTCDataChannel.onmessage') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onopen/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onopen/index.html
@@ -51,23 +51,7 @@ dc.onopen = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-onopen', 'RTCDataChannel.onopen')
-        }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -43,23 +43,7 @@ if (!dc.ordered) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-ordered', 'RTCDataChannel.ordered')
-        }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/protocol/index.html
+++ b/files/en-us/web/api/rtcdatachannel/protocol/index.html
@@ -58,23 +58,7 @@ function handleChannelMessage(dataChannel, msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-protocol',
-        'RTCDataChannel.protocol') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/readystate/index.html
+++ b/files/en-us/web/api/rtcdatachannel/readystate/index.html
@@ -81,22 +81,7 @@ function sendMessage(msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-datachannel-readystate', 'RTCDataChannel.readyState') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/send/index.html
+++ b/files/en-us/web/api/rtcdatachannel/send/index.html
@@ -95,23 +95,7 @@ function sendMessage(msg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannel-send', 'RTCDataChannel.send()')
-        }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/channel/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/channel/index.html
@@ -43,23 +43,7 @@ browser-compat: api.RTCDataChannelEvent.channel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-datachannelevent-channel',
-        'RTCDataChannelEvent.channel') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/index.html
@@ -35,20 +35,7 @@ browser-compat: api.RTCDataChannelEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#rtcdatachannelevent', 'RTCDataChannelEvent') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
@@ -60,23 +60,7 @@ browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdatachannelevent', 'RTCDataChannelEvent') }}
-      </td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.html
@@ -70,22 +70,7 @@ browser-compat: api.RTCDtlsTransport.error_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dfn-rtcdtlstransport-error', 'RTCDtlsTransport: error event')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
@@ -35,21 +35,7 @@ browser-compat: api.RTCDtlsTransport.iceTransport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcdtlstransport-icetransport",
-        "RTCDtlsTransport.iceTransport")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/index.html
@@ -114,20 +114,7 @@ function tallySenders(pc) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#dom-rtcdtlstransport", "RTCDtlsTransport")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/state/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.html
@@ -53,21 +53,7 @@ browser-compat: api.RTCDtlsTransport.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcdtlstransport-state",
-        "RTCDtlsTransport.state")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/index.html
@@ -55,20 +55,7 @@ browser-compat: api.RTCDTMFSender
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#rtcdtmfsender", "RTCDTMFSender")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
@@ -71,21 +71,7 @@ browser-compat: api.RTCDTMFSender.insertDTMF
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-RTCDTMFSender-insertDTMF',
-        'RTCDTMFSender.insertDTMF()') }}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/ontonechange/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/ontonechange/index.html
@@ -38,21 +38,7 @@ browser-compat: api.RTCDTMFSender.ontonechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcdtmfsender-ontonechange', 'ontonechange')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.html
@@ -80,21 +80,7 @@ browser-compat: api.RTCDTMFSender.toneBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-RTCDTMFSender-tonebuffer',
-        'RTCDTMFSender.toneBuffer') }}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.html
@@ -68,20 +68,7 @@ browser-compat: api.RTCDTMFSender.tonechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-RTCDTMFSender-tonechange', 'tonechange') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Definition for the WebRTC API</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/index.html
@@ -48,20 +48,7 @@ browser-compat: api.RTCDTMFToneChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-RTCDTMFSender-tonechange', 'RTCDTMFToneChangeEvent') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
@@ -51,21 +51,7 @@ browser-compat: api.RTCDTMFToneChangeEvent.RTCDTMFToneChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdtmftonechangeevent',
-        'RTCDTMFToneChangeEvent()') }}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
@@ -41,23 +41,7 @@ browser-compat: api.RTCDTMFToneChangeEvent.tone
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcdtmftonechangeevent-tone',
-        'RTCDTMFToneChangeEvent.tone') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.html
+++ b/files/en-us/web/api/rtcerror/errordetail/index.html
@@ -77,23 +77,7 @@ browser-compat: api.RTCError.errorDetail
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror-errordetail', 'RTCError.errorDetail')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/index.html
+++ b/files/en-us/web/api/rtcerror/index.html
@@ -56,22 +56,7 @@ browser-compat: api.RTCError
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror', 'RTCError')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/receivedalert/index.html
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.html
@@ -40,23 +40,7 @@ browser-compat: api.RTCError.receivedAlert
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror-receivedalert',
-        'RTCError.receivedAlert')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.html
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.html
@@ -40,23 +40,7 @@ browser-compat: api.RTCError.sctpCauseCode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror-sctpcausecode',
-        'RTCError.sctpCauseCode')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.html
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.html
@@ -38,23 +38,7 @@ browser-compat: api.RTCError.sdpLineNumber
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror-sdplinenumber',
-        'RTCError.sdpLineNumber')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerror/sentalert/index.html
+++ b/files/en-us/web/api/rtcerror/sentalert/index.html
@@ -37,22 +37,7 @@ browser-compat: api.RTCError.sentAlert
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerror-sentalert', 'RTCError.sentAlert')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerrorevent/error/index.html
+++ b/files/en-us/web/api/rtcerrorevent/error/index.html
@@ -81,23 +81,7 @@ browser-compat: api.RTCErrorEvent.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcerrorevent-error', 'RTCErrorEvent.error')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcerrorevent/index.html
+++ b/files/en-us/web/api/rtcerrorevent/index.html
@@ -44,22 +44,7 @@ browser-compat: api.RTCErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcerrorevent', 'RTCErrorEvent')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/address/index.html
+++ b/files/en-us/web/api/rtcicecandidate/address/index.html
@@ -106,20 +106,7 @@ browser-compat: api.RTCIceCandidate.address
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-address', 'RTCIceCandidate: address')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/candidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/candidate/index.html
@@ -97,21 +97,7 @@ browser-compat: api.RTCIceCandidate.candidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-candidate',
-        'RTCIceCandidate.candidate')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/component/index.html
+++ b/files/en-us/web/api/rtcicecandidate/component/index.html
@@ -65,21 +65,7 @@ browser-compat: api.RTCIceCandidate.component
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-component',
-        'RTCIceCandidate.component')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.html
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.html
@@ -62,21 +62,7 @@ browser-compat: api.RTCIceCandidate.foundation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-foundation',
-        'RTCIceCandidate.foundation')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/index.html
@@ -82,20 +82,7 @@ browser-compat: api.RTCIceCandidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebRTC 1.0', '#rtcicecandidate-interface', 'RTCIceCandidate')}}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/port/index.html
+++ b/files/en-us/web/api/rtcicecandidate/port/index.html
@@ -76,21 +76,7 @@ browser-compat: api.RTCIceCandidate.port
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-port', 'RTCIceCandidate.port')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidate/priority/index.html
@@ -86,21 +86,7 @@ function handleCandidate(candidateString) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-priority',
-        'RTCIceCandidate.priority')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.html
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.html
@@ -72,21 +72,7 @@ browser-compat: api.RTCIceCandidate.protocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-protocol',
-        'RTCIceCandidate.protocol')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/relatedaddress/index.html
+++ b/files/en-us/web/api/rtcicecandidate/relatedaddress/index.html
@@ -97,21 +97,7 @@ browser-compat: api.RTCIceCandidate.relatedAddress
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-relatedaddress',
-        'RTCIceCandidate.relatedAddress')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/relatedport/index.html
+++ b/files/en-us/web/api/rtcicecandidate/relatedport/index.html
@@ -89,21 +89,7 @@ if (relIP &amp;&amp; relPort) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-relatedport',
-        'RTCIceCandidate.relatedPort')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
@@ -91,20 +91,7 @@ browser-compat: api.RTCIceCandidate.RTCIceCandidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dfn-rtcicecandidate', 'RTCIceCandidate()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
@@ -56,21 +56,7 @@ browser-compat: api.RTCIceCandidate.sdpMid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-sdpmid',
-        'RTCIceCandidate.sdpMid')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.html
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.html
@@ -56,21 +56,7 @@ browser-compat: api.RTCIceCandidate.sdpMLineIndex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-sdpmlineindex',
-        'RTCIceCandidate.sdpMLineIndex')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.html
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.html
@@ -54,21 +54,7 @@ browser-compat: api.RTCIceCandidate.tcpType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-tcptype',
-        'RTCIceCandidate.tcpType')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/tojson/index.html
+++ b/files/en-us/web/api/rtcicecandidate/tojson/index.html
@@ -46,21 +46,7 @@ browser-compat: api.RTCIceCandidate.toJSON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-tojson',
-        'RTCIceCandidate.toJSON()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/type/index.html
+++ b/files/en-us/web/api/rtcicecandidate/type/index.html
@@ -61,21 +61,7 @@ browser-compat: api.RTCIceCandidate.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-type', 'RTCIceCandidate.type')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.html
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.html
@@ -121,21 +121,7 @@ browser-compat: api.RTCIceCandidate.usernameFragment
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-usernamefragment',
-        'RTCIceCandidate.usernameFragment')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/candidate/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/candidate/index.html
@@ -50,22 +50,7 @@ browser-compat: api.RTCIceCandidateInit.candidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcicecandidateinit-candidate', 'RTCIceCandidateInit.candidate') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/index.html
@@ -33,20 +33,7 @@ browser-compat: api.RTCIceCandidateInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidateinit', 'RTCIceCandidateInit')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/sdpmid/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/sdpmid/index.html
@@ -29,23 +29,7 @@ browser-compat: api.RTCIceCandidateInit.sdpMid
 
 <h2 id="Specifications">Specifications</h2>
 
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcicecandidateinit-sdpmid', 'RTCIceCandidateInit.sdpMid') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/sdpmlineindex/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/sdpmlineindex/index.html
@@ -28,22 +28,7 @@ browser-compat: api.RTCIceCandidateInit.sdpMLineIndex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcicecandidateinit-sdpmlineindex', 'RTCIceCandidateInit.sdpMLineIndex') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/usernamefragment/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/usernamefragment/index.html
@@ -29,22 +29,7 @@ browser-compat: api.RTCIceCandidateInit.usernameFragment
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcicecandidateinit-usernamefragment', 'RTCIceCandidateInit.usernameFragment') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepair/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/index.html
@@ -34,22 +34,7 @@ browser-compat: api.RTCIceCandidatePair
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcicecandidatepair', 'RTCIceCandidatePair')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.html
@@ -52,23 +52,7 @@ var localCandidate = candidatePair.local;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidatepair-local',
-        'RTCIceCandidatePair.local')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepair/remote/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/remote/index.html
@@ -52,23 +52,7 @@ var remoteCandidate = candidatePair.remote;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidatepair-remote',
-        'RTCIceCandidatePair.remote')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.html
@@ -58,24 +58,7 @@ browser-compat: api.RTCIceCandidatePairStats.availableIncomingBitrate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-availableincomingbitrate',
-        'RTCIceCandidatePairStats.availableIncomingBitrate') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.html
@@ -67,24 +67,7 @@ browser-compat: api.RTCIceCandidatePairStats.availableOutgoingBitrate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-availableoutgoingbitrate',
-        'RTCIceCandidatePairStats.availableoutgoingbitrate') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.html
@@ -41,24 +41,7 @@ browser-compat: api.RTCIceCandidatePairStats.bytesReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-bytesreceived',
-        'RTCIceCandidatePairStats.bytesReceived') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.html
@@ -41,24 +41,7 @@ browser-compat: api.RTCIceCandidatePairStats.bytesSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-bytessent', 'RTCIceCandidatePairStats.bytesSent')
-        }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.html
@@ -45,24 +45,7 @@ browser-compat: api.RTCIceCandidatePairStats.circuitBreakerTriggerCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-circuitbreakertriggercount',
-        'RTCIceCandidatePairStats.circuitBreakerTriggerCount') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.html
@@ -46,24 +46,7 @@ browser-compat: api.RTCIceCandidatePairStats.consentExpiredTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-consentexpiredtimestamp',
-        'RTCIceCandidatePairStats.consentExpiredTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.html
@@ -38,24 +38,7 @@ browser-compat: api.RTCIceCandidatePairStats.consentRequestsSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-consentrequestssent',
-        'RTCIceCandidatePairStats.consentRequestsSent') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.html
@@ -45,24 +45,7 @@ browser-compat: api.RTCIceCandidatePairStats.currentRoundTripTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-currentroundtriptime',
-        'RTCIceCandidatePairStats.currentRoundTripTime') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
@@ -48,24 +48,7 @@ browser-compat: api.RTCIceCandidatePairStats.firstRequestTimeStamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-firstrequesttimestamp',
-        'RTCIceCandidatePairStats.firstRequestTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/index.html
@@ -130,22 +130,7 @@ browser-compat: api.RTCIceCandidatePairStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC Statistics Identifiers', '#dom-rtcicecandidatepairstats', 'RTCIceCandidatePairStats') }}</td>
-   <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.html
@@ -36,24 +36,7 @@ browser-compat: api.RTCIceCandidatePairStats.lastPacketReceivedTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-lastpacketreceivedtimestamp',
-        'RTCIceCandidatePairStats.lastPacketReceivedTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.html
@@ -38,24 +38,7 @@ browser-compat: api.RTCIceCandidatePairStats.lastPacketSentTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-lastpacketsenttimestamp',
-        'RTCIceCandidatePairStats.lastPacketSentTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.html
@@ -48,24 +48,7 @@ browser-compat: api.RTCIceCandidatePairStats.lastRequestTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-lastrequesttimestamp',
-        'RTCIceCandidatePairStats.lastRequestTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.html
@@ -39,24 +39,7 @@ browser-compat: api.RTCIceCandidatePairStats.lastResponseTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-lastresponsetimestamp',
-        'RTCIceCandidatePairStats.lastResponseTimestamp') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.html
@@ -44,24 +44,7 @@ browser-compat: api.RTCIceCandidatePairStats.localCandidateId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-localcandidateid',
-        'RTCIceCandidatePairStats.localCandidateId') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.html
@@ -45,24 +45,7 @@ browser-compat: api.RTCIceCandidatePairStats.nominated
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-nominated', 'RTCIceCandidatePairStats.nominated')
-        }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.html
@@ -38,24 +38,7 @@ browser-compat: api.RTCIceCandidatePairStats.packetsReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-packetsreceived',
-        'RTCIceCandidatePairStats.packetsReceived') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.html
@@ -40,24 +40,7 @@ browser-compat: api.RTCIceCandidatePairStats.packetsSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-packetssent',
-        'RTCIceCandidatePairStats.packetsSent') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
@@ -45,24 +45,7 @@ browser-compat: api.RTCIceCandidatePairStats.priority
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-priority', 'RTCIceCandidatePairStats.priority') }}
-      </td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.html
@@ -39,24 +39,7 @@ browser-compat: api.RTCIceCandidatePairStats.remoteCandidateId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-remotecandidateid',
-        'RTCIceCandidatePairStats.remoteCandidateId') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.html
@@ -46,24 +46,7 @@ browser-compat: api.RTCIceCandidatePairStats.requestsReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-requestsreceived',
-        'RTCIceCandidatePairStats.requestsReceived') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.html
@@ -45,24 +45,7 @@ browser-compat: api.RTCIceCandidatePairStats.requestsSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-requestssent',
-        'RTCIceCandidatePairStats.requestsSent') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.html
@@ -38,24 +38,7 @@ browser-compat: api.RTCIceCandidatePairStats.responsesReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-responsesreceived',
-        'RTCIceCandidatePairStats.responsesReceived') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.html
@@ -42,24 +42,7 @@ browser-compat: api.RTCIceCandidatePairStats.responsesSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-responsessent',
-        'RTCIceCandidatePairStats.responsesSent') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.html
@@ -50,24 +50,7 @@ browser-compat: api.RTCIceCandidatePairStats.retransmissionsReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-retransmissionsreceived',
-        'RTCIceCandidatePairStats.retransmissionsReceived') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.html
@@ -34,24 +34,7 @@ browser-compat: api.RTCIceCandidatePairStats.retransmissionsSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ SpecName('WebRTC Statistics Identifiers',
-                '#dom-rtcicecandidatepairstats-retransmissionssent',
-                'RTCIceCandidatePairStats.retransmissionsSent') }}</td>
-            <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-            <td>Initial specification.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/state/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/state/index.html
@@ -61,23 +61,7 @@ browser-compat: api.RTCIceCandidatePairStats.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-state', 'RTCIceCandidatePairStats.state') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.html
@@ -52,24 +52,7 @@ browser-compat: api.RTCIceCandidatePairStats.totalRoundTripTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-totalroundtriptime',
-        'RTCIceCandidatePairStats.totalRoundTripTime') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.html
@@ -41,24 +41,7 @@ browser-compat: api.RTCIceCandidatePairStats.transportId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatepairstats-transportid',
-        'RTCIceCandidatePairStats.transportId') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.html
@@ -59,23 +59,7 @@ browser-compat: api.RTCIceCandidateStats.address
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatestats-address', 'RTCIceCandidateStats.address') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.html
@@ -35,23 +35,7 @@ browser-compat: api.RTCIceCandidateStats.candidateType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers', '#dom-rtcicecandidatestats',
-        'RTCIceCandidateStats.candidateType') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/deleted/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/deleted/index.html
@@ -78,23 +78,7 @@ browser-compat: api.RTCIceCandidateStats.deleted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatestats-deleted', 'RTCIceCandidateStats.deleted') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/index.html
@@ -80,22 +80,7 @@ if (rtcStats &amp;&amp; rtcStats.type === "local-candidate") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC Statistics Identifiers', '#icecandidate-dict*', 'RTCIceCandidateStats') }}</td>
-   <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.html
@@ -34,23 +34,7 @@ browser-compat: api.RTCIceCandidateStats.port
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers', '#dom-rtcicecandidatestats-port',
-        'RTCIceCandidateStats.port') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/priority/index.html
@@ -89,23 +89,7 @@ browser-compat: api.RTCIceCandidateStats.priority
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ SpecName('WebRTC Statistics Identifiers',
-                '#dom-rtcicecandidatestats-port', 'RTCIceCandidateStats.port') }}</td>
-            <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-            <td>Initial specification.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
@@ -37,23 +37,7 @@ browser-compat: api.RTCIceCandidateStats.protocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatestats-protocol', 'RTCIceCandidateStats.protocol') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.html
@@ -56,24 +56,7 @@ browser-compat: api.RTCIceCandidateStats.relayProtocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatestats-relayprotocol', 'RTCIceCandidateStats.relayProtocol')
-        }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.html
@@ -43,24 +43,7 @@ browser-compat: api.RTCIceCandidateStats.transportId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcicecandidatestats-transportid', 'RTCIceCandidateStats.transportId') }}
-      </td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/url/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/url/index.html
@@ -45,23 +45,7 @@ browser-compat: api.RTCIceCandidateStats.url
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Statistics Identifiers', '#dom-rtcicecandidatestats-url',
-        'RTCIceCandidateStats.url') }}</td>
-      <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecandidatetype/index.html
+++ b/files/en-us/web/api/rtcicecandidatetype/index.html
@@ -42,20 +42,7 @@ browser-compat: api.RTCIceCandidateType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidatetype', 'RTCIceCandidateType')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecomponent/index.html
+++ b/files/en-us/web/api/rtcicecomponent/index.html
@@ -36,20 +36,7 @@ browser-compat: api.RTCIceComponent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcicecomponent', 'RTCIceComponent')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicecredentialtype/index.html
+++ b/files/en-us/web/api/rtcicecredentialtype/index.html
@@ -27,22 +27,7 @@ browser-compat: api.RTCIceCredentialType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcicecredentialtype', 'RTCIceCredentialType') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicegathererstate/index.html
+++ b/files/en-us/web/api/rtcicegathererstate/index.html
@@ -33,20 +33,7 @@ browser-compat: api.RTCIceGathererState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcicegathererstate', 'RTCIceGathererState')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceparameters/index.html
+++ b/files/en-us/web/api/rtciceparameters/index.html
@@ -38,22 +38,7 @@ browser-compat: api.RTCIceParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtciceparameters', 'RTCIceParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceparameters/password/index.html
+++ b/files/en-us/web/api/rtciceparameters/password/index.html
@@ -35,23 +35,7 @@ browser-compat: api.RTCIceParameters.password
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtciceparameters-password',
-        'RTCIceParameters.password')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceparameters/usernamefragment/index.html
+++ b/files/en-us/web/api/rtciceparameters/usernamefragment/index.html
@@ -42,23 +42,7 @@ browser-compat: api.RTCIceParameters.usernameFragment
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtciceparameters-usernamefragment',
-        'RTCIceParameters.usernameFragment')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceprotocol/index.html
+++ b/files/en-us/web/api/rtciceprotocol/index.html
@@ -35,20 +35,7 @@ browser-compat: api.RTCIceProtocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtciceprotocol', 'RTCIceProtocol')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicerole/index.html
+++ b/files/en-us/web/api/rtcicerole/index.html
@@ -36,20 +36,7 @@ browser-compat: api.RTCIceRole
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcicerole', 'RTCIceRole')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceserver/credential/index.html
+++ b/files/en-us/web/api/rtciceserver/credential/index.html
@@ -59,23 +59,7 @@ var <em>credential</em> = <em>iceServer</em>.credential;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtciceserver-credential',
-        'RTCIceServer.credential') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceserver/credentialtype/index.html
+++ b/files/en-us/web/api/rtciceserver/credentialtype/index.html
@@ -62,23 +62,7 @@ var <em>credentialType</em> = <em>iceServer</em>.credentialType;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtciceserver-credential',
-        'RTCIceServer.credential') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceserver/urls/index.html
+++ b/files/en-us/web/api/rtciceserver/urls/index.html
@@ -121,22 +121,7 @@ iceServers.push(iceServer);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtciceserver-urls', 'RTCIceServer.urls') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtciceserver/username/index.html
+++ b/files/en-us/web/api/rtciceserver/username/index.html
@@ -57,23 +57,7 @@ var <em>username</em> = <em>iceServer</em>.username;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtciceserver-username', 'RTCIceServer.username')
-        }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetcpcandidatetype/index.html
+++ b/files/en-us/web/api/rtcicetcpcandidatetype/index.html
@@ -34,20 +34,7 @@ browser-compat: api.RTCIceTcpCandidateType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcicetcpcandidatetype', 'RTCIceTcpCandidateType')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/component/index.html
+++ b/files/en-us/web/api/rtcicetransport/component/index.html
@@ -39,21 +39,7 @@ browser-compat: api.RTCIceTransport.component
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-icetransport-component',
-        'RTCIceTransport.component')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.html
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.html
@@ -36,21 +36,7 @@ browser-compat: api.RTCIceTransport.gatheringState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-icetransport-gatheringstate',
-        'RTCIceTransport.gatheringState')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.html
@@ -73,20 +73,7 @@ browser-compat: api.RTCIceTransport.gatheringstatechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-icetransport-gatheringstatechange', 'gatheringstatechange') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.html
+++ b/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.html
@@ -64,21 +64,7 @@ localCandidates.forEach(function(candidate, index)) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-getlocalcandidates',
-        'RTCIceCandidate.getLocalCandidates()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getlocalparameters/index.html
+++ b/files/en-us/web/api/rtcicetransport/getlocalparameters/index.html
@@ -51,23 +51,7 @@ browser-compat: api.RTCIceTransport.getLocalParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-getlocalparameters',
-        'RTCIceTransport.getLocalParameters')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getremotecandidates/index.html
+++ b/files/en-us/web/api/rtcicetransport/getremotecandidates/index.html
@@ -63,21 +63,7 @@ remoteCandidates.forEach(function(candidate, index)) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-getremotecandidates',
-        'RTCIceCandidate.getRemoteCandidates()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getremoteparameters/index.html
+++ b/files/en-us/web/api/rtcicetransport/getremoteparameters/index.html
@@ -34,23 +34,7 @@ browser-compat: api.RTCIceTransport.getRemoteParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-getremoteparameters',
-                'RTCIceTransport.getRemoteParameters')}}</td>
-            <td>{{Spec2('WebRTC 1.0')}}</td>
-            <td>Initial specification.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
+++ b/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
@@ -71,23 +71,7 @@ browser-compat: api.RTCIceTransport.getSelectedCandidatePair
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-getselectedcandidatepair',
-				'RTCIceTransport.getSelectedCandidatePair()')}}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/index.html
+++ b/files/en-us/web/api/rtcicetransport/index.html
@@ -72,20 +72,7 @@ browser-compat: api.RTCIceTransport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport', 'RTCIceTransport')}}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/ongatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcicetransport/ongatheringstatechange/index.html
@@ -60,23 +60,7 @@ iceTransport.ongatheringstatechange = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-ongatheringstatechange',
-        'RTCIceTransport.ongatheringstatechange')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
@@ -65,23 +65,7 @@ iceTransport.onselectedcandidatepairchange = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-onselectedcandidatepairchange',
-        'RTCIceTransport.onselectedcandidatepairchange')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/onstatechange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onstatechange/index.html
@@ -59,23 +59,7 @@ iceTransport.onstatechange = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicetransport-onstatechange',
-        'RTCIceTransport.onstatechange')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/role/index.html
+++ b/files/en-us/web/api/rtcicetransport/role/index.html
@@ -45,21 +45,7 @@ browser-compat: api.RTCIceTransport.role
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-icetransport-role', 'RTCIceTransport.role')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.html
@@ -72,20 +72,7 @@ iceTransport.onselectedcandidatepairchange = ev =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-icetransport-selectedcandidatepairchange', 'selectedcandidatepairchange') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/state/index.html
+++ b/files/en-us/web/api/rtcicetransport/state/index.html
@@ -43,20 +43,7 @@ browser-compat: api.RTCIceTransport.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#rtcicetransportstate', 'RTCIceTransportState')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransport/statechange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/statechange_event/index.html
@@ -67,20 +67,7 @@ iceTransport.onstatechange = ev =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#event-icetransport-statechange', 'statechange') }}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcicetransportstate/index.html
+++ b/files/en-us/web/api/rtcicetransportstate/index.html
@@ -64,20 +64,7 @@ browser-compat: api.rtcicetransportstate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcicerole', 'RTCIceRole')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcidentityassertion/index.html
+++ b/files/en-us/web/api/rtcidentityassertion/index.html
@@ -26,20 +26,7 @@ browser-compat: api.RTCIdentityAssertion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.html
@@ -63,22 +63,7 @@ browser-compat: api.RTCInboundRtpStreamStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#inboundrtpstats-dict*', 'RTCInboundRtpStreamStats') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/rtc[a-i]* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- A bunch of typedefs, enums, dictionaries, and their members (which will be dealt as part of a _dictionary_ project): `RTCIceRole`, `RTCIceParameters`, `RTCIceParameters.usernameFragment`, `RTCIceParameters.password`, `RTCIceTcpCandidateType`, `RTCIceTransportState`, `RTCIceGathererState`, `RTCInboundRtpStreamStats` (and its 17 children!), `RTCOutboundRtpStreamStats` (and its 12 children), `RTCIceProtocol`, `RTCIceCandidatePair`, `RTCIceCandidatePair.remote`, `RTCIceCandidatePair.local`, `RTCRtpCapabilities`, `RTCNetworkType`, `RTCRtpCodecCapability`, `RTCStatsType`, `RTCRtpParameters`, and`RTCRtpReceiveParameters` (Yes, WebRTC docs are a major offender here)
- `RTCError`, `RTCError.sctpCauseCode`, `RTCError.receivedAlert`, `api.RTCError.errorDetail`, `RTCError.sdpLineNumber`, and `RTCError.sentAlert` are missing `spec_url`. This will be added in mdn/browser-compat-data#11039.
- `RTCDtlsTransport.error_event`, `RTCDtlsTransport.close_event` that are already missing the bcd table. I kept them that way as I'm not sure it is much shipped and we'll be updated at that point anyway.
- `RTCRtpTransceiver.stopped` is deprecated and no more on the standard track.
- `RTCRtpSender.setStreams` is missing `spec_url`. This will be added in mdn/browser-compat-data#11048.

All other pages look fine.