### PR TITLE
Replace spec table with {{specifications}} for api/s* (part 3)

### DIFF
--- a/files/en-us/web/api/staticrange/collapsed/index.html
+++ b/files/en-us/web/api/staticrange/collapsed/index.html
@@ -33,25 +33,7 @@ browser-compat: api.StaticRange.collapsed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-collapsed', 'collapsed')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Static Range','#dom-staticrange-collapsed','collapsed')}}</td>
-      <td>{{Spec2('Static Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/endcontainer/index.html
+++ b/files/en-us/web/api/staticrange/endcontainer/index.html
@@ -28,25 +28,7 @@ browser-compat: api.StaticRange.endContainer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-endcontainer', 'endContainer')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Static Range','#dom-staticrange-endcontainer','endContainer')}}</td>
-      <td>{{Spec2('Static Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/endoffset/index.html
+++ b/files/en-us/web/api/staticrange/endoffset/index.html
@@ -33,25 +33,7 @@ browser-compat: api.StaticRange.endOffset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-endoffset', 'endOffset')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Static Range','#dom-staticrange-endoffset','endOffset')}}</td>
-      <td>{{Spec2('Static Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/index.html
+++ b/files/en-us/web/api/staticrange/index.html
@@ -58,25 +58,7 @@ browser-compat: api.StaticRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-staticrange', 'StaticRange')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Static Range','#interface-staticrange','StaticRange')}}</td>
-   <td>{{Spec2('Static Range')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/startcontainer/index.html
+++ b/files/en-us/web/api/staticrange/startcontainer/index.html
@@ -33,26 +33,7 @@ browser-compat: api.StaticRange.startContainer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-range-startcontainer', 'startContainer ')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Static Range','#dom-staticrange-startcontainer','startContainer')}}
-      </td>
-      <td>{{Spec2('Static Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/staticrange/staticrange/index.html
+++ b/files/en-us/web/api/staticrange/staticrange/index.html
@@ -69,20 +69,7 @@ browser-compat: api.StaticRange.StaticRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-staticrange-staticrange','StaticRange()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/index.html
@@ -71,20 +71,7 @@ browser-compat: api.StereoPannerNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#stereopannernode', 'StereoPannerNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stereopannernode/pan/index.html
+++ b/files/en-us/web/api/stereopannernode/pan/index.html
@@ -37,20 +37,7 @@ panNode.pan.value = -0.5;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-stereopannernode-pan', 'pan')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stereopannernode/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/stereopannernode/index.html
@@ -48,20 +48,7 @@ browser-compat: api.StereoPannerNode.StereoPannerNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web Audio API','#dom-stereopannernode-stereopannernode','StereoPannerNode()')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/clear/index.html
+++ b/files/en-us/web/api/storage/clear/index.html
@@ -42,23 +42,7 @@ browser-compat: api.Storage.clear
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-clear',
-        'Storage.clear')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/getitem/index.html
+++ b/files/en-us/web/api/storage/getitem/index.html
@@ -59,21 +59,7 @@ browser-compat: api.Storage.getItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-getitem',
-        'Storage.getItem')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/index.html
+++ b/files/en-us/web/api/storage/index.html
@@ -76,20 +76,7 @@ function setStyles() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#storage', 'Storage')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/key/index.html
+++ b/files/en-us/web/api/storage/key/index.html
@@ -57,21 +57,7 @@ browser-compat: api.Storage.key
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-key', 'Storage.key')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/length/index.html
+++ b/files/en-us/web/api/storage/length/index.html
@@ -44,21 +44,7 @@ browser-compat: api.Storage.length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-length',
-        'Storage.length')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/removeitem/index.html
+++ b/files/en-us/web/api/storage/removeitem/index.html
@@ -66,23 +66,7 @@ browser-compat: api.Storage.removeItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-removeitem',
-        'Storage.removeItem')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storage/setitem/index.html
+++ b/files/en-us/web/api/storage/setitem/index.html
@@ -60,21 +60,7 @@ browser-compat: api.Storage.setItem
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-setitem',
-        'Storage.setItem')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storageestimate/index.html
+++ b/files/en-us/web/api/storageestimate/index.html
@@ -33,20 +33,7 @@ browser-compat: api.StorageEstimate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Storage', '#dictdef-storageestimate', 'StorageEstimate')}}</td>
-   <td>{{Spec2('Storage')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storageestimate/quota/index.html
+++ b/files/en-us/web/api/storageestimate/quota/index.html
@@ -36,22 +36,7 @@ browser-compat: api.StorageEstimate.quota
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Storage', '#dom-storageestimate-quota', 'quota')}}</td>
-      <td>{{Spec2('Storage')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storageestimate/usage/index.html
+++ b/files/en-us/web/api/storageestimate/usage/index.html
@@ -36,22 +36,7 @@ browser-compat: api.StorageEstimate.usage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Storage', '#dom-storageestimate-usage', 'usage')}}</td>
-      <td>{{Spec2('Storage')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storageevent/index.html
+++ b/files/en-us/web/api/storageevent/index.html
@@ -112,23 +112,7 @@ browser-compat: api.StorageEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Statuc</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "webstorage.html#the-storageevent-interface", "The
-        <code>StorageEvent</code> interface")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storagemanager/estimate/index.html
+++ b/files/en-us/web/api/storagemanager/estimate/index.html
@@ -70,22 +70,7 @@ browser-compat: api.StorageManager.estimate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Storage','#dom-storagemanager-estimate','estimate()')}}</td>
-   <td>{{Spec2('Storage')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storagemanager/index.html
+++ b/files/en-us/web/api/storagemanager/index.html
@@ -31,20 +31,7 @@ browser-compat: api.StorageManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Storage','#storagemanager','StorageManger')}}</td>
-			<td>{{Spec2('Storage')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storagemanager/persist/index.html
+++ b/files/en-us/web/api/storagemanager/persist/index.html
@@ -41,20 +41,7 @@ browser-compat: api.StorageManager.persist
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Storage','#dom-storagemanager-persist','persist')}}</td>
-      <td>{{Spec2('Storage')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/storagemanager/persisted/index.html
+++ b/files/en-us/web/api/storagemanager/persisted/index.html
@@ -40,20 +40,7 @@ browser-compat: api.StorageManager.persisted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Storage','#dom-storagemanager-persisted','persisted')}}</td>
-      <td>{{Spec2('Storage')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymap/append/index.html
+++ b/files/en-us/web/api/stylepropertymap/append/index.html
@@ -51,20 +51,7 @@ buttonEl.attributeStyleMap.append('background-image', 'linear-gradient(180deg, b
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymap-append','append()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymap/clear/index.html
+++ b/files/en-us/web/api/stylepropertymap/clear/index.html
@@ -42,20 +42,7 @@ buttonEl.attributeStyleMap.clear();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymap-clear','clear()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymap/delete/index.html
+++ b/files/en-us/web/api/stylepropertymap/delete/index.html
@@ -48,20 +48,7 @@ buttonEl.attributeStyleMap.delete('background-image');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymap-delete','delete()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymap/index.html
+++ b/files/en-us/web/api/stylepropertymap/index.html
@@ -38,20 +38,7 @@ browser-compat: api.StylePropertyMap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Typed OM", "#stylepropertymap", "StylePropertyMap")}}</td>
-   <td>{{Spec2("CSS Typed OM")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymap/set/index.html
+++ b/files/en-us/web/api/stylepropertymap/set/index.html
@@ -50,20 +50,7 @@ buttonEl.attributeStyleMap.set('padding-top', CSS.px(10));
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymap-set','set()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/entries/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/entries/index.html
@@ -53,20 +53,7 @@ console.log(iterableStyles.next().value);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#the-stylepropertymap','entries()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/foreach/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/foreach/index.html
@@ -67,20 +67,7 @@ allComputedStyles.forEach((elem, index, arr) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#the-stylepropertymap','forEach()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/get/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/get/index.html
@@ -92,20 +92,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymapreadonly-get','get()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/getall/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/getall/index.html
@@ -55,21 +55,7 @@ console.log(allBkImages); // logs an array with each background image as an item
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymapreadonly-getall','getAll()')}}
-      </td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/has/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/has/index.html
@@ -50,20 +50,7 @@ console.log(hasPadTop); // logs true if padding-top is present in style attribut
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymapreadonly-has','has()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.html
@@ -88,20 +88,7 @@ for (const [prop, val] of stylePropertyMap) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Typed OM','#stylepropertymapreadonly','StylePropertyMapReadOnly')}}</td>
-   <td>{{Spec2('CSS Typed OM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/keys/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/keys/index.html
@@ -48,20 +48,7 @@ console.log(props.next().value); // returns align-content
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#the-stylepropertymap','keys()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/size/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/size/index.html
@@ -45,20 +45,7 @@ console.log(amountStyles); // logs 338
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#dom-stylepropertymapreadonly-size','size')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylepropertymapreadonly/values/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/values/index.html
@@ -50,20 +50,7 @@ console.log(vals.next().value); // returns a CSSStyleValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('CSS Typed OM','#the-stylepropertymap','values()')}}</td>
-      <td>{{Spec2('CSS Typed OM')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/disabled/index.html
+++ b/files/en-us/web/api/stylesheet/disabled/index.html
@@ -36,26 +36,7 @@ if (stylesheet.disabled) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-stylesheet-disabled", "StyleSheet.disabled")}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td>No change from {{SpecName("DOM2 Style")}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM2 Style", "stylesheets.html#StyleSheets-StyleSheet-disabled",
-        "StyleSheet.disabled")}}</td>
-      <td>{{Spec2("DOM2 Style")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/href/index.html
+++ b/files/en-us/web/api/stylesheet/href/index.html
@@ -54,22 +54,7 @@ browser-compat: api.StyleSheet.href
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-stylesheet-href", "StyleSheet: href")}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/index.html
@@ -36,25 +36,7 @@ browser-compat: api.StyleSheet
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSSOM', '#stylesheet', 'StyleSheet') }}</td>
-   <td>{{ Spec2('CSSOM') }}</td>
-   <td>No change from {{ SpecName('DOM2 Style') }}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('DOM2 Style', 'stylesheets.html#StyleSheets-StyleSheet', 'StyleSheet') }}</td>
-   <td>{{ Spec2('DOM2 Style') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/media/index.html
+++ b/files/en-us/web/api/stylesheet/media/index.html
@@ -51,22 +51,7 @@ document.styleSheets[1].media: {"0":"screen"}
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM', '#dom-stylesheet-media', 'StyleSheet: media')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/ownernode/index.html
+++ b/files/en-us/web/api/stylesheet/ownernode/index.html
@@ -47,22 +47,7 @@ browser-compat: api.StyleSheet.ownerNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSSOM', '#dom-stylesheet-ownernode', 'StyleSheet: ownerNode')}}</td>
-      <td>{{Spec2('CSSOM')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/parentstylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/parentstylesheet/index.html
@@ -36,23 +36,7 @@ if (stylesheet.parentStyleSheet) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-stylesheet-parentstylesheet", "StyleSheet:
-        parentStyleSheet")}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/title/index.html
+++ b/files/en-us/web/api/stylesheet/title/index.html
@@ -17,22 +17,7 @@ browser-compat: api.StyleSheet.title
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM", "#dom-stylesheet-title", "StyleSheet: title")}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheet/type/index.html
+++ b/files/en-us/web/api/stylesheet/type/index.html
@@ -26,22 +26,7 @@ browser-compat: api.StyleSheet.type
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSSOM", "#dom-stylesheet-type", "StyleSheet: type")}}</td>
-      <td>{{Spec2("CSSOM")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/stylesheetlist/index.html
+++ b/files/en-us/web/api/stylesheetlist/index.html
@@ -39,22 +39,7 @@ browser-compat: api.StyleSheetList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSSOM", "#the-stylesheetlist-interface", 'CSSStyleSheetList')}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/submitevent/index.html
+++ b/files/en-us/web/api/submitevent/index.html
@@ -60,22 +60,7 @@ form.addEventListener("submit", (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "form-control-infrastructure.html#submitevent", "SubmitEvent")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/submitevent/submitevent/index.html
+++ b/files/en-us/web/api/submitevent/submitevent/index.html
@@ -60,23 +60,7 @@ form.dispatchEvent(submitEvent);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "form-control-infrastructure.html#submitevent",
-        "SubmitEvent()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/submitevent/submitter/index.html
+++ b/files/en-us/web/api/submitevent/submitter/index.html
@@ -41,24 +41,7 @@ browser-compat: api.SubmitEvent.submitter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG',
-        "form-control-infrastructure.html#dom-submitevent-submitter",
-        "SubmitEvent.submitter")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.html
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.html
@@ -161,21 +161,7 @@ browser-compat: api.SubtleCrypto.decrypt
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#SubtleCrypto-method-decrypt',
-        'SubtleCrypto.decrypt()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.html
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.html
@@ -238,21 +238,7 @@ deriveBitsButton.addEventListener("click", () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-deriveBits',
-        'SubtleCrypto.deriveBits()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.html
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.html
@@ -295,21 +295,7 @@ async function encrypt(plaintext, salt, iv) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-deriveKey',
-        'SubtleCrypto.deriveKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/digest/index.html
+++ b/files/en-us/web/api/subtlecrypto/digest/index.html
@@ -154,23 +154,7 @@ console.log(digestHex);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-digest',
-        'SubtleCrypto.digest()')}}</td>
-      <td>{{Spec2('Web Crypto API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/encrypt/index.html
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.html
@@ -267,21 +267,7 @@ function encryptMessage(key) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#SubtleCrypto-method-encrypt',
-        'SubtleCrypto.encrypt()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/exportkey/index.html
+++ b/files/en-us/web/api/subtlecrypto/exportkey/index.html
@@ -286,21 +286,7 @@ window.crypto.subtle.generateKey(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-exportKey',
-        'SubtleCrypto.exportKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/generatekey/index.html
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.html
@@ -168,21 +168,7 @@ browser-compat: api.SubtleCrypto.generateKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-generateKey',
-        'SubtleCrypto.generateKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/importkey/index.html
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.html
@@ -427,21 +427,7 @@ function importPrivateKey(jwk) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-importKey',
-        'SubtleCrypto.importKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/index.html
+++ b/files/en-us/web/api/subtlecrypto/index.html
@@ -264,20 +264,7 @@ browser-compat: api.SubtleCrypto
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('Web Crypto API', '#subtlecrypto-interface', 'SubtleCrypto') }}</td>
-   <td>{{ Spec2('Web Crypto API') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/sign/index.html
+++ b/files/en-us/web/api/subtlecrypto/sign/index.html
@@ -244,21 +244,7 @@ let signature = await window.crypto.subtle.sign(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-sign',
-        'SubtleCrypto.sign()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/unwrapkey/index.html
+++ b/files/en-us/web/api/subtlecrypto/unwrapkey/index.html
@@ -504,21 +504,7 @@ async function unwrapPrivateKey(wrappedKey) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-unwrapKey',
-        'SubtleCrypto.unwrapKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/verify/index.html
+++ b/files/en-us/web/api/subtlecrypto/verify/index.html
@@ -245,21 +245,7 @@ async function verifyMessage(key) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-verify',
-        'SubtleCrypto.verify()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/subtlecrypto/wrapkey/index.html
+++ b/files/en-us/web/api/subtlecrypto/wrapkey/index.html
@@ -504,21 +504,7 @@ window.crypto.subtle.generateKey(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{ SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-wrapKey',
-        'SubtleCrypto.wrapKey()') }}</td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaelement/index.html
+++ b/files/en-us/web/api/svgaelement/index.html
@@ -61,27 +61,7 @@ linkRef.onclick = function(){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "linking.html#InterfaceSVGAElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced inheritance from {{domxref("SVGElement")}} by {{domxref("SVGGraphicsElement")}} and removed the interface implementations of <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("HTMLHyperlinkElementUtils")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "linking.html#InterfaceSVGAElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaelement/target/index.html
+++ b/files/en-us/web/api/svgaelement/target/index.html
@@ -38,20 +38,7 @@ linkRef.target ='_blank';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'linking.html#InterfaceSVGAElement', 'target')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaltglyphdefelement/index.html
+++ b/files/en-us/web/api/svgaltglyphdefelement/index.html
@@ -29,20 +29,7 @@ browser-compat: api.SVGAltGlyphDefElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGAltGlyphDefElement", "SVGAltGlyphDefElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaltglyphelement/format/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/format/index.html
@@ -85,20 +85,7 @@ browser-compat: api.SVGAltGlyphElement.format
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <td>Specification</td>
-            <td>Status</td>
-            <td>Comment</td>
-        </tr>
-        <tr>
-            <td>{{SpecName('SVG1.1', '#format', 'format')}}</td>
-            <td>{{Spec2('SVG1.1')}}</td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaltglyphelement/glyphref/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/glyphref/index.html
@@ -37,20 +37,7 @@ browser-compat: api.SVGAltGlyphElement.glyphRef
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>Specification</td>
-      <td>Status</td>
-      <td>Comment</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG1.1', 'text.html#InterfaceSVGGlyphRefElement', 'glyphRef')}}</td>
-      <td>{{Spec2('SVG1.1')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaltglyphelement/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/index.html
@@ -31,20 +31,7 @@ browser-compat: api.SVGAltGlyphElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGAltGlyphElement", "SVGAltGlyphElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgaltglyphitemelement/index.html
+++ b/files/en-us/web/api/svgaltglyphitemelement/index.html
@@ -29,20 +29,7 @@ browser-compat: api.SVGAltGlyphItemElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGAltGlyphItemElement", "SVGAltGlyphItemElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgangle/index.html
+++ b/files/en-us/web/api/svgangle/index.html
@@ -85,27 +85,7 @@ browser-compat: api.SVGAngle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#InterfaceSVGAngle", "SVGElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Adds the {{domxref("SVGElement.dataset", "dataset")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "types.html#InterfaceSVGAngle", "SVGElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatecolorelement/index.html
+++ b/files/en-us/web/api/svganimatecolorelement/index.html
@@ -26,20 +26,7 @@ browser-compat: api.SVGAnimateColorElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGAnimateColorElement", "SVGAnimateColorElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatedstring/animval/index.html
+++ b/files/en-us/web/api/svganimatedstring/animval/index.html
@@ -17,25 +17,7 @@ browser-compat: api.SVGAnimatedString.animVal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'types.html#__svg__SVGAnimatedString__animVal')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'types.html#__svg__SVGAnimatedString__animVal')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatedstring/baseval/index.html
+++ b/files/en-us/web/api/svganimatedstring/baseval/index.html
@@ -9,25 +9,7 @@ browser-compat: api.SVGAnimatedString.baseVal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'types.html#__svg__SVGAnimatedString__baseVal')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'types.html#__svg__SVGAnimatedString__baseVal')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatedstring/index.html
+++ b/files/en-us/web/api/svganimatedstring/index.html
@@ -28,25 +28,7 @@ browser-compat: api.SVGAnimatedString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'types.html#InterfaceSVGAnimatedString')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'types.html#InterfaceSVGAnimatedString')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimateelement/index.html
+++ b/files/en-us/web/api/svganimateelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGAnimateElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGAnimateElement", "SVGAnimateElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>Removed the inheritance from <code>SVGStylable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGAnimateElement", "SVGAnimateElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatemotionelement/index.html
+++ b/files/en-us/web/api/svganimatemotionelement/index.html
@@ -24,25 +24,7 @@ browser-compat: api.SVGAnimateMotionElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGAnimateMotionElement", "SVGAnimateMotionElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGAnimateMotionElement", "SVGAnimateMotionElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimatetransformelement/index.html
+++ b/files/en-us/web/api/svganimatetransformelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGAnimateTransformElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGAnimateTransformElement", "SVGAnimateTransformElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGAnimateTransformElement", "SVGAnimateTransformElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/beginevent_event/index.html
+++ b/files/en-us/web/api/svganimationelement/beginevent_event/index.html
@@ -96,20 +96,7 @@ animateElem.addEventListener('repeatEvent', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-BeginEvent', 'beginEvent')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/endevent_event/index.html
+++ b/files/en-us/web/api/svganimationelement/endevent_event/index.html
@@ -111,20 +111,7 @@ btn.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-EndEvent', 'endEvent')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/index.html
+++ b/files/en-us/web/api/svganimationelement/index.html
@@ -71,25 +71,7 @@ browser-compat: api.SVGAnimationElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGAnimationElement", "SVGAnimationElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGAnimationElement", "SVGAnimationElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/onbegin/index.html
+++ b/files/en-us/web/api/svganimationelement/onbegin/index.html
@@ -26,21 +26,7 @@ browser-compat: api.SVGAnimationElement.onbegin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>Specification</td>
-      <td>Status</td>
-      <td>Comment</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG Animations 2", "#__svg__SVGAnimationElement__onbegin",
-        "SVGAnimationElement.onbegin")}}</td>
-      <td>{{Spec2("SVG Animations 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/onend/index.html
+++ b/files/en-us/web/api/svganimationelement/onend/index.html
@@ -26,21 +26,7 @@ browser-compat: api.SVGAnimationElement.onend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>Specification</td>
-      <td>Status</td>
-      <td>Comment</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG Animations 2", "#__svg__SVGAnimationElement__onend",
-        "SVGAnimationElement.onend")}}</td>
-      <td>{{Spec2("SVG Animations 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/onrepeat/index.html
+++ b/files/en-us/web/api/svganimationelement/onrepeat/index.html
@@ -26,21 +26,7 @@ browser-compat: api.SVGAnimationElement.onrepeat
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>Specification</td>
-      <td>Status</td>
-      <td>Comment</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG Animations 2", "#__svg__SVGAnimationElement__onrepeat",
-        "SVGAnimationElement.onrepeat")}}</td>
-      <td>{{Spec2("SVG Animations 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/repeatevent_event/index.html
+++ b/files/en-us/web/api/svganimationelement/repeatevent_event/index.html
@@ -98,20 +98,7 @@ animateElem.addEventListener('repeatEvent', (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-RepeatEvent', 'repeatEvent')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svganimationelement/targetelement/index.html
+++ b/files/en-us/web/api/svganimationelement/targetelement/index.html
@@ -25,28 +25,7 @@ browser-compat: api.SVGAnimationElement.targetElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>Specification</td>
-      <td>Status</td>
-      <td>Comment</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG Animations 2", "#__svg__SVGAnimationElement__targetElement",
-        "SVGAnimationElement.targetElement")}}</td>
-      <td>{{Spec2("SVG Animations 2")}}</td>
-      <td>Added <code>null</code> as return value in case that no target element is being
-        animated.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG1.1", "animate.html#__svg__SVGAnimationElement__targetElement",
-        "SVGAnimationElement.targetElement")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcircleelement/cx/index.html
+++ b/files/en-us/web/api/svgcircleelement/cx/index.html
@@ -41,25 +41,7 @@ console.log(circle.cx);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#__svg__SVGCircleElement__cx", "SVGCircleElement.cx")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#__svg__SVGCircleElement__cx", "SVGCircleElement.cx")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcircleelement/cy/index.html
+++ b/files/en-us/web/api/svgcircleelement/cy/index.html
@@ -41,25 +41,7 @@ console.log(circle.cy);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#__svg__SVGCircleElement__cy", "SVGCircleElement.cy")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#__svg__SVGCircleElement__cy", "SVGCircleElement.cy")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcircleelement/index.html
+++ b/files/en-us/web/api/svgcircleelement/index.html
@@ -69,25 +69,7 @@ browser-compat: api.SVGCircleElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGCircleElement", "SVGCircleElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGCircleElement", "SVGCircleElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcircleelement/r/index.html
+++ b/files/en-us/web/api/svgcircleelement/r/index.html
@@ -41,25 +41,7 @@ console.log(circle.r);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#__svg__SVGCircleElement__r", "SVGCircleElement.r")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#__svg__SVGCircleElement__r", "SVGCircleElement.r")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgclippathelement/index.html
+++ b/files/en-us/web/api/svgclippathelement/index.html
@@ -30,25 +30,7 @@ browser-compat: api.SVGClipPathElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#InterfaceSVGClipPathElement", "SVGClipPathElement")}}</td>
-   <td>{{Spec2("CSS Masks")}}</td>
-   <td>Removed the inheritance from <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, <code>SVGTransformable</code>, and {{domxref("SVGUnitTypes")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "masking.html#InterfaceSVGClipPathElement", "SVGClipPathElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcomponenttransferfunctionelement/index.html
+++ b/files/en-us/web/api/svgcomponenttransferfunctionelement/index.html
@@ -84,25 +84,7 @@ browser-compat: api.SVGComponentTransferFunctionElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGComponentTransferFunctionElement", "SVGComponentTransferFunctionElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGComponentTransferFunctionElement", "SVGComponentTransferFunctionElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgcursorelement/index.html
+++ b/files/en-us/web/api/svgcursorelement/index.html
@@ -32,20 +32,7 @@ browser-compat: api.SVGCursorElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "interact.html#InterfaceSVGCursorElement", "SVGCursorElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgdefselement/index.html
+++ b/files/en-us/web/api/svgdefselement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGDefsElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGDefsElement", "SVGDefsElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGraphicsElement")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGDefsElement", "SVGDefsElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgdescelement/index.html
+++ b/files/en-us/web/api/svgdescelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGDescElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGDescElement", "SVGDescElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the inheritance from <code>SVGLangSpace</code> and <code>SVGStylable</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGDescElement", "SVGDescElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/error_event/index.html
+++ b/files/en-us/web/api/svgelement/error_event/index.html
@@ -44,20 +44,7 @@ browser-compat: api.SVGElement.error_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-ErrorEvent', 'error')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/index.html
+++ b/files/en-us/web/api/svgelement/index.html
@@ -67,25 +67,7 @@ browser-compat: api.SVGElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("SVG2", "types.html#InterfaceSVGElement", "SVGElement")}}</td>
-			<td>{{Spec2("SVG2")}}</td>
-			<td>Adds the {{DOMxRef("SVGElement.dataset", "dataset")}} property.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("SVG1.1", "types.html#InterfaceSVGElement", "SVGElement")}}</td>
-			<td>{{Spec2("SVG1.1")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/load_event/index.html
+++ b/files/en-us/web/api/svgelement/load_event/index.html
@@ -42,20 +42,7 @@ browser-compat: api.SVGElement.load_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-LoadEvent', 'load')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/resize_event/index.html
+++ b/files/en-us/web/api/svgelement/resize_event/index.html
@@ -44,20 +44,7 @@ browser-compat: api.SVGElement.resize_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#changes-interact', 'event changes in SVG2')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/scroll_event/index.html
+++ b/files/en-us/web/api/svgelement/scroll_event/index.html
@@ -42,20 +42,7 @@ browser-compat: api.SVGElement.scroll_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#changes-interact', 'event changes in SVG2')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgelement/unload_event/index.html
+++ b/files/en-us/web/api/svgelement/unload_event/index.html
@@ -42,20 +42,7 @@ browser-compat: api.SVGElement.unload_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG2', 'single-page.html#interact-UnloadEvent', 'unload')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgellipseelement/index.html
+++ b/files/en-us/web/api/svgellipseelement/index.html
@@ -60,27 +60,7 @@ browser-compat: api.SVGEllipseElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGEllipseElement", "SVGEllipseElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGEllipseElement", "SVGEllipseElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfeblendelement/index.html
+++ b/files/en-us/web/api/svgfeblendelement/index.html
@@ -86,25 +86,7 @@ browser-compat: api.SVGFEBlendElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEBlendElement", "SVGFEBlendElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEBlendElement", "SVGFEBlendElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfecolormatrixelement/index.html
+++ b/files/en-us/web/api/svgfecolormatrixelement/index.html
@@ -83,25 +83,7 @@ browser-compat: api.SVGFEColorMatrixElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEColorMatrixElement", "SVGFEColorMatrixElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEColorMatrixElement", "SVGFEColorMatrixElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfecomponenttransferelement/index.html
+++ b/files/en-us/web/api/svgfecomponenttransferelement/index.html
@@ -40,25 +40,7 @@ browser-compat: api.SVGFEComponentTransferElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEComponentTransferElement", "SVGFEComponentTransferElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEComponentTransferElement", "SVGFEComponentTransferElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfecompositeelement/index.html
+++ b/files/en-us/web/api/svgfecompositeelement/index.html
@@ -91,25 +91,7 @@ browser-compat: api.SVGFECompositeElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFECompositeElement", "SVGFECompositeElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFECompositeElement", "SVGFECompositeElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfeconvolvematrixelement/index.html
+++ b/files/en-us/web/api/svgfeconvolvematrixelement/index.html
@@ -94,25 +94,7 @@ browser-compat: api.SVGFEConvolveMatrixElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEConvolveMatrixElement", "SVGFEConvolveMatrixElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEConvolveMatrixElement", "SVGFEConvolveMatrixElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfediffuselightingelement/index.html
+++ b/files/en-us/web/api/svgfediffuselightingelement/index.html
@@ -48,25 +48,7 @@ browser-compat: api.SVGFEDiffuseLightingElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEDiffuseLightingElement", "SVGFEDiffuseLightingElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEDiffuseLightingElement", "SVGFEDiffuseLightingElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfedisplacementmapelement/index.html
+++ b/files/en-us/web/api/svgfedisplacementmapelement/index.html
@@ -85,25 +85,7 @@ browser-compat: api.SVGFEDisplacementMapElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEDisplacementMapElement", "SVGFEDisplacementMapElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEDisplacementMapElement", "SVGFEDisplacementMapElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfedistantlightelement/index.html
+++ b/files/en-us/web/api/svgfedistantlightelement/index.html
@@ -32,25 +32,7 @@ browser-compat: api.SVGFEDistantLightElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEDistantLightElement", "SVGFEDistantLightElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEDistantLightElement", "SVGFEDistantLightElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfedropshadowelement/index.html
+++ b/files/en-us/web/api/svgfedropshadowelement/index.html
@@ -53,20 +53,7 @@ browser-compat: api.SVGFEDropShadowElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEDropShadowElement", "SVGFEDropShadowElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfefloodelement/index.html
+++ b/files/en-us/web/api/svgfefloodelement/index.html
@@ -38,25 +38,7 @@ browser-compat: api.SVGFEFloodElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEFloodElement", "SVGFEFloodElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEFloodElement", "SVGFEFloodElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfefuncaelement/index.html
+++ b/files/en-us/web/api/svgfefuncaelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGFEFuncAElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEFuncAElement", "SVGFEFuncAElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEFuncAElement", "SVGFEFuncAElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfefuncbelement/index.html
+++ b/files/en-us/web/api/svgfefuncbelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGFEFuncBElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEFuncBElement", "SVGFEFuncBElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEFuncBElement", "SVGFEFuncBElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfefuncgelement/index.html
+++ b/files/en-us/web/api/svgfefuncgelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGFEFuncGElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEFuncGElement", "SVGFEFuncGElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEFuncGElement", "SVGFEFuncGElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfefuncrelement/index.html
+++ b/files/en-us/web/api/svgfefuncrelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGFEFuncRElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEFuncRElement", "SVGFEFuncRElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEFuncRElement", "SVGFEFuncRElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfegaussianblurelement/index.html
+++ b/files/en-us/web/api/svgfegaussianblurelement/index.html
@@ -83,25 +83,7 @@ browser-compat: api.SVGFEGaussianBlurElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEGaussianBlurElement", "SVGFEGaussianBlurElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Added <code>edgeMode</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEGaussianBlurElement", "SVGFEGaussianBlurElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfeimageelement/index.html
+++ b/files/en-us/web/api/svgfeimageelement/index.html
@@ -44,25 +44,7 @@ browser-compat: api.SVGFEImageElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEImageElement", "SVGFEImageElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEImageElement", "SVGFEImageElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfemergeelement/index.html
+++ b/files/en-us/web/api/svgfemergeelement/index.html
@@ -38,25 +38,7 @@ browser-compat: api.SVGFEMergeElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEMergeElement", "SVGFEMergeElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEMergeElement", "SVGFEMergeElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfemergenodeelement/index.html
+++ b/files/en-us/web/api/svgfemergenodeelement/index.html
@@ -30,25 +30,7 @@ browser-compat: api.SVGFEMergeNodeElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEMergeNodeElement", "SVGFEMergeNodeElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEMergeNodeElement", "SVGFEMergeNodeElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfemorphologyelement/index.html
+++ b/files/en-us/web/api/svgfemorphologyelement/index.html
@@ -73,25 +73,7 @@ browser-compat: api.SVGFEMorphologyElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEMorphologyElement", "SVGFEMorphologyElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEMorphologyElement", "SVGFEMorphologyElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfeoffsetelement/index.html
+++ b/files/en-us/web/api/svgfeoffsetelement/index.html
@@ -44,25 +44,7 @@ browser-compat: api.SVGFEOffsetElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEOffsetElement", "SVGFEOffsetElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEOffsetElement", "SVGFEOffsetElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfepointlightelement/index.html
+++ b/files/en-us/web/api/svgfepointlightelement/index.html
@@ -34,25 +34,7 @@ browser-compat: api.SVGFEPointLightElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFEPointLightElement", "SVGFEPointLightElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFEPointLightElement", "SVGFEPointLightElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfespecularlightingelement/index.html
+++ b/files/en-us/web/api/svgfespecularlightingelement/index.html
@@ -50,25 +50,7 @@ browser-compat: api.SVGFESpecularLightingElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFESpecularLightingElement", "SVGFESpecularLightingElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFESpecularLightingElement", "SVGFESpecularLightingElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfespotlightelement/index.html
+++ b/files/en-us/web/api/svgfespotlightelement/index.html
@@ -44,25 +44,7 @@ browser-compat: api.SVGFESpotLightElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFESpotLightElement", "SVGFESpotLightElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFESpotLightElement", "SVGFESpotLightElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfetileelement/index.html
+++ b/files/en-us/web/api/svgfetileelement/index.html
@@ -40,25 +40,7 @@ browser-compat: api.SVGFETileElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFETileElement", "SVGFETileElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFETileElement", "SVGFETileElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfeturbulenceelement/index.html
+++ b/files/en-us/web/api/svgfeturbulenceelement/index.html
@@ -106,25 +106,7 @@ browser-compat: api.SVGFETurbulenceElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFETurbulenceElement", "SVGFETurbulenceElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFETurbulenceElement", "SVGFETurbulenceElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfilterelement/index.html
+++ b/files/en-us/web/api/svgfilterelement/index.html
@@ -47,25 +47,7 @@ browser-compat: api.SVGFilterElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Filters 1.0", "#InterfaceSVGFilterElement", "SVGFilterElement")}}</td>
-   <td>{{Spec2("Filters 1.0")}}</td>
-   <td>Removed the inheritance from <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGUnitTypes")}} and removed the <code>setFilterRes()</code> function</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "filters.html#InterfaceSVGFilterElement", "SVGFilterElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontelement/index.html
+++ b/files/en-us/web/api/svgfontelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontElement", "SVGFontElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontfaceelement/index.html
+++ b/files/en-us/web/api/svgfontfaceelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontFaceElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontFaceElement", "SVGFontFaceElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontfaceformatelement/index.html
+++ b/files/en-us/web/api/svgfontfaceformatelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontFaceFormatElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontFaceFormatElement", "SVGFontFaceFormatElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontfacenameelement/index.html
+++ b/files/en-us/web/api/svgfontfacenameelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontFaceNameElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontFaceNameElement", "SVGFontFaceNameElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontfacesrcelement/index.html
+++ b/files/en-us/web/api/svgfontfacesrcelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontFaceSrcElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontFaceSrcElement", "SVGFontFaceSrcElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgfontfaceurielement/index.html
+++ b/files/en-us/web/api/svgfontfaceurielement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGFontFaceUriElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGFontFaceUriElement", "SVGFontFaceUriElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgforeignobjectelement/index.html
+++ b/files/en-us/web/api/svgforeignobjectelement/index.html
@@ -36,25 +36,7 @@ browser-compat: api.SVGForeignObjectElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "embedded.html#ForeignObjectElement", "SVGForeignObjectElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGraphicsElement")}} and {{domxref("SVGURIReference")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "extend.html#InterfaceSVGForeignObjectElement", "SVGForeignObjectElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggelement/index.html
+++ b/files/en-us/web/api/svggelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGGElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGGElement", "SVGGElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGGElement", "SVGGElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/getpointatlength/index.html
+++ b/files/en-us/web/api/svggeometryelement/getpointatlength/index.html
@@ -35,23 +35,7 @@ browser-compat: api.SVGGeometryElement.getPointAtLength
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("SVG2", "types.html#__svg__SVGGeometryElement__getPointAtLength",
-        "SVGGeometryElement.getTotalLength()")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/gettotallength/index.html
+++ b/files/en-us/web/api/svggeometryelement/gettotallength/index.html
@@ -27,21 +27,7 @@ browser-compat: api.SVGGeometryElement.getTotalLength
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "types.html#__svg__SVGGeometryElement__getTotalLength",
-        "SVGGeometryElement.getTotalLength()")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/index.html
+++ b/files/en-us/web/api/svggeometryelement/index.html
@@ -42,20 +42,7 @@ browser-compat: api.SVGGeometryElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#InterfaceSVGGeometryElement", "SVGGeometryElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.html
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.html
@@ -64,21 +64,7 @@ console.log('Point at 40,30:', circle.isPointInFill(new DOMPoint(40, 30)));</pre
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "types.html#__svg__SVGGeometryElement__isPointInFill",
-        "SVGGeometryElement.isPointInFill()")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.html
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.html
@@ -69,21 +69,7 @@ console.log('Point at 83,17:', circle.isPointInStroke(new DOMPoint(83, 17)));</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "types.html#__svg__SVGGeometryElement__isPointInStroke",
-        "SVGGeometryElement.isPointInStroke()")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggeometryelement/pathlength/index.html
+++ b/files/en-us/web/api/svggeometryelement/pathlength/index.html
@@ -24,21 +24,7 @@ browser-compat: api.SVGGeometryElement.pathLength
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "types.html#__svg__SVGGeometryElement__pathLength",
-        "SVGGeometryElement.pathLength")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgglyphelement/index.html
+++ b/files/en-us/web/api/svgglyphelement/index.html
@@ -31,20 +31,7 @@ browser-compat: api.SVGGlyphElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGGlyphElement", "SVGGlyphElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgglyphrefelement/index.html
+++ b/files/en-us/web/api/svgglyphrefelement/index.html
@@ -40,20 +40,7 @@ browser-compat: api.SVGGlyphRefElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGGlyphRefElement", "SVGGlyphRefElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggradientelement/index.html
+++ b/files/en-us/web/api/svggradientelement/index.html
@@ -68,25 +68,7 @@ browser-compat: api.SVGGradientElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGGradientElement", "SVGGradientElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed inheritance of <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGUnitTypes")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGGradientElement", "SVGGradientElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggraphicselement/copy_event/index.html
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.html
@@ -78,25 +78,7 @@ browser-compat: api.SVGGraphicsElement.copy_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#SVGDOMDependencies")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition that the clipboard events apply to SVG elements.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Clipboard API', '#clipboard-event-copy')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggraphicselement/cut_event/index.html
+++ b/files/en-us/web/api/svggraphicselement/cut_event/index.html
@@ -49,25 +49,7 @@ browser-compat: api.SVGGraphicsElement.cut_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#SVGDOMDependencies")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition that the clipboard events apply to SVG elements.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Clipboard API", "#clipboard-event-cut")}}</td>
-   <td>{{Spec2("Clipboard API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggraphicselement/getbbox/index.html
+++ b/files/en-us/web/api/svggraphicselement/getbbox/index.html
@@ -100,23 +100,7 @@ rectBoundingClientRect.setAttribute('height', boundingClientRectGroup.height);</
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('SVG1.1', 'types.html#__svg__SVGLocatable__getBBox', 'getBBox')}}
-      </td>
-      <td>{{Spec2('SVG1.1')}}</td>
-      <td>Initial definition (applies to SVG elements only).</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggraphicselement/index.html
+++ b/files/en-us/web/api/svggraphicselement/index.html
@@ -58,22 +58,7 @@ browser-compat: api.SVGGraphicsElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#InterfaceSVGGraphicsElement", "SVGGraphicsElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svggraphicselement/paste_event/index.html
+++ b/files/en-us/web/api/svggraphicselement/paste_event/index.html
@@ -77,27 +77,7 @@ browser-compat: api.SVGGraphicsElement.paste_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#SVGDOMDependencies")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Definition that the clipboard events apply to SVG elements.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Clipboard API", "#clipboard-event-paste")}}</td>
-   <td>{{Spec2("Clipboard API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svghkernelement/index.html
+++ b/files/en-us/web/api/svghkernelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGHKernElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGHKernElement", "SVGHKernElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/decode/index.html
+++ b/files/en-us/web/api/svgimageelement/decode/index.html
@@ -42,25 +42,7 @@ browser-compat: api.SVGImageElement.decode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG2')}}</td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#dom-img-decode','decode()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/decoding/index.html
+++ b/files/en-us/web/api/svgimageelement/decoding/index.html
@@ -45,20 +45,7 @@ img.src = 'img/logo.svg';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG','#image-decoding-hint','decoding')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/height/index.html
+++ b/files/en-us/web/api/svgimageelement/height/index.html
@@ -31,22 +31,7 @@ browser-compat: api.SVGImageElement.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('SVG2','single-page.html#embedded-__svg__SVGImageElement__height','height')}}
-      </td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/index.html
+++ b/files/en-us/web/api/svgimageelement/index.html
@@ -52,25 +52,7 @@ browser-compat: api.SVGImageElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("SVG2", "embedded.html#InterfaceSVGImageElement", "SVGImageElement")}}</td>
-			<td>{{Spec2("SVG2")}}</td>
-			<td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> and added the <code>crossOrigin</code> property.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGImageElement", "SVGImageElement")}}</td>
-			<td>{{Spec2("SVG1.1")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgimageelement/preserveaspectratio/index.html
@@ -32,27 +32,7 @@ browser-compat: api.SVGImageElement.preserveAspectRatio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG2", "coords.html#PreserveAspectRatioAttribute",
-        "preserveAspectRatio")}}</td>
-      <td>{{Spec2("SVG2")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>{{SpecName("SVG1.1", "coords.html#PreserveAspectRatioAttribute",
-        "preserveAspectRatio")}}</td>
-      <td>{{Spec2("SVG1.1")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/width/index.html
+++ b/files/en-us/web/api/svgimageelement/width/index.html
@@ -31,22 +31,7 @@ browser-compat: api.SVGImageElement.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('SVG2','single-page.html#embedded-__svg__SVGImageElement__width','width')}}
-      </td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/x/index.html
+++ b/files/en-us/web/api/svgimageelement/x/index.html
@@ -30,21 +30,7 @@ browser-compat: api.SVGImageElement.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG2','single-page.html#embedded-__svg__SVGImageElement__x','x')}}
-      </td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgimageelement/y/index.html
+++ b/files/en-us/web/api/svgimageelement/y/index.html
@@ -30,21 +30,7 @@ browser-compat: api.SVGImageElement.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('SVG2','single-page.html#embedded-__svg__SVGImageElement__y','y')}}
-      </td>
-      <td>{{Spec2('SVG2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svglineargradientelement/index.html
+++ b/files/en-us/web/api/svglineargradientelement/index.html
@@ -36,25 +36,7 @@ browser-compat: api.SVGLinearGradientElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGLinearGradientElement", "SVGLinearGradientElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGLinearGradientElement", "SVGLinearGradientElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svglineelement/index.html
+++ b/files/en-us/web/api/svglineelement/index.html
@@ -36,25 +36,7 @@ browser-compat: api.SVGLineElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGLineElement", "SVGLineElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGeometryElement")}} and removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGLineElement", "SVGLineElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -105,20 +105,7 @@ console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#InterfaceSVGMarkerElement", "SVGMarkerElement")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.html
@@ -39,20 +39,7 @@ console.log(marker.markerHeight.baseVal.value); // 6</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerHeight", "SVGMarkerElement.markerHeight")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -49,20 +49,7 @@ console.log(marker.markerUnits.baseVal); // 2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerUnits", "SVGMarkerElement.markerUnits")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
@@ -39,20 +39,7 @@ console.log(marker.markerWidth.baseVal.value); // 6</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerWidth", "SVGMarkerElement.markerWidth")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.html
@@ -39,20 +39,7 @@ console.log(marker.orientAngle.baseVal.value); // 180 as .5turn is 180deg.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__orientAngle", "SVGMarkerElement.orientAngle")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -50,20 +50,7 @@ console.log(marker.orientType.baseVal); // 2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerUnits", "SVGMarkerElement.orientType")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -80,20 +80,7 @@ console.log(marker.preserveAspectRatio.baseVal.meetOrSlice); // 1 </pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGFitToViewBox__preserveAspectRatio", "SVGMarkerElement.preserveAspectRatio")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/refx/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refx/index.html
@@ -39,20 +39,7 @@ console.log(marker.refX.baseVal.value); // 5</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__refX", "SVGMarkerElement.refX")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/refy/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.html
@@ -39,20 +39,7 @@ console.log(marker.refY.baseVal.value); // 5</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__refY", "SVGMarkerElement.refY")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
@@ -48,20 +48,7 @@ console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__setOrientToAngle", "SVGMarkerElement.setOrientToAngle()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
@@ -42,20 +42,7 @@ console.log(marker.orientAngle.baseVal.value);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__setOrientToAuto", "SVGMarkerElement.setOrientToAuto()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.html
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.html
@@ -40,20 +40,7 @@ console.log(marker.viewBox.baseVal.width); //10</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGFitToViewBox__viewBox", "SVGMarkerElement.viewBox")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/svgmaskelement/index.html
+++ b/files/en-us/web/api/svgmaskelement/index.html
@@ -40,25 +40,7 @@ browser-compat: api.SVGMaskElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#InterfaceSVGMaskElement", "SVGMaskElement")}}</td>
-   <td>{{Spec2("CSS Masks")}}</td>
-   <td>Removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "masking.html#InterfaceSVGMaskElement", "SVGMaskElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmatrix/index.html
+++ b/files/en-us/web/api/svgmatrix/index.html
@@ -79,20 +79,7 @@ browser-compat: api.SVGMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "coords.html#InterfaceSVGMatrix", "SVGMatrix")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmetadataelement/index.html
+++ b/files/en-us/web/api/svgmetadataelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGMetadataElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "single-page.html#struct-InterfaceSVGMetadataElement", "SVGMetadataElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "metadata.html#InterfaceSVGMetadataElement", "SVGMetadataElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmissingglyphelement/index.html
+++ b/files/en-us/web/api/svgmissingglyphelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGMissingGlyphElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGMissingGlyphElement", "SVGMissingGlyphElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgmpathelement/index.html
+++ b/files/en-us/web/api/svgmpathelement/index.html
@@ -30,25 +30,7 @@ browser-compat: api.SVGMPathElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGMPathElement", "SVGMPathElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>Removed the implemented interface <code>SVGExternalResourcesRequired</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGMPathElement", "SVGMPathElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgnumber/index.html
+++ b/files/en-us/web/api/svgnumber/index.html
@@ -30,25 +30,7 @@ browser-compat: api.SVGNumber
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#InterfaceSVGNumber", "SVGNumber")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "types.html#InterfaceSVGNumber", "SVGNumber")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpathelement/index.html
+++ b/files/en-us/web/api/svgpathelement/index.html
@@ -72,25 +72,7 @@ browser-compat: api.SVGPathElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "paths.html#InterfaceSVGPathElement", "SVGPathElement")}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Removed the <code>getPathSegAtLength()</code> and <code>createSVGPathSeg*</code> methods and moved the <code>pathLength</code> property and the <code>getTotalLength()</code> and <code>getPointAtLength()</code> methods to {{domxref("SVGGeometryElement")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "paths.html#InterfaceSVGPathElement", "SVGPathElement")}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpatternelement/index.html
+++ b/files/en-us/web/api/svgpatternelement/index.html
@@ -44,25 +44,7 @@ browser-compat: api.SVGPatternElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGPatternElement", "SVGPatternElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGPatternElement", "SVGPatternElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpolygonelement/index.html
+++ b/files/en-us/web/api/svgpolygonelement/index.html
@@ -32,25 +32,7 @@ browser-compat: api.SVGPolygonElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPolygonElement", "SVGPolygonElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGPolygonElement", "SVGPolygonElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpolylineelement/index.html
+++ b/files/en-us/web/api/svgpolylineelement/index.html
@@ -32,25 +32,7 @@ browser-compat: api.SVGPolylineElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPolylineElement", "SVGPolylineElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGPolylineElement", "SVGPolylineElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgradialgradientelement/index.html
+++ b/files/en-us/web/api/svgradialgradientelement/index.html
@@ -37,25 +37,7 @@ browser-compat: api.SVGRadialGradientElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGRadialGradientElement", "SVGRadialGradientElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGRadialGradientElement", "SVGRadialGradientElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgrect/index.html
+++ b/files/en-us/web/api/svgrect/index.html
@@ -35,25 +35,7 @@ browser-compat: api.SVGRect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Geometry Interfaces", "#DOMRect", "DOMRect")}}</td>
-   <td>{{Spec2("Geometry Interfaces")}}</td>
-   <td>Changed SVGRect as a legacy alias of DOMRect.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "types.html#InterfaceSVGRect", "SVGRect")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgrectelement/index.html
+++ b/files/en-us/web/api/svgrectelement/index.html
@@ -69,25 +69,7 @@ browser-compat: api.SVGRectElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGRectElement", "SVGRectElement")}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGRectElement", "SVGRectElement")}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgrenderingintent/index.html
+++ b/files/en-us/web/api/svgrenderingintent/index.html
@@ -71,20 +71,7 @@ browser-compat: api.SVGRenderingIntent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "types.html#InterfaceSVGRenderingIntent", "SVGRenderingIntent")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgscriptelement/index.html
+++ b/files/en-us/web/api/svgscriptelement/index.html
@@ -32,25 +32,7 @@ browser-compat: api.SVGScriptElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "interact.html#InterfaceSVGScriptElement", "SVGScriptElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the implemented interface <code>SVGExternalResourcesRequired</code> and added the <code>crossOrigin</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "script.html#InterfaceSVGScriptElement", "SVGScriptElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgsetelement/index.html
+++ b/files/en-us/web/api/svgsetelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGSetElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG Animations 2", "#InterfaceSVGSetElement", "SVGSetElement")}}</td>
-   <td>{{Spec2("SVG Animations 2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "animate.html#InterfaceSVGSetElement", "SVGSetElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgstopelement/index.html
+++ b/files/en-us/web/api/svgstopelement/index.html
@@ -30,27 +30,7 @@ browser-compat: api.SVGStopElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGStopElement", "SVGStopElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed inheritance from <code>SVGStylable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGStopElement", "SVGStopElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgstyleelement/index.html
+++ b/files/en-us/web/api/svgstyleelement/index.html
@@ -42,27 +42,7 @@ browser-compat: api.SVGStyleElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "styling.html#InterfaceSVGStyleElement", "SVGStyleElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Added inheritance of <code>LinkStyle</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "styling.html#InterfaceSVGStyleElement", "SVGStyleElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgsvgelement/index.html
+++ b/files/en-us/web/api/svgsvgelement/index.html
@@ -143,27 +143,7 @@ browser-compat: api.SVGSVGElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("SVG2", "struct.html#InterfaceSVGSVGElement", "SVGSVGElement")}}</td>
-			<td>{{Spec2("SVG2")}}</td>
-			<td>Replaced the inheritance from {{domxref("SVGElement")}} by {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, <code>SVGLocatable</code>, {{domxref("DocumentEvent")}}, {{domxref("ViewCSS")}}, and {{domxref("DocumentCSS")}} and added implemented interface {{domxref("WindowEventHandlers")}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGSVGElement", "SVGSVGElement")}}</td>
-			<td>{{Spec2("SVG1.1")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgswitchelement/index.html
+++ b/files/en-us/web/api/svgswitchelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGSwitchElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGSwitchElement", "SVGSwitchElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGSwitchElement", "SVGSwitchElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgsymbolelement/index.html
+++ b/files/en-us/web/api/svgsymbolelement/index.html
@@ -27,25 +27,7 @@ browser-compat: api.SVGSymbolElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGSymbolElement", "SVGSymbolElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, and <code>SVGStylable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGSymbolElement", "SVGSymbolElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtextcontentelement/index.html
+++ b/files/en-us/web/api/svgtextcontentelement/index.html
@@ -84,25 +84,7 @@ browser-compat: api.SVGTextContentElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#InterfaceSVGTextContentElement", "SVGTextContentElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Changed inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and <code>getStartPositionOfChar()</code> and removed implementations of <code>SVGTests</code>, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code> interfaces and <code>getEndPositionOfChar()</code> to return a {{domxref("DOMPoint")}} instead of an {{domxref("SVGPoint")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTextContentElement", "SVGTextContentElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtextelement/index.html
+++ b/files/en-us/web/api/svgtextelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGTextElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#InterfaceSVGTextElement", "SVGTextElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the implemented interface <code>SVGTransformable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTextElement", "SVGTextElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtextpathelement/index.html
+++ b/files/en-us/web/api/svgtextpathelement/index.html
@@ -92,25 +92,7 @@ browser-compat: api.SVGTextPathElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#InterfaceSVGTextPathElement", "SVGTextPathElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTextPathElement", "SVGTextPathElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtextpositioningelement/index.html
+++ b/files/en-us/web/api/svgtextpositioningelement/index.html
@@ -38,25 +38,7 @@ browser-compat: api.SVGTextPositioningElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#InterfaceSVGTextPositioningElement", "SVGTextPositioningElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTextPositioningElement", "SVGTextPositioningElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtitleelement/index.html
+++ b/files/en-us/web/api/svgtitleelement/index.html
@@ -25,27 +25,7 @@ browser-compat: api.SVGTitleElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGTitleElement", "SVGTitleElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed inheritance from <code>SVGLangSpace</code> and <code>SVGStylable</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGTitleElement", "SVGTitleElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtransformlist/index.html
+++ b/files/en-us/web/api/svgtransformlist/index.html
@@ -261,25 +261,7 @@ browser-compat: api.SVGTransformList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "coords.html#InterfaceSVGTransformList", "SVGTransformList")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "coords.html#InterfaceSVGTransformList", "SVGTransformList")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtrefelement/index.html
+++ b/files/en-us/web/api/svgtrefelement/index.html
@@ -28,20 +28,7 @@ browser-compat: api.SVGTRefElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTRefElement", "SVGTRefElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgtspanelement/index.html
+++ b/files/en-us/web/api/svgtspanelement/index.html
@@ -25,25 +25,7 @@ browser-compat: api.SVGTSpanElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "text.html#InterfaceSVGTSpanElement", "SVGTSpanElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTSpanElement", "SVGTSpanElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgunittypes/index.html
+++ b/files/en-us/web/api/svgunittypes/index.html
@@ -52,25 +52,7 @@ browser-compat: api.SVGUnitTypes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "types.html#InterfaceSVGUnitTypes", "SVGUnitTypes")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "types.html#InterfaceSVGUnitTypes", "SVGUnitTypes")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svguseelement/index.html
+++ b/files/en-us/web/api/svguseelement/index.html
@@ -40,27 +40,7 @@ browser-compat: api.SVGUseElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("SVG2", "struct.html#InterfaceSVGUseElement", "SVGUseElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Redefined the properties <code>instanceRoot</code> and <code>animatedInstanceRoot</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGUseElement", "SVGUseElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgviewelement/index.html
+++ b/files/en-us/web/api/svgviewelement/index.html
@@ -28,25 +28,7 @@ browser-compat: api.SVGViewElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG2", "linking.html#InterfaceSVGViewElement", "SVGViewElement")}}</td>
-   <td>{{Spec2("SVG2")}}</td>
-   <td>Removed a mixin <code>SVGExternalResourcesRequired</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "linking.html#InterfaceSVGViewElement", "SVGViewElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgvkernelement/index.html
+++ b/files/en-us/web/api/svgvkernelement/index.html
@@ -27,20 +27,7 @@ browser-compat: api.SVGVKernElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("SVG1.1", "fonts.html#InterfaceSVGVKernElement", "SVGVKernElement")}}</td>
-   <td>{{Spec2("SVG1.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/syncevent/lastchance/index.html
+++ b/files/en-us/web/api/syncevent/lastchance/index.html
@@ -31,17 +31,7 @@ browser-compat: api.SyncEvent.lastChance
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-    </tr>
-    <tr>
-      <td><a href="https://wicg.github.io/background-sync/spec/#sync-event">Web Background
-          Synchronization</a></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/syncevent/tag/index.html
+++ b/files/en-us/web/api/syncevent/tag/index.html
@@ -29,20 +29,7 @@ browser-compat: api.SyncEvent.tag
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Background Sync','#sync-event', 'tag')}}</td>
-      <td>{{Spec2('Background Sync')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/syncmanager/index.html
+++ b/files/en-us/web/api/syncmanager/index.html
@@ -29,20 +29,7 @@ browser-compat: api.SyncManager
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Background Sync','#sync-manager-interface','SyncManager')}}</td>
-   <td>{{Spec2('Background Sync')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/s* (last part) to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `SVGMarkerElement` and children had no mdn_url. This is fixed by mdn/browser-compat-data#11056.
- `SVGAltGlyphElement.format` is deprecated. So I leave it that way.
- SVGGraphicsElement's `cut`, `copy`, and `paste` events have no bcd: it will be dealt at that moment.

All other pages look fine.