### PR TITLE
Fix missing warning emphasis

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -128,7 +128,7 @@ const greeting = "I'm a good example";
 <h5>Warnings</h5>
 
 <pre>
-&gt; **Warning: This is how you write a warning.
+&gt; **Warning:** This is how you write a warning.
 &gt;
 &gt; It can have multiple paragraphs.
 </pre>


### PR DESCRIPTION
Just showed @fiji-flo this page and his eagle eyes immediately spotted the missing emphasis markers