### PR TITLE
Fix Toggle button example button functions

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/button_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.html
@@ -169,7 +169,7 @@ ul {
 
 <h4 id="HTML_2">HTML</h4>
 
-<pre class="brush: html">&lt;button type="button" onclick="handleBtnClick()" onKeyDown="handleBtnKeyDown()"&gt;
+<pre class="brush: html">&lt;button type="button" onclick="handleBtnClick(event)" onKeyDown="handleBtnKeyDown(event)"&gt;
   Mute Audio
 &lt;/button&gt;
 


### PR DESCRIPTION
## What was wrong/why is this fix needed?
The button functions in the Toggle button example did not pass the event preventing them from working.

## MDN URL of the main page changed
<https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#toggle_button_example>

## Issue number (if there is an associated issue)
N/A

## Anything else that could help us review it
N/A