### PR TITLE
Fix “Advanced techniques: Creating and sequencing audio” doc 404

### DIFF
--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
@@ -91,7 +91,7 @@ const audioCtx = new AudioContext();</pre>
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: In our example the wavetable is held in a separate JavaScript file (<code>wavetable.js</code>), because there are <em>so</em> many values. It is taken from a <a href="https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/archive/demos/wave-tables">repository of wavetables, </a>which can be found in the <a href="https://github.com/GoogleChromeLabs/web-audio-samples/">Web Audio API examples from Google Chrome Labs</a>.</p>
+<p><strong>Note</strong>: In our example the wavetable is held in a separate JavaScript file (<code>wavetable.js</code>), because there are <em>so</em> many values. It is taken from a <a href="https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/archive/demos/wave-tables">repository of wavetables</a>, which can be found in the <a href="https://github.com/GoogleChromeLabs/web-audio-samples/">Web Audio API examples from Google Chrome Labs</a>.</p>
 </div>
 
 <h3 id="The_Oscillator">The Oscillator</h3>

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
@@ -91,7 +91,7 @@ const audioCtx = new AudioContext();</pre>
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: In our example the wavetable is held in a separate JavaScript file (<code>wavetable.js</code>), because there are <em>so</em> many values. It is taken from a <a href="https://github.com/GoogleChromeLabs/web-audio-samples/tree/gh-pages/samples/audio/wave-tables">repository of wavetables, </a>which can be found in the <a href="https://github.com/GoogleChromeLabs/web-audio-samples/">Web Audio API examples from Google Chrome Labs</a>.</p>
+<p><strong>Note</strong>: In our example the wavetable is held in a separate JavaScript file (<code>wavetable.js</code>), because there are <em>so</em> many values. It is taken from a <a href="https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/archive/demos/wave-tables">repository of wavetables, </a>which can be found in the <a href="https://github.com/GoogleChromeLabs/web-audio-samples/">Web Audio API examples from Google Chrome Labs</a>.</p>
 </div>
 
 <h3 id="The_Oscillator">The Oscillator</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Link was broken

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques

> Issue number (if there is an associated issue)
Fixes #5960 


