### PR TITLE
Replace spec table with {{specifications}} for api/s* (part 2)

### DIFF
--- a/files/en-us/web/api/serviceworker/index.html
+++ b/files/en-us/web/api/serviceworker/index.html
@@ -79,20 +79,7 @@ browser-compat: api.ServiceWorker
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#serviceworker', 'ServiceWorker')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworker/onerror/index.html
+++ b/files/en-us/web/api/serviceworker/onerror/index.html
@@ -39,20 +39,7 @@ if (navigator.serviceWorker) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#handler-abstractworker-onerror", "onerror")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworker/onstatechange/index.html
+++ b/files/en-us/web/api/serviceworker/onstatechange/index.html
@@ -64,21 +64,7 @@ if (serviceWorker) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworker-onstatechange',
-        'ServiceWorker.onstatechange')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworker/scripturl/index.html
+++ b/files/en-us/web/api/serviceworker/scripturl/index.html
@@ -35,20 +35,7 @@ browser-compat: api.ServiceWorker.scriptURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-url', 'scriptURL')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworker/state/index.html
+++ b/files/en-us/web/api/serviceworker/state/index.html
@@ -71,20 +71,7 @@ if (serviceWorker) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-state', 'state')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/controller/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/controller/index.html
@@ -46,21 +46,7 @@ browser-compat: api.ServiceWorkerContainer.controller
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#navigator-service-worker-controller',
-        'ServiceWorkerRegistration.controller')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/getregistration/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/getregistration/index.html
@@ -47,21 +47,7 @@ browser-compat: api.ServiceWorkerContainer.getRegistration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkercontainer-getregistration',
-        'ServiceWorkerContainer: getRegistration')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/getregistrations/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/getregistrations/index.html
@@ -42,21 +42,7 @@ browser-compat: api.ServiceWorkerContainer.getRegistrations
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#navigator-service-worker-getRegistrations',
-        'getRegistrations()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/index.html
@@ -92,20 +92,7 @@ browser-compat: api.ServiceWorkerContainer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#serviceworkercontainer', 'ServiceWorkerContainer')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/message_event/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/message_event/index.html
@@ -59,18 +59,7 @@ navigator.serviceWorker.addEventListener('message', (message) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#dom-serviceworkercontainer-onmessage', 'message')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/oncontrollerchange/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/oncontrollerchange/index.html
@@ -32,21 +32,7 @@ browser-compat: api.ServiceWorkerContainer.oncontrollerchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkercontainer-oncontrollerchange',
-        'ServiceWorkerContainer: oncontrollerchange')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/onmessage/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/onmessage/index.html
@@ -41,21 +41,7 @@ browser-compat: api.ServiceWorkerContainer.onmessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkerglobalscope-onmessage',
-        'ServiceWorkerContainer: onmessage')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/ready/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/ready/index.html
@@ -48,21 +48,7 @@ browser-compat: api.ServiceWorkerContainer.ready
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#navigator-service-worker-ready',
-        'ServiceWorkerRegistration.ready')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/register/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.html
@@ -130,21 +130,7 @@ browser-compat: api.ServiceWorkerContainer.register
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkercontainer-register',
-        'ServiceWorkerContainer: register')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/startmessages/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/startmessages/index.html
@@ -67,21 +67,7 @@ navigator.serviceWorker.startMessages();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkercontainer-startmessages',
-        'ServiceWorkerContainer: startMessages()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.html
@@ -58,20 +58,7 @@ browser-compat: api.ServiceWorkerGlobalScope.activate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#service-worker-global-scope-activate-event', 'activate')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/caches/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/caches/index.html
@@ -27,21 +27,7 @@ browser-compat: api.ServiceWorkerGlobalScope.caches
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#global-caches',
-        'ServiceWorkerGlobalScope.caches')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/clients/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/clients/index.html
@@ -30,23 +30,7 @@ browser-compat: api.ServiceWorkerGlobalScope.clients
 
 <h2 id="Specifications">Specifications</h2>
 
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-global-scope-clients',
-        'ServiceWorkerRegistration.clients')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.<br>
-         </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
@@ -60,20 +60,7 @@ browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Content Index API','#extensions-to-service-worker-global','contentdelete')}}</td>
-   <td>{{Spec2('Content Index API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.html
@@ -120,22 +120,7 @@ browser-compat: api.ServiceWorkerGlobalScope
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Service Workers', '#serviceworkerglobalscope-interface', 'ServiceWorkerGlobalScope')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/install_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/install_event/index.html
@@ -66,20 +66,7 @@ browser-compat: api.ServiceWorkerGlobalScope.install_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#service-worker-global-scope-install-event', 'install')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/message_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/message_event/index.html
@@ -67,18 +67,7 @@ addEventListener('message', event =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#eventdef-serviceworkerglobalscope-message', 'message')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.html
@@ -82,20 +82,7 @@ browser-compat: api.ServiceWorkerGlobalScope.notificationclick_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-serviceworkerglobalscope-onnotificationclick','onnotificationclick')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.html
@@ -39,20 +39,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#service-worker-global-scope-event-handlers', 'Event Handlers')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
@@ -36,20 +36,7 @@ browser-compat: api.ServiceWorkerGlobalScope.oncontentdelete
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Content Index API','#extensions-to-service-worker-global','contentdelete')}}</td>
-   <td>{{Spec2('Content Index API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onfetch/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onfetch/index.html
@@ -66,21 +66,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onfetch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-global-scope-event-handlers',
-        'Event Handlers')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.html
@@ -44,20 +44,7 @@ browser-compat: api.ServiceWorkerGlobalScope.oninstall
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#service-worker-global-scope-event-handlers', 'Event Handlers')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onmessage/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onmessage/index.html
@@ -48,21 +48,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onmessage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-global-scope-event-handlers',
-        'Event Handlers')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.html
@@ -50,20 +50,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onnotificationclick
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications','#dom-serviceworkerglobalscope-onnotificationclick','onnotificationclick')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Initial definition. This property is specified on the {{domxref('Notifications_API')}} even though it's part of {{domxref('ServiceWorkerGlobalScope')}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.html
@@ -46,23 +46,7 @@ self.onnotificationclose = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-serviceworkerglobalscope-onnotificationclose','onnotificationclick')}}
-      </td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial definition. This property is specified on the
-        {{domxref('Notifications_API')}} even though it's part of
-        {{domxref('ServiceWorkerGlobalScope')}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.html
@@ -31,20 +31,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onperiodicsync
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Periodic Background Sync','#extensions-to-serviceworkerregistration','onperiodicsync')}}</td>
-   <td>{{Spec2('Periodic Background Sync')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onpush/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onpush/index.html
@@ -59,21 +59,7 @@ self.addEventListener('push', function(PushEvent) { ... })
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API', '#dom-serviceworkerglobalscope-onpush', 'onpush')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition. This event is specified in the Push API, but accessed
-        through {{domxref("ServiceWorkerGlobalScope")}}.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.html
@@ -40,22 +40,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onpushsubscriptionchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API', '#dom-serviceworkerglobalscope-onpushsubscriptionchange',
-        'onpushsubscriptionchange')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition (Note: This event is specified in the Push API, but accessed
-        through {{domxref("ServiceWorkerGlobalScope")}}.)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onsync/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onsync/index.html
@@ -14,18 +14,7 @@ self.addEventListener('sync', function(SyncEvent) { ... })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th>Specification</th>
-        </tr>
-        <tr>
-            <td><a
-                    href="https://wicg.github.io/background-sync/spec/#dom-serviceworkerglobalscope-onsync">Web
-                    Background Synchronization</a></td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.html
@@ -54,20 +54,7 @@ browser-compat: api.ServiceWorkerGlobalScope.periodicsync_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Periodic Background Sync','#extensions-to-serviceworkerregistration','periodicsync')}}</td>
-   <td>{{Spec2('Periodic Background Sync')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/push_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/push_event/index.html
@@ -58,22 +58,7 @@ browser-compat: api.ServiceWorkerGlobalScope.push_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Push API', '#extensions-to-the-serviceworkerglobalscope-interface', 'push')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.html
@@ -81,22 +81,7 @@ browser-compat: api.ServiceWorkerGlobalScope.pushsubscriptionchange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Push API', '#the-pushsubscriptionchange-event', 'pushsubscriptionchange')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/registration/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/registration/index.html
@@ -26,21 +26,7 @@ browser-compat: api.ServiceWorkerGlobalScope.registration
 
 <h2 id="Specifications">Specifications</h2>
 
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#service-worker-global-scope-registration', 'ServiceWorkerGlobalScope.registration')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.html
@@ -45,20 +45,7 @@ browser-compat: api.ServiceWorkerGlobalScope.skipWaiting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#dom-serviceworkerglobalscope-skipwaiting', 'skipWaiting()')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/active/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/active/index.html
@@ -44,22 +44,7 @@ browser-compat: api.ServiceWorkerRegistration.active
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkerregistration-active',
-        'ServiceWorkerRegistration.active')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.<br>
-         </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.html
@@ -61,22 +61,7 @@ navigator.serviceWorker.ready.then(function(registration) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications',
-        '#dom-serviceworkerregistration-getnotifications',
-        'ServiceWorkerRegistration.getNotifications()')}}</td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/index.html
@@ -101,35 +101,7 @@ browser-compat: api.ServiceWorkerRegistration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Service Workers', '#serviceworkerregistration', 'ServiceWorkerRegistration')}}</td>
-   <td>{{Spec2('Service Workers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Push API', '#dom-serviceworkerregistration-pushmanager', 'PushManager')}}</td>
-   <td>{{Spec2('Push API')}}</td>
-   <td>Adds the {{domxref("PushManager","pushManager")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Adds the {{domxref("ServiceWorkerRegistration.showNotification()","showNotification()")}} method and the {{domxref("ServiceWorkerRegistration.getNotifications()","getNotifications()")}} method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Sync')}}</td>
-   <td>{{Spec2('Background Sync')}}</td>
-   <td>Adds the {{domxref("ServiceWorkerRegistration.sync","sync")}} property.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/index/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.html
@@ -56,20 +56,7 @@ const contentIndex = self.registration.index;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Content Index API','#extensions-to-service-worker-registration','index')}}</td>
-      <td>{{Spec2('Content Index API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/installing/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/installing/index.html
@@ -34,21 +34,7 @@ browser-compat: api.ServiceWorkerRegistration.installing
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkerregistration-installing',
-        'ServiceWorkerRegistration.installing')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
@@ -29,21 +29,7 @@ browser-compat: api.ServiceWorkerRegistration.navigationPreload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
-      </td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/onupdatefound/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/onupdatefound/index.html
@@ -30,21 +30,7 @@ browser-compat: api.ServiceWorkerRegistration.onupdatefound
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkerregistration-onupdatefound',
-        'ServiceWorkerRegistration.onupdatefound')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
@@ -56,20 +56,7 @@ const periodicSync = self.registration.periodicSync;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Periodic Background Sync','#extensions-to-serviceworkerregistration','periodicSync')}}</td>
-      <td>{{Spec2('Periodic Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/pushmanager/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/pushmanager/index.html
@@ -57,20 +57,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Push API', '#pushmanager-interface', 'PushManager')}}</td>
-      <td>{{Spec2('Push API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/scope/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/scope/index.html
@@ -29,21 +29,7 @@ browser-compat: api.ServiceWorkerRegistration.scope
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#dom-serviceworkerregistration-scope',
-        'ServiceWorkerRegistration.scope')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.html
@@ -133,21 +133,7 @@ function showNotification() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Notifications','#dom-serviceworkerregistration-shownotification','showNotification()')}}
-      </td>
-      <td>{{Spec2('Web Notifications')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/sync/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/sync/index.html
@@ -29,20 +29,7 @@ browser-compat: api.ServiceWorkerRegistration.sync
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Background Sync')}}</td>
-      <td>{{Spec2('Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/unregister/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/unregister/index.html
@@ -60,21 +60,7 @@ browser-compat: api.ServiceWorkerRegistration.unregister
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', 'navigator-service-worker-unregister',
-        'ServiceWorkerRegistration.unregister()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/update/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/update/index.html
@@ -57,21 +57,7 @@ browser-compat: api.ServiceWorkerRegistration.update
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#service-worker-registration-update',
-        'ServiceWorkerRegistration.update()')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/serviceworkerregistration/waiting/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/waiting/index.html
@@ -34,22 +34,7 @@ browser-compat: api.ServiceWorkerRegistration.waiting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#navigator-service-worker-waiting',
-        'ServiceWorkerRegistration.waiting')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.<br>
-         </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/activeelement/index.html
+++ b/files/en-us/web/api/shadowroot/activeelement/index.html
@@ -31,18 +31,7 @@ let focusedElem = shadow.activeElement;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-documentorshadowroot-activeelement', 'activeElement')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.html
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.html
@@ -40,24 +40,7 @@ let hostElem = shadow.delegatesFocus;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG',
-        '#dom-shadowroot-delegatesfocus', 'delegatesFocus')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/fullscreenelement/index.html
+++ b/files/en-us/web/api/shadowroot/fullscreenelement/index.html
@@ -32,18 +32,7 @@ let fullscreenElem = shadow.fullscreenElement;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-documentorshadowroot-fullscreenelement', 'fullscreenElement')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/getanimations/index.html
+++ b/files/en-us/web/api/shadowroot/getanimations/index.html
@@ -56,18 +56,7 @@ shadow.getAnimations().forEach(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Animations', '#dom-documentorshadowroot-getanimations', 'DocumentOrShadowRoot.getAnimations()' )}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/host/index.html
+++ b/files/en-us/web/api/shadowroot/host/index.html
@@ -37,22 +37,7 @@ let hostElem = shadow.host;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-shadowroot-host','ShadowRoot.host')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/index.html
+++ b/files/en-us/web/api/shadowroot/index.html
@@ -87,22 +87,7 @@ attributeChangedCallback(name, oldValue, newValue) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#interface-shadowroot','Interface ShadowRoot')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/innerhtml/index.html
+++ b/files/en-us/web/api/shadowroot/innerhtml/index.html
@@ -36,23 +36,7 @@ shadow.innerHTML = '&lt;strong&gt;This element should be more important!&lt;/str
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM Parsing', '#dom-innerhtml-innerhtml', 'ShadowRoot.innerHTML')}}
-      </td>
-      <td>{{Spec2('DOM Parsing')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/mode/index.html
+++ b/files/en-us/web/api/shadowroot/mode/index.html
@@ -49,20 +49,7 @@ browser-compat: api.ShadowRoot.mode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM WHATWG','#dom-shadowroot-mode','ShadowRoot.mode')}}</td>
-			<td>{{Spec2('DOM WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/pictureinpictureelement/index.html
+++ b/files/en-us/web/api/shadowroot/pictureinpictureelement/index.html
@@ -35,18 +35,7 @@ let pipElem = shadow.pictureInPictureElement;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Picture-in-Picture','#dom-documentorshadowroot-pictureinpictureelement', 'pictureInPictureElement')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/pointerlockelement/index.html
+++ b/files/en-us/web/api/shadowroot/pointerlockelement/index.html
@@ -34,18 +34,7 @@ let pleElem = shadow.pointerLockElement;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Pointer Lock','#extensions-to-the-documentorshadowroot-mixin','pointerLockElement')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/shadowroot/stylesheets/index.html
+++ b/files/en-us/web/api/shadowroot/stylesheets/index.html
@@ -32,16 +32,7 @@ let styleSheets = shadow.styleSheets;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSSOM','#extensions-to-the-document-or-shadow-root-interface','DocumentOrShadowRoot.styleSheets')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworker/index.html
+++ b/files/en-us/web/api/sharedworker/index.html
@@ -85,20 +85,7 @@ myWorker.port.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#sharedworker", "SharedWorker")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from {{SpecName("Web Workers")}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworker/onerror/index.html
+++ b/files/en-us/web/api/sharedworker/onerror/index.html
@@ -32,20 +32,7 @@ mySharedWorker.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "#handler-abstractworker-onerror", "onerror")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworker/port/index.html
+++ b/files/en-us/web/api/sharedworker/port/index.html
@@ -42,21 +42,7 @@ myWorker.port.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-sharedworker-port", "port")}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworker/sharedworker/index.html
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.html
@@ -106,20 +106,7 @@ myWorker.port.onmessage = function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "#dom-sharedworker", "SharedWorker()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/close/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/close/index.html
@@ -33,20 +33,7 @@ browser-compat: api.SharedWorkerGlobalScope.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-sharedworkerglobalscope-close', 'close()')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.html
@@ -70,20 +70,7 @@ browser-compat: api.SharedWorkerGlobalScope.connect_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-workerglobalscope-connect", "connect event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.html
@@ -97,22 +97,7 @@ browser-compat: api.SharedWorkerGlobalScope
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#sharedworkerglobalscope', 'SharedWorkerGlobalScope')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/name/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/name/index.html
@@ -42,20 +42,7 @@ browser-compat: api.SharedWorkerGlobalScope.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-sharedworkerglobalscope-name', 'name')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.html
@@ -43,20 +43,7 @@ browser-compat: api.SharedWorkerGlobalScope.onconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#handler-sharedworkerglobalscope-onconnect', 'onconnect')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/abort/index.html
+++ b/files/en-us/web/api/sourcebuffer/abort/index.html
@@ -95,21 +95,7 @@ sourceBuffer.appendBuffer(buf);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-sourcebuffer-abort', 'abort()')}}
-      </td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/appendbuffer/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendbuffer/index.html
@@ -50,21 +50,7 @@ browser-compat: api.SourceBuffer.appendBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-sourcebuffer-appendbuffer',
-        'appendBuffer()')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/appendbufferasync/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendbufferasync/index.html
@@ -64,23 +64,7 @@ browser-compat: api.SourceBuffer.appendBufferAsync
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Not currently part of any specification. This is being experimented with under the
-  auspices of the <strong>Web Platform Incubator Community Group</strong> (WICG).</p>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition; does not include this method.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowend/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendwindowend/index.html
@@ -69,21 +69,7 @@ browser-compat: api.SourceBuffer.appendWindowEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-appendwindowend',
-        'appendWindowEnd')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowstart/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendwindowstart/index.html
@@ -70,21 +70,7 @@ browser-compat: api.SourceBuffer.appendWindowStart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-appendwindowstart',
-        'appendWindowStart')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/audiotracks/index.html
+++ b/files/en-us/web/api/sourcebuffer/audiotracks/index.html
@@ -34,21 +34,7 @@ browser-compat: api.SourceBuffer.audioTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-audiotracks',
-        'audioTracks')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/buffered/index.html
+++ b/files/en-us/web/api/sourcebuffer/buffered/index.html
@@ -36,21 +36,7 @@ browser-compat: api.SourceBuffer.buffered
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-buffered',
-        'buffered')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/index.html
+++ b/files/en-us/web/api/sourcebuffer/index.html
@@ -127,20 +127,7 @@ function fetchAB (url, cb) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Source Extensions', '#sourcebuffer', 'SourceBuffer')}}</td>
-   <td>{{Spec2('Media Source Extensions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/mode/index.html
+++ b/files/en-us/web/api/sourcebuffer/mode/index.html
@@ -98,21 +98,7 @@ if (curMode == 'segments') {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-mode', 'mode')}}
-      </td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/remove/index.html
+++ b/files/en-us/web/api/sourcebuffer/remove/index.html
@@ -73,21 +73,7 @@ browser-compat: api.SourceBuffer.remove
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-sourcebuffer-remove', 'remove()')}}
-      </td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/removeasync/index.html
+++ b/files/en-us/web/api/sourcebuffer/removeasync/index.html
@@ -60,22 +60,7 @@ browser-compat: api.SourceBuffer.removeAsync
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Not currently part of the MSE specification.</p>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/texttracks/index.html
+++ b/files/en-us/web/api/sourcebuffer/texttracks/index.html
@@ -34,21 +34,7 @@ browser-compat: api.SourceBuffer.textTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-texttracks',
-        'textTracks')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/timestampoffset/index.html
+++ b/files/en-us/web/api/sourcebuffer/timestampoffset/index.html
@@ -63,21 +63,7 @@ browser-compat: api.SourceBuffer.timestampOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-timestampoffset',
-        'timestampOffset')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/updating/index.html
+++ b/files/en-us/web/api/sourcebuffer/updating/index.html
@@ -37,21 +37,7 @@ browser-compat: api.SourceBuffer.updating
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-updating',
-        'updating')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/videotracks/index.html
+++ b/files/en-us/web/api/sourcebuffer/videotracks/index.html
@@ -34,21 +34,7 @@ browser-compat: api.SourceBuffer.videoTracks
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebuffer-videotracks',
-        'videoTracks')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebufferlist/index.html
+++ b/files/en-us/web/api/sourcebufferlist/index.html
@@ -59,20 +59,7 @@ for (var i = 0; i &lt; sourceBufferList.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Source Extensions', '#sourcebufferlist', 'SourceBufferList')}}</td>
-   <td>{{Spec2('Media Source Extensions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebufferlist/length/index.html
+++ b/files/en-us/web/api/sourcebufferlist/length/index.html
@@ -34,21 +34,7 @@ browser-compat: api.SourceBufferList.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#idl-def-sourcebufferlist-length',
-        'length')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammar/index.html
+++ b/files/en-us/web/api/speechgrammar/index.html
@@ -48,20 +48,7 @@ console.log(speechRecognitionList[0].weight); // should return 1 - the same as t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-speechgrammar', 'SpeechGrammar')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammar/speechgrammar/index.html
+++ b/files/en-us/web/api/speechgrammar/speechgrammar/index.html
@@ -42,21 +42,7 @@ speechRecognitionList[1] = newGrammar; // should add the new SpeechGrammar objec
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', 'dom-speechgrammar-speechgrammar',
-				'SpeechGrammar()')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammar/src/index.html
+++ b/files/en-us/web/api/speechgrammar/src/index.html
@@ -42,20 +42,7 @@ console.log(speechRecognitionList[0].weight); // should return 1 - the same as t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammar-src', 'src')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammar/weight/index.html
+++ b/files/en-us/web/api/speechgrammar/weight/index.html
@@ -42,20 +42,7 @@ console.log(speechRecognitionList[0].weight); // should return 1 - the same as t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammar-weight', 'weight')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.html
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.html
@@ -53,21 +53,7 @@ recognition.grammars = speechRecognitionList;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammarlist-addfromstring',
-        'addFromString()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.html
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.html
@@ -58,21 +58,7 @@ speechRecognitionList.addFromURI('http://www.example.com/grammar.txt'); // adds 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammarlist-addfromuri',
-        'addFromURI()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/index.html
+++ b/files/en-us/web/api/speechgrammarlist/index.html
@@ -56,20 +56,7 @@ recognition.grammars = speechRecognitionList;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechgrammarlist-speechgrammarlist', 'SpeechGrammarList()')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/item/index.html
+++ b/files/en-us/web/api/speechgrammarlist/item/index.html
@@ -42,20 +42,7 @@ var myFirstGrammar = speechRecognitionList[0]; // var should contain the SpeechG
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammarlist-item', 'item()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/length/index.html
+++ b/files/en-us/web/api/speechgrammarlist/length/index.html
@@ -43,20 +43,7 @@ speechRecognitionList.length; // should return 1.
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechgrammarlist-length', 'length')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.html
+++ b/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.html
@@ -47,21 +47,7 @@ recognition.grammars = speechRecognitionList;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#speechreco-speechgrammarlist',
-        'SpeechGrammarList')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/abort/index.html
+++ b/files/en-us/web/api/speechrecognition/abort/index.html
@@ -61,20 +61,7 @@ recognition.onspeechend = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-abort', 'abort()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/audioend_event/index.html
+++ b/files/en-us/web/api/speechrecognition/audioend_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('audioend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/audiostart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/audiostart_event/index.html
@@ -53,20 +53,7 @@ recognition.addEventListener('audiostart', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/continuous/index.html
+++ b/files/en-us/web/api/speechrecognition/continuous/index.html
@@ -53,21 +53,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-continuous',
-        'continuous')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/end_event/index.html
+++ b/files/en-us/web/api/speechrecognition/end_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('end', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/error_event/index.html
+++ b/files/en-us/web/api/speechrecognition/error_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('error', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/grammars/index.html
+++ b/files/en-us/web/api/speechrecognition/grammars/index.html
@@ -51,21 +51,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-grammars', 'grammars')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/index.html
+++ b/files/en-us/web/api/speechrecognition/index.html
@@ -131,20 +131,7 @@ recognition.onresult = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-section', 'SpeechRecognition')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/interimresults/index.html
+++ b/files/en-us/web/api/speechrecognition/interimresults/index.html
@@ -55,21 +55,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-interimresults',
-        'interimResults')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/lang/index.html
+++ b/files/en-us/web/api/speechrecognition/lang/index.html
@@ -51,20 +51,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-lang', 'lang')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/maxalternatives/index.html
+++ b/files/en-us/web/api/speechrecognition/maxalternatives/index.html
@@ -52,21 +52,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-maxalternatives',
-        'maxAlternatives')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/nomatch_event/index.html
+++ b/files/en-us/web/api/speechrecognition/nomatch_event/index.html
@@ -52,20 +52,7 @@ recognition.addEventListener('nomatch', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onaudioend/index.html
+++ b/files/en-us/web/api/speechrecognition/onaudioend/index.html
@@ -37,21 +37,7 @@ recognition.onaudioend = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onaudioend',
-        'onaudioend')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onaudiostart/index.html
+++ b/files/en-us/web/api/speechrecognition/onaudiostart/index.html
@@ -36,21 +36,7 @@ recognition.onaudiostart = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onaudiostart',
-        'onaudiostart')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onend/index.html
+++ b/files/en-us/web/api/speechrecognition/onend/index.html
@@ -37,20 +37,7 @@ recognition.onend = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onend', 'onend')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onerror/index.html
+++ b/files/en-us/web/api/speechrecognition/onerror/index.html
@@ -36,20 +36,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onerror', 'onerror')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onnomatch/index.html
+++ b/files/en-us/web/api/speechrecognition/onnomatch/index.html
@@ -47,21 +47,7 @@ recognition.onnomatch = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onnomatch', 'onnomatch')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onresult/index.html
+++ b/files/en-us/web/api/speechrecognition/onresult/index.html
@@ -50,21 +50,7 @@ browser-compat: api.SpeechRecognition.onresult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onresult', 'onresult')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onsoundend/index.html
+++ b/files/en-us/web/api/speechrecognition/onsoundend/index.html
@@ -35,21 +35,7 @@ browser-compat: api.SpeechRecognition.onsoundend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onsoundend',
-        'onsoundend')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onsoundstart/index.html
+++ b/files/en-us/web/api/speechrecognition/onsoundstart/index.html
@@ -35,21 +35,7 @@ browser-compat: api.SpeechRecognition.onsoundstart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onsoundstart',
-        'onsoundstart')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onspeechend/index.html
+++ b/files/en-us/web/api/speechrecognition/onspeechend/index.html
@@ -36,21 +36,7 @@ browser-compat: api.SpeechRecognition.onspeechend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onspeechend',
-        'onspeechend')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onspeechstart/index.html
+++ b/files/en-us/web/api/speechrecognition/onspeechstart/index.html
@@ -36,21 +36,7 @@ browser-compat: api.SpeechRecognition.onspeechstart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onspeechstart',
-        'onspeechstart')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/onstart/index.html
+++ b/files/en-us/web/api/speechrecognition/onstart/index.html
@@ -35,20 +35,7 @@ browser-compat: api.SpeechRecognition.onstart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-onstart', 'onstart')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/result_event/index.html
+++ b/files/en-us/web/api/speechrecognition/result_event/index.html
@@ -57,20 +57,7 @@ recognition.addEventListener('result', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/soundend_event/index.html
+++ b/files/en-us/web/api/speechrecognition/soundend_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('soundend', function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/soundstart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/soundstart_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('soundstart', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/speechend_event/index.html
+++ b/files/en-us/web/api/speechrecognition/speechend_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('speechend', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/speechrecognition/index.html
+++ b/files/en-us/web/api/speechrecognition/speechrecognition/index.html
@@ -46,21 +46,7 @@ recognition.maxAlternatives = 1;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-speechrecognition',
-        'SpeechRecognition()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/speechstart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/speechstart_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('speechstart', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/start/index.html
+++ b/files/en-us/web/api/speechrecognition/start/index.html
@@ -61,20 +61,7 @@ recognition.onspeechend = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-start', 'start()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/start_event/index.html
+++ b/files/en-us/web/api/speechrecognition/start_event/index.html
@@ -50,20 +50,7 @@ recognition.addEventListener('start', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-events', 'speech recognition events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognition/stop/index.html
+++ b/files/en-us/web/api/speechrecognition/stop/index.html
@@ -61,20 +61,7 @@ recognition.onspeechend = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognition-stop', 'stop()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionalternative/confidence/index.html
+++ b/files/en-us/web/api/speechrecognitionalternative/confidence/index.html
@@ -56,21 +56,7 @@ browser-compat: api.SpeechRecognitionAlternative.confidence
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionalternative-confidence',
-        'confidence')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionalternative/index.html
+++ b/files/en-us/web/api/speechrecognitionalternative/index.html
@@ -45,20 +45,7 @@ browser-compat: api.SpeechRecognitionAlternative
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechreco-alternative', 'SpeechRecognitionAlternative')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionalternative/transcript/index.html
+++ b/files/en-us/web/api/speechrecognitionalternative/transcript/index.html
@@ -54,21 +54,7 @@ browser-compat: api.SpeechRecognitionAlternative.transcript
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionalternative-transcript',
-        'transcript')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/error/index.html
+++ b/files/en-us/web/api/speechrecognitionerrorevent/error/index.html
@@ -64,21 +64,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionerrorevent-error',
-        'error')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/index.html
+++ b/files/en-us/web/api/speechrecognitionerrorevent/index.html
@@ -29,20 +29,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechrecognitionerrorevent', 'SpeechRecognitionErrorEvent')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/message/index.html
+++ b/files/en-us/web/api/speechrecognitionerrorevent/message/index.html
@@ -41,21 +41,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionerrorevent-message',
-        'message')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionevent/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/index.html
@@ -51,20 +51,7 @@ browser-compat: api.SpeechRecognitionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#speechreco-event', 'SpeechRecognitionEvent')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionevent/resultindex/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/resultindex/index.html
@@ -42,21 +42,7 @@ browser-compat: api.SpeechRecognitionEvent.resultIndex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionevent-resultindex',
-        'resultIndex')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionevent/results/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/results/index.html
@@ -58,21 +58,7 @@ browser-compat: api.SpeechRecognitionEvent.results
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionevent-results', 'results')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresult/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/index.html
@@ -52,20 +52,7 @@ browser-compat: api.SpeechRecognitionResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechreco-result', 'SpeechRecognitionResult')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresult/isfinal/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/isfinal/index.html
@@ -50,21 +50,7 @@ browser-compat: api.SpeechRecognitionResult.isFinal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionresult-isfinal',
-        'isFinal')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresult/item/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/item/index.html
@@ -52,21 +52,7 @@ browser-compat: api.SpeechRecognitionResult.item
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionresult-item', 'item()')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresult/length/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/length/index.html
@@ -57,21 +57,7 @@ browser-compat: api.SpeechRecognitionResult.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionresult-length', 'length')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresultlist/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.html
@@ -50,20 +50,7 @@ browser-compat: api.SpeechRecognitionResultList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechreco-resultlist', 'SpeechRecognitionResultList')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresultlist/item/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/item/index.html
@@ -52,21 +52,7 @@ browser-compat: api.SpeechRecognitionResultList.item
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionresultlist-item',
-        'item()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechrecognitionresultlist/length/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/length/index.html
@@ -53,21 +53,7 @@ browser-compat: api.SpeechRecognitionResultList.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechrecognitionresultlist-length',
-        'length')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/cancel/index.html
+++ b/files/en-us/web/api/speechsynthesis/cancel/index.html
@@ -47,21 +47,7 @@ synth.cancel(); // utterance1 stops being spoken immediately, and both are remov
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-cancel', 'cancel()')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/getvoices/index.html
+++ b/files/en-us/web/api/speechsynthesis/getvoices/index.html
@@ -78,21 +78,7 @@ if (typeof speechSynthesis !== 'undefined' &amp;&amp; speechSynthesis.onvoicesch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesis-getvoices', 'getVoices()')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/index.html
+++ b/files/en-us/web/api/speechsynthesis/index.html
@@ -121,20 +121,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#tts-section', 'SpeechSynthesis')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.html
+++ b/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.html
@@ -68,21 +68,7 @@ if (speechSynthesis.onvoiceschanged !== undefined) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesis-onvoiceschanged',
-        'onvoiceschanged')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/pause/index.html
+++ b/files/en-us/web/api/speechsynthesis/pause/index.html
@@ -45,21 +45,7 @@ synth.pause(); // pauses utterances being spoken</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-pause', 'pause()')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/paused/index.html
+++ b/files/en-us/web/api/speechsynthesis/paused/index.html
@@ -46,21 +46,7 @@ var amIPaused = synth.paused; // will return true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-paused', 'paused')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/pending/index.html
+++ b/files/en-us/web/api/speechsynthesis/pending/index.html
@@ -43,21 +43,7 @@ var amIPending = synth.pending; // will return true if utterance 1 is still bein
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-pending', 'pending')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/resume/index.html
+++ b/files/en-us/web/api/speechsynthesis/resume/index.html
@@ -48,21 +48,7 @@ synth.resume() // resumes speaking</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-resume', 'resume()')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/speak/index.html
+++ b/files/en-us/web/api/speechsynthesis/speak/index.html
@@ -64,20 +64,7 @@ browser-compat: api.SpeechSynthesis.speak
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesis-speak', 'speak()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/speaking/index.html
+++ b/files/en-us/web/api/speechsynthesis/speaking/index.html
@@ -45,21 +45,7 @@ var amISpeaking = synth.speaking; // will return true if utterance 1 or utteranc
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesis-speaking',
-				'speaking')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
+++ b/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
@@ -66,20 +66,7 @@ synth.onvoiceschanged = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#tts-events', 'speech synthesis events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.html
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.html
@@ -103,21 +103,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesiserrorevent-error', 'error')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.html
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.html
@@ -63,20 +63,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechsynthesiserrorevent', 'SpeechSynthesisErrorEvent')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/charindex/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/charindex/index.html
@@ -39,21 +39,7 @@ browser-compat: api.SpeechSynthesisEvent.charIndex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesisevent-charindex',
-				'charIndex')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.html
@@ -37,21 +37,7 @@ browser-compat: api.SpeechSynthesisEvent.elapsedTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesisevent-elapsedtime',
-				'elapsedTime')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/index.html
@@ -49,20 +49,7 @@ utterThis.onboundary = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechsynthesisevent', 'SpeechSynthesisEvent')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/name/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/name/index.html
@@ -40,21 +40,7 @@ browser-compat: api.SpeechSynthesisEvent.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesisevent-name', 'name')}}
-			</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/utterance/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/utterance/index.html
@@ -38,21 +38,7 @@ browser-compat: api.SpeechSynthesisEvent.utterance
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#dom-speechsynthesisevent-utterance',
-				'utterance')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.boundary_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/end_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/end_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.end_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/error_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/error_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.error_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/index.html
@@ -101,20 +101,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#tts-section', 'SpeechSynthesisUtterance')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.html
@@ -61,21 +61,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-lang', 'lang')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/mark_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/mark_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.mark_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onboundary/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onboundary/index.html
@@ -60,21 +60,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onboundary',
-        'onboundary')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onend/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onend/index.html
@@ -60,21 +60,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onend', 'onend')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onerror/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onerror/index.html
@@ -58,21 +58,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onerror',
-        'onerror')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onmark/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onmark/index.html
@@ -61,21 +61,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onmark', 'onmark')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onpause/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onpause/index.html
@@ -61,21 +61,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onpause',
-        'onpause')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onresume/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onresume/index.html
@@ -63,21 +63,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onresume',
-        'onresume')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/onstart/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onstart/index.html
@@ -62,21 +62,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-onstart',
-        'onstart')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/pause_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/pause_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.pause_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
@@ -65,21 +65,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-pitch', 'pitch')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.html
@@ -69,21 +69,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-rate', 'rate')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/resume_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/resume_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.resume_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
@@ -62,22 +62,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API',
-        '#dom-speechsynthesisutterance-speechsynthesisutterance',
-        'SpeechSynthesisUtterance()')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/start_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/start_event/index.html
@@ -48,20 +48,7 @@ browser-compat: api.SpeechSynthesisUtterance.start_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Speech API', '#utterance-events', 'speech synthesis utterance events')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/text/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.html
@@ -63,21 +63,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-text', 'text')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/voice/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/voice/index.html
@@ -62,21 +62,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-voice', 'voice')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/volume/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/volume/index.html
@@ -64,21 +64,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisutterance-volume', 'volume')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/default/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/default/index.html
@@ -52,21 +52,7 @@ browser-compat: api.SpeechSynthesisVoice.default
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisvoice-default', 'default')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/index.html
@@ -83,20 +83,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Speech API', '#speechsynthesisvoice', 'SpeechSynthesisVoice')}}</td>
-			<td>{{Spec2('Web Speech API')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/lang/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/lang/index.html
@@ -45,20 +45,7 @@ browser-compat: api.SpeechSynthesisVoice.lang
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisvoice-lang', 'lang')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/localservice/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/localservice/index.html
@@ -52,21 +52,7 @@ browser-compat: api.SpeechSynthesisVoice.localService
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisvoice-localservice',
-        'localService')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/name/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/name/index.html
@@ -45,20 +45,7 @@ browser-compat: api.SpeechSynthesisVoice.name
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisvoice-name', 'name')}}</td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.html
@@ -50,21 +50,7 @@ browser-compat: api.SpeechSynthesisVoice.voiceURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Speech API', '#dom-speechsynthesisvoice-voiceuri', 'voiceURI')}}
-      </td>
-      <td>{{Spec2('Web Speech API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/startoffset/index.html
+++ b/files/en-us/web/api/staticrange/startoffset/index.html
@@ -32,25 +32,7 @@ browser-compat: api.StaticRange.startOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-startoffset', 'startOffset')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Static Range','#dom-staticrange-startoffset','startOffset')}}</td>
-      <td>{{Spec2('Static Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/s* (second part, up to Speech* included) to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `ServiceWorkerGlobalScope.oncontentdelete`, ServiceWorkerGlobalScope's `contentdelete_event`, and `ServiceWorkerRegistration.index` are a draft pages of a proposed API not yet implemented by anyone. I leave it as is for the moment (I _hate_ these draft banners.)
- ServiceWorkerGlobalScope's `periodicsync_event` and `ServiceWorkerGlobalScope.onperiodicsync` are missing `spec_url`. This will be fixed in mdn/browser-compat-data#11054.
- `SourceBuffer.removeAsync()` and `SourceBuffer.appendBufferAsync()` are non-standard. Their previous spec links weren't deep links anyway. I leave it that way.
- `SpeechGrammar()` is non-standard, implemented only with a prefix and the previous link in the removed table was bogus. I keep it with the macro.

All other pages look fine.