### PR TITLE
Update return type of Date.getUTCMonth to include NaN

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
@@ -24,12 +24,11 @@ browser-compat: javascript.builtins.Date.getUTCMonth
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A <code>number</code>. If the date is valid, an integer number, between 0 and 11,
+<p>A <code>number</code>. If the <code>Date</code> object represents a valid date, an integer number, between 0 and 11,
   corresponding to the month of the given date according to universal time. 0 for January,
   1 for February, 2 for March, and so on. Otherwise, <code><a
     href="/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN">NaN</a></code>
-  if the Date object it’s called from isn’t valid.
-</p>
+  if the <code>Date</code> object doesn’t represent a valid date.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
@@ -24,8 +24,14 @@ browser-compat: javascript.builtins.Date.getUTCMonth
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An integer number, between 0 and 11, corresponding to the month of the given date
-  according to universal time. 0 for January, 1 for February, 2 for March, and so on.</p>
+<p>
+  One of the following:
+  <ul>
+    <li>An integer number, between 0 and 11, corresponding to the month of the given date
+  according to universal time. 0 for January, 1 for February, 2 for March, and so on.</li>
+    <li><code>NaN</code> if the date is <code>NaN</code></li>
+  </ul> 
+</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
@@ -24,13 +24,11 @@ browser-compat: javascript.builtins.Date.getUTCMonth
 
 <h3 id="Return_value">Return value</h3>
 
-<p>
-  One of the following:
-  <ul>
-    <li>An integer number, between 0 and 11, corresponding to the month of the given date
-  according to universal time. 0 for January, 1 for February, 2 for March, and so on.</li>
-    <li><code>NaN</code> if the date is <code>NaN</code></li>
-  </ul> 
+<p>A <code>number</code>. If the date is valid, an integer number, between 0 and 11,
+  corresponding to the month of the given date according to universal time. 0 for January,
+  1 for February, 2 for March, and so on. Otherwise, <code><a
+    href="/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN">NaN</a></code>
+  if the Date object it’s called from isn’t valid.
 </p>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
## What was wrong/why is this fix needed? (quick summary only)

Add NaN for non-number dates.

## MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth

## Issue number (if there is an associated issue)

Fixes #6030

## Anything else that could help us review it

This is as per the spec linked at the bottom of the page
