### PR TITLE
Replace spec table with {{specifications}} for api/u*

### DIFF
--- a/files/en-us/web/api/uievent/detail/index.html
+++ b/files/en-us/web/api/uievent/detail/index.html
@@ -21,25 +21,7 @@ browser-compat: api.UIEvent.detail
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events','#widl-UIEvent-detail','UIEvent.detail')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Events','#Events-UIEvent-detail','UIEvent.detail')}}</td>
-   <td>{{Spec2('DOM2 Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/uievent/index.html
+++ b/files/en-us/web/api/uievent/index.html
@@ -64,35 +64,7 @@ browser-compat: api.UIEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('InputDeviceCapabilities')}}</td>
-   <td>{{Spec2('InputDeviceCapabilities')}}</td>
-   <td>Added <code>sourceCapabilities</code> property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('UI Events')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-   <td>Extend DOM3</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Events', '#interface-UIEvent', 'UIEvent')}}</td>
-   <td>{{Spec2('DOM3 Events')}}</td>
-   <td>Added the <code>UIEvent()</code> constructor, deprecated the <code>initUIEvent()</code> method and changed the type of <code>view</code> from <code>AbstractView</code> to <code>WindowProxy</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Events', '#Events-UIEvent', 'UIEvent')}}</td>
-   <td>{{Spec2('DOM2 Events')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/uievent/inituievent/index.html
+++ b/files/en-us/web/api/uievent/inituievent/index.html
@@ -63,26 +63,7 @@ e.initUIEvent("click", true, true, window, 1);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#widl-UIEvent-initUIEvent',
-        'UIEvent.initUIEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>From {{SpecName('DOM2 Events')}}, deprecated.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-UIEvent', 'UIEvent.initUIEvent()')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/uievent/sourcecapabilities/index.html
+++ b/files/en-us/web/api/uievent/sourcecapabilities/index.html
@@ -41,22 +41,7 @@ browser-compat: api.UIEvent.sourceCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Specification</th>
-      <th>Status</th>
-      <th>Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('InputDeviceCapabilities','#dom-uievent-sourcecapabilities','sourceCapabilities')}}
-      </td>
-      <td>{{Spec2('InputDeviceCapabilities')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/uievent/uievent/index.html
+++ b/files/en-us/web/api/uievent/uievent/index.html
@@ -48,27 +48,7 @@ browser-compat: api.UIEvent.UIEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('InputDeviceCapabilities')}}</td>
-      <td>{{Spec2('InputDeviceCapabilities')}}</td>
-      <td>Added <code>sourceCapabilities</code> property.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events','#interface-UIEvent','UIEvent()')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/uievent/view/index.html
+++ b/files/en-us/web/api/uievent/view/index.html
@@ -28,26 +28,7 @@ browser-compat: api.UIEvent.view
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM3 Events', '#interface-UIEvent', 'UIEvent')}}</td>
-      <td>{{Spec2('DOM3 Events')}}</td>
-      <td>From {{SpecName('DOM2 Events')}}, changed the type of <code>view</code> from
-        <code>AbstractView</code> to <code>WindowProxy</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM2 Events', '#Events-UIEvent', 'UIEvent')}}</td>
-      <td>{{Spec2('DOM2 Events')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/ulongrange/index.html
+++ b/files/en-us/web/api/ulongrange/index.html
@@ -31,20 +31,7 @@ browser-compat: api.ULongRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture', '#dom-ulongrange', 'ULongRange')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/createobjecturl/index.html
+++ b/files/en-us/web/api/url/createobjecturl/index.html
@@ -84,30 +84,7 @@ browser-compat: api.URL.createObjectURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File API', '#dfn-createObjectURL', 'createObjectURL()')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-url-createobjecturl', 'URL')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td>
-        <p>MediaSource extension.</p>
-
-        <p>Older versions of this specification used <code>createObjectURL()</code> for
-          {{domxref("MediaStream")}} objects; this is no longer supported.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/hash/index.html
+++ b/files/en-us/web/api/url/hash/index.html
@@ -39,20 +39,7 @@ console.log(url.hash); // Logs: '#Examples'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-hash', 'URL.hash')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/host/index.html
+++ b/files/en-us/web/api/url/host/index.html
@@ -43,20 +43,7 @@ console.log(url.host); // "developer.mozilla.org:4097"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-host', 'URL.host')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/hostname/index.html
+++ b/files/en-us/web/api/url/hostname/index.html
@@ -33,20 +33,7 @@ console.log(url.hostname); // Logs: 'developer.mozilla.org'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-hostname', 'URL.hostname')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/href/index.html
+++ b/files/en-us/web/api/url/href/index.html
@@ -34,20 +34,7 @@ console.log(url.href); // Logs: 'https://developer.mozilla.org/en-US/docs/Web/AP
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-href', 'URL.href')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/index.html
+++ b/files/en-us/web/api/url/index.html
@@ -117,27 +117,7 @@ console.log(parsedUrl.searchParams.get("id")); // "123"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('File API', '#creating-revoking', 'URL')}}</td>
-   <td>{{Spec2('File API')}}</td>
-   <td>Added the static methods <code>URL.createObjectURL()</code> and <code>URL.revokeObjectURL</code><code>()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('URL', '#api', 'API')}}</td>
-   <td>{{Spec2('URL')}}</td>
-   <td>Initial definition (implements <code>URLUtils</code>).</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/origin/index.html
+++ b/files/en-us/web/api/url/origin/index.html
@@ -48,20 +48,7 @@ console.log(url.origin); // Logs 'https://mozilla.org'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-origin', 'URL.origin')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/password/index.html
+++ b/files/en-us/web/api/url/password/index.html
@@ -39,20 +39,7 @@ console.log(url.password) // Logs "flabada"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-password', 'URL.password')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/pathname/index.html
+++ b/files/en-us/web/api/url/pathname/index.html
@@ -36,20 +36,7 @@ console.log(url.pathname); // Logs "/en-US/docs/Web/API/URL/pathname"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-pathname', 'URL.pathname')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/port/index.html
+++ b/files/en-us/web/api/url/port/index.html
@@ -36,20 +36,7 @@ console.log(url.port); // Logs '80'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-port', 'URL.port')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/protocol/index.html
+++ b/files/en-us/web/api/url/protocol/index.html
@@ -35,20 +35,7 @@ console.log(url.protocol); // Logs "https:"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-protocol', 'protocol')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/revokeobjecturl/index.html
+++ b/files/en-us/web/api/url/revokeobjecturl/index.html
@@ -46,20 +46,7 @@ browser-compat: api.URL.revokeObjectURL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('File API', '#dfn-revokeObjectURL', 'revokeObjectURL()')}}</td>
-      <td>{{Spec2('File API')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/search/index.html
+++ b/files/en-us/web/api/url/search/index.html
@@ -39,20 +39,7 @@ console.log(url.search); // Logs "?q=123"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-search', 'URL.search')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/searchparams/index.html
+++ b/files/en-us/web/api/url/searchparams/index.html
@@ -39,20 +39,7 @@ let age = parseInt(params.get('age')); // is the number 18</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-searchparams', 'searchParams')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/tojson/index.html
+++ b/files/en-us/web/api/url/tojson/index.html
@@ -35,20 +35,7 @@ url.toJSON(); // should return the URL as a string</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('URL', '#dom-url-tojson', 'toJSON()')}}</td>
-			<td>{{Spec2('URL')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/tostring/index.html
+++ b/files/en-us/web/api/url/tostring/index.html
@@ -35,20 +35,7 @@ url.toString(); // should return the URL as a string
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#URL-stringification-behavior', 'stringifier')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/url/index.html
+++ b/files/en-us/web/api/url/url/index.html
@@ -91,22 +91,7 @@ let d = new URL('/en-US/docs', b);                     // =
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('URL', '#constructors', 'URL.URL()')}}</td>
-			<td>{{Spec2('URL')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/url/username/index.html
+++ b/files/en-us/web/api/url/username/index.html
@@ -36,20 +36,7 @@ console.log(url.username) // Logs "anonymous"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-url-username', 'username')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/append/index.html
+++ b/files/en-us/web/api/urlsearchparams/append/index.html
@@ -48,22 +48,7 @@ params.append('foo', 4);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-append', "append()")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/delete/index.html
+++ b/files/en-us/web/api/urlsearchparams/delete/index.html
@@ -42,22 +42,7 @@ params.delete('foo'); //Query string is now: 'bar=2'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-delete', "delete()")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/entries/index.html
+++ b/files/en-us/web/api/urlsearchparams/entries/index.html
@@ -49,23 +49,7 @@ key2, value2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#interface-urlsearchparams', "entries() (see
-        \"iterable\")")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/foreach/index.html
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.html
@@ -50,23 +50,7 @@ value2 key2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#interface-urlsearchparams', "forEach() (see
-        \"iterable\")")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/get/index.html
+++ b/files/en-us/web/api/urlsearchparams/get/index.html
@@ -49,22 +49,7 @@ let age = parseInt(params.get(&quot;age&quot;), 10); // is the number 18
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-get', "get()")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/getall/index.html
+++ b/files/en-us/web/api/urlsearchparams/getall/index.html
@@ -45,22 +45,7 @@ console.log(params.getAll('foo')) //Prints ["1","4"].
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-getall', "getAll()")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/has/index.html
+++ b/files/en-us/web/api/urlsearchparams/has/index.html
@@ -43,22 +43,7 @@ params.has('bar') === true; //true
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-has', "has()")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/index.html
+++ b/files/en-us/web/api/urlsearchparams/index.html
@@ -115,22 +115,7 @@ searchParams.get("bin2"); // "E+AXQB+A"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('URL', '#urlsearchparams', "URLSearchParams")}}</td>
-   <td>{{Spec2('URL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/keys/index.html
+++ b/files/en-us/web/api/urlsearchparams/keys/index.html
@@ -51,23 +51,7 @@ key2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#interface-urlsearchparams', "keys() (see \"iterable\")")}}
-      </td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/set/index.html
+++ b/files/en-us/web/api/urlsearchparams/set/index.html
@@ -113,22 +113,7 @@ console.info( url, url.toString() )
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('URL', '#dom-urlsearchparams-set', "set()")}}</td>
-			<td>{{Spec2('URL')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/sort/index.html
+++ b/files/en-us/web/api/urlsearchparams/sort/index.html
@@ -49,20 +49,7 @@ console.log(searchParams.toString());
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-sort','sort()')}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/tostring/index.html
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.html
@@ -57,23 +57,7 @@ let params = new URLSearchParams('foo=1&amp;bar=2');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#interface-urlsearchparams', "toString() (see
-        \"stringifier\")")}}</td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.html
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.html
@@ -61,23 +61,7 @@ var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#dom-urlsearchparams-urlsearchparams', "URLSearchParams()")}}
-      </td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/urlsearchparams/values/index.html
+++ b/files/en-us/web/api/urlsearchparams/values/index.html
@@ -48,23 +48,7 @@ value2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('URL', '#interface-urlsearchparams', "values() (see \"iterable\")")}}
-      </td>
-      <td>{{Spec2('URL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usb/getdevices/index.html
+++ b/files/en-us/web/api/usb/getdevices/index.html
@@ -47,20 +47,7 @@ browser-compat: api.USB.getDevices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web USB","#dom-usb-getdevices","getDevices")}}</td>
-      <td>{{Spec2("Web USB")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usb/index.html
+++ b/files/en-us/web/api/usb/index.html
@@ -38,20 +38,7 @@ browser-compat: api.USB
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#enumeration','USB')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usb/onconnect/index.html
+++ b/files/en-us/web/api/usb/onconnect/index.html
@@ -23,20 +23,7 @@ browser-compat: api.USB.onconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web USB","#dom-usb-onconnect","onconnect")}}</td>
-      <td>{{Spec2("Web USB")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usb/ondisconnect/index.html
+++ b/files/en-us/web/api/usb/ondisconnect/index.html
@@ -23,20 +23,7 @@ browser-compat: api.USB.ondisconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usb-ondisconnect','ondisconnect')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usb/requestdevice/index.html
+++ b/files/en-us/web/api/usb/requestdevice/index.html
@@ -72,21 +72,7 @@ navigator.usb.requestDevice({filters: filters})
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Web USB","#dom-usb-requestdevice-options-options","requestDevice")}}
-      </td>
-      <td>{{Spec2("Web USB")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbalternateinterface/index.html
+++ b/files/en-us/web/api/usbalternateinterface/index.html
@@ -42,20 +42,7 @@ browser-compat: api.USBAlternateInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbalternateinterface','USBAlternateInterface')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.html
@@ -32,20 +32,7 @@ browser-compat: api.USBConfiguration.configurationName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#ref-for-dom-usbconfiguration-configurationname','configurationName')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
@@ -31,20 +31,7 @@ browser-compat: api.USBConfiguration.configurationValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#ref-for-dom-usbconfiguration-configurationvalue','configurationValue')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/index.html
@@ -35,20 +35,7 @@ browser-compat: api.USBConfiguration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web USB','#configurations','USBConfiguration')}}</td>
-			<td>{{Spec2('Web USB')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.html
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.html
@@ -30,20 +30,7 @@ browser-compat: api.USBConfiguration.interfaces
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#ref-for-dom-usbconfiguration-interfaces','interfaces')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
@@ -38,20 +38,7 @@ browser-compat: api.USBConfiguration.USBConfiguration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbconfiguration-usbconfiguration','USBConfiguration() constructor')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/device/index.html
+++ b/files/en-us/web/api/usbconnectionevent/device/index.html
@@ -30,20 +30,7 @@ browser-compat: api.USBConnectionEvent.device
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web USB','#dom-usbconnectionevent-device','USBConnectionEvent.device')}}</td>
-			<td>{{Spec2('Web USB')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/index.html
@@ -40,20 +40,7 @@ navigator.usb.addEventListener('disconnect', event => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web USB','#usbconnectionevent','USBConnectionEvent')}}</td>
-			<td>{{Spec2('Web USB')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
@@ -47,20 +47,7 @@ browser-compat: api.USBConnectionEvent.USBConnectionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Web USB','#dom-usbconnectionevent-usbconnectionevent','USBConnectionEvent()')}}</td>
-			<td>{{Spec2('Web USB')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/claiminterface/index.html
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.html
@@ -49,20 +49,7 @@ browser-compat: api.USBDevice.claimInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-claiminterface','claimInterface()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/clearhalt/index.html
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.html
@@ -68,20 +68,7 @@ browser-compat: api.USBDevice.clearHalt
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-clearhalt','clearHalt()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/close/index.html
+++ b/files/en-us/web/api/usbdevice/close/index.html
@@ -32,20 +32,7 @@ browser-compat: api.USBDevice.close
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-close','close()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/configuration/index.html
+++ b/files/en-us/web/api/usbdevice/configuration/index.html
@@ -41,20 +41,7 @@ browser-compat: api.USBDevice.configuration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-configuration','configuration')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/configurations/index.html
+++ b/files/en-us/web/api/usbdevice/configurations/index.html
@@ -29,20 +29,7 @@ browser-compat: api.USBDevice.configurations
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-configurations','configurations')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/controltransferin/index.html
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.html
@@ -53,21 +53,7 @@ browser-compat: api.USBDevice.controlTransferIn
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-controltransferin','controlTransferIn()')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/controltransferout/index.html
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.html
@@ -55,20 +55,7 @@ browser-compat: api.USBDevice.controlTransferOut
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-controltransferout','controlTransferOut()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/deviceclass/index.html
+++ b/files/en-us/web/api/usbdevice/deviceclass/index.html
@@ -29,20 +29,7 @@ browser-compat: api.USBDevice.deviceClass
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-deviceclass','deviceClass')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/deviceprotocol/index.html
+++ b/files/en-us/web/api/usbdevice/deviceprotocol/index.html
@@ -30,20 +30,7 @@ browser-compat: api.USBDevice.deviceProtocol
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-deviceprotocol','deviceProtocol')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/devicesubclass/index.html
+++ b/files/en-us/web/api/usbdevice/devicesubclass/index.html
@@ -30,20 +30,7 @@ browser-compat: api.USBDevice.deviceSubclass
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-devicesubclass','deviceSubclass')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/deviceversionmajor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionmajor/index.html
@@ -29,21 +29,7 @@ browser-compat: api.USBDevice.deviceVersionMajor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-deviceversionmajor','deviceVersionMajor')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/deviceversionminor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionminor/index.html
@@ -29,21 +29,7 @@ browser-compat: api.USBDevice.deviceVersionMinor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-deviceversionminor','deviceVersionMinor')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
@@ -29,20 +29,7 @@ browser-compat: api.USBDevice.deviceVersionSubminor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-deviceversionsubminor','deviceVersionSubminor')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/index.html
+++ b/files/en-us/web/api/usbdevice/index.html
@@ -88,20 +88,7 @@ browser-compat: api.USBDevice
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#device-usage','USBDevice')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
@@ -40,20 +40,7 @@ browser-compat: api.USBDevice.isochronousTransferIn
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-isochronoustransferin','isochronousTransferIn()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
@@ -42,20 +42,7 @@ browser-compat: api.USBDevice.isochronousTransferOut
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-isochronoustransferout','isochronousTransferOut()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/manufacturername/index.html
+++ b/files/en-us/web/api/usbdevice/manufacturername/index.html
@@ -29,21 +29,7 @@ browser-compat: api.USBDevice.manufacturerName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-manufacturername','manufacturerName')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/open/index.html
+++ b/files/en-us/web/api/usbdevice/open/index.html
@@ -32,20 +32,7 @@ browser-compat: api.USBDevice.open
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-open','open()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/opened/index.html
+++ b/files/en-us/web/api/usbdevice/opened/index.html
@@ -57,20 +57,7 @@ browser-compat: api.USBDevice.opened
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-opened','opened')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/productid/index.html
+++ b/files/en-us/web/api/usbdevice/productid/index.html
@@ -28,20 +28,7 @@ browser-compat: api.USBDevice.productId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-productid','productId')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/productname/index.html
+++ b/files/en-us/web/api/usbdevice/productname/index.html
@@ -28,20 +28,7 @@ browser-compat: api.USBDevice.productName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-productname','productName')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.html
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.html
@@ -36,21 +36,7 @@ browser-compat: api.USBDevice.releaseInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-releaseinterface','releaseInterface()')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/reset/index.html
+++ b/files/en-us/web/api/usbdevice/reset/index.html
@@ -32,20 +32,7 @@ browser-compat: api.USBDevice.reset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-reset','reset()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
@@ -39,21 +39,7 @@ browser-compat: api.USBDevice.selectAlternateInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-selectalternateinterface','selectAlternateInterface()')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.html
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.html
@@ -36,20 +36,7 @@ browser-compat: api.USBDevice.selectConfiguration
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-selectconfiguration','selectConfiguration')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/serialnumber/index.html
+++ b/files/en-us/web/api/usbdevice/serialnumber/index.html
@@ -28,20 +28,7 @@ browser-compat: api.USBDevice.serialNumber
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-serialnumber','serialNumber')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/transferin/index.html
+++ b/files/en-us/web/api/usbdevice/transferin/index.html
@@ -40,20 +40,7 @@ browser-compat: api.USBDevice.transferIn
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-transferin','transferIn()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/transferout/index.html
+++ b/files/en-us/web/api/usbdevice/transferout/index.html
@@ -39,20 +39,7 @@ browser-compat: api.USBDevice.transferOut
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-transferout','transferOut()')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/usbversionmajor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionmajor/index.html
@@ -31,20 +31,7 @@ browser-compat: api.USBDevice.usbVersionMajor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-usbversionmajor','usbVersionMajor')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/usbversionminor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionminor/index.html
@@ -31,20 +31,7 @@ browser-compat: api.USBDevice.usbVersionMinor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-usbversionminor','usbVersionMinor')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/usbversionsubminor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionsubminor/index.html
@@ -31,21 +31,7 @@ browser-compat: api.USBDevice.usbVersionSubminor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-usbversionsubminor','usbVersionSubminor')}}
-      </td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbdevice/vendorid/index.html
+++ b/files/en-us/web/api/usbdevice/vendorid/index.html
@@ -27,20 +27,7 @@ browser-compat: api.USBDevice.vendorId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web USB','#dom-usbdevice-vendorid','vendorId')}}</td>
-      <td>{{Spec2('Web USB')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbendpoint/index.html
+++ b/files/en-us/web/api/usbendpoint/index.html
@@ -92,20 +92,7 @@ for (const interface of device.configuration.interfaces) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#endpoints','USBEndPoint')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbinterface/index.html
+++ b/files/en-us/web/api/usbinterface/index.html
@@ -38,20 +38,7 @@ browser-compat: api.USBInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbinterface','USBInterface')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbintransferresult/index.html
+++ b/files/en-us/web/api/usbintransferresult/index.html
@@ -40,20 +40,7 @@ browser-compat: api.USBInTransferResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbintransferresult','USBInTransferResult')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbisochronousintransferpacket/index.html
+++ b/files/en-us/web/api/usbisochronousintransferpacket/index.html
@@ -40,20 +40,7 @@ browser-compat: api.USBIsochronousInTransferPacket
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbisochronousintransferpacket','USBIsochronousInTransferPacket')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbisochronousintransferresult/index.html
+++ b/files/en-us/web/api/usbisochronousintransferresult/index.html
@@ -34,20 +34,7 @@ browser-compat: api.USBIsochronousInTransferResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbisochronousintransferresult','USBIsochronousInTransferResult')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbisochronousouttransferpacket/index.html
+++ b/files/en-us/web/api/usbisochronousouttransferpacket/index.html
@@ -39,20 +39,7 @@ browser-compat: api.USBIsochronousOutTransferPacket
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbisochronousouttransferpacket','USBIsochronousOutTransferPacket')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbisochronousouttransferresult/index.html
+++ b/files/en-us/web/api/usbisochronousouttransferresult/index.html
@@ -32,20 +32,7 @@ browser-compat: api.USBIsochronousOutTransferResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbisochronousouttransferresult','USBIsochronousOutTransferResult')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/usbouttransferresult/index.html
+++ b/files/en-us/web/api/usbouttransferresult/index.html
@@ -40,20 +40,7 @@ browser-compat: api.USBOutTransferResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#usbouttransferresult','USBOutTransferResult')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/u* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- `USBConnectionEvent`, `USBConnectionEvent()`, and `USBConnectionEvnet.device`. This is fixed in mdn/browser-compat-data#11066

All other pages look fine.