### PR TITLE
Adding the global revert value to properties A and B

### DIFF
--- a/files/en-us/web/css/align-content/index.html
+++ b/files/en-us/web/css/align-content/index.html
@@ -54,6 +54,7 @@ align-content: unsafe center;
 /* Global values */
 align-content: inherit;
 align-content: initial;
+align-content: revert;
 align-content: unset;
 </pre>
 

--- a/files/en-us/web/css/align-items/index.html
+++ b/files/en-us/web/css/align-items/index.html
@@ -38,6 +38,7 @@ align-items: unsafe center;
 /* Global values */
 align-items: inherit;
 align-items: initial;
+align-items: revert;
 align-items: unset;
 </pre>
 

--- a/files/en-us/web/css/align-self/index.html
+++ b/files/en-us/web/css/align-self/index.html
@@ -46,6 +46,7 @@ align-self: unsafe center;
 /* Global values */
 align-self: inherit;
 align-self: initial;
+align-self: revert;
 align-self: unset;</pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/align-tracks/index.html
+++ b/files/en-us/web/css/align-tracks/index.html
@@ -28,6 +28,7 @@ align-tracks: start,center,end;
 /* Global values */
 align-tracks: inherit;
 align-tracks: initial;
+align-tracks: revert;
 align-tracks: unset;
 </pre>
 

--- a/files/en-us/web/css/all/index.html
+++ b/files/en-us/web/css/all/index.html
@@ -20,10 +20,8 @@ browser-compat: css.properties.all
 <pre class="brush:css no-line-numbers">/* Global values */
 all: initial;
 all: inherit;
-all: unset;
-
-/* CSS Cascading and Inheritance Level 4 */
 all: revert;
+all: unset;
 </pre>
 
 <p>The <code>all</code> property is specified as one of the CSS global keyword values. Note that none of these values affect the {{cssxref("unicode-bidi")}} and {{cssxref("direction")}} properties.</p>

--- a/files/en-us/web/css/animation-delay/index.html
+++ b/files/en-us/web/css/animation-delay/index.html
@@ -26,6 +26,12 @@ animation-delay: -1500ms;
 
 /* Multiple animations */
 animation-delay: 2.1s, 480ms;
+
+/* Global values */
+animation-delay: inherit;
+animation-delay: initial;
+animation-delay: revert;
+animation-delay: unset;
 </pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/animation-direction/index.html
+++ b/files/en-us/web/css/animation-direction/index.html
@@ -32,6 +32,7 @@ animation-direction: alternate, reverse, normal;
 /* Global values */
 animation-direction: inherit;
 animation-direction: initial;
+animation-direction: revert;
 animation-direction: unset;
 </pre>
 

--- a/files/en-us/web/css/animation-duration/index.html
+++ b/files/en-us/web/css/animation-duration/index.html
@@ -26,6 +26,12 @@ animation-duration: 120ms;
 /* Multiple animations */
 animation-duration: 1.64s, 15.22s;
 animation-duration: 10s, 35s, 230ms;
+
+/* Global values */
+animation-duration: inherit;
+animation-duration: initial;
+animation-duration: revert;
+animation-duration: unset;
 </pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/animation-fill-mode/index.html
+++ b/files/en-us/web/css/animation-fill-mode/index.html
@@ -28,6 +28,12 @@ animation-fill-mode: both;
 /* Multiple animations */
 animation-fill-mode: none, backwards;
 animation-fill-mode: both, forwards, none;
+
+/* Global values */
+animation-fill-mode: inherit;
+animation-fill-mode: initial;
+animation-fill-mode: revert;
+animation-fill-mode: unset;
 </pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/animation-iteration-count/index.html
+++ b/files/en-us/web/css/animation-iteration-count/index.html
@@ -29,7 +29,13 @@ animation-iteration-count: 3;
 animation-iteration-count: 2.4;
 
 /* Multiple values */
-animation-iteration-count: 2, 0, infinite;</pre>
+animation-iteration-count: 2, 0, infinite;
+
+/* Global values */
+animation-iteration-count: inherit;
+animation-iteration-count: initial;
+animation-iteration-count: revert;
+animation-iteration-count: unset;</pre>
 
 <p>The <strong><code>animation-iteration-count</code></strong> property is specified as one or more comma-separated values.</p>
 

--- a/files/en-us/web/css/animation-name/index.html
+++ b/files/en-us/web/css/animation-name/index.html
@@ -30,9 +30,10 @@ animation-name: test1, animation4;
 animation-name: none, -moz-specific, sliding;
 
 /* Global values */
-animation-name: <a href="/en-US/docs/Web/CSS/initial">initial</a>
-animation-name: <a href="/en-US/docs/Web/CSS/inherit">inherit</a>
-animation-name: <a href="/en-US/docs/Web/CSS/unset">unset</a></pre>
+animation-name: initial;
+animation-name: inherit;
+animation-name: revert;
+animation-name: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/animation-play-state/index.html
+++ b/files/en-us/web/css/animation-play-state/index.html
@@ -29,6 +29,7 @@ animation-play-state: paused, running, running;
 /* Global values */
 animation-play-state: inherit;
 animation-play-state: initial;
+animation-play-state: revert;
 animation-play-state: unset;
 </pre>
 

--- a/files/en-us/web/css/animation-timing-function/index.html
+++ b/files/en-us/web/css/animation-timing-function/index.html
@@ -48,6 +48,7 @@ animation-timing-function: ease, step-start, cubic-bezier(0.1, 0.7, 1.0, 0.1);
 /* Global values */
 animation-timing-function: inherit;
 animation-timing-function: initial;
+animation-timing-function: revert;
 animation-timing-function: unset;
 </pre>
 

--- a/files/en-us/web/css/appearance/index.html
+++ b/files/en-us/web/css/appearance/index.html
@@ -53,6 +53,12 @@ appearance: progress-bar;
 /* Partial list of available values in WebKit/Blink (as well as Gecko and Edge) */
 -webkit-appearance: media-mute-button;
 -webkit-appearance: caret;
+
+/* Global values */
+appearance: inherit;
+appearance: initial;
+appearance: revert;
+appearance: unset;
 </pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/aspect-ratio/index.html
+++ b/files/en-us/web/css/aspect-ratio/index.html
@@ -19,6 +19,7 @@ browser-compat: css.properties.aspect-ratio
 /* Global values */
 aspect-ratio: inherit;
 aspect-ratio: initial;
+aspect-ratio: revert;
 aspect-ratio: unset;
 </pre>
 

--- a/files/en-us/web/css/backdrop-filter/index.html
+++ b/files/en-us/web/css/backdrop-filter/index.html
@@ -42,6 +42,7 @@ backdrop-filter: url(filters.svg#filter) blur(4px) saturate(150%);
 /* Global values */
 backdrop-filter: inherit;
 backdrop-filter: initial;
+backdrop-filter: revert;
 backdrop-filter: unset;
 </pre>
 

--- a/files/en-us/web/css/backface-visibility/index.html
+++ b/files/en-us/web/css/backface-visibility/index.html
@@ -26,6 +26,7 @@ backface-visibility: hidden;
 /* Global values */
 backface-visibility: inherit;
 backface-visibility: initial;
+backface-visibility: revert;
 backface-visibility: unset;</pre>
 
 <p>The <code>backface-visibility</code> property is specified as one of the keywords listed below.</p>

--- a/files/en-us/web/css/background-attachment/index.html
+++ b/files/en-us/web/css/background-attachment/index.html
@@ -27,6 +27,7 @@ background-attachment: local;
 /* Global values */
 background-attachment: inherit;
 background-attachment: initial;
+background-attachment: revert;
 background-attachment: unset;
 </pre>
 

--- a/files/en-us/web/css/background-blend-mode/index.html
+++ b/files/en-us/web/css/background-blend-mode/index.html
@@ -27,6 +27,7 @@ background-blend-mode: darken, luminosity;
 /* Global values */
 background-blend-mode: initial;
 background-blend-mode: inherit;
+background-blend-mode: revert;
 background-blend-mode: unset;
 </pre>
 

--- a/files/en-us/web/css/background-clip/index.html
+++ b/files/en-us/web/css/background-clip/index.html
@@ -38,6 +38,7 @@ background-clip: text;
 /* Global values */
 background-clip: inherit;
 background-clip: initial;
+background-clip: revert;
 background-clip: unset;
 </pre>
 

--- a/files/en-us/web/css/background-color/index.html
+++ b/files/en-us/web/css/background-color/index.html
@@ -49,9 +49,10 @@ background-color: currentcolor;
 background-color: transparent;
 
 /* Global values */
-background-color: currentcolor;
-background-color: transparent;
-background-color: transparent;
+background-color: inherit;
+background-color: initial;
+background-color: revert;
+background-color: unset;
 </pre>
 
 <p>The <code>background-color</code> property is specified as a single <code>>&lt;color&gt;</code> value.</p>

--- a/files/en-us/web/css/background-image/index.html
+++ b/files/en-us/web/css/background-image/index.html
@@ -33,7 +33,13 @@ browser-compat: css.properties.background-image
 
 <pre class="brush: css no-line-numbers">background-image:
   linear-gradient(to bottom, rgba(255,255,0,0.5), rgba(0,0,255,0.5)),
-  url('catfront.png');</pre>
+  url('catfront.png');
+
+/* Global values */
+background-image: inherit;
+background-image: initial;
+background-image: revert;
+background-image: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/background-origin/index.html
+++ b/files/en-us/web/css/background-origin/index.html
@@ -27,6 +27,7 @@ background-origin: content-box;
 /* Global values */
 background-origin: inherit;
 background-origin: initial;
+background-origin: revert;
 background-origin: unset;
 </pre>
 

--- a/files/en-us/web/css/background-position-x/index.html
+++ b/files/en-us/web/css/background-position-x/index.html
@@ -44,6 +44,7 @@ background-position-x: 0px, center;
 /* Global values */
 background-position-x: inherit;
 background-position-x: initial;
+background-position-x: revert;
 background-position-x: unset;
 </pre>
 

--- a/files/en-us/web/css/background-position-y/index.html
+++ b/files/en-us/web/css/background-position-y/index.html
@@ -44,6 +44,7 @@ background-position-y: 0px, center;
 /* Global values */
 background-position-y: inherit;
 background-position-y: initial;
+background-position-y: revert;
 background-position-y: unset;
 </pre>
 

--- a/files/en-us/web/css/background-position/index.html
+++ b/files/en-us/web/css/background-position/index.html
@@ -44,6 +44,7 @@ background-position: top right 10px;
 /* Global values */
 background-position: inherit;
 background-position: initial;
+background-position: revert;
 background-position: unset;
 </pre>
 

--- a/files/en-us/web/css/background-repeat/index.html
+++ b/files/en-us/web/css/background-repeat/index.html
@@ -36,6 +36,7 @@ background-repeat: no-repeat round;
 /* Global values */
 background-repeat: inherit;
 background-repeat: initial;
+background-repeat: revert;
 background-repeat: unset;
 </pre>
 

--- a/files/en-us/web/css/background-size/index.html
+++ b/files/en-us/web/css/background-size/index.html
@@ -45,6 +45,7 @@ background-size: 6px, auto, contain;
 /* Global values */
 background-size: inherit;
 background-size: initial;
+background-size: revert;
 background-size: unset;
 </pre>
 

--- a/files/en-us/web/css/background/index.html
+++ b/files/en-us/web/css/background/index.html
@@ -45,7 +45,12 @@ background: border-box red;
 
 /* A single image, centered and scaled */
 background: no-repeat center/80% url("../img/image.png");
-</pre>
+
+/* Global values */
+background: inherit;
+background: initial;
+background: revert;
+background: unset;</pre>
 
 <p>The <code>background</code> property is specified as one or more background layers, separated by commas.</p>
 

--- a/files/en-us/web/css/block-size/index.html
+++ b/files/en-us/web/css/block-size/index.html
@@ -38,6 +38,7 @@ block-size: auto;
 /* Global values */
 block-size: inherit;
 block-size: initial;
+block-size: revert;
 block-size: unset;
 </pre>
 

--- a/files/en-us/web/css/border-block-color/index.html
+++ b/files/en-us/web/css/border-block-color/index.html
@@ -22,7 +22,12 @@ browser-compat: css.properties.border-block-color
 
 <pre class="brush:css no-line-numbers">border-block-color: yellow;
 border-block-color: #F5F6F7;
-</pre>
+
+/* Global values */
+border-block-color: inherit;
+border-block-color: initial;
+border-block-color: revert;
+border-block-color: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block-end-color/index.html
+++ b/files/en-us/web/css/border-block-end-color/index.html
@@ -24,7 +24,12 @@ browser-compat: css.properties.border-block-end-color
 
 <pre class="brush:css no-line-numbers">border-block-end-color: yellow;
 border-block-end-color: #F5F6F7;
-</pre>
+
+/* Global values */
+border-block-end-color: inherit;
+border-block-end-color: initial;
+border-block-end-color: revert;
+border-block-end-color: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("border-inline-start-color")}}, and {{cssxref("border-inline-end-color")}}, which define the other border colors of the element.</p>
 

--- a/files/en-us/web/css/border-block-end-style/index.html
+++ b/files/en-us/web/css/border-block-end-style/index.html
@@ -26,7 +26,12 @@ browser-compat: css.properties.border-block-end-style
 border-block-end-style: dashed;
 border-block-end-style: dotted;
 border-block-end-style: groove;
-</pre>
+
+/* Global values */
+border-block-end-style: inherit;
+border-block-end-style: initial;
+border-block-end-style: revert;
+border-block-end-style: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-style")}}, {{cssxref("border-inline-start-style")}}, and {{cssxref("border-inline-end-style")}}, which define the other border styles of the element.</p>
 

--- a/files/en-us/web/css/border-block-end-width/index.html
+++ b/files/en-us/web/css/border-block-end-width/index.html
@@ -25,7 +25,12 @@ browser-compat: css.properties.border-block-end-width
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-block-end-width: 5px;
 border-block-end-width: thick;
-</pre>
+
+/* Global values */
+border-block-end-width: inherit;
+border-block-end-width: initial;
+border-block-end-width: revert;
+border-block-end-width: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-width")}}, {{cssxref("border-inline-start-width")}}, and {{cssxref("border-inline-end-width")}}, which define the other border widths of the element.</p>
 

--- a/files/en-us/web/css/border-block-end/index.html
+++ b/files/en-us/web/css/border-block-end/index.html
@@ -35,7 +35,12 @@ browser-compat: css.properties.border-block-end
 <pre class="brush:css no-line-numbers">border-block-end: 1px;
 border-block-end: 2px dotted;
 border-block-end: medium dashed blue;
-</pre>
+
+/* Global values */
+border-block-end: inherit;
+border-block-end: initial;
+border-block-end: revert;
+border-block-end: unset;</pre>
 
 <p><code>border-block-end</code> can be used to set the values for one or more of {{cssxref("border-block-end-width")}}, {{cssxref("border-block-end-style")}}, and {{cssxref("border-block-end-color")}}. The physical border to which it maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 

--- a/files/en-us/web/css/border-block-start-color/index.html
+++ b/files/en-us/web/css/border-block-start-color/index.html
@@ -24,7 +24,12 @@ browser-compat: css.properties.border-block-start-color
 
 <pre class="brush:css no-line-numbers">border-block-start-color: blue;
 border-block-start-color: #4c5d21;
-</pre>
+
+/* Global values */
+border-block-start-color: inherit;
+border-block-start-color: initial;
+border-block-start-color: revert;
+border-block-start-color: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-end-color")}}, {{cssxref("border-inline-start-color")}}, and {{cssxref("border-inline-end-color")}}, which define the other border colors of the element.</p>
 

--- a/files/en-us/web/css/border-block-start-style/index.html
+++ b/files/en-us/web/css/border-block-start-style/index.html
@@ -26,7 +26,12 @@ browser-compat: css.properties.border-block-start-style
 border-block-start-style: dashed;
 border-block-start-style: dotted;
 border-block-start-style: groove;
-</pre>
+
+/* Global values */
+border-block-start-style: inherit;
+border-block-start-style: initial;
+border-block-start-style: revert;
+border-block-start-style: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-end-style")}}, {{cssxref("border-inline-start-style")}}, and {{cssxref("border-inline-end-style")}}, which define the other border styles of the element.</p>
 

--- a/files/en-us/web/css/border-block-start-width/index.html
+++ b/files/en-us/web/css/border-block-start-width/index.html
@@ -25,7 +25,12 @@ browser-compat: css.properties.border-block-start-width
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-block-start-width: 5px;
 border-block-start-width: thick;
-</pre>
+
+/* Global values */
+border-block-start-width: inherit;
+border-block-start-width: initial;
+border-block-start-width: revert;
+border-block-start-width: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-end-width")}}, {{cssxref("border-inline-start-width")}}, and {{cssxref("border-inline-end-width")}}, which define the other border widths of the element.</p>
 

--- a/files/en-us/web/css/border-block-start/index.html
+++ b/files/en-us/web/css/border-block-start/index.html
@@ -36,7 +36,12 @@ browser-compat: css.properties.border-block-start
 <pre class="brush:css  no-line-numbers">border-block-start: 1px;
 border-block-start: 2px dotted;
 border-block-start: medium dashed blue;
-</pre>
+
+/* Global values */
+border-block-start: inherit;
+border-block-start: initial;
+border-block-start: revert;
+border-block-start: unset;</pre>
 
 <p><code>border-block-start</code> can be used to set the values for one or more of {{cssxref("border-block-start-width")}}, {{cssxref("border-block-start-style")}}, and {{cssxref("border-block-start-color")}}. The physical border to which it maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 

--- a/files/en-us/web/css/border-block-style/index.html
+++ b/files/en-us/web/css/border-block-style/index.html
@@ -24,7 +24,13 @@ browser-compat: css.properties.border-block-style
 <pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
 border-block-style: dashed;
 border-block-style: dotted;
-border-block-style: groove;</pre>
+border-block-style: groove;
+
+/* Global values */
+border-block-style: inherit;
+border-block-style: initial;
+border-block-style: revert;
+border-block-style: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block-width/index.html
+++ b/files/en-us/web/css/border-block-width/index.html
@@ -22,7 +22,13 @@ browser-compat: css.properties.border-block-width
 
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-block-width: 5px;
-border-block-width: thick;</pre>
+border-block-width: thick;
+
+/* Global values */
+border-block-width: inherit;
+border-block-width: initial;
+border-block-width: revert;
+border-block-width: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block/index.html
+++ b/files/en-us/web/css/border-block/index.html
@@ -35,7 +35,13 @@ browser-compat: css.properties.border-block
 
 <pre class="brush:css no-line-numbers">border-block: 1px;
 border-block: 2px dotted;
-border-block: medium dashed blue;</pre>
+border-block: medium dashed blue;
+
+/* Global values */
+border-block: inherit;
+border-block: initial;
+border-block: revert;
+border-block: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-bottom-color/index.html
+++ b/files/en-us/web/css/border-bottom-color/index.html
@@ -28,6 +28,7 @@ border-bottom-color: transparent;
 /* Global values */
 border-bottom-color: inherit;
 border-bottom-color: initial;
+border-bottom-color: revert;
 border-bottom-color: unset;
 </pre>
 

--- a/files/en-us/web/css/border-bottom-left-radius/index.html
+++ b/files/en-us/web/css/border-bottom-left-radius/index.html
@@ -44,7 +44,11 @@ border-bottom-left-radius: 20% 10%;
 /* border-bottom-left-radius: <em>horizontal</em> <em>vertical</em> */
 border-bottom-left-radius: 0.5em 1em;
 
-border-bottom-left-radius: inherit;</pre>
+/* Global values */
+border-bottom-left-radius: inherit;
+border-bottom-left-radius: initial;
+border-bottom-left-radius: revert;
+border-bottom-left-radius: unset;</pre>
 
 <p>With one value:</p>
 

--- a/files/en-us/web/css/border-bottom-right-radius/index.html
+++ b/files/en-us/web/css/border-bottom-right-radius/index.html
@@ -38,7 +38,11 @@ border-bottom-right-radius: 20% 10%; /* 20% of horizontal(width) and 10% of vert
 /* border-bottom-right-radius: horizontal vertical */
 border-bottom-right-radius: 0.5em 1em;
 
-border-bottom-right-radius: inherit;</pre>
+/* Global values */
+border-bottom-right-radius: inherit;
+border-bottom-right-radius: initial;
+border-bottom-right-radius: revert;
+border-bottom-right-radius: unset;</pre>
 
 <p>With one value:</p>
 

--- a/files/en-us/web/css/border-bottom-style/index.html
+++ b/files/en-us/web/css/border-bottom-style/index.html
@@ -34,6 +34,7 @@ border-bottom-style: outset;
 /* Global values */
 border-bottom-style: inherit;
 border-bottom-style: initial;
+border-bottom-style: revert;
 border-bottom-style: unset;
 </pre>
 

--- a/files/en-us/web/css/border-bottom-width/index.html
+++ b/files/en-us/web/css/border-bottom-width/index.html
@@ -30,6 +30,7 @@ border-bottom-width: 6px;
 /* Global keywords */
 border-bottom-width: inherit;
 border-bottom-width: initial;
+border-bottom-width: revert;
 border-bottom-width: unset;
 </pre>
 

--- a/files/en-us/web/css/border-bottom/index.html
+++ b/files/en-us/web/css/border-bottom/index.html
@@ -44,7 +44,12 @@ border-bottom: none thick green;
 <pre class="brush: css no-line-numbers">border-bottom: 1px;
 border-bottom: 2px dotted;
 border-bottom: medium dashed blue;
-</pre>
+
+/* Global values */
+border-bottom: inherit;
+border-bottom: initial;
+border-bottom: revert;
+border-bottom: unset;</pre>
 
 <p>The three values of the shorthand property can be specified in any order, and one or two of them may be omitted.</p>
 

--- a/files/en-us/web/css/border-collapse/index.html
+++ b/files/en-us/web/css/border-collapse/index.html
@@ -29,6 +29,7 @@ border-collapse: separate;
 /* Global values */
 border-collapse: inherit;
 border-collapse: initial;
+border-collapse: revert;
 border-collapse: unset;
 </pre>
 

--- a/files/en-us/web/css/border-color/index.html
+++ b/files/en-us/web/css/border-color/index.html
@@ -53,6 +53,7 @@ border-color: red yellow green blue;
 /* Global values */
 border-color: inherit;
 border-color: initial;
+border-color: revert;
 border-color: unset;
 </pre>
 

--- a/files/en-us/web/css/border-end-end-radius/index.html
+++ b/files/en-us/web/css/border-end-end-radius/index.html
@@ -27,6 +27,7 @@ border-end-end-radius: 1em 2em;
 /* Global values */
 border-end-end-radius: inherit;
 border-end-end-radius: initial;
+border-end-end-radius: revert;
 border-end-end-radius: unset;
 </pre>
 

--- a/files/en-us/web/css/border-end-start-radius/index.html
+++ b/files/en-us/web/css/border-end-start-radius/index.html
@@ -27,6 +27,7 @@ border-end-start-radius: 1em 2em;
 /* Global values */
 border-end-start-radius: inherit;
 border-end-start-radius: initial;
+border-end-start-radius: revert;
 border-end-start-radius: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image-outset/index.html
+++ b/files/en-us/web/css/border-image-outset/index.html
@@ -37,6 +37,7 @@ border-image-outset: 7px 12px 14px 5px;
 /* Global values */
 border-image-outset: inherit;
 border-image-outset: initial;
+border-image-outset: revert;
 border-image-outset: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image-repeat/index.html
+++ b/files/en-us/web/css/border-image-repeat/index.html
@@ -29,6 +29,7 @@ border-image-repeat: round stretch;
 /* Global values */
 border-image-repeat: inherit;
 border-image-repeat: initial;
+border-image-repeat: revert;
 border-image-repeat: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image-slice/index.html
+++ b/files/en-us/web/css/border-image-slice/index.html
@@ -50,6 +50,7 @@ border-image-slice: 10% fill 7 12;
 /* Global values */
 border-image-slice: inherit;
 border-image-slice: initial;
+border-image-slice: revert;
 border-image-slice: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image-source/index.html
+++ b/files/en-us/web/css/border-image-source/index.html
@@ -29,6 +29,7 @@ border-image-source: linear-gradient(to top, red, yellow);
 /* Global values */
 border-image-source: inherit;
 border-image-source: initial;
+border-image-source: revert;
 border-image-source: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image-width/index.html
+++ b/files/en-us/web/css/border-image-width/index.html
@@ -43,6 +43,7 @@ border-image-width: 5% 2em 10% auto;
 /* Global values */
 border-image-width: inherit;
 border-image-width: initial;
+border-image-width: revert;
 border-image-width: unset;
 </pre>
 

--- a/files/en-us/web/css/border-image/index.html
+++ b/files/en-us/web/css/border-image/index.html
@@ -44,7 +44,12 @@ border-image: linear-gradient(red, blue) 27 / 35px;
 
 /* source | slice | width | outset | repeat */
 border-image: url("/images/border.png") 27 23 / 50px 30px / 1rem round space;
-</pre>
+
+/* Global values */
+border-image: inherit;
+border-image: initial;
+border-image: revert;
+border-image: unset;</pre>
 
 <p>The <code>border-image</code> property may be specified with anywhere from one to five of the values listed below.</p>
 

--- a/files/en-us/web/css/border-inline-color/index.html
+++ b/files/en-us/web/css/border-inline-color/index.html
@@ -21,7 +21,13 @@ browser-compat: css.properties.border-inline-color
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush:css no-line-numbers">border-inline-color: yellow;
-border-inline-color: #F5F6F7;</pre>
+border-inline-color: #F5F6F7;
+
+/* Global values */
+border-inline-color: inherit;
+border-inline-color: initial;
+border-inline-color: revert;
+border-inline-color: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline-end-color/index.html
+++ b/files/en-us/web/css/border-inline-end-color/index.html
@@ -24,7 +24,12 @@ browser-compat: css.properties.border-inline-end-color
 
 <pre class="brush:css no-line-numbers">border-inline-end-color: rebeccapurple;
 border-inline-end-color: #663399;
-</pre>
+
+/* Global values */
+border-inline-end-color: inherit;
+border-inline-end-color: initial;
+border-inline-end-color: revert;
+border-inline-end-color: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("border-block-end-color")}}, and {{cssxref("border-inline-start-color")}}, which define the other border colors of the element.</p>
 

--- a/files/en-us/web/css/border-inline-end-style/index.html
+++ b/files/en-us/web/css/border-inline-end-style/index.html
@@ -26,7 +26,12 @@ browser-compat: css.properties.border-inline-end-style
 border-inline-end-style: dashed;
 border-inline-end-style: dotted;
 border-inline-end-style: groove;
-</pre>
+
+/* Global values */
+border-inline-end-style: inherit;
+border-inline-end-style: initial;
+border-inline-end-style: revert;
+border-inline-end-style: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-style")}}, {{cssxref("border-block-end-style")}}, and {{cssxref("border-inline-start-style")}}, which define the other border styles of the element.</p>
 

--- a/files/en-us/web/css/border-inline-end-width/index.html
+++ b/files/en-us/web/css/border-inline-end-width/index.html
@@ -25,7 +25,12 @@ browser-compat: css.properties.border-inline-end-width
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-inline-end-width: 2px;
 border-inline-end-width: thick;
-</pre>
+
+/* Global values */
+border-inline-end-width: inherit;
+border-inline-end-width: initial;
+border-inline-end-width: revert;
+border-inline-end-width: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-width")}}, {{cssxref("border-block-end-width")}}, and {{cssxref("border-inline-start-width")}}, which define the other border widths of the element.</p>
 

--- a/files/en-us/web/css/border-inline-end/index.html
+++ b/files/en-us/web/css/border-inline-end/index.html
@@ -36,7 +36,12 @@ browser-compat: css.properties.border-inline-end
 <pre class="brush:css no-line-numbers">border-inline-end: 1px;
 border-inline-end: 2px dashed;
 border-inline-end: medium dashed blue;
-</pre>
+
+/* Global values */
+border-inline-end: inherit;
+border-inline-end: initial;
+border-inline-end: revert;
+border-inline-end: unset;</pre>
 
 <p>The physical border to which <code>border-inline-end</code> maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 

--- a/files/en-us/web/css/border-inline-start-color/index.html
+++ b/files/en-us/web/css/border-inline-start-color/index.html
@@ -24,7 +24,12 @@ browser-compat: css.properties.border-inline-start-color
 
 <pre class="brush:css no-line-numbers">border-inline-start-color: red;
 border-inline-start-color: #ee4141;
-</pre>
+
+/* Global values */
+border-inline-start-color: inherit;
+border-inline-start-color: initial;
+border-inline-start-color: revert;
+border-inline-start-color: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("border-block-end-color")}}, and {{cssxref("border-inline-end-color")}}, which define the other border colors of the element.</p>
 

--- a/files/en-us/web/css/border-inline-start-style/index.html
+++ b/files/en-us/web/css/border-inline-start-style/index.html
@@ -25,6 +25,7 @@ browser-compat: css.properties.border-inline-start-style
 <pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
 border-inline-start-style: dashed;
 border-inline-start-style: dotted;
+border-inline-start-style: revert;
 border-inline-start-style: groove;
 </pre>
 

--- a/files/en-us/web/css/border-inline-start-width/index.html
+++ b/files/en-us/web/css/border-inline-start-width/index.html
@@ -25,7 +25,12 @@ browser-compat: css.properties.border-inline-start-width
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-inline-start-width: 5px;
 border-inline-start-width: thick;
-</pre>
+
+/* Global values */
+border-inline-start-width: inherit;
+border-inline-start-width: initial;
+border-inline-start-width: revert;
+border-inline-start-width: unset;</pre>
 
 <p>Related properties are {{cssxref("border-block-start-width")}}, {{cssxref("border-block-end-width")}}, and {{cssxref("border-inline-end-width")}}, which define the other border widths of the element.</p>
 

--- a/files/en-us/web/css/border-inline-start/index.html
+++ b/files/en-us/web/css/border-inline-start/index.html
@@ -36,7 +36,12 @@ browser-compat: css.properties.border-inline-start
 <pre class="brush:css no-line-numbers">border-inline-start: 1px;
 border-inline-start: 2px dotted;
 border-inline-start: medium dashed green;
-</pre>
+
+/* Global values */
+border-inline-start: inherit;
+border-inline-start: initial;
+border-inline-start: revert;
+border-inline-start: unset;</pre>
 
 <p>The physical border to which <code>border-inline-start</code> maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 

--- a/files/en-us/web/css/border-inline-style/index.html
+++ b/files/en-us/web/css/border-inline-style/index.html
@@ -23,6 +23,7 @@ browser-compat: css.properties.border-inline-style
 <pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
 border-inline-style: dashed;
 border-inline-style: dotted;
+border-inline-style: revert;
 border-inline-style: groove;</pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/border-inline-width/index.html
+++ b/files/en-us/web/css/border-inline-width/index.html
@@ -23,7 +23,13 @@ browser-compat: css.properties.border-inline-width
 <pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
 border-inline-width: 5px 10px;
 border-inline-width: 5px;
-border-inline-width: thick;</pre>
+border-inline-width: thick;
+
+/* Global values */
+border-inline-width: inherit;
+border-inline-width: initial;
+border-inline-width: revert;
+border-inline-width: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline/index.html
+++ b/files/en-us/web/css/border-inline/index.html
@@ -34,7 +34,13 @@ browser-compat: css.properties.border-inline
 
 <pre class="brush:css no-line-numbers">border-inline: 1px;
 border-inline: 2px dotted;
-border-inline: medium dashed blue;</pre>
+border-inline: medium dashed blue;
+
+/* Global values */
+border-inline: inherit;
+border-inline: initial;
+border-inline: revert;
+border-inline: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-left-color/index.html
+++ b/files/en-us/web/css/border-left-color/index.html
@@ -28,6 +28,7 @@ border-left-color: transparent;
 /* Global values */
 border-left-color: inherit;
 border-left-color: initial;
+border-left-color: revert;
 border-left-color: unset;
 </pre>
 

--- a/files/en-us/web/css/border-left-style/index.html
+++ b/files/en-us/web/css/border-left-style/index.html
@@ -34,6 +34,7 @@ border-left-style: outset;
 /* Global values */
 border-left-style: inherit;
 border-left-style: initial;
+border-left-style: revert;
 border-left-style: unset;
 </pre>
 

--- a/files/en-us/web/css/border-left-width/index.html
+++ b/files/en-us/web/css/border-left-width/index.html
@@ -30,6 +30,7 @@ border-left-width: 6px;
 /* Global keywords */
 border-left-width: inherit;
 border-left-width: initial;
+border-left-width: revert;
 border-left-width: unset;
 </pre>
 

--- a/files/en-us/web/css/border-left/index.html
+++ b/files/en-us/web/css/border-left/index.html
@@ -44,6 +44,12 @@ border-left: none thick green;
 <pre class="brush: css no-line-numbers">border-left: 1px;
 border-left: 2px dotted;
 border-left: medium dashed blue;
+
+/* Global values */
+border-left: inherit;
+border-left: initial;
+border-left: revert;
+border-left: unset;
 </pre>
 
 <p>The three values of the shorthand property can be specified in any order, and one or two of them may be omitted.</p>

--- a/files/en-us/web/css/border-radius/index.html
+++ b/files/en-us/web/css/border-radius/index.html
@@ -65,6 +65,7 @@ border-radius: 10px 5% / 20px 25em 30px 35em;
 /* Global values */
 border-radius: inherit;
 border-radius: initial;
+border-radius: revert;
 border-radius: unset;
 </pre>
 

--- a/files/en-us/web/css/border-right-color/index.html
+++ b/files/en-us/web/css/border-right-color/index.html
@@ -28,6 +28,7 @@ border-right-color: transparent;
 /* Global values */
 border-right-color: inherit;
 border-right-color: initial;
+border-right-color: revert;
 border-right-color: unset;
 </pre>
 

--- a/files/en-us/web/css/border-right-style/index.html
+++ b/files/en-us/web/css/border-right-style/index.html
@@ -34,6 +34,7 @@ border-right-style: outset;
 /* Global values */
 border-right-style: inherit;
 border-right-style: initial;
+border-right-style: revert;
 border-right-style: unset;
 </pre>
 

--- a/files/en-us/web/css/border-right-width/index.html
+++ b/files/en-us/web/css/border-right-width/index.html
@@ -30,6 +30,7 @@ border-right-width: 6px;
 /* Global keywords */
 border-right-width: inherit;
 border-right-width: initial;
+border-right-width: revert;
 border-right-width: unset;
 </pre>
 

--- a/files/en-us/web/css/border-right/index.html
+++ b/files/en-us/web/css/border-right/index.html
@@ -44,6 +44,12 @@ border-right: none thick green;
 <pre class="brush: css no-line-numbers">border-right: 1px;
 border-right: 2px dotted;
 border-right: medium dashed green;
+
+/* Global values */
+border-right: inherit;
+border-right: initial;
+border-right: revert;
+border-right: unset;
 </pre>
 
 <p>The three values of the shorthand property can be specified in any order, and one or two of them may be omitted.</p>

--- a/files/en-us/web/css/border-spacing/index.html
+++ b/files/en-us/web/css/border-spacing/index.html
@@ -32,6 +32,7 @@ border-spacing: 1cm 2em;
 /* Global values */
 border-spacing: inherit;
 border-spacing: initial;
+border-spacing: revert;
 border-spacing: unset;
 </pre>
 

--- a/files/en-us/web/css/border-start-end-radius/index.html
+++ b/files/en-us/web/css/border-start-end-radius/index.html
@@ -27,6 +27,7 @@ border-start-end-radius: 1em 2em;
 /* Global values */
 border-start-end-radius: inherit;
 border-start-end-radius: initial;
+border-start-end-radius: revert;
 border-start-end-radius: unset;
 </pre>
 

--- a/files/en-us/web/css/border-start-start-radius/index.html
+++ b/files/en-us/web/css/border-start-start-radius/index.html
@@ -27,6 +27,7 @@ border-start-start-radius: 1em 2em;
 /* Global values */
 border-start-start-radius: inherit;
 border-start-start-radius: initial;
+border-start-start-radius: revert;
 border-start-start-radius: unset;
 </pre>
 

--- a/files/en-us/web/css/border-style/index.html
+++ b/files/en-us/web/css/border-style/index.html
@@ -52,6 +52,7 @@ border-style: none solid dotted dashed;
 /* Global values */
 border-style: inherit;
 border-style: initial;
+border-style: revert;
 border-style: unset;
 </pre>
 

--- a/files/en-us/web/css/border-top-color/index.html
+++ b/files/en-us/web/css/border-top-color/index.html
@@ -28,6 +28,7 @@ border-top-color: transparent;
 /* Global values */
 border-top-color: inherit;
 border-top-color: initial;
+border-top-color: revert;
 border-top-color: unset;
 </pre>
 

--- a/files/en-us/web/css/border-top-left-radius/index.html
+++ b/files/en-us/web/css/border-top-left-radius/index.html
@@ -34,6 +34,12 @@ border-top-left-radius: 3px;
 border-top-left-radius: 0.5em 1em;
 
 border-top-left-radius: inherit;
+
+/* Global values */
+border-top-left-radius: inherit;
+border-top-left-radius: initial;
+border-top-left-radius: revert;
+border-top-left-radius: unset;
 </pre>
 
 <p>With one value:</p>

--- a/files/en-us/web/css/border-top-right-radius/index.html
+++ b/files/en-us/web/css/border-top-right-radius/index.html
@@ -34,6 +34,12 @@ border-top-right-radius: 3px;
 border-top-right-radius: 0.5em 1em;
 
 border-top-right-radius: inherit;
+
+/* Global values */
+border-top-right-radius: inherit;
+border-top-right-radius: initial;
+border-top-right-radius: revert;
+border-top-right-radius: unset;
 </pre>
 
 <p>With one value:</p>

--- a/files/en-us/web/css/border-top-style/index.html
+++ b/files/en-us/web/css/border-top-style/index.html
@@ -36,6 +36,7 @@ border-top-style: outset;
 /* Global values */
 border-top-style: inherit;
 border-top-style: initial;
+border-top-style: revert;
 border-top-style: unset;
 </pre>
 

--- a/files/en-us/web/css/border-top-width/index.html
+++ b/files/en-us/web/css/border-top-width/index.html
@@ -30,6 +30,7 @@ border-top-width: 6px;
 /* Global keywords */
 border-top-width: inherit;
 border-top-width: initial;
+border-top-width: revert;
 border-top-width: unset;
 </pre>
 

--- a/files/en-us/web/css/border-top/index.html
+++ b/files/en-us/web/css/border-top/index.html
@@ -44,6 +44,12 @@ border-top: none thick green;
 <pre class="brush: css no-line-numbers">border-top: 1px;
 border-top: 2px dotted;
 border-top: medium dashed green;
+
+/* Global values */
+border-top: inherit;
+border-top: initial;
+border-top: revert;
+border-top: unset;
 </pre>
 
 <p>The three values of the shorthand property can be specified in any order, and one or two of them may be omitted.</p>

--- a/files/en-us/web/css/border-width/index.html
+++ b/files/en-us/web/css/border-width/index.html
@@ -48,6 +48,7 @@ border-width: 1px 2em 0 4rem;
 /* Global keywords */
 border-width: inherit;
 border-width: initial;
+border-width: revert;
 border-width: unset;
 </pre>
 

--- a/files/en-us/web/css/bottom/index.html
+++ b/files/en-us/web/css/bottom/index.html
@@ -43,6 +43,7 @@ bottom: auto;
 /* Global values */
 bottom: inherit;
 bottom: initial;
+bottom: revert;
 bottom: unset;
 </pre>
 

--- a/files/en-us/web/css/box-decoration-break/index.html
+++ b/files/en-us/web/css/box-decoration-break/index.html
@@ -37,6 +37,7 @@ box-decoration-break: clone;
 /* Global values */
 box-decoration-break: initial;
 box-decoration-break: inherit;
+box-decoration-break: revert;
 box-decoration-break: unset;
 </pre>
 

--- a/files/en-us/web/css/box-direction/index.html
+++ b/files/en-us/web/css/box-direction/index.html
@@ -23,6 +23,7 @@ box-direction: reverse;
 /* Global values */
 box-direction: inherit;
 box-direction: initial;
+box-direction: revert;
 box-direction: unset;
 </pre>
 

--- a/files/en-us/web/css/box-shadow/index.html
+++ b/files/en-us/web/css/box-shadow/index.html
@@ -50,6 +50,7 @@ box-shadow: 3px 3px red, -1em 0 0.4em olive;
 /* Global keywords */
 box-shadow: inherit;
 box-shadow: initial;
+box-shadow: revert;
 box-shadow: unset;
 </pre>
 

--- a/files/en-us/web/css/box-sizing/index.html
+++ b/files/en-us/web/css/box-sizing/index.html
@@ -42,6 +42,15 @@ browser-compat: css.properties.box-sizing
 
 <h2 id="Syntax">Syntax</h2>
 
+<pre class="brush: css">box-sizing: border-box;
+box-sizing: content-box;
+
+/* Global values */
+box-sizing: inherit;
+box-sizing: initial;
+box-sizing: revert;
+box-sizing: unset;</pre>
+
 <p>The <code>box-sizing</code> property is specified as a single keyword chosen from the list of values below.</p>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/break-after/index.html
+++ b/files/en-us/web/css/break-after/index.html
@@ -39,6 +39,7 @@ break-after: region;
 /* Global values */
 break-after: inherit;
 break-after: initial;
+break-after: revert;
 break-after: unset;
 </pre>
 

--- a/files/en-us/web/css/break-before/index.html
+++ b/files/en-us/web/css/break-before/index.html
@@ -39,6 +39,7 @@ break-before: region;
 /* Global values */
 break-before: inherit;
 break-before: initial;
+break-before: revert;
 break-before: unset;
 </pre>
 

--- a/files/en-us/web/css/break-inside/index.html
+++ b/files/en-us/web/css/break-inside/index.html
@@ -24,6 +24,7 @@ break-inside: avoid-region;
 /* Global values */
 break-inside: inherit;
 break-inside: initial;
+break-inside: revert;
 break-inside: unset;
 </pre>
 


### PR DESCRIPTION
Part of #3047

Adds the global CSS value revert to a batch of CSS properties (those starting with a or b, which is a lot as CSS is mostly borders it turns out).

Also adding the global properties to those missing them.
