### PR TITLE
Replace spec table with {{specifications}} for api/t*

### DIFF
--- a/files/en-us/web/api/taskattributiontiming/containerid/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.html
@@ -28,20 +28,7 @@ browser-compat: api.TaskAttributionTiming.containerId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containerid','containerId')}}</td>
-      <td>{{Spec2('Long Tasks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/taskattributiontiming/containername/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.html
@@ -28,20 +28,7 @@ browser-compat: api.TaskAttributionTiming.containerName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containername','containerName')}}</td>
-      <td>{{Spec2('Long Tasks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.html
@@ -28,20 +28,7 @@ browser-compat: api.TaskAttributionTiming.containerSrc
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containersrc','containerSrc')}}</td>
-      <td>{{Spec2('Long Tasks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.html
@@ -28,20 +28,7 @@ browser-compat: api.TaskAttributionTiming.containerType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containertype','containerType')}}</td>
-      <td>{{Spec2('Long Tasks')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/taskattributiontiming/index.html
+++ b/files/en-us/web/api/taskattributiontiming/index.html
@@ -31,20 +31,7 @@ browser-compat: api.TaskAttributionTiming
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Long Tasks','#sec-TaskAttributionTiming','TaskAttributionTiming')}}</td>
-   <td>{{Spec2('Long Tasks')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/assignedslot/index.html
+++ b/files/en-us/web/api/text/assignedslot/index.html
@@ -27,20 +27,7 @@ browser-compat: api.Text.assignedSlot
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG','#dom-slotable-assignedslot','assignedSlot')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -55,41 +55,7 @@ browser-compat: api.Text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#text', 'Text')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Removed the <code>isElementContentWhitespace</code> property.<br>
-    Removed the <code>replaceWholeText()</code> method.<br>
-    Added the <code>Text()</code> constructor.<br>
-    Added the <code>assignedSlot</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#ID-1312295772', 'Text')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Added the <code>isElementContentWhitespace</code> and <code>wholeText</code> properties.<br>
-    Added the <code>replaceWholeText()</code> method.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core', 'core.html#ID-1312295772', 'Text')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No change from {{SpecName('DOM1')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1', 'level-one-core.html#ID-1312295772', 'Text')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/replacewholetext/index.html
+++ b/files/en-us/web/api/text/replacewholetext/index.html
@@ -36,20 +36,7 @@ browser-compat: api.Text.replaceWholeText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-1312295772', 'Text')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/splittext/index.html
+++ b/files/en-us/web/api/text/splittext/index.html
@@ -83,37 +83,7 @@ p.insertBefore(u, bar);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-text-splittext', 'Text.splitText')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM3 Core')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Core', 'core.html#ID-38853C1D', 'Text.splitText')}}</td>
-      <td>{{Spec2('DOM3 Core')}}</td>
-      <td>No change from {{SpecName('DOM2 Core')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Core', 'core.html#ID-38853C1D', 'Text.splitText')}}</td>
-      <td>{{Spec2('DOM2 Core')}}</td>
-      <td>No change from {{SpecName('DOM1')}}.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM1', 'level-one-core.html#ID-38853C1D', 'Text.splitText')}}</td>
-      <td>{{Spec2('DOM1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/text/index.html
+++ b/files/en-us/web/api/text/text/index.html
@@ -29,20 +29,7 @@ browser-compat: api.Text.Text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-text-text', 'Text()')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/wholetext/index.html
+++ b/files/en-us/web/api/text/wholetext/index.html
@@ -69,25 +69,7 @@ browser-compat: api.Text.wholeText
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-text-wholetext', 'Text.wholeText')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>No significant change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core', 'core.html#Text3-wholeText', 'Text.wholeText')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoder/decode/index.html
+++ b/files/en-us/web/api/textdecoder/decode/index.html
@@ -68,20 +68,7 @@ document.getElementById('decoded-value').textContent = str;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Encoding", "#dom-textdecoder-decode", "TextDecoder.decode()")}}</td>
-      <td>{{Spec2("Encoding")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoder/encoding/index.html
+++ b/files/en-us/web/api/textdecoder/encoding/index.html
@@ -82,21 +82,7 @@ browser-compat: api.TextDecoder.encoding
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Encoding', '#dom-textdecoder-encoding', 'TextDecoder.encoding')}}
-      </td>
-      <td>{{Spec2('Encoding')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/index.html
@@ -78,22 +78,7 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Encoding", "#interface-textdecoder", "TextDecoder")}}</td>
-   <td>{{Spec2("Encoding")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoder/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.html
@@ -55,20 +55,7 @@ var textDecoder4 = new TextDecoder(&quot;iso-2022-cn&quot;); // Throw a TypeErro
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Encoding', '#dom-textdecoder', 'TextDecoder()')}}</td>
-      <td>{{Spec2('Encoding')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -29,20 +29,7 @@ console.log(stream.encoding); // returns the default "utf-8"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#dom-textdecoder-encoding", "TextDecoderStream.encoding")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -29,20 +29,7 @@ console.log(stream.fatal); // returns false</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName("Encoding", "#dom-textdecoder-fatal", "TextDecoderStream.fatal")}}</td>
-     <td>{{Spec2("Encoding")}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -28,20 +28,7 @@ console.log(stream.ignoreBOM); // returns false</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#textdecoder-ignore-bom-flag", "TextDecoderStream.ignoreBOM")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -43,20 +43,7 @@ browser-compat: api.TextDecoderStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#interface-TextDecoderStream", "TextDecoderStream")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -29,20 +29,7 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Streams", "#dom-generictransformstream-readable", "readable")}}</td>
-    <td>{{Spec2("Streams")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -39,20 +39,7 @@ const stream = response.body.pipeThrough(new TextDecoderStream());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#dom-textdecoderstream", "TextDecoderStream()")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textdecoderstream/writable/index.html
+++ b/files/en-us/web/api/textdecoderstream/writable/index.html
@@ -29,20 +29,7 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Streams", "#dom-generictransformstream-writable", "writable")}}</td>
-    <td>{{Spec2("Streams")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/textencoder/encode/index.html
+++ b/files/en-us/web/api/textencoder/encode/index.html
@@ -51,21 +51,7 @@ resultPara.textContent += encoded;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Encoding", "#dom-textencoder-encode",
-        "TextEncoder.prototype.encode()")}}</td>
-      <td>{{Spec2("Encoding")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoder/encodeinto/index.html
+++ b/files/en-us/web/api/textencoder/encodeinto/index.html
@@ -283,21 +283,7 @@ resultPara.textContent += 'Bytes read: ' + encodedResults.read +
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <tbody>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-        <tr>
-            <td>{{SpecName("Encoding", "#dom-textencoder-encodeinto",
-                "TextEncoder.encode()")}}</td>
-            <td>{{Spec2("Encoding")}}</td>
-            <td>Initial definition.</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoder/encoding/index.html
+++ b/files/en-us/web/api/textencoder/encoding/index.html
@@ -25,23 +25,7 @@ browser-compat: api.TextEncoder.encoding
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Encoding", "#dom-textencoder-encoding", "TextEncoder.encoding")}}
-      </td>
-      <td>{{Spec2("Encoding")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/index.html
@@ -118,22 +118,7 @@ console.log(view); // Uint8Array(3) [226, 130, 172]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Encoding", "#interface-textencoder", "TextEncoder")}}</td>
-   <td>{{Spec2("Encoding")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoder/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/textencoder/index.html
@@ -47,22 +47,7 @@ browser-compat: api.TextEncoder.TextEncoder
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Encoding", "#dom-textencoder", "TextEncoder()")}}</td>
-      <td>{{Spec2("Encoding")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoderstream/encoding/index.html
+++ b/files/en-us/web/api/textencoderstream/encoding/index.html
@@ -31,20 +31,7 @@ console.log(stream.encoding);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#dom-textencoder-encoding", "TextEncoderStream.encoding")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/index.html
@@ -40,20 +40,7 @@ browser-compat: api.TextEncoderStream
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#interface-textencoderstream", "TextEncoderStream")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoderstream/readable/index.html
+++ b/files/en-us/web/api/textencoderstream/readable/index.html
@@ -30,20 +30,7 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Streams", "#dom-generictransformstream-readable", "readable")}}</td>
-    <td>{{Spec2("Streams")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.html
@@ -25,20 +25,7 @@ fetch('/dest', { method: 'POST', body, headers: {'Content-Type': 'text/plain; ch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Encoding", "#dom-textencoderstream", "TextEncoderStream()")}}</td>
-    <td>{{Spec2("Encoding")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textencoderstream/writable/index.html
+++ b/files/en-us/web/api/textencoderstream/writable/index.html
@@ -30,20 +30,7 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{SpecName("Streams", "#dom-generictransformstream-writable", "writable")}}</td>
-    <td>{{Spec2("Streams")}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxascent/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxascent/index.html
@@ -24,16 +24,7 @@ text.actualBoundingBoxAscent; // 8;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-actualboundingboxascent", "TextMetrics.actualBoundingBoxAscent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.html
@@ -24,16 +24,7 @@ text.actualBoundingBoxDescent; // 0;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-actualboundingboxdescent", "TextMetrics.actualBoundingBoxDescent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxleft/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxleft/index.html
@@ -24,16 +24,7 @@ text.actualBoundingBoxLeft; // 0;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-actualboundingboxleft", "TextMetrics.actualBoundingBoxLeft")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxright/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxright/index.html
@@ -24,16 +24,7 @@ text.actualBoundingBoxRight; // 15.633333333333333;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-actualboundingboxright", "TextMetrics.actualBoundingBoxRight")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/alphabeticbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/alphabeticbaseline/index.html
@@ -24,16 +24,7 @@ text.alphabeticBaseline; // -0;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-alphabeticbaseline", "TextMetrics.alphabeticBaseline")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/emheightascent/index.html
+++ b/files/en-us/web/api/textmetrics/emheightascent/index.html
@@ -24,16 +24,7 @@ text.emHeightAscent; // 7.59765625;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-emheightascent", "TextMetrics.emHeightAscent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/emheightdescent/index.html
+++ b/files/en-us/web/api/textmetrics/emheightdescent/index.html
@@ -24,16 +24,7 @@ text.emHeightDescent; // -2.40234375;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-emheightdescent", "TextMetrics.emHeightDescent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/fontboundingboxascent/index.html
+++ b/files/en-us/web/api/textmetrics/fontboundingboxascent/index.html
@@ -24,16 +24,7 @@ text.fontBoundingBoxAscent; // 10;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-fontboundingboxascent", "TextMetrics.fontBoundingBoxAscent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.html
+++ b/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.html
@@ -24,16 +24,7 @@ text.fontBoundingBoxDescent; // 3;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-fontboundingboxdescent", "TextMetrics.fontBoundingBoxDescent")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/hangingbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/hangingbaseline/index.html
@@ -24,16 +24,7 @@ text.hangingBaseline; // 6.078125;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-hangingbaseline", "TextMetrics.hangingBaseline")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/ideographicbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/ideographicbaseline/index.html
@@ -24,16 +24,7 @@ text.ideographicBaseline; // -1.201171875;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-ideographicbaseline", "TextMetrics.ideographicBaseline")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/index.html
+++ b/files/en-us/web/api/textmetrics/index.html
@@ -107,18 +107,7 @@ console.log(Math.abs(textMetrics.actualBoundingBoxLeft) +
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "the-canvas-element.html#textmetrics", "TextMetrics")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/textmetrics/width/index.html
+++ b/files/en-us/web/api/textmetrics/width/index.html
@@ -31,16 +31,7 @@ text.width; // 16;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-textmetrics-width", "TextMetrics.width")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrack/cuechange_event/index.html
+++ b/files/en-us/web/api/texttrack/cuechange_event/index.html
@@ -77,20 +77,7 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#event-media-cuechange', 'cuechange')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrack/index.html
+++ b/files/en-us/web/api/texttrack/index.html
@@ -68,20 +68,7 @@ browser-compat: api.TextTrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{ SpecName('HTML WHATWG', '#texttrack', 'TextTrack') }}</td>
-			<td>{{ Spec2('HTML WHATWG') }}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrack/mode/index.html
+++ b/files/en-us/web/api/texttrack/mode/index.html
@@ -118,22 +118,7 @@ browser-compat: api.TextTrack.mode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('HTML WHATWG', '#dom-texttrack-mode', 'mode') }}</td>
-      <td>{{ Spec2('HTML WHATWG') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrackcue/index.html
+++ b/files/en-us/web/api/texttrackcue/index.html
@@ -50,25 +50,7 @@ browser-compat: api.TextTrackCue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','#texttrackcue','TextTrackCue')}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C','#texttrackcue','TextTrackCue')}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
@@ -52,20 +52,7 @@ video.onplay = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{ SpecName('HTML WHATWG', '#dom-texttrackcuelist-length', 'TextTrackCueList.length') }}</td>
-    <td>{{ Spec2('HTML WHATWG') }}</td>
-    <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrackcuelist/index.html
+++ b/files/en-us/web/api/texttrackcuelist/index.html
@@ -41,20 +41,7 @@ video.onplay = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{ SpecName('HTML WHATWG', '#texttrackcuelist', 'TextTrackCueList') }}</td>
-    <td>{{ Spec2('HTML WHATWG') }}</td>
-    <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttrackcuelist/length/index.html
+++ b/files/en-us/web/api/texttrackcuelist/length/index.html
@@ -56,20 +56,7 @@ video.onplay = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-    <td>{{ SpecName('HTML WHATWG', '#dom-texttrackcuelist-length', 'TextTrackCueList.length') }}</td>
-    <td>{{ Spec2('HTML WHATWG') }}</td>
-    <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/texttracklist/addtrack_event/index.html
@@ -56,18 +56,7 @@ mediaElement.textTracks.onaddtrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-addtrack', 'addtrack')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/change_event/index.html
+++ b/files/en-us/web/api/texttracklist/change_event/index.html
@@ -53,18 +53,7 @@ mediaElement.textTracks.onchange = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-change', 'change')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/gettrackbyid/index.html
+++ b/files/en-us/web/api/texttracklist/gettrackbyid/index.html
@@ -52,23 +52,7 @@ browser-compat: api.TextTrackList.getTrackById
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-texttracklist-gettrackbyid',
-        'TextTrackList.getTrackById()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/index.html
+++ b/files/en-us/web/api/texttracklist/index.html
@@ -90,22 +90,7 @@ function updateTrackCount(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#texttracklist', 'TexTrackList')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/length/index.html
+++ b/files/en-us/web/api/texttracklist/length/index.html
@@ -51,22 +51,7 @@ if (mediaElem.textTracks) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-texttracklist-length', 'TextTrackList: length')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/texttracklist/onaddtrack/index.html
@@ -65,22 +65,7 @@ browser-compat: api.TextTrackList.onaddtrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'TextTrackList: onaddtrack')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/onchange/index.html
+++ b/files/en-us/web/api/texttracklist/onchange/index.html
@@ -50,22 +50,7 @@ trackList.onchange = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'TextTrackList: onchange')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/texttracklist/onremovetrack/index.html
@@ -61,22 +61,7 @@ browser-compat: api.TextTrackList.onremovetrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'TextTrackList: onremovetrack')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/texttracklist/removetrack_event/index.html
+++ b/files/en-us/web/api/texttracklist/removetrack_event/index.html
@@ -56,18 +56,7 @@ mediaElement.textTracks.onremovetrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-removetrack', 'removetrack')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/timeranges/end/index.html
+++ b/files/en-us/web/api/timeranges/end/index.html
@@ -58,22 +58,7 @@ if (buf.length == 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-timeranges-end", "TimeRanges.end()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/timeranges/index.html
+++ b/files/en-us/web/api/timeranges/index.html
@@ -40,22 +40,7 @@ browser-compat: api.TimeRanges
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#time-ranges", "TimeRanges")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/timeranges/length/index.html
+++ b/files/en-us/web/api/timeranges/length/index.html
@@ -45,23 +45,7 @@ if (buf.length == 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-timeranges-length", "TimeRanges.length()")}}
-      </td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/timeranges/start/index.html
+++ b/files/en-us/web/api/timeranges/start/index.html
@@ -58,20 +58,7 @@ if (buf.length == 1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("HTML WHATWG", "#dom-timeranges-start", "TimeRanges.start()")}}</td>
-      <td>{{Spec2("HTML WHATWG")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/clientx/index.html
+++ b/files/en-us/web/api/touch/clientx/index.html
@@ -66,27 +66,7 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-clientx')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-clientX')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/clienty/index.html
+++ b/files/en-us/web/api/touch/clienty/index.html
@@ -65,27 +65,7 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-clienty')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>No changes since last version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-clientY')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/force/index.html
+++ b/files/en-us/web/api/touch/force/index.html
@@ -56,20 +56,7 @@ browser-compat: api.Touch.force
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-force')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/identifier/index.html
+++ b/files/en-us/web/api/touch/identifier/index.html
@@ -39,27 +39,7 @@ browser-compat: api.Touch.identifier
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-identifier')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>No change.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-identifier')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/index.html
+++ b/files/en-us/web/api/touch/index.html
@@ -73,27 +73,7 @@ browser-compat: api.Touch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events 2', '#touch-interface', 'Touch')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Added <code>radiusX</code>, <code>radiusY</code>, <code>rotationAngle</code>, <code>force</code> properties, as well as the <code>Touch()</code> constructor.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#touch-interface', 'Touch')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/pagex/index.html
+++ b/files/en-us/web/api/touch/pagex/index.html
@@ -54,25 +54,7 @@ src.addEventListener('touchmove', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-pagex')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>No change from the previous version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-pageX')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/pagey/index.html
+++ b/files/en-us/web/api/touch/pagey/index.html
@@ -53,25 +53,7 @@ src.addEventListener('touchmove', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touch-pagey')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>No change from last version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events', '#widl-Touch-pageY')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/radiusx/index.html
+++ b/files/en-us/web/api/touch/radiusx/index.html
@@ -64,20 +64,7 @@ function rotate (e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-radiusx')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/radiusy/index.html
+++ b/files/en-us/web/api/touch/radiusy/index.html
@@ -40,20 +40,7 @@ browser-compat: api.Touch.radiusY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-radiusy')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/rotationangle/index.html
+++ b/files/en-us/web/api/touch/rotationangle/index.html
@@ -38,20 +38,7 @@ browser-compat: api.Touch.rotationAngle
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-rotationangle')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/screenx/index.html
+++ b/files/en-us/web/api/touch/screenx/index.html
@@ -50,25 +50,7 @@ src.addEventListener('touchstart', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-screenx')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#widl-Touch-screenX')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/screeny/index.html
+++ b/files/en-us/web/api/touch/screeny/index.html
@@ -33,25 +33,7 @@ browser-compat: api.Touch.screenY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-screeny')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#widl-Touch-screenY')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/target/index.html
+++ b/files/en-us/web/api/touch/target/index.html
@@ -49,25 +49,7 @@ src.addEventListener('touchstart', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touch-target')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#widl-Touch-target')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touch/touch/index.html
+++ b/files/en-us/web/api/touch/touch/index.html
@@ -42,22 +42,7 @@ browser-compat: api.Touch.Touch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#touchevent-interface', 'TouchEvent')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/altkey/index.html
+++ b/files/en-us/web/api/touchevent/altkey/index.html
@@ -48,25 +48,7 @@ browser-compat: api.TouchEvent.altKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-altkey')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-altKey')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/changedtouches/index.html
+++ b/files/en-us/web/api/touchevent/changedtouches/index.html
@@ -53,25 +53,7 @@ browser-compat: api.TouchEvent.changedTouches
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-changedtouches')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-changedTouches')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/ctrlkey/index.html
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.html
@@ -36,25 +36,7 @@ browser-compat: api.TouchEvent.ctrlKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-ctrlkey')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-ctrlKey')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/index.html
+++ b/files/en-us/web/api/touchevent/index.html
@@ -111,27 +111,7 @@ browser-compat: api.TouchEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#touchevent-interface', 'TouchEvent')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Added <code>ontouchstart</code>, <code>ontouchend</code>, <code>ontouchmove</code>, <code>ontouchend</code> global attribute handlers</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#touchevent-interface', 'TouchEvent')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/metakey/index.html
+++ b/files/en-us/web/api/touchevent/metakey/index.html
@@ -40,25 +40,7 @@ browser-compat: api.TouchEvent.metaKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-metakey')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-metaKey')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/shiftkey/index.html
+++ b/files/en-us/web/api/touchevent/shiftkey/index.html
@@ -36,25 +36,7 @@ browser-compat: api.TouchEvent.shiftKey
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-shiftkey')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-shiftKey')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/targettouches/index.html
+++ b/files/en-us/web/api/touchevent/targettouches/index.html
@@ -44,25 +44,7 @@ browser-compat: api.TouchEvent.targetTouches
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#dom-touchevent-targettouches')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events','#widl-TouchEvent-targetTouches')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchevent/touches/index.html
+++ b/files/en-us/web/api/touchevent/touches/index.html
@@ -65,25 +65,7 @@ browser-compat: api.TouchEvent.touches
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touchevent-touches')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events','#widl-TouchEvent-touches')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchlist/index.html
+++ b/files/en-us/web/api/touchlist/index.html
@@ -38,27 +38,7 @@ browser-compat: api.TouchList
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Touch Events 2','#touchlist-interface')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Non-stable version.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#touchlist-interface')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchlist/item/index.html
+++ b/files/en-us/web/api/touchlist/item/index.html
@@ -63,25 +63,7 @@ target.addEventListener('touchstart', function(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touchlist-item')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events','#widl-TouchList-item-getter-Touch-unsigned-long-index')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/touchlist/length/index.html
+++ b/files/en-us/web/api/touchlist/length/index.html
@@ -53,25 +53,7 @@ target.addEventListener('touchstart', function(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events 2','#dom-touchlist-length')}}</td>
-      <td>{{Spec2('Touch Events 2')}}</td>
-      <td>Non-stable version.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Touch Events','#widl-TouchList-length')}}</td>
-      <td>{{Spec2('Touch Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trackevent/index.html
+++ b/files/en-us/web/api/trackevent/index.html
@@ -85,25 +85,7 @@ function handleTrackEvent(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "media.html#the-trackevent-interface", "TrackEvent")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#trackevent", "TrackEvent")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trackevent/track/index.html
+++ b/files/en-us/web/api/trackevent/track/index.html
@@ -35,27 +35,7 @@ browser-compat: api.TrackEvent.track
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "media.html#dom-trackevent-track",
-        "TrackEvent.track")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-trackevent-track",
-        "TrackEvent.track")}}</td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trackevent/trackevent/index.html
+++ b/files/en-us/web/api/trackevent/trackevent/index.html
@@ -57,28 +57,7 @@ browser-compat: api.TrackEvent.TrackEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', "media.html#dom-trackevent-trackevent",
-        "TrackEvent()")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML5 W3C',
-        "semantics-embedded-content.html#dom-trackevent-trackevent", "TrackEvent()")}}
-      </td>
-      <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transferable/index.html
+++ b/files/en-us/web/api/transferable/index.html
@@ -31,27 +31,7 @@ browser-compat: api.Transferable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "infrastructure.html#transferable-objects", "Transferable")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Replaced <code>Transferable</code> interface with <code>[Transferable]</code> Web IDL extended attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "infrastructure.html#transferable-objects", "Transferable")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transitionevent/elapsedtime/index.html
+++ b/files/en-us/web/api/transitionevent/elapsedtime/index.html
@@ -26,23 +26,7 @@ browser-compat: api.TransitionEvent.elapsedTime
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Transitions', '#Events-TransitionEvent-elapsedTime',
-        'TransitionEvent.elapsedTime') }}</td>
-      <td>{{ Spec2('CSS3 Transitions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/index.html
@@ -58,22 +58,7 @@ browser-compat: api.TransitionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Transitions', '#interface-transitionevent', 'TransitionEvent') }}</td>
-   <td>{{ Spec2('CSS3 Transitions') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transitionevent/propertyname/index.html
+++ b/files/en-us/web/api/transitionevent/propertyname/index.html
@@ -22,23 +22,7 @@ browser-compat: api.TransitionEvent.propertyName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Transitions', '#Events-TransitionEvent-propertyName',
-        'TransitionEvent.propertyName') }}</td>
-      <td>{{ Spec2('CSS3 Transitions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transitionevent/pseudoelement/index.html
+++ b/files/en-us/web/api/transitionevent/pseudoelement/index.html
@@ -27,23 +27,7 @@ browser-compat: api.TransitionEvent.pseudoElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Transitions', '#Events-TransitionEvent-pseudoElement',
-        'TransitionEvent.pseudoElement') }}</td>
-      <td>{{ Spec2('CSS3 Transitions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/transitionevent/transitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.html
@@ -58,23 +58,7 @@ browser-compat: api.TransitionEvent.TransitionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSS3 Transitions', '#dom-transitionevent-transitionevent',
-        'TransitionEvent()') }}</td>
-      <td>{{ Spec2('CSS3 Transitions')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/currentnode/index.html
+++ b/files/en-us/web/api/treewalker/currentnode/index.html
@@ -32,28 +32,7 @@ root = treeWalker.currentNode; // the root element as it is the first element!
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-currentnode',
-        'TreeWalker.currrentNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-currentNode', 'TreeWalker.currentNode')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -36,17 +36,7 @@ expand = treeWalker.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-expandEntityReferences',
-        'TreeWalker.expandEntityReferences')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/filter/index.html
+++ b/files/en-us/web/api/treewalker/filter/index.html
@@ -36,26 +36,7 @@ nodeFilter = treeWalker.filter; // document.body in this case
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-filter', 'TreeWalker.filter')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Traversal-TreeWalker-filter',
-        'TreeWalker.filter')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/firstchild/index.html
+++ b/files/en-us/web/api/treewalker/firstchild/index.html
@@ -35,27 +35,7 @@ var node = treeWalker.firstChild(); // returns the first child of the root eleme
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-firstchild',
-        'TreeWalker.firstChild')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-firstChild', 'TreeWalker.firstChild')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/index.html
+++ b/files/en-us/web/api/treewalker/index.html
@@ -133,25 +133,7 @@ browser-compat: api.TreeWalker
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-treewalker', 'TreeWalker')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Removed the <code>expandEntityReferences</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Traversal-TreeWalker', 'TreeWalker')}}</td>
-   <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/lastchild/index.html
+++ b/files/en-us/web/api/treewalker/lastchild/index.html
@@ -34,27 +34,7 @@ var node = treeWalker.lastChild(); // returns the last visible child of the root
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-lastchild', 'TreeWalker.lastChild')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-lastChild', 'TreeWalker.lastChild')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/nextnode/index.html
+++ b/files/en-us/web/api/treewalker/nextnode/index.html
@@ -35,27 +35,7 @@ var node = treeWalker.nextNode(); // returns the first child of root, as it is t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-nextnode', 'TreeWalker.nextNode')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-nextNode', 'TreeWalker.nextNode')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/nextsibling/index.html
+++ b/files/en-us/web/api/treewalker/nextsibling/index.html
@@ -35,28 +35,7 @@ var node = treeWalker.nextSibling(); // returns null if the first child of the r
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-nextsibling',
-        'TreeWalker.nextSibling')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-nextSibling', 'TreeWalker.nextSibling')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/parentnode/index.html
+++ b/files/en-us/web/api/treewalker/parentnode/index.html
@@ -36,27 +36,7 @@ var node = treeWalker.parentNode(); // returns null as there is no parent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-parentnode',
-        'TreeWalker.parentNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-parentNode', 'TreeWalker.parentNode')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/previousnode/index.html
+++ b/files/en-us/web/api/treewalker/previousnode/index.html
@@ -36,28 +36,7 @@ var node = treeWalker.previousNode(); // returns null as there is no parent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-previousnode',
-        'TreeWalker.previousNode')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-previousNode', 'TreeWalker.previousNode')}}
-      </td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/previoussibling/index.html
+++ b/files/en-us/web/api/treewalker/previoussibling/index.html
@@ -36,28 +36,7 @@ var node = treeWalker.previousSibling(); // returns null as there is no previous
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-previoussibling',
-        'TreeWalker.previousSibling')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-previousSibling',
-        'TreeWalker.previousSibling')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/root/index.html
+++ b/files/en-us/web/api/treewalker/root/index.html
@@ -30,26 +30,7 @@ root = treeWalker.root; // document.body in this case
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-root', 'TreeWalker.root')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range', 'traversal.html#Traversal-TreeWalker-root',
-        'TreeWalker.root')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/treewalker/whattoshow/index.html
+++ b/files/en-us/web/api/treewalker/whattoshow/index.html
@@ -123,27 +123,7 @@ if( (treeWalker.whatToShow == NodeFilter.SHOW_ALL) ||
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-treewalker-whattoshow',
-        'TreeWalker.whatToShow')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>No change from {{SpecName('DOM2 Traversal_Range')}}</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Traversal_Range',
-        'traversal.html#Traversal-TreeWalker-whatToShow', 'TreeWalker.whatToShow')}}</td>
-      <td>{{Spec2('DOM2 Traversal_Range')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedhtml/index.html
+++ b/files/en-us/web/api/trustedhtml/index.html
@@ -43,20 +43,7 @@ el.innerHTML = escaped;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trusted-html','TrustedHTML')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedhtml/tojson/index.html
+++ b/files/en-us/web/api/trustedhtml/tojson/index.html
@@ -35,20 +35,7 @@ console.log(escaped.toJSON());
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedhtml-tojson','TrustedHTML.toJSON()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedhtml/tostring/index.html
+++ b/files/en-us/web/api/trustedhtml/tostring/index.html
@@ -35,20 +35,7 @@ console.log(escaped.toString());
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trustedhtml-stringification-behavior','TrustedHTML.toString()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscript/index.html
+++ b/files/en-us/web/api/trustedscript/index.html
@@ -33,20 +33,7 @@ console.log(sanitized); /* a TrustedScript object */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trusted-script','TrustedScript')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscript/tojson/index.html
+++ b/files/en-us/web/api/trustedscript/tojson/index.html
@@ -31,20 +31,7 @@ browser-compat: api.TrustedScript.toJSON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedscript-tojson','TrustedScript.toJSON()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscript/tostring/index.html
+++ b/files/en-us/web/api/trustedscript/tostring/index.html
@@ -31,20 +31,7 @@ console.log(sanitized.toString());
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trustedscript-stringification-behavior','TrustedScript.toString()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscripturl/index.html
+++ b/files/en-us/web/api/trustedscripturl/index.html
@@ -33,20 +33,7 @@ console.log(sanitized;) /* a TrustedScriptURL object */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trused-script-url','TrustedScriptURL')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscripturl/tojson/index.html
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.html
@@ -31,20 +31,7 @@ browser-compat: api.TrustedScriptURL.toJSON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedscripturl-tojson','TrustedScriptURL.toJSON()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedscripturl/tostring/index.html
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.html
@@ -31,20 +31,7 @@ console.log(sanitized.toString());
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trustedscripturl-stringification-behavior','TrustedScriptURL.toString()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -45,20 +45,7 @@ browser-compat: api.TrustedTypePolicy.createHTML
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createhtml','TrustedTypePolicy.createHTML()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.html
@@ -45,20 +45,7 @@ browser-compat: api.TrustedTypePolicy.createScript
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createscript','TrustedTypePolicy.createScript()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
@@ -45,20 +45,7 @@ browser-compat: api.TrustedTypePolicy.createScriptURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createscripturl','TrustedTypePolicy.createScriptURL()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -52,20 +52,7 @@ el.innerHTML = escaped;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trustedtypepolicy',"TrustedTypePolicy")}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/name/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.html
@@ -32,20 +32,7 @@ console.log(escapeHTMLPolicy.name); /* "myEscapePolicy" */</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-name',"TrustedTypePolicy.name")}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -86,20 +86,7 @@ browser-compat: api.TrustedTypePolicyFactory.createPolicy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-createpolicy','TrustedTypePolicyFactory.createPolicy()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -35,20 +35,7 @@ console.log(trustedTypes.defaultPolicy); // a TrustedTypePolicy object</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-defaultpolicy','TrustedTypePolicyFactory.defaultPolicy')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -30,20 +30,7 @@ browser-compat: api.TrustedTypePolicyFactory.emptyHTML
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-emptyhtml','TrustedTypePolicyFactory.emptyHTML')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -33,20 +33,7 @@ eval(supportsTS ? myTrustedScriptObj : myTrustedScriptObj.toString());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-emptyscript','TrustedTypePolicyFactory.emptyScript')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -49,20 +49,7 @@ browser-compat: api.TrustedTypePolicyFactory.getAttributeType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-getattributetype','TrustedTypePolicyFactory.getAttributeType()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -47,20 +47,7 @@ browser-compat: api.TrustedTypePolicyFactory.getPropertyType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-getpropertytype','TrustedTypePolicyFactory.getPropertyType()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -58,20 +58,7 @@ console.log(trustedTypes.isHTML(escaped)) // true;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#trusted-type-policy-factory','TrustedTypePolicyFactory')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -47,20 +47,7 @@ console.log(trustedTypes.isHTML("&lt;div&gt;plain string&lt;/div&gt;")); // fals
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-ishtml','TrustedTypePolicyFactory.isHTML()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -47,20 +47,7 @@ console.log(trustedTypes.isScript("eval('2 + 2')")); // false</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-isscript','TrustedTypePolicyFactory.isScript()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -47,20 +47,7 @@ console.log(trustedTypes.isScriptURL("https://example.com/myscript.js")); // fal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-isscripturl','TrustedTypePolicyFactory.isScriptURL()')}}</td>
-    <td>{{Spec2('Trusted Types')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/t* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `TrustedScript` and its 2 children,`TrustedScriptURL` and its 2 children, `TrustedTypePolicyFactory`and its 9 children, and `TrustedTypePolicy` and its 4 children were missing both `mdn_url` and `spec_url`. (`TrustedScript.toJSON`, `TrustedHTML.toJSON`, and `TrustedScriptURL.toJSON` were also missing the compat section on bcd) All this is being fixed in mdn/browser-compat-data#11063.
- `TreeWalker.expandEntityReferences` and `Text.replaceWholeText` are deprecated and therefore the link to the spec is outdated. I leave it that way.
- `TrackEvent()` has no workng bcd table, so both will be fixed together.
- `TextTrackList.onremovetrack`, `TextTrackList.onchange`, `TextTrackList.onaddtrack`, `TextTrackCueList`and its 2 children had no `spec_url`. This is fixed in mdn/browser-compat-data#11064

All other pages look fine.