### PR TITLE
Replace spec table with {{specifications}} for api/v*

### DIFF
--- a/files/en-us/web/api/validitystate/badinput/index.html
+++ b/files/en-us/web/api/validitystate/badinput/index.html
@@ -28,30 +28,7 @@ if (input.validity.badInput) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-badinput', 'ValidityState.badInput') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Live Standard</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-badinput', 'ValidityState.badInput') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from the previous snapshot {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-badinput', 'ValidityState.badInput') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>First snapshot of  {{SpecName('HTML WHATWG')}} containing this interface.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/index.html
+++ b/files/en-us/web/api/validitystate/index.html
@@ -44,32 +44,7 @@ browser-compat: api.ValidityState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'form-control-infrastructure.html#validitystate', 'ValidityState') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Living Standard</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#validitystate-validitystate', 'ValidityState') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from the previous snapshot {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#validitystate', 'ValidityState') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>First snapshot of  {{SpecName('HTML WHATWG')}} containing this interface.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/patternmismatch/index.html
+++ b/files/en-us/web/api/validitystate/patternmismatch/index.html
@@ -43,30 +43,7 @@ browser-compat: api.ValidityState.patternMismatch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-patternmismatch', 'ValidityState.patternMismatch') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-patternmismatch', 'ValidityState.patternMismatch') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-patternmismatch', 'ValidityState.patternMismatch') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/rangeoverflow/index.html
+++ b/files/en-us/web/api/validitystate/rangeoverflow/index.html
@@ -21,30 +21,7 @@ browser-compat: api.ValidityState.rangeOverflow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-rangeoverflow', 'ValidityState.rangeOverflow') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-rangeoverflow', 'ValidityState.rangeOverflow') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-rangeoverflow', 'ValidityState.rangeOverflow') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/rangeunderflow/index.html
+++ b/files/en-us/web/api/validitystate/rangeunderflow/index.html
@@ -21,30 +21,7 @@ browser-compat: api.ValidityState.rangeUnderflow
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-rangeunderflow', 'ValidityState.rangeUnderflow') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-rangeunderflow', 'ValidityState.rangeUnderflow') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-rangeunderflow', 'ValidityState.rangeUnderflow') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/stepmismatch/index.html
+++ b/files/en-us/web/api/validitystate/stepmismatch/index.html
@@ -23,30 +23,7 @@ browser-compat: api.ValidityState.stepMismatch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-stepmismatch', 'ValidityState.stepMismatch') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-stepmismatch', 'ValidityState.stepMismatch') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-stepmismatch', 'ValidityState.stepMismatch') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/toolong/index.html
+++ b/files/en-us/web/api/validitystate/toolong/index.html
@@ -16,30 +16,7 @@ browser-compat: api.ValidityState.tooLong
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-toolong', 'ValidityState.tooLong') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-toolong', 'ValidityState.tooLong') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-toolong', 'ValidityState.tooLong') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/tooshort/index.html
+++ b/files/en-us/web/api/validitystate/tooshort/index.html
@@ -7,30 +7,7 @@ browser-compat: api.ValidityState.tooShort
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-tooshort', 'ValidityState.tooShort') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-tooshort', 'ValidityState.tooShort') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-tooshort', 'ValidityState.tooShort') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/validitystate/typemismatch/index.html
+++ b/files/en-us/web/api/validitystate/typemismatch/index.html
@@ -69,30 +69,7 @@ browser-compat: api.ValidityState.typeMismatch
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'constraints.html#dom-validitystate-typemismatch', 'ValidityState.typeMismatch') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#dom-validitystate-typemismatch', 'ValidityState.typeMismatch') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#dom-validitystate-typemismatch', 'ValidityState.typeMismatch') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoconfiguration/index.html
+++ b/files/en-us/web/api/videoconfiguration/index.html
@@ -45,22 +45,7 @@ const mediaConfig = {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Media Capabilities','#videoconfiguration','VideoConfiguration')}}</td>
-   <td>{{Spec2('Media Capabilities')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.html
@@ -58,22 +58,7 @@ if (quality.corruptedVideoFrames/quality.totalVideoFrames &gt; 0.05) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Playback Quality',
-        '#dom-videoplaybackquality-corruptedvideoframes', 'VideoPlaybackQuality:
-        corruptedVideoFrames')}}</td>
-      <td>{{Spec2('Media Playback Quality')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.html
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.html
@@ -52,21 +52,7 @@ if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Media Playback Quality', '#videoplaybackquality-interface',
-				'VideoPlaybackQuality.corruptedVideoFrames')}}</td>
-			<td>{{Spec2('Media Playback Quality')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.html
@@ -58,21 +58,7 @@ percentElem.innerText = Math.trunc(dropPercent).toString(10);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Playback Quality', '#videoplaybackquality-interface',
-        'VideoPlaybackQuality.droppedVideoFrames')}}</td>
-      <td>{{Spec2('Media Playback Quality')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/index.html
+++ b/files/en-us/web/api/videoplaybackquality/index.html
@@ -49,20 +49,7 @@ browser-compat: api.VideoPlaybackQuality
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Playback Quality', '#idl-def-videoplaybackquality', 'VideoPlaybackQuality')}}</td>
-   <td>{{Spec2('Media Playback Quality')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.html
@@ -59,21 +59,7 @@ if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Media Playback Quality', '#videoplaybackquality-interface',
-        'VideoPlaybackQuality.totalVideoFrames')}}</td>
-      <td>{{Spec2('Media Playback Quality')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/id/index.html
+++ b/files/en-us/web/api/videotrack/id/index.html
@@ -42,22 +42,7 @@ browser-compat: api.VideoTrack.id
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotrack-id', 'VideoTrack: id')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/index.html
+++ b/files/en-us/web/api/videotrack/index.html
@@ -61,22 +61,7 @@ var tracks = el.videoTracks;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#videotrack', 'VideoTrack')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/kind/index.html
+++ b/files/en-us/web/api/videotrack/kind/index.html
@@ -60,22 +60,7 @@ browser-compat: api.VideoTrack.kind
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotrack-kind', 'VideoTrack: kind')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/label/index.html
+++ b/files/en-us/web/api/videotrack/label/index.html
@@ -69,22 +69,7 @@ browser-compat: api.VideoTrack.label
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotrack-label', 'VideoTrack: label')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/language/index.html
+++ b/files/en-us/web/api/videotrack/language/index.html
@@ -40,23 +40,7 @@ browser-compat: api.VideoTrack.language
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotrack-language', 'VideoTrack: language')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/selected/index.html
+++ b/files/en-us/web/api/videotrack/selected/index.html
@@ -35,23 +35,7 @@ browser-compat: api.VideoTrack.selected
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotrack-selected', 'VideoTrack: selected')}}
-      </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotrack/sourcebuffer/index.html
+++ b/files/en-us/web/api/videotrack/sourcebuffer/index.html
@@ -36,23 +36,7 @@ browser-compat: api.VideoTrack.sourceBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Media Source Extensions', '#dom-videotrack-sourcebuffer',
-        'VideoTrack: sourceBuffer')}}</td>
-      <td>{{Spec2('Media Source Extensions')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/videotracklist/addtrack_event/index.html
@@ -52,18 +52,7 @@ videoElement.videoTracks.onaddtrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-addtrack', 'addtrack')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/change_event/index.html
+++ b/files/en-us/web/api/videotracklist/change_event/index.html
@@ -63,18 +63,7 @@ toggleTrackButton.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-change', 'change')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/gettrackbyid/index.html
+++ b/files/en-us/web/api/videotracklist/gettrackbyid/index.html
@@ -50,23 +50,7 @@ browser-compat: api.VideoTrackList.getTrackById
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-gettrackbyid',
-        'VideoTrackList.getTrackById()')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/index.html
+++ b/files/en-us/web/api/videotracklist/index.html
@@ -92,22 +92,7 @@ function updateTrackCount(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#videotracklist', 'VideoTrackList')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/length/index.html
+++ b/files/en-us/web/api/videotracklist/length/index.html
@@ -54,22 +54,7 @@ if (videoElem.videoTracks) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-length', 'VideoTrackList: length')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/videotracklist/onaddtrack/index.html
@@ -67,22 +67,7 @@ browser-compat: api.VideoTrackList.onaddtrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'VideoTrackList: onaddtrack')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/onchange/index.html
+++ b/files/en-us/web/api/videotracklist/onchange/index.html
@@ -67,22 +67,7 @@ trackList.onchange = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'VideoTrackList: onchange')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/videotracklist/onremovetrack/index.html
@@ -61,22 +61,7 @@ browser-compat: api.VideoTrackList.onremovetrack
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'VideoTrackList: onremovetrack')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/removetrack_event/index.html
+++ b/files/en-us/web/api/videotracklist/removetrack_event/index.html
@@ -57,18 +57,7 @@ videoElement.videoTracks.onremovetrack = (event) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'media.html#event-media-removetrack', 'removetrack')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/videotracklist/selectedindex/index.html
+++ b/files/en-us/web/api/videotracklist/selectedindex/index.html
@@ -31,22 +31,7 @@ browser-compat: api.VideoTrackList.selectedIndex
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-selectedindex', 'VideoTrackList: selectedIndex')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/height/index.html
+++ b/files/en-us/web/api/visualviewport/height/index.html
@@ -28,20 +28,7 @@ browser-compat: api.VisualViewport.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-height','height')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/index.html
+++ b/files/en-us/web/api/visualviewport/index.html
@@ -105,20 +105,7 @@ window.visualViewport.addEventListener('resize', viewportHandler);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Visual Viewport','#the-visualviewport-interface','VisualViewport')}}</td>
-   <td>{{Spec2('Visual Viewport')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/offsetleft/index.html
+++ b/files/en-us/web/api/visualviewport/offsetleft/index.html
@@ -28,21 +28,7 @@ browser-compat: api.VisualViewport.offsetLeft
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-offsetleft','offsetLeft')}}
-      </td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/offsettop/index.html
+++ b/files/en-us/web/api/visualviewport/offsettop/index.html
@@ -28,20 +28,7 @@ browser-compat: api.VisualViewport.offsetTop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-offsettop','offsetTop')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/onresize/index.html
+++ b/files/en-us/web/api/visualviewport/onresize/index.html
@@ -34,20 +34,7 @@ browser-compat: api.VisualViewport.onresize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-onresize','onresize')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/onscroll/index.html
+++ b/files/en-us/web/api/visualviewport/onscroll/index.html
@@ -34,20 +34,7 @@ browser-compat: api.VisualViewport.onscroll
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-onscroll','onscroll')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/pageleft/index.html
+++ b/files/en-us/web/api/visualviewport/pageleft/index.html
@@ -28,20 +28,7 @@ browser-compat: api.VisualViewport.pageLeft
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-pageleft','pageLeft')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/pagetop/index.html
+++ b/files/en-us/web/api/visualviewport/pagetop/index.html
@@ -28,20 +28,7 @@ browser-compat: api.VisualViewport.pageTop
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-pagetop','pageTop')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/resize_event/index.html
+++ b/files/en-us/web/api/visualviewport/resize_event/index.html
@@ -51,20 +51,7 @@ browser-compat: api.VisualViewport.resize_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Visual Viewport','#events','VisualViewport events')}}</td>
-   <td>{{Spec2('Visual Viewport')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/scale/index.html
+++ b/files/en-us/web/api/visualviewport/scale/index.html
@@ -27,20 +27,7 @@ browser-compat: api.VisualViewport.scale
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Visual Viewport','#dom-visualviewport-scale','scale')}}</td>
-			<td>{{Spec2('Visual Viewport')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/scroll_event/index.html
+++ b/files/en-us/web/api/visualviewport/scroll_event/index.html
@@ -51,20 +51,7 @@ browser-compat: api.VisualViewport.scroll_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Visual Viewport','#events','VisualViewport events')}}</td>
-   <td>{{Spec2('Visual Viewport')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/width/index.html
+++ b/files/en-us/web/api/visualviewport/width/index.html
@@ -27,20 +27,7 @@ browser-compat: api.VisualViewport.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Visual Viewport','#dom-visualviewport-width','width')}}</td>
-      <td>{{Spec2('Visual Viewport')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
@@ -99,20 +99,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-cancelanimationframe', 'cancelAnimationFrame()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRDisplay.capabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-capabilities', 'capabilities')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthfar/index.html
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.html
@@ -42,20 +42,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-depthfar', 'depthFar')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthnear/index.html
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.html
@@ -42,20 +42,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-depthnear', 'depthNear')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRDisplay.displayId
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-displayid', 'displayId')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VRDisplay.displayName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-displayname', 'displayName')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.html
@@ -83,20 +83,7 @@ browser-compat: api.VRDisplay.exitPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-exitpresent', 'exitPresent()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -39,20 +39,7 @@ browser-compat: api.VRDisplay.getEyeParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-geteyeparameters', 'getEyeParameters()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -103,20 +103,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-geteyeparameters', 'getEyeParameters()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -36,20 +36,7 @@ browser-compat: api.VRDisplay.getLayers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-getlayers', 'getLayers()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getpose/index.html
+++ b/files/en-us/web/api/vrdisplay/getpose/index.html
@@ -59,20 +59,7 @@ browser-compat: api.VRDisplay.getPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-getpose', 'getPose()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -91,20 +91,7 @@ browser-compat: api.VRDisplay
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrdisplay', 'VRDisplay')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -50,20 +50,7 @@ browser-compat: api.VRDisplay.isConnected
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-isconnected', 'isConnected')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -51,20 +51,7 @@ browser-compat: api.VRDisplay.isPresenting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-ispresenting', 'isPresenting')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
@@ -105,20 +105,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-requestanimationframe', 'requestAnimationFrame()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.html
@@ -93,20 +93,7 @@ browser-compat: api.VRDisplay.requestPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-requestpresent', 'requestPresent()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/resetpose/index.html
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.html
@@ -47,20 +47,7 @@ btn.addEventListener('click', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-resetpose', 'resetPose()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -32,20 +32,7 @@ browser-compat: api.VRDisplay.stageParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-stageparameters', 'stageParameters')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.html
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.html
@@ -99,20 +99,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplay-submitframe', 'submitFrame()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplaycapabilities-canpresent', 'canPresent')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -35,20 +35,7 @@ browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplaycapabilities-hasexternaldisplay', 'hasExternalDisplay')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -32,20 +32,7 @@ browser-compat: api.VRDisplayCapabilities.hasOrientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplaycapabilities-hasorientation', 'hasOrientation')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRDisplayCapabilities.hasPosition
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplaycapabilities-hasposition', 'hasPosition')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -56,20 +56,7 @@ browser-compat: api.VRDisplayCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrdisplaycapabilities', 'VRDisplayCapabilities')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRDisplayCapabilities.maxLayers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplaycapabilities-maxlayers', 'maxLayers')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRDisplayEvent.display
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplayeventinit-display', 'display')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -43,20 +43,7 @@ browser-compat: api.VRDisplayEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrdisplayevent', 'VRDisplayEvent')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -38,20 +38,7 @@ browser-compat: api.VRDisplayEvent.reason
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrdisplayeventinit-reason', 'reason')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -45,20 +45,7 @@ browser-compat: api.VRDisplayEvent.VRDisplayEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebVR 1.1', '#dom-vrdisplayevent-vrdisplayevent', 'VRDisplayEvent()')}}</td>
-			<td>{{Spec2('WebVR 1.1')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -32,20 +32,7 @@ browser-compat: api.VREyeParameters.fieldOfView
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vreyeparameters-fieldofview', 'fieldOfView')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -62,20 +62,7 @@ browser-compat: api.VREyeParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebVR 1.1', '#vreyeparameters', 'VREyeParameters')}}</td>
-			<td>{{Spec2('WebVR 1.1')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -37,20 +37,7 @@ browser-compat: api.VREyeParameters.offset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vreyeparameters-offset', 'offset')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VREyeParameters.renderHeight
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vreyeparameters-renderheight', 'renderHeight')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VREyeParameters.renderWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vreyeparameters-renderwidth', 'renderWidth')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRFieldOfView.downDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrfieldofview-downdegrees', 'downDegrees')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/index.html
@@ -80,20 +80,7 @@ function reportFieldOfView() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-interface-vrfieldofview', 'VRFieldOfView')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRFieldOfView.leftDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrfieldofview-leftdegrees', 'leftDegrees')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRFieldOfView.rightDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrfieldofview-rightdegrees', 'rightDegrees')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRFieldOfView.upDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrfieldofview-updegrees', 'upDegrees')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -46,20 +46,7 @@ browser-compat: api.VRFrameData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrframedata', 'VRFrameData')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -37,20 +37,7 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-leftprojectionmatrix', 'leftProjectionMatrix')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -37,20 +37,7 @@ browser-compat: api.VRFrameData.leftViewMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-leftviewmatrix', 'leftViewMatrix')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -31,20 +31,7 @@ browser-compat: api.VRFrameData.pose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-pose', 'pose')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -37,20 +37,7 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-rightprojectionmatrix', 'rightProjectionMatrix')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -37,20 +37,7 @@ browser-compat: api.VRFrameData.rightViewMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-rightviewmatrix', 'rightViewMatrix')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/timestamp/index.html
+++ b/files/en-us/web/api/vrframedata/timestamp/index.html
@@ -65,20 +65,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-timestamp', 'timestamp')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -30,20 +30,7 @@ browser-compat: api.VRFrameData.VRFrameData
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrframedata-vrframedata', 'VRFrameData()')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -72,20 +72,7 @@ if(navigator.getVRDisplays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrlayerinit', 'VRLayerInit')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -41,20 +41,7 @@ myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrlayerinit-leftbounds', 'leftBounds')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -41,20 +41,7 @@ myVRLayerInit.rightBounds = [0.5, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrlayerinit-rightbounds', 'rightBounds')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -32,20 +32,7 @@ myVRLayerInit.source = myCanvas;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrlayerinit-source', 'source')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -54,20 +54,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-angularacceleration', 'angularAcceleration')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -54,20 +54,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-angularvelocity', 'angularVelocity')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -48,20 +48,7 @@ browser-compat: api.VRPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrpose', 'VRPose')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -54,20 +54,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-linearacceleration', 'linearAcceleration')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -54,20 +54,7 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-linearvelocity', 'linearVelocity')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -46,20 +46,7 @@ browser-compat: api.VRPose.orientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-orientation', 'orientation')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -49,20 +49,7 @@ browser-compat: api.VRPose.position
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrpose-position', 'position')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -51,20 +51,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrstageparameters', 'VRStageParameters')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VRStageParameters.sittingToStandingTransform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrstageparameters-sittingtostandingtransform', 'sittingToStandingTransform')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VRStageParameters.sizeX
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrstageparameters-sizex', 'sizeX')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -33,20 +33,7 @@ browser-compat: api.VRStageParameters.sizeY
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1', '#dom-vrstageparameters-sizey', 'sizeY')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vttcue/index.html
+++ b/files/en-us/web/api/vttcue/index.html
@@ -100,20 +100,7 @@ video.addEventListener('loadedmetadata', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebVTT")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vttcue/vttcue/index.html
+++ b/files/en-us/web/api/vttcue/vttcue/index.html
@@ -55,20 +55,7 @@ var cue = new VTTCue(2, 3, 'Cool text to be displayed');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebVTT", "#dom-vttcue-vttcue", "VTTCue()")}}</td>
-      <td>{{Spec2("WebVTT")}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vttregion/index.html
+++ b/files/en-us/web/api/vttregion/index.html
@@ -50,20 +50,7 @@ cue.region = region;  // This cue will be drawn only within this region.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebVTT")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/v* to the {{Specifications}} macros. 

A few pages don't get a spec table anymore (but a message):
- All WebVR pages (VR*) as WebVR, though still implemented, is superseded by WebXR. I leave it that way. [64 pages!]
- `VTTRegion` was missing a spec_url. This is fixed in mdn/browser-compat-data#11067
- `ValidityState.patternMismatch`, `ValidityState.rangeOverflow`, `ValidityState.rangeUnderflow` and `ValidityState.stepMismatch` were missing the spec_url field. This is fixed in mdn/browser-compat-data#11068
- `VideoConfiguration` is a dictionary without bcd. I leave it that way.

All other pages look fine.