### PR TITLE
Replace spec table with {{specifications}} for api/rtc[j-z]*

### DIFF
--- a/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.html
@@ -47,22 +47,7 @@ browser-compat: api.RTCInboundRtpStreamStats.averageRtcpInterval
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-averagertcpinterval',
-        'RTCInboundRtpStreamStats.averageRtcpInterval')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.html
@@ -44,22 +44,7 @@ browser-compat: api.RTCInboundRtpStreamStats.bytesReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-bytesreceived',
-        'RTCInboundRtpStreamStats.bytesReceived')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.html
@@ -41,22 +41,7 @@ browser-compat: api.RTCInboundRtpStreamStats.fecPacketsDiscarded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-fecpacketsdiscarded',
-        'RTCInboundRtpStreamStats.fecPacketsDiscarded')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.html
@@ -46,22 +46,7 @@ browser-compat: api.RTCInboundRtpStreamStats.fecPacketsReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName('WebRTC Statistics Identifiers',
-                '#dom-rtcinboundrtpstreamstats-fecpacketsreceived',
-                'RTCInboundRtpStreamStats.fecPacketsReceived')}}</td>
-            <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.html
@@ -48,22 +48,7 @@ browser-compat: api.RTCInboundRtpStreamStats.firCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-fircount', 'RTCInboundRtpStreamStats.firCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.html
@@ -39,22 +39,7 @@ browser-compat: api.RTCInboundRtpStreamStats.framesDecoded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-framesdecoded',
-        'RTCInboundRtpStreamStats.framesDecoded')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.html
@@ -41,22 +41,7 @@ browser-compat: api.RTCInboundRtpStreamStats.lastPacketReceivedTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-lastpacketreceivedtimestamp',
-        'RTCInboundRtpStreamStats.lastPacketReceivedTimestamp')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.html
@@ -37,22 +37,7 @@ browser-compat: api.RTCInboundRtpStreamStats.nackCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-nackcount', 'RTCInboundRtpStreamStats.nackCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.html
@@ -53,22 +53,7 @@ browser-compat: api.RTCInboundRtpStreamStats.packetsDuplicated
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-packetsduplicated',
-        'RTCInboundRtpStreamStats.packetsDuplicated')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.html
@@ -36,22 +36,7 @@ browser-compat: api.RTCInboundRtpStreamStats.packetsFailedDecryption
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-packetsfaileddecryption',
-        'RTCInboundRtpStreamStats.packetsFailedDecryption')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.html
@@ -48,22 +48,7 @@ browser-compat: api.RTCInboundRtpStreamStats.perDscpPacketsReceived
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-perdscppacketsreceived',
-        'RTCInboundRtpStreamStats.perDscpPacketsReceived')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.html
@@ -49,22 +49,7 @@ browser-compat: api.RTCInboundRtpStreamStats.pliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-plicount', 'RTCInboundRtpStreamStats.pliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.html
@@ -98,21 +98,7 @@ browser-compat: api.RTCInboundRtpStreamStats.qpSum
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-qpsum', 'RTCInboundRtpStreamStats.qpSum')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.html
@@ -41,22 +41,7 @@ browser-compat: api.RTCInboundRtpStreamStats.receiverId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-receiverid',
-        'RTCInboundRtpStreamStats.receiverId')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.html
@@ -42,22 +42,7 @@ browser-compat: api.RTCInboundRtpStreamStats.remoteId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-remoteid', 'RTCInboundRtpStreamStats.remoteId')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.html
@@ -54,22 +54,7 @@ browser-compat: api.RTCInboundRtpStreamStats.sliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-slicount', 'RTCInboundRtpStreamStats.sliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.html
@@ -41,22 +41,7 @@ browser-compat: api.RTCInboundRtpStreamStats.trackId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-trackId', 'RTCInboundRtpStreamStats.trackId')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcnetworktype/index.html
+++ b/files/en-us/web/api/rtcnetworktype/index.html
@@ -53,20 +53,7 @@ browser-compat: api.RTCNetworkType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#rtcnetworktype-enum', 'RTCNetworkType')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcofferansweroptions/index.html
+++ b/files/en-us/web/api/rtcofferansweroptions/index.html
@@ -29,20 +29,7 @@ browser-compat: api.RTCOfferAnswerOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcofferansweroptions', 'RTCOfferAnswerOptions')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcofferoptions/icerestart/index.html
+++ b/files/en-us/web/api/rtcofferoptions/icerestart/index.html
@@ -86,21 +86,7 @@ browser-compat: api.RTCOfferOptions.iceRestart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcofferoptions-icerestart',
-        'RTCOfferOptions.iceRestart')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcofferoptions/index.html
+++ b/files/en-us/web/api/rtcofferoptions/index.html
@@ -28,20 +28,7 @@ browser-compat: api.RTCOfferOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtcofferoptions', 'RTCOfferOptions')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.html
@@ -50,22 +50,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.averageRtcpInterval
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-averagertcpinterval',
-        'RTCOutboundRtpStreamStats.averageRtcpInterval')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.html
@@ -53,22 +53,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.firCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-fircount', 'RTCOutboundRtpStreamStats.firCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.html
@@ -42,22 +42,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.framesEncoded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-framesencoded',
-        'RTCOutboundRtpStreamStats.framesEncoded')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.html
@@ -70,22 +70,7 @@ browser-compat: api.RTCOutboundRtpStreamStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#outboundrtpstats-dict*', 'RTCOutboundRtpStreamStats') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.html
@@ -43,22 +43,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.lastPacketSentTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-lastpacketsenttimestamp',
-        'RTCOutboundRtpStreamStats.lastPacketSentTimestamp')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.html
@@ -43,22 +43,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.nackCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-nackcount',
-        'RTCOutboundRtpStreamStats.nackCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.html
@@ -48,22 +48,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.perDscpPacketsSent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-perDscpPacketsSent',
-        'RTCOutboundRtpStreamStats.perDscpPacketsSent')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.html
@@ -54,22 +54,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.pliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-plicount', 'RTCOutboundRtpStreamStats.pliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.html
@@ -101,21 +101,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.qpSum
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-qpsum', 'RTCOutboundRtpStreamStats.qpSum')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.html
@@ -49,22 +49,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.qualityLimitationReason
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-qualityLimitationReason',
-        'RTCOutboundRtpStreamStats.qualityLimitationReason')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.html
@@ -39,22 +39,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.remoteId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-remoteid', 'RTCOutboundRtpStreamStats.remoteId')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.html
@@ -54,22 +54,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.sliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-slicount', 'RTCOutboundRtpStreamStats.sliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.html
@@ -45,22 +45,7 @@ browser-compat: api.RTCOutboundRtpStreamStats.trackId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-RTCOutboundRtpStreamStats-trackId', 'RTCOutboundRtpStreamStats.trackId')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
@@ -175,23 +175,7 @@ signalingChannel.onmessage = receivedString =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-addicecandidate',
-				'RTCPeerConnection.addIceCandidate()') }}</td>
-			<td>{{ Spec2('WebRTC 1.0') }}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addstream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addstream/index.html
@@ -99,23 +99,7 @@ if (pc.removeTrack) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#legacy-interface-extensions',
-        'RTCPeerConnection.addStream()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
@@ -273,23 +273,7 @@ pc.setRemoteDescription(desc).then(function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-addtrack',
-        'RTCPeerConnection.addTrack()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
@@ -53,21 +53,7 @@ browser-compat: api.RTCPeerConnection.addTransceiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcpeerconnection-addtransceiver",
-        "RTCPeerConnection.addTransceiver()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.html
@@ -82,24 +82,7 @@ pc.addEventListener('icecandidate', e =&gt; (pc.canTrickleIceCandidates) &amp;&a
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ SpecName('WebRTC 1.0',
-                '#dom-rtcpeerconnection-cantrickleicecandidates',
-                'RTCPeerConnection.canTrickleIceCandidates') }}</td>
-            <td>{{ Spec2('WebRTC 1.0') }}</td>
-            <td>Initial specification.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/close/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/close/index.html
@@ -56,23 +56,7 @@ dc.onclose = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-close',
-				'RTCPeerConnection.close()') }}</td>
-			<td>{{ Spec2('WebRTC 1.0') }}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
@@ -43,23 +43,7 @@ var connectionState = pc.connectionState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-connection-state',
-        'RTCPeerConnection.connectionState') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
@@ -68,22 +68,7 @@ browser-compat: api.RTCPeerConnection.connectionstatechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#event-connectionstatechange', 'connectionstatechange')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.html
@@ -121,21 +121,7 @@ browser-compat: api.RTCPeerConnection.createAnswer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-createanswer',
-        'createAnswer()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -167,21 +167,7 @@ channel.onmessage = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-peerconnection-createdatachannel',
-        'createDataChannel()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
@@ -199,21 +199,7 @@ browser-compat: api.RTCPeerConnection.createOffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-createoffer',
-        'createOffer()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.html
@@ -69,23 +69,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-currentlocaldesc',
-        'RTCPeerConnection.currentLocalDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.html
@@ -69,23 +69,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-currentremotedesc',
-        'RTCPeerConnection.currentRemoteDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.html
@@ -71,20 +71,7 @@ browser-compat: api.RTCPeerConnection.datachannel_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-datachannel', 'datachannel') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Basic definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
@@ -123,21 +123,7 @@ browser-compat: api.RTCPeerConnection.generateCertificate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-generatecertificate',
-        'RTCPeerConnection.generateCertificate()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.html
@@ -73,21 +73,7 @@ if ((configuration.certificates != undefined) &amp;&amp; (!configuration.certifi
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-getconfiguration',
-        'getConfiguration()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
@@ -39,23 +39,7 @@ var assertion = await pc.getIdentityAssertion();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Identity', '#dfn-getidentityassertion',
-        'RTCPeerConnection.getIdentityAssertion()') }}</td>
-      <td>{{ Spec2('WebRTC Identity') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
@@ -40,23 +40,7 @@ browser-compat: api.RTCPeerConnection.getReceivers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-getreceivers',
-				'RTCPeerConnection.getReceivers()') }}</td>
-			<td>{{ Spec2('WebRTC 1.0') }}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
@@ -57,23 +57,7 @@ browser-compat: api.RTCPeerConnection.getSenders
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-getsenders',
-        'RTCPeerConnection.getSenders()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.html
@@ -131,22 +131,7 @@ browser-compat: api.RTCPeerConnection.getStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0',
-        '#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector',
-        'RTCPeerConnection.getStats()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.html
@@ -48,21 +48,7 @@ browser-compat: api.RTCPeerConnection.getTransceivers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcpeerconnection-gettransceivers",
-        "RTCPeerConnection.getTransceivers()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.html
@@ -123,20 +123,7 @@ browser-compat: api.RTCPeerConnection.icecandidate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-icecandidate', 'icecandidate') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
@@ -67,20 +67,7 @@ browser-compat: api.RTCPeerConnection.icecandidateerror_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#event-icecandidateerror', 'icecandidateerror')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
@@ -49,23 +49,7 @@ var state = pc.iceConnectionState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-ice-connection-state',
-        'RTCPeerConnection.iceConnectionState') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
@@ -78,20 +78,7 @@ browser-compat: api.RTCPeerConnection.iceconnectionstatechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-iceconnectionstatechange', 'iceconnectionstatechange') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
@@ -41,23 +41,7 @@ var state = pc.iceGatheringState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-ice-gathering-state',
-        'RTCPeerConnection.iceGatheringState') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.html
@@ -82,22 +82,7 @@ browser-compat: api.RTCPeerConnection.icegatheringstatechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#event-icegatheringstatechange', 'icecandidatestatechange')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -324,22 +324,7 @@ browser-compat: api.RTCPeerConnection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#interface-definition', 'RTCPeerConnection')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
@@ -50,23 +50,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-localdescription',
-        'RTCPeerConnection.localDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.html
@@ -80,20 +80,7 @@ browser-compat: api.RTCPeerConnection.negotiationneeded_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-negotiation', 'negotiationneeded') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
@@ -56,23 +56,7 @@ browser-compat: api.RTCPeerConnection.onconnectionstatechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onconnectionstatechange',
-        'RTCPeerConnection.onconnectionstatechange') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
@@ -48,23 +48,7 @@ browser-compat: api.RTCPeerConnection.ondatachannel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-ondatachannel',
-        'RTCPeerConnection.ondatachannel') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
@@ -73,23 +73,7 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onicecandidate',
-        'RTCPeerConnection.onicecandidate') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
@@ -45,23 +45,7 @@ browser-compat: api.RTCPeerConnection.onicecandidateerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onicecandidateerror',
-				'RTCPeerConnection.onicecandidateerror') }}</td>
-			<td>{{ Spec2('WebRTC 1.0') }}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
@@ -55,23 +55,7 @@ browser-compat: api.RTCPeerConnection.oniceconnectionstatechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-oniceconnectionstatechange',
-        'RTCPeerConnection.oniceconnectionstatechange') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
@@ -69,23 +69,7 @@ browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onicegatheringstatechange',
-        'RTCPeerConnection.onicegatheringstatechange') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
@@ -67,23 +67,7 @@ browser-compat: api.RTCPeerConnection.onnegotiationneeded
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onnegotiationneeded',
-        'RTCPeerConnection.onnegotiationneeded') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
@@ -72,23 +72,7 @@ browser-compat: api.RTCPeerConnection.onsignalingstatechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-onsignalingstatechange',
-        'RTCPeerConnection.onsignalingstatechange')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
@@ -57,23 +57,7 @@ browser-compat: api.RTCPeerConnection.ontrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-ontrack',
-        'RTCPeerConnection.ontrack')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
@@ -74,22 +74,7 @@ async function getIdentityAssertion(pc) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Identity', '#dfn-peeridentity') }}</td>
-      <td>{{ Spec2('WebRTC Identity') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.html
@@ -55,23 +55,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-pendinglocaldesc',
-        'RTCPeerConnection.pendingLocalDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.html
@@ -54,23 +54,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-pendingremotedesc',
-        'RTCPeerConnection.pendingRemoteDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
@@ -56,23 +56,7 @@ else {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-remotedescription',
-        'RTCPeerConnection.remoteDescription') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
@@ -73,23 +73,7 @@ document.getElementById("closeButton").addEventListener("click", function(event)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-removetrack',
-        'RTCPeerConnection.removeTrack()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/restartice/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/restartice/index.html
@@ -94,23 +94,7 @@ browser-compat: api.RTCPeerConnection.restartIce
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-restartice',
-        'RTCPeerConnection.restartIce()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.html
@@ -41,20 +41,7 @@ browser-compat: api.RTCPeerConnection.RTCPeerConnection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-peerconnection', 'RTCPeerConnection()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/sctp/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/sctp/index.html
@@ -51,23 +51,7 @@ var maxMessageSize = sctp.maxMessageSize;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-sctp',
-        'RTCPeerConnection.sctp') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.html
@@ -108,21 +108,7 @@ myPeerConnection.createOffer({"iceRestart": true}).then(function(offer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnection-setconfiguration',
-        'setConfiguration()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
@@ -49,23 +49,7 @@ pc.setIdentityAssertion("developer.mozilla.org");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC Identity', '#dfn-setidentityprovider',
-        'RTCPeerConnection.setIdentityProvider()') }}</td>
-      <td>{{ Spec2('WebRTC Identity') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
@@ -177,23 +177,7 @@ browser-compat: api.RTCPeerConnection.setLocalDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-setlocaldescription',
-        'RTCPeerConnection.setLocalDescription()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.html
@@ -249,23 +249,7 @@ createMyStream();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-setremotedescription',
-				'RTCPeerConnection.setRemoteDescription()') }}</td>
-			<td>{{ Spec2('WebRTC 1.0') }}</td>
-			<td>Initial specification.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
@@ -61,23 +61,7 @@ var state = pc.signalingState;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-peerconnection-signaling-state',
-        'RTCPeerConnection.signalingState') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.html
@@ -64,20 +64,7 @@ browser-compat: api.RTCPeerConnection.signalingstatechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#event-signalingstatechange', 'signalingstatechange') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/track_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/track_event/index.html
@@ -73,22 +73,7 @@ pc.addEventListener("track", e =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#event-track', 'track')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.html
@@ -62,21 +62,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.address
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcpeerconnectioniceerrorevent-address',
-        'RTCPeerConnectionIceErrorEvent.address')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
@@ -56,20 +56,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebRTC 1.0', '#rtcpeerconnectioniceerrorevent', 'RTCPeerConnectionIceErrorEvent')}}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
@@ -41,23 +41,7 @@ browser-compat: api.RTCPeerConnectionIceEvent.candidate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnectioniceevent-candidate',
-        'RTCPeerConnectionIceEvent.candidate') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.html
@@ -45,20 +45,7 @@ browser-compat: api.RTCPeerConnectionIceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#rtcpeerconnectioniceevent', 'RTCPeerConnectionIceEvent') }}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.html
@@ -55,21 +55,7 @@ browser-compat: api.RTCPeerConnectionIceEvent.RTCPeerConnectionIceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcpeerconnectioniceevent-constructor',
-        'RTCPeerConnectionIceEvent()') }}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.html
@@ -41,20 +41,7 @@ browser-compat: api.RTCRemoteOutboundRtpStreamStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC Statistics Identifiers', '#remoteoutboundrtpstats-dict*', 'RTCRemoteOutboundRtpStreamStats')}}</td>
-   <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.html
@@ -264,22 +264,7 @@ async function networkTestStart(pc) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcremoteoutboundrtpstreamstats-localid',
-        'RTCRemoteOutboundRtpStreamStats.localId')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.html
@@ -45,22 +45,7 @@ browser-compat: api.RTCRemoteOutboundRtpStreamStats.remoteTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcremoteoutboundrtpstreamstats-remotetimestamp',
-        'RTCRemoteOutboundRtpStreamStats.remoteTimestamp')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtcpparameters/index.html
+++ b/files/en-us/web/api/rtcrtcpparameters/index.html
@@ -40,20 +40,7 @@ browser-compat: api.RTCRtcpParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtcpparameters','RTCRtcpParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.html
@@ -61,20 +61,7 @@ browser-compat: api.RTCRtpCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#rtcrtpcapabilities", "RTCRtpCapabilities")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcodeccapability/index.html
+++ b/files/en-us/web/api/rtcrtpcodeccapability/index.html
@@ -43,20 +43,7 @@ browser-compat: api.RTCRtpCodecCapability
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#rtcrtpcodeccapability", "RTCRtpCodecCapability")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
@@ -52,20 +52,7 @@ browser-compat: api.RTCRtpContributingSource.audioLevel
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpcontributingsource-audiolevel','audioLevel')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/index.html
@@ -34,20 +34,7 @@ browser-compat: api.RTCRtpContributingSource
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpcontributingsource','RTCRtpContributingSource')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
@@ -38,20 +38,7 @@ browser-compat: api.RTCRtpContributingSource.rtpTimestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsynchronizationsource-rtptimestamp','rtpTimestamp')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
@@ -34,20 +34,7 @@ browser-compat: api.RTCRtpContributingSource.source
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpcontributingsource-source','source')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
@@ -30,21 +30,7 @@ browser-compat: api.RTCRtpContributingSource.timestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpcontributingsource-timestamp','timestamp')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.html
@@ -43,20 +43,7 @@ browser-compat: api.RTCRtpEncodingParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpencodingparameters','RTCRtpEncodingParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
@@ -53,21 +53,7 @@ browser-compat: api.RTCRtpEncodingParameters.maxBitrate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpencodingparameters-maxbitrate','RTCRtpEncodingParameters.maxBitrate')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
@@ -55,21 +55,7 @@ browser-compat: api.RTCRtpEncodingParameters.scaleResolutionDownBy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpencodingparameters-scaleresolutiondownby','RTCRtpEncodingParameters.scaleResolutionDownBy')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpparameters/index.html
+++ b/files/en-us/web/api/rtcrtpparameters/index.html
@@ -52,20 +52,7 @@ browser-compat: api.RTCRtpParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiveparameters','RTCRtpReceiveParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiveparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiveparameters/index.html
@@ -30,20 +30,7 @@ browser-compat: api.RTCRtpReceiveParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiveparameters','RTCRtpReceiveParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.html
@@ -99,21 +99,7 @@ browser-compat: api.RTCRtpReceiver.getCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpreceiver-getcapabilities",
-        "RTCRtpReceiver.getCapabilities()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
@@ -38,21 +38,7 @@ browser-compat: api.RTCRtpReceiver.getContributingSources
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiver-getcontributingsources','getContributingSources()')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
@@ -53,20 +53,7 @@ browser-compat: api.RTCRtpReceiver.getParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiver-getparameters','RTCRtpReceiver.getParameters()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
@@ -50,24 +50,7 @@ browser-compat: api.RTCRtpReceiver.getStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0',
-        '#widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport',
-        'RTCRtpReceiver.getStats()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/index.html
@@ -54,20 +54,7 @@ browser-compat: api.RTCRtpReceiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#rtcrtpreceiver-interface','RTCRtpReceiver')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/track/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/track/index.html
@@ -31,20 +31,7 @@ browser-compat: api.RTCRtpReceiver.track
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtpreceiver-track','track')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/transport/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/transport/index.html
@@ -54,21 +54,7 @@ browser-compat: api.RTCRtpReceiver.transport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpreceiver-transport",
-        "RTCRtpReceiver.transport")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.html
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.html
@@ -45,20 +45,7 @@ browser-compat: api.RTCRtpSender.dtmf
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpsender-dtmf", "RTCRtpSender.dtmf")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities/index.html
@@ -96,21 +96,7 @@ browser-compat: api.RTCRtpSender.getCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpsender-getcapabilities",
-        "RTCRtpSender.getCapabilities()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.html
@@ -50,21 +50,7 @@ browser-compat: api.RTCRtpSender.getParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsender-getparameters','getParameters()')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.html
@@ -50,23 +50,7 @@ browser-compat: api.RTCRtpSender.getStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#widl-RTCRtpSender-getStats-Promise-RTCStatsReport',
-        'RTCRtpSender.getStats()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/index.html
+++ b/files/en-us/web/api/rtcrtpsender/index.html
@@ -66,20 +66,7 @@ browser-compat: api.RTCRtpSender
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#rtcrtpsender-interface", "RTCRtpSender")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.html
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.html
@@ -126,21 +126,7 @@ navigator.mediaDevices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpsender-replacetrack",
-        "RTCRtpSender.replaceTrack()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.html
@@ -196,20 +196,7 @@ browser-compat: api.RTCRtpSender.setParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsender-setparameters','RTCRtpSender.setParameters()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.html
@@ -87,21 +87,7 @@ rtcRtpSender.setStreams([<em>mediaStream...</em>]);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpsender-setstreams",
-        "RTCRtpSender.setStreams()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/track/index.html
+++ b/files/en-us/web/api/rtcrtpsender/track/index.html
@@ -33,20 +33,7 @@ browser-compat: api.RTCRtpSender.track
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsender-track','track')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/transport/index.html
+++ b/files/en-us/web/api/rtcrtpsender/transport/index.html
@@ -54,21 +54,7 @@ browser-compat: api.RTCRtpSender.transport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtpsender-transport",
-        "RTCRtpSender.transport")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
+++ b/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
@@ -52,21 +52,7 @@ browser-compat: api.RTCRtpSendParameters.encodings
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsendparameters-encodings','RTCRtpSendParameters.encodings')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsendparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsendparameters/index.html
@@ -48,20 +48,7 @@ browser-compat: api.RTCRtpSendParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsendparameters','RTCRtpSendParameters')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/codecid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/codecid/index.html
@@ -38,21 +38,7 @@ browser-compat: api.RTCRtpStreamStats.codecId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcrtpstreamstats-codecid',
-        'RTCRtpStreamStats.codecId')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/fircount/index.html
@@ -50,29 +50,7 @@ browser-compat: api.RTCRtpStreamStats.firCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-fircount', 'RTCInboundRtpStreamStats: firCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcoutboundrtpstreamstats-fircount', 'RTCOutboundRtpStreamStats:
-        firCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/index.html
@@ -70,20 +70,7 @@ browser-compat: api.RTCRtpStreamStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC Statistics Identifiers', '#streamstats-dict*', 'RTCRtpStreamStats')}}</td>
-   <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/kind/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/kind/index.html
@@ -47,21 +47,7 @@ browser-compat: api.RTCRtpStreamStats.kind
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcrtpstreamstats-kind',
-        'RTCRtpStreamStats.kind')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.html
@@ -43,29 +43,7 @@ browser-compat: api.RTCRtpStreamStats.nackCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-nackcount', 'RTCInboundRtpStreamStats:
-        nackCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcoutboundrtpstreamstats-nackcount', 'RTCOutboundRtpStreamStats:
-        nackCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/plicount/index.html
@@ -57,29 +57,7 @@ browser-compat: api.RTCRtpStreamStats.pliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-plicount', 'RTCInboundRtpStreamStats: pliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcoutboundrtpstreamstats-plicount', 'RTCOutboundRtpStreamStats:
-        pliCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.html
@@ -103,27 +103,7 @@ browser-compat: api.RTCRtpStreamStats.qpSum
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-qpsum', 'RTCInboundRtpStreamStats: qpSum')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcoutboundrtpstreamstats-qpsum', 'RTCOutboundRtpStreamStats: qpSum')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/slicount/index.html
@@ -49,29 +49,7 @@ browser-compat: api.RTCRtpStreamStats.sliCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcinboundrtpstreamstats-slicount', 'RTCInboundRtpStreamStats: sliCount')}}
-      </td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcoutboundrtpstreamstats-slicount', 'RTCOutboundRtpStreamStats:
-        sliCount')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.html
@@ -51,21 +51,7 @@ browser-compat: api.RTCRtpStreamStats.ssrc
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcrtpstreamstats-ssrc',
-        'RTCRtpStreamStats.ssrc')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/trackid/index.html
@@ -43,21 +43,7 @@ browser-compat: api.RTCRtpStreamStats.trackId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcrtpstreamstats-trackid',
-        'RTCRtpStreamStats.trackId')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/transportid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/transportid/index.html
@@ -36,21 +36,7 @@ browser-compat: api.RTCRtpStreamStats.transportId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC Statistics Identifiers',
-        '#dom-rtcrtpstreamstats-transportid', 'RTCRtpStreamStats.transportId')}}</td>
-      <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
+++ b/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
@@ -34,20 +34,7 @@ browser-compat: api.RTCRtpSynchronizationSource
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsynchronizationsource','RTCRtpSynchronizationSource')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.html
@@ -37,21 +37,7 @@ browser-compat: api.RTCRtpTransceiver.currentDirection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-currentdirection",
-        "RTCRtpTransceiver.currentDirection")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/direction/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/direction/index.html
@@ -71,21 +71,7 @@ browser-compat: api.RTCRtpTransceiver.direction
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-direction",
-        "RTCRtpTransceiver.direction")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/index.html
@@ -50,20 +50,7 @@ browser-compat: api.RTCRtpTransceiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#rtcrtptransceiver-interface", "RTCRtpTransceiver")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/mid/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/mid/index.html
@@ -35,21 +35,7 @@ browser-compat: api.RTCRtpTransceiver.mid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtptransceiver-mid", "RTCRtpTransceiver.mid")}}
-      </td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/receiver/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/receiver/index.html
@@ -32,21 +32,7 @@ browser-compat: api.RTCRtpTransceiver.receiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-receiver",
-        "RTCRtpTransceiver.receiver")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/sender/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/sender/index.html
@@ -33,21 +33,7 @@ browser-compat: api.RTCRtpTransceiver.sender
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-sender",
-        "RTCRtpTransceiver.sender")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.html
@@ -96,21 +96,7 @@ var availReceiveCodecs = transceiver.receiver.getCapabilities("video").codecs;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-setcodecpreferences",
-        "RTCRtpTransceiver.setCodecPreferences()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/stop/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stop/index.html
@@ -73,21 +73,7 @@ browser-compat: api.RTCRtpTransceiver.stop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-stop",
-        "RTCRtpTransceiver.stop()")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
@@ -48,21 +48,7 @@ browser-compat: api.RTCRtpTransceiver.stopped
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiver-stopped",
-        "RTCRtpTransceiver.stopped")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverdirection/index.html
@@ -63,20 +63,7 @@ browser-compat: api.RTCRtpTransceiverDirection
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiverdirection", "RTCRtpTransceiverDirection")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverinit/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverinit/index.html
@@ -31,20 +31,7 @@ browser-compat: api.RTCRtpTransceiverInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebRTC 1.0", "#dom-rtcrtptransceiverinit", "RTCRtpTransceiverInit")}}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsctptransport/index.html
+++ b/files/en-us/web/api/rtcsctptransport/index.html
@@ -51,20 +51,7 @@ browser-compat: api.RTCSctpTransport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("WebRTC 1.0", "#rtcsctptransport-interface", "RTCSctpTransport")}}</td>
-			<td>{{Spec2("WebRTC 1.0")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsctptransport/state/index.html
+++ b/files/en-us/web/api/rtcsctptransport/state/index.html
@@ -44,21 +44,7 @@ browser-compat: api.RTCSctpTransport.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebRTC 1.0", "#dom-rtcsctptransport-state",
-        "RTCSctpTransport.state")}}</td>
-      <td>{{Spec2("WebRTC 1.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/index.html
@@ -95,20 +95,7 @@ browser-compat: api.RTCSessionDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{ SpecName('WebRTC 1.0', '#rtcsessiondescription-class', 'RTCSessionDescription') }}</td>
-			<td>{{Spec2('WebRTC 1.0')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
@@ -79,24 +79,7 @@ browser-compat: api.RTCSessionDescription.RTCSessionDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0',
-        '#widl-ctor-RTCSessionDescription--RTCSessionDescriptionInit-descriptionInitDict',
-        'RTCSessionDescription()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/sdp/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/sdp/index.html
@@ -47,23 +47,7 @@ alert(pc.remoteDescription.sdp);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcsessiondescription-sdp',
-        'RTCSessionDescription.sdp') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/tojson/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/tojson/index.html
@@ -44,23 +44,7 @@ alert(JSON.stringify(sd)); // This call the toJSON() method behind the scene.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcsessiondescription-tojson',
-        'RTCSessionDescription: toJSON()') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/type/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.html
@@ -48,23 +48,7 @@ alert(pc.remoteDescription.type);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('WebRTC 1.0', '#dom-rtcsessiondescription-type',
-        'RTCSessionDescription.type') }}</td>
-      <td>{{ Spec2('WebRTC 1.0') }}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstats/id/index.html
+++ b/files/en-us/web/api/rtcstats/id/index.html
@@ -39,20 +39,7 @@ browser-compat: api.RTCStats.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcstats-id', 'RTCStats.id')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstats/index.html
+++ b/files/en-us/web/api/rtcstats/index.html
@@ -58,22 +58,7 @@ browser-compat: api.RTCStats
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcstats', 'RTCStats') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstats/timestamp/index.html
+++ b/files/en-us/web/api/rtcstats/timestamp/index.html
@@ -42,20 +42,7 @@ browser-compat: api.RTCStats.timestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcstats-timestamp', 'RTCStats.timestamp')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstats/type/index.html
+++ b/files/en-us/web/api/rtcstats/type/index.html
@@ -36,20 +36,7 @@ browser-compat: api.RTCStats.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcstats-type', 'RTCStats.type')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstatsicecandidatepairstate/index.html
+++ b/files/en-us/web/api/rtcstatsicecandidatepairstate/index.html
@@ -40,22 +40,7 @@ browser-compat: api.RTCStatsIceCandidatePairState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC Statistics Identifiers', '#rtcstatsicecandidatepairstate-enum', 'RTCStatsIceCandidatePairState') }}</td>
-   <td>{{ Spec2('WebRTC Statistics Identifiers') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstatsreport/index.html
+++ b/files/en-us/web/api/rtcstatsreport/index.html
@@ -43,22 +43,7 @@ browser-compat: api.RTCStatsReport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#rtcstatsreport-object', 'RTCStatsReport') }}</td>
-   <td>{{ Spec2('WebRTC 1.0') }}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcstatstype/index.html
+++ b/files/en-us/web/api/rtcstatstype/index.html
@@ -60,20 +60,7 @@ browser-compat: api.RTCStatsType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcstatstype', 'RTCStatsType')}}</td>
-   <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/index.html
+++ b/files/en-us/web/api/rtctrackevent/index.html
@@ -69,22 +69,7 @@ browser-compat: api.RTCTrackEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackevent', 'RTCTrackEvent')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/receiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/receiver/index.html
@@ -44,23 +44,7 @@ browser-compat: api.RTCTrackEvent.receiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-trackevent-receiver', 'RTCTrackEvent.receiver')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/rtctrackevent/index.html
+++ b/files/en-us/web/api/rtctrackevent/rtctrackevent/index.html
@@ -47,22 +47,7 @@ browser-compat: api.RTCTrackEvent.RTCTrackEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#constructors-3', 'RTCTrackEvent()')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/streams/index.html
+++ b/files/en-us/web/api/rtctrackevent/streams/index.html
@@ -35,23 +35,7 @@ browser-compat: api.RTCTrackEvent.streams
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackevent-streams',
-        'RTCTrackEvent.streams')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/track/index.html
+++ b/files/en-us/web/api/rtctrackevent/track/index.html
@@ -35,23 +35,7 @@ browser-compat: api.RTCTrackEvent.track
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackevent-track', 'RTCTrackEvent.track')}}
-      </td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackevent/transceiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/transceiver/index.html
@@ -44,23 +44,7 @@ browser-compat: api.RTCTrackEvent.transceiver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-trackevent-transceiver',
-        'RTCTrackEvent.transceiver')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackeventinit/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/index.html
@@ -37,22 +37,7 @@ browser-compat: api.RTCTrackEventInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackeventinit', 'RTCTrackEventInit')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackeventinit/receiver/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/receiver/index.html
@@ -37,23 +37,7 @@ var <em>rtpReceiver</em> = <em>trackEventInit</em>.receiver;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackeventinit-receiver',
-        'RTCTrackEventInit.receiver')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackeventinit/streams/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/streams/index.html
@@ -41,23 +41,7 @@ var <em>streamList</em> = <em>trackEventInit</em>.streams;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackeventinit-streams',
-        'RTCTrackEventInit.streams')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackeventinit/track/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/track/index.html
@@ -39,23 +39,7 @@ var <em>track</em> = <em>trackEventInit</em>.track;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackeventinit-track',
-        'RTCTrackEventInit.track')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtctrackeventinit/transceiver/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/transceiver/index.html
@@ -38,23 +38,7 @@ var <em>rtpTransceiver</em> = <em>trackEventInit</em>.transceiver;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtctrackeventinit-transceiver',
-        'RTCTrackEventInit.transceiver')}}</td>
-      <td>{{Spec2('WebRTC 1.0')}}</td>
-      <td>Initial specification.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/rtc[j-z]* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- A few pages are deprecated and no more on the standard track; we keep the error messages (that will be improved in a 2nd pass): `RTCRtpTransceiver.stopped`,`RTCPeerConnection.identityresult_event`, `RTCPeerConnection.peeridentity_event`, `RTCPeerConnection.idpvalidationerror_event`, `RTCPeerConnection.idpassertionerror_event`, `RTCSessionDescription()`.
- Dictionaries and typedefs. Here these pages will be revisted (and have no bcd): so we keep them that way: `RTCStats` and its 3 children, `RTCRtcpParameters`, `RTCStatsIceCandidatePairState`, `RTCRTPStreamStats` and 1 children, `RTCNetworkType`, `RTCRtpCapabilities`, `RTCNetworkType`, `RTCRtpCodecCapability`, `RTCStatsType`, `RTCRtpReceiveParameters`, and `RTCRtpContributingSource.rtpTimestamp`.
- `RTCRtpSender.setStreams` was missing spec_url and is fixed in mdn/browser-compat-data#11048.
- `RTCPeerConnectionIceErrorEvent.address` is missing a BCD entry (and will be fixed in mdn/browser-compat-data#11151.
- On `RTCPeerConnection` the two events, `icegatheringstate_event` and `icecandidateerror_events`, were missing their cd entries,  and `RTCPeerConnection.getTranceivers` is missing a `spec_url`entry . All this will be fixed in mdn/browser-compat-data#11150.


All other pages look fine.