### PR TITLE
Replace spec table with {{specifications}} for api/s* (part 1)

### DIFF
--- a/files/en-us/web/api/sanitizer/index.html
+++ b/files/en-us/web/api/sanitizer/index.html
@@ -41,20 +41,7 @@ console.log(result);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML Sanitizer API','#sanitizer-api','sanitizer')}}</td>
-   <td>{{Spec2('HTML Sanitizer API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sanitizer/sanitize/index.html
+++ b/files/en-us/web/api/sanitizer/sanitize/index.html
@@ -47,20 +47,7 @@ const result = new Sanitizer().sanitize(stringToClean);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML Sanitizer API','#sanitizer-api','sanitizeToString')}}</td>
-      <td>{{Spec2('HTML Sanitizer API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sanitizer/sanitizer/index.html
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.html
@@ -76,20 +76,7 @@ const drop = new Sanitizer({dropElements: [ "b" ]).sanitizeToString(sample);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML Sanitizer API','#sanitizer-api','sanitizer')}}</td>
-      <td>{{Spec2('HTML Sanitizer API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sanitizer/sanitizetostring/index.html
+++ b/files/en-us/web/api/sanitizer/sanitizetostring/index.html
@@ -48,20 +48,7 @@ console.log(result);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML Sanitizer API','#sanitizer-api','sanitizeToString')}}</td>
-      <td>{{Spec2('HTML Sanitizer API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/availheight/index.html
+++ b/files/en-us/web/api/screen/availheight/index.html
@@ -75,22 +75,7 @@ browser-compat: api.Screen.availHeight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-screen-availheight', 'Screen.availHeight')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/availwidth/index.html
+++ b/files/en-us/web/api/screen/availwidth/index.html
@@ -26,22 +26,7 @@ console.log(screenAvailWidth);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM View", "#dom-screen-availwidth", "Screen.availWidth")}}</td>
-      <td>{{Spec2("CSSOM View")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/colordepth/index.html
+++ b/files/en-us/web/api/screen/colordepth/index.html
@@ -32,22 +32,7 @@ if ( window.screen.colorDepth &lt; 8) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-screen-colordepth', 'Screen.colorDepth')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/height/index.html
+++ b/files/en-us/web/api/screen/height/index.html
@@ -41,22 +41,7 @@ browser-compat: api.Screen.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-screen-height', 'Screen.height')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/index.html
+++ b/files/en-us/web/api/screen/index.html
@@ -76,22 +76,7 @@ browser-compat: api.Screen
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM View", "#the-screen-interface", "Screen")}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/lockorientation/index.html
+++ b/files/en-us/web/api/screen/lockorientation/index.html
@@ -117,24 +117,7 @@ if (screen.lockOrientationUniversal(["landscape-primary", "landscape-secondary"]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Screen Orientation',
-        'published/20140220.html#extensions-to-the-screen-interface',
-        'lockOrientation()')}}</td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition (Not present in the draft anymore)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/onorientationchange/index.html
+++ b/files/en-us/web/api/screen/onorientationchange/index.html
@@ -30,24 +30,7 @@ browser-compat: api.Screen.onorientationchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Screen Orientation',
-        'published/20140220.html#extensions-to-the-screen-interface',
-        'onorientationchange')}}</td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition (Not present in the draft anymore)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/orientation/index.html
+++ b/files/en-us/web/api/screen/orientation/index.html
@@ -46,23 +46,7 @@ if (orientation === "landscape-primary") {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Screen Orientation', '#dom-screen-orientation',
-				'orientation')}}</td>
-			<td>{{Spec2('Screen Orientation')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/pixeldepth/index.html
+++ b/files/en-us/web/api/screen/pixeldepth/index.html
@@ -33,22 +33,7 @@ if ( window.screen.pixelDepth &gt; 8 ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-screen-pixeldepth', 'Screen.pixelDepth')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/unlockorientation/index.html
+++ b/files/en-us/web/api/screen/unlockorientation/index.html
@@ -45,24 +45,7 @@ if (unlockOrientation()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Screen Orientation',
-        'published/20140220.html#extensions-to-the-screen-interface',
-        'lockOrientation()')}}</td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition (Not present in the draft anymore)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/width/index.html
+++ b/files/en-us/web/api/screen/width/index.html
@@ -38,22 +38,7 @@ if (window.screen.width &gt;= 1024 &amp;&amp; window.screen.height &gt;= 768) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dom-screen-width', 'Screen.width')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/angle/index.html
+++ b/files/en-us/web/api/screenorientation/angle/index.html
@@ -27,20 +27,7 @@ browser-compat: api.ScreenOrientation.angle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Orientation','#dom-screenorientation-angle','angle')}}</td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/index.html
+++ b/files/en-us/web/api/screenorientation/index.html
@@ -43,20 +43,7 @@ browser-compat: api.ScreenOrientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Screen Orientation', '#screenorientation-interface', 'ScreenOrientation')}}</td>
-   <td>{{Spec2('Screen Orientation')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/lock/index.html
+++ b/files/en-us/web/api/screenorientation/lock/index.html
@@ -45,21 +45,7 @@ browser-compat: api.ScreenOrientation.lock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Orientation','#dom-screenorientation-lock','lock()')}}
-			</td>
-			<td>{{Spec2('Screen Orientation')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/onchange/index.html
+++ b/files/en-us/web/api/screenorientation/onchange/index.html
@@ -24,21 +24,7 @@ screen.orientation.onchange = function(e) { ... }</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Orientation','#dom-screenorientation-onchange','onchange')}}
-      </td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/type/index.html
+++ b/files/en-us/web/api/screenorientation/type/index.html
@@ -28,20 +28,7 @@ browser-compat: api.ScreenOrientation.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Orientation','#dom-screenorientation-type','type')}}</td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screenorientation/unlock/index.html
+++ b/files/en-us/web/api/screenorientation/unlock/index.html
@@ -31,21 +31,7 @@ browser-compat: api.ScreenOrientation.unlock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Screen Orientation','#dom-screenorientation-unlock','unlock()')}}
-      </td>
-      <td>{{Spec2('Screen Orientation')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.html
+++ b/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.html
@@ -70,20 +70,7 @@ browser-compat: api.ScriptProcessorNode.audioprocess_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#AudioProcessingEvent-section', 'AudioProcessingEvent')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.html
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.html
@@ -35,20 +35,7 @@ console.log(scriptNode.bufferSize);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-ScriptProcessorNode-bufferSize', 'bufferSize')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/index.html
+++ b/files/en-us/web/api/scriptprocessornode/index.html
@@ -80,20 +80,7 @@ browser-compat: api.ScriptProcessorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#the-scriptprocessornode-interface---deprecated', 'ScriptProcessorNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
@@ -32,20 +32,7 @@ scriptNode.onaudioprocess = function() { ... }</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-ScriptProcessorNode-onaudioprocess', 'onaudioprocess')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scrolltooptions/behavior/index.html
+++ b/files/en-us/web/api/scrolltooptions/behavior/index.html
@@ -39,20 +39,7 @@ browser-compat: api.ScrollToOptions.behavior
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSSOM View', '#dictdef-scrolloptions', 'behavior')}}</td>
-      <td>{{Spec2('CSSOM View')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scrolltooptions/index.html
+++ b/files/en-us/web/api/scrolltooptions/index.html
@@ -54,20 +54,7 @@ browser-compat: api.ScrollToOptions
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM View', '#dictdef-scrolltooptions', 'ScrollToOptions')}}</td>
-   <td>{{Spec2('CSSOM View')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scrolltooptions/left/index.html
+++ b/files/en-us/web/api/scrolltooptions/left/index.html
@@ -31,20 +31,7 @@ browser-compat: api.ScrollToOptions.left
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSSOM View', '#dom-scrolltooptions-left', 'left')}}</td>
-			<td>{{Spec2('CSSOM View')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scrolltooptions/top/index.html
+++ b/files/en-us/web/api/scrolltooptions/top/index.html
@@ -31,20 +31,7 @@ browser-compat: api.ScrollToOptions.top
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSSOM View', '#dom-scrolltooptions-top', 'top')}}</td>
-			<td>{{Spec2('CSSOM View')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.html
@@ -35,20 +35,7 @@ browser-compat: api.SecurityPolicyViolationEvent.blockedURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-blockeduri','blockedURI')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.html
@@ -36,20 +36,7 @@ browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-columnnumber','columnNumber')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.html
@@ -39,20 +39,7 @@ browser-compat: api.SecurityPolicyViolationEvent.disposition
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-disposition','disposition')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.html
@@ -37,20 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.documentURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-documenturi','documentURI')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.html
@@ -37,21 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.effectiveDirective
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-effectivedirective','effectiveDirective')}}
-      </td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.html
@@ -62,25 +62,7 @@ browser-compat: api.SecurityPolicyViolationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSP 1.1','#firing-securitypolicyviolationevent-events','SecurityPolicyViolationEvent')}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSP 3.0','#report-violation','SecurityPolicyViolationEvent')}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.html
@@ -36,20 +36,7 @@ browser-compat: api.SecurityPolicyViolationEvent.lineNumber
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-linenumber','lineNumber')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.html
@@ -37,20 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.originalPolicy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-originalpolicy','originalPolicy')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.html
@@ -38,21 +38,7 @@ browser-compat: api.SecurityPolicyViolationEvent.referrer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-referrer','referrer')}}
-      </td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.html
@@ -39,20 +39,7 @@ browser-compat: api.SecurityPolicyViolationEvent.sample
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-sample','sample')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
@@ -93,21 +93,7 @@ browser-compat: api.SecurityPolicyViolationEvent.SecurityPolicyViolationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-securitypolicyviolationevent','SecurityPolicyViolationEvent')}}
-      </td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.html
@@ -37,20 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.sourceFile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-sourcefile','sourceFile')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.html
@@ -37,20 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.statusCode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-statuscode','statusCode')}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.html
@@ -37,21 +37,7 @@ browser-compat: api.SecurityPolicyViolationEvent.violatedDirective
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-violateddirective','violatedDirective')}}
-      </td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/addrange/index.html
+++ b/files/en-us/web/api/selection/addrange/index.html
@@ -65,21 +65,7 @@ button.addEventListener('click', function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-addrange', 'Selection.addRange()')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/anchornode/index.html
+++ b/files/en-us/web/api/selection/anchornode/index.html
@@ -28,21 +28,7 @@ browser-compat: api.Selection.anchorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-anchornode',
-        'Selection.anchorNode')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/anchoroffset/index.html
+++ b/files/en-us/web/api/selection/anchoroffset/index.html
@@ -27,21 +27,7 @@ browser-compat: api.Selection.anchorOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-anchoroffset',
-        'Selection.anchorOffset')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/collapse/index.html
+++ b/files/en-us/web/api/selection/collapse/index.html
@@ -43,21 +43,7 @@ window.getSelection().collapse(body,0);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-collapse', 'Selection.collapse()')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/collapsetoend/index.html
+++ b/files/en-us/web/api/selection/collapsetoend/index.html
@@ -27,21 +27,7 @@ browser-compat: api.Selection.collapseToEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-collapsetoend',
-        'Selection.collapseToEnd()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/collapsetostart/index.html
+++ b/files/en-us/web/api/selection/collapsetostart/index.html
@@ -27,21 +27,7 @@ browser-compat: api.Selection.collapseToStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-collapsetostart',
-        'Selection.collapseToStart()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/containsnode/index.html
+++ b/files/en-us/web/api/selection/containsnode/index.html
@@ -73,21 +73,7 @@ document.addEventListener('selectionchange', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-containsnode',
-        'Selection.containsNode()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/deletefromdocument/index.html
+++ b/files/en-us/web/api/selection/deletefromdocument/index.html
@@ -54,21 +54,7 @@ function deleteSelection() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-deletefromdocument',
-        'Selection.deleteFromDocument()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/extend/index.html
+++ b/files/en-us/web/api/selection/extend/index.html
@@ -37,21 +37,7 @@ browser-compat: api.Selection.extend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-extend', 'Selection.extend()')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/focusnode/index.html
+++ b/files/en-us/web/api/selection/focusnode/index.html
@@ -29,21 +29,7 @@ browser-compat: api.Selection.focusNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-focusnode', 'Selection.focusNode')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/focusoffset/index.html
+++ b/files/en-us/web/api/selection/focusoffset/index.html
@@ -27,21 +27,7 @@ browser-compat: api.Selection.focusOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-focusoffset',
-        'Selection.focusOffset')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/getrangeat/index.html
+++ b/files/en-us/web/api/selection/getrangeat/index.html
@@ -48,20 +48,7 @@ for(let i = 0; i &lt; sel.rangeCount; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Selection API', '#dom-selection-getrangeat', 'Selection: getRangeAt()')}}</td>
-			<td>{{Spec2('Selection API')}}</td>
-			<td>Current</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/index.html
+++ b/files/en-us/web/api/selection/index.html
@@ -164,20 +164,7 @@ var range  = selObj.getRangeAt(0);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Selection API", "#selection-interface", "Selection")}}</td>
-   <td>{{Spec2("Selection API")}}</td>
-   <td>The Selection API specification is based on the HTML Editing APIs specification and focuses on the Selection-related functionality.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/iscollapsed/index.html
+++ b/files/en-us/web/api/selection/iscollapsed/index.html
@@ -31,21 +31,7 @@ browser-compat: api.Selection.isCollapsed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-iscollapsed',
-        'Selection.isCollapsed')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/rangecount/index.html
+++ b/files/en-us/web/api/selection/rangecount/index.html
@@ -67,21 +67,7 @@ browser-compat: api.Selection.rangeCount
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-rangecount',
-        'Selection.rangeCount')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/removeallranges/index.html
+++ b/files/en-us/web/api/selection/removeallranges/index.html
@@ -32,21 +32,7 @@ browser-compat: api.Selection.removeAllRanges
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-removeallranges',
-        'Selection.removeAllRanges()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/removerange/index.html
+++ b/files/en-us/web/api/selection/removerange/index.html
@@ -49,21 +49,7 @@ if(s.rangeCount &gt; 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-removerange',
-        'Selection.removeRange()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/selectallchildren/index.html
+++ b/files/en-us/web/api/selection/selectallchildren/index.html
@@ -57,21 +57,7 @@ button.addEventListener('click', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-selectallchildren',
-        'Selection.selectAllChildren()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.html
+++ b/files/en-us/web/api/selection/setbaseandextent/index.html
@@ -133,21 +133,7 @@ button.onclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-setbaseandextent',
-        'Selection.setBaseAndExtent()')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/tostring/index.html
+++ b/files/en-us/web/api/selection/tostring/index.html
@@ -42,21 +42,7 @@ alert(window.getSelection().toString())  // What is actually being effectively c
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-stringifier', 'Selection stringifier')}}
-      </td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/selection/type/index.html
+++ b/files/en-us/web/api/selection/type/index.html
@@ -50,20 +50,7 @@ document.onselectionchange = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Selection API', '#dom-selection-type', 'Selection.type')}}</td>
-      <td>{{Spec2('Selection API')}}</td>
-      <td>Current</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/activated/index.html
+++ b/files/en-us/web/api/sensor/activated/index.html
@@ -32,20 +32,7 @@ browser-compat: api.Sensor.activated
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-activated','activated')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>    Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/hasreading/index.html
+++ b/files/en-us/web/api/sensor/hasreading/index.html
@@ -32,20 +32,7 @@ browser-compat: api.Sensor.hasReading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-hasreading','hasReading')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/index.html
+++ b/files/en-us/web/api/sensor/index.html
@@ -66,20 +66,7 @@ browser-compat: api.Sensor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Generic Sensor','#the-sensor-interface','Sensor')}}</td>
-			<td>{{Spec2('Generic Sensor')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/onactivate/index.html
+++ b/files/en-us/web/api/sensor/onactivate/index.html
@@ -30,20 +30,7 @@ browser-compat: api.Sensor.onactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-onactivate','onactivate')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/onerror/index.html
+++ b/files/en-us/web/api/sensor/onerror/index.html
@@ -30,20 +30,7 @@ browser-compat: api.Sensor.onerror
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-onerror','onerror')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/onreading/index.html
+++ b/files/en-us/web/api/sensor/onreading/index.html
@@ -30,20 +30,7 @@ browser-compat: api.Sensor.onreading
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-onreading','onreading')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/start/index.html
+++ b/files/en-us/web/api/sensor/start/index.html
@@ -31,20 +31,7 @@ browser-compat: api.Sensor.start
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-start','start')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/stop/index.html
+++ b/files/en-us/web/api/sensor/stop/index.html
@@ -35,20 +35,7 @@ browser-compat: api.Sensor.stop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-stop','stop')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensor/timestamp/index.html
+++ b/files/en-us/web/api/sensor/timestamp/index.html
@@ -32,20 +32,7 @@ browser-compat: api.Sensor.timestamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensor-timestamp','timestamp')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensorerrorevent/error/index.html
+++ b/files/en-us/web/api/sensorerrorevent/error/index.html
@@ -30,20 +30,7 @@ browser-compat: api.SensorErrorEvent.error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#sensor-error-event-error','error')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensorerrorevent/index.html
+++ b/files/en-us/web/api/sensorerrorevent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.SensorErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Generic Sensor','#the-sensor-error-event-interface','SensorErrorEvent')}}</td>
-   <td>{{Spec2('Generic Sensor')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.html
+++ b/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.html
@@ -39,20 +39,7 @@ browser-compat: api.SensorErrorEvent.SensorErrorEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Generic Sensor','#dom-sensorerrorevent-sensorerrorevent','SensorErrorEvent')}}</td>
-      <td>{{Spec2('Generic Sensor')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serial/getports/index.html
+++ b/files/en-us/web/api/serial/getports/index.html
@@ -38,20 +38,7 @@ browser-compat: api.Serial.getPorts
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serial-getports','Serial.getPorts()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serial/index.html
+++ b/files/en-us/web/api/serial/index.html
@@ -70,20 +70,7 @@ button.addEventListener('click', () => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#serial-interface','Serial')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serial/onconnect/index.html
+++ b/files/en-us/web/api/serial/onconnect/index.html
@@ -30,20 +30,7 @@ Serial.addEventListener('connect', <var>function(event)</var>);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serial-onconnect','Serial.onconnect')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serial/ondisconnect/index.html
+++ b/files/en-us/web/api/serial/ondisconnect/index.html
@@ -30,20 +30,7 @@ Serial.addEventListener('disconnect', <var>function(event)</var>);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serial-ondisconnect','Serial.ondisconnect')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serial/requestport/index.html
+++ b/files/en-us/web/api/serial/requestport/index.html
@@ -62,20 +62,7 @@ browser-compat: api.Serial.requestPort
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serial-requestport','Serial.requestPort()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/close/index.html
+++ b/files/en-us/web/api/serialport/close/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SerialPort.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-close','SerialPort.close()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/getinfo/index.html
+++ b/files/en-us/web/api/serialport/getinfo/index.html
@@ -34,20 +34,7 @@ browser-compat: api.SerialPort.getInfo
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-getinfo','SerialPort.getInfo()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/getsignals/index.html
+++ b/files/en-us/web/api/serialport/getsignals/index.html
@@ -47,20 +47,7 @@ browser-compat: api.SerialPort.getSignals
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-getsignals','SerialPort.getSignals()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/index.html
+++ b/files/en-us/web/api/serialport/index.html
@@ -94,20 +94,7 @@ writer.releaseLock();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport','SerialPort')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/onconnect/index.html
+++ b/files/en-us/web/api/serialport/onconnect/index.html
@@ -21,20 +21,7 @@ SerialPort.addEventListener('connect', <var>function(event)</var>);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-onconnect','SerialPort.onconnect')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/ondisconnect/index.html
+++ b/files/en-us/web/api/serialport/ondisconnect/index.html
@@ -20,20 +20,7 @@ SerialPort.addEventListener('disconnect', <var>function(event)</var>);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-ondisconnect','SerialPort.ondisconnect')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/open/index.html
+++ b/files/en-us/web/api/serialport/open/index.html
@@ -60,20 +60,7 @@ browser-compat: api.SerialPort.open
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-open','SerialPort.open()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/readable/index.html
+++ b/files/en-us/web/api/serialport/readable/index.html
@@ -44,20 +44,7 @@ browser-compat: api.SerialPort.readable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-readable','SerialPort.readable')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/setsignals/index.html
+++ b/files/en-us/web/api/serialport/setsignals/index.html
@@ -50,20 +50,7 @@ browser-compat: api.SerialPort.setSignals
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-setsignals','SerialPort.setSignals()')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serialport/writable/index.html
+++ b/files/en-us/web/api/serialport/writable/index.html
@@ -31,20 +31,7 @@ writer.releaseLock();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Serial API','#dom-serialport-writable','SerialPort.writable')}}</td>
-   <td>{{Spec2('Web Serial API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/s* (first part, up to ServiceWorker not included) to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `ScriptProcessorNode` and its 3 children have been deprecated; so I'm keeping the change
- `Screen.onorientationchange` (Non-standard & deprecated); I'm keeping the change.
- `Screen.lockOrientation` & `Screen.unlockOrientation` are deprecated; so I'm keeping the changes.

All other pages look fine.