### PR TITLE
Add strict type comparison example in Array.prototype.includes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -77,6 +77,7 @@ includes(searchElement, fromIndex)
 [1, 2, 3].includes(3, 3)   // false
 [1, 2, 3].includes(3, -1)  // true
 [1, 2, NaN].includes(NaN)  // true
+["1", "2", "3"].includes(3) // false
 </pre>
 
 <h3 id="fromIndex_is_greater_than_or_equal_to_the_array_length">

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -72,12 +72,13 @@ includes(searchElement, fromIndex)
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">[1, 2, 3].includes(2)      // true
-[1, 2, 3].includes(4)      // false
-[1, 2, 3].includes(3, 3)   // false
-[1, 2, 3].includes(3, -1)  // true
-[1, 2, NaN].includes(NaN)  // true
-["1", "2", "3"].includes(3) // false
+<pre class="brush: js">
+[1, 2, 3].includes(2)         // true
+[1, 2, 3].includes(4)         // false
+[1, 2, 3].includes(3, 3)      // false
+[1, 2, 3].includes(3, -1)     // true
+[1, 2, NaN].includes(NaN)     // true
+["1", "2", "3"].includes(3)   // false
 </pre>
 
 <h3 id="fromIndex_is_greater_than_or_equal_to_the_array_length">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
I have added an example to support strict equality comparison for `Array.prototype.includes`.
I strongly believe that this would be helpful for a lot of people.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
