### PR TITLE
Adding the global revert value to properties R through Z

### DIFF
--- a/files/en-us/web/css/resize/index.html
+++ b/files/en-us/web/css/resize/index.html
@@ -35,6 +35,7 @@ resize: inline;
 /* Global values */
 resize: inherit;
 resize: initial;
+resize: revert;
 resize: unset;  </pre>
 
 <p>The <code>resize</code> property is specified as a single keyword value from the list below.</p>

--- a/files/en-us/web/css/right/index.html
+++ b/files/en-us/web/css/right/index.html
@@ -32,6 +32,7 @@ right: auto;
 /* Global values */
 right: inherit;
 right: initial;
+right: revert;
 right: unset;
 </pre>
 

--- a/files/en-us/web/css/rotate/index.html
+++ b/files/en-us/web/css/rotate/index.html
@@ -32,7 +32,13 @@ rotate: y 0.25turn;
 rotate: z 1.57rad;
 
 /* Vector plus angle value */
-rotate: 1 1 1 90deg;</pre>
+rotate: 1 1 1 90deg;
+
+/* Global values */
+rotate: inherit;
+rotate: initial;
+rotate: revert;
+rotate: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/row-gap/index.html
+++ b/files/en-us/web/css/row-gap/index.html
@@ -30,6 +30,7 @@ row-gap: 10%;
 /* Global values */
 row-gap: inherit;
 row-gap: initial;
+row-gap: revert;
 row-gap: unset;
 </pre>
 

--- a/files/en-us/web/css/ruby-align/index.html
+++ b/files/en-us/web/css/ruby-align/index.html
@@ -22,6 +22,7 @@ ruby-align: space-around;
 /* Global values */
 ruby-align: inherit;
 ruby-align: initial;
+ruby-align: revert;
 ruby-align: unset;
 </pre>
 

--- a/files/en-us/web/css/ruby-position/index.html
+++ b/files/en-us/web/css/ruby-position/index.html
@@ -24,6 +24,7 @@ ruby-position: alternate;
 /* Global values */
 ruby-position: inherit;
 ruby-position: initial;
+ruby-position: revert;
 ruby-position: unset;
 </pre>
 

--- a/files/en-us/web/css/scale/index.html
+++ b/files/en-us/web/css/scale/index.html
@@ -28,7 +28,13 @@ scale: 0.5;
 scale: 2 0.5;
 
 /* Three values */
-scale: 2 0.5 2;</pre>
+scale: 2 0.5 2;
+
+/* Global values */
+scale: inherit;
+scale: initial;
+scale: revert;
+scale: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/scroll-behavior/index.html
+++ b/files/en-us/web/css/scroll-behavior/index.html
@@ -30,6 +30,7 @@ scroll-behavior: smooth;
 /* Global values */
 scroll-behavior: inherit;
 scroll-behavior: initial;
+scroll-behavior: revert;
 scroll-behavior: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-block-end/index.html
+++ b/files/en-us/web/css/scroll-margin-block-end/index.html
@@ -22,6 +22,7 @@ scroll-margin-block-end: 1em;
 /* Global values */
 scroll-margin-block-end: inherit;
 scroll-margin-block-end: initial;
+scroll-margin-block-end: revert;
 scroll-margin-block-end: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-block-start/index.html
+++ b/files/en-us/web/css/scroll-margin-block-start/index.html
@@ -24,6 +24,7 @@ scroll-margin-block-start: 1em;
 /* Global values */
 scroll-margin-block-start: inherit;
 scroll-margin-block-start: initial;
+scroll-margin-block-start: revert;
 scroll-margin-block-start: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-block/index.html
+++ b/files/en-us/web/css/scroll-margin-block/index.html
@@ -31,6 +31,7 @@ scroll-margin-block: 1em .5em ;
 /* Global values */
 scroll-margin-block: inherit;
 scroll-margin-block: initial;
+scroll-margin-block: revert;
 scroll-margin-block: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-bottom/index.html
+++ b/files/en-us/web/css/scroll-margin-bottom/index.html
@@ -27,6 +27,7 @@ scroll-margin-bottom: 1em;
 /* Global values */
 scroll-margin-bottom: inherit;
 scroll-margin-bottom: initial;
+scroll-margin-bottom: revert;
 scroll-margin-bottom: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-inline-end/index.html
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.html
@@ -23,6 +23,7 @@ scroll-margin-inline-end: 1em;
 /* Global values */
 scroll-margin-inline-end: inherit;
 scroll-margin-inline-end: initial;
+scroll-margin-inline-end: revert;
 scroll-margin-inline-end: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-inline-start/index.html
+++ b/files/en-us/web/css/scroll-margin-inline-start/index.html
@@ -26,6 +26,7 @@ scroll-margin-inline-start: 1em;
 /* Global values */
 scroll-margin-inline-start: inherit;
 scroll-margin-inline-start: initial;
+scroll-margin-inline-start: revert;
 scroll-margin-inline-start: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-inline/index.html
+++ b/files/en-us/web/css/scroll-margin-inline/index.html
@@ -33,6 +33,7 @@ scroll-margin-inline: 1em .5em ;
 /* Global values */
 scroll-margin-inline: inherit;
 scroll-margin-inline: initial;
+scroll-margin-inline: revert;
 scroll-margin-inline: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-left/index.html
+++ b/files/en-us/web/css/scroll-margin-left/index.html
@@ -27,6 +27,7 @@ scroll-margin-left: 1em;
 /* Global values */
 scroll-margin-left: inherit;
 scroll-margin-left: initial;
+scroll-margin-left: revert;
 scroll-margin-left: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-right/index.html
+++ b/files/en-us/web/css/scroll-margin-right/index.html
@@ -26,6 +26,7 @@ scroll-margin-right: 1em;
 /* Global values */
 scroll-margin-right: inherit;
 scroll-margin-right: initial;
+scroll-margin-right: revert;
 scroll-margin-right: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin-top/index.html
+++ b/files/en-us/web/css/scroll-margin-top/index.html
@@ -26,6 +26,7 @@ scroll-margin-top: 1em;
 /* Global values */
 scroll-margin-top: inherit;
 scroll-margin-top: initial;
+scroll-margin-top: revert;
 scroll-margin-top: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-margin/index.html
+++ b/files/en-us/web/css/scroll-margin/index.html
@@ -38,6 +38,7 @@ scroll-margin: 1em .5em 1em 1em;
 /* Global values */
 scroll-margin: inherit;
 scroll-margin: initial;
+scroll-margin: revert;
 scroll-margin: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-block-end/index.html
+++ b/files/en-us/web/css/scroll-padding-block-end/index.html
@@ -32,6 +32,7 @@ scroll-padding-block-end: 10%;
 /* Global values */
 scroll-padding-block-end: inherit;
 scroll-padding-block-end: initial;
+scroll-padding-block-end: revert;
 scroll-padding-block-end: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-block-start/index.html
+++ b/files/en-us/web/css/scroll-padding-block-start/index.html
@@ -30,6 +30,7 @@ scroll-padding-block-start: 10%;
 /* Global values */
 scroll-padding-block-start: inherit;
 scroll-padding-block-start: initial;
+scroll-padding-block-start: revert;
 scroll-padding-block-start: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-block/index.html
+++ b/files/en-us/web/css/scroll-padding-block/index.html
@@ -41,6 +41,7 @@ scroll-padding-block: 10%;
 /* Global values */
 scroll-padding-block: inherit;
 scroll-padding-block: initial;
+scroll-padding-block: revert;
 scroll-padding-block: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-bottom/index.html
+++ b/files/en-us/web/css/scroll-padding-bottom/index.html
@@ -30,6 +30,7 @@ scroll-padding-bottom: 10%;
 /* Global values */
 scroll-padding-bottom: inherit;
 scroll-padding-bottom: initial;
+scroll-padding-bottom: revert;
 scroll-padding-bottom: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-inline-end/index.html
+++ b/files/en-us/web/css/scroll-padding-inline-end/index.html
@@ -29,6 +29,7 @@ scroll-padding-inline-end: 10%;
 /* Global values */
 scroll-padding-inline-end: inherit;
 scroll-padding-inline-end: initial;
+scroll-padding-inline-end: revert;
 scroll-padding-inline-end: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-inline-start/index.html
+++ b/files/en-us/web/css/scroll-padding-inline-start/index.html
@@ -29,6 +29,7 @@ scroll-padding-inline-start: 10%;
 /* Global values */
 scroll-padding-inline-start: inherit;
 scroll-padding-inline-start: initial;
+scroll-padding-inline-start: revert;
 scroll-padding-inline-start: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-inline/index.html
+++ b/files/en-us/web/css/scroll-padding-inline/index.html
@@ -42,6 +42,7 @@ scroll-padding-inline: 10%;
 /* Global values */
 scroll-padding-inline: inherit;
 scroll-padding-inline: initial;
+scroll-padding-inline: revert;
 scroll-padding-inline: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-left/index.html
+++ b/files/en-us/web/css/scroll-padding-left/index.html
@@ -29,6 +29,7 @@ scroll-padding-left: 10%;
 /* Global values */
 scroll-padding-left: inherit;
 scroll-padding-left: initial;
+scroll-padding-left: revert;
 scroll-padding-left: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-right/index.html
+++ b/files/en-us/web/css/scroll-padding-right/index.html
@@ -29,6 +29,7 @@ scroll-padding-right: 10%;
 /* Global values */
 scroll-padding-right: inherit;
 scroll-padding-right: initial;
+scroll-padding-right: revert;
 scroll-padding-right: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding-top/index.html
+++ b/files/en-us/web/css/scroll-padding-top/index.html
@@ -29,6 +29,7 @@ scroll-padding-top: 10%;
 /* Global values */
 scroll-padding-top: inherit;
 scroll-padding-top: initial;
+scroll-padding-top: revert;
 scroll-padding-top: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-padding/index.html
+++ b/files/en-us/web/css/scroll-padding/index.html
@@ -40,6 +40,7 @@ scroll-padding: 10%;
 /* Global values */
 scroll-padding: inherit;
 scroll-padding: initial;
+scroll-padding: revert;
 scroll-padding: unset;
 </pre>
 

--- a/files/en-us/web/css/scroll-snap-align/index.html
+++ b/files/en-us/web/css/scroll-snap-align/index.html
@@ -24,6 +24,7 @@ scroll-snap-align: center;
 /* Global values */
 scroll-snap-align: inherit;
 scroll-snap-align: initial;
+scroll-snap-align: revert;
 scroll-snap-align: unset;
 </pre>
 

--- a/files/en-us/web/css/scrollbar-color/index.html
+++ b/files/en-us/web/css/scrollbar-color/index.html
@@ -34,6 +34,7 @@ The first applies to the thumb of the scrollbar, the second to the track. */
 /* Global values */
 scrollbar-color: inherit;
 scrollbar-color: initial;
+scrollbar-color: revert;
 scrollbar-color: unset;
 </pre>
 

--- a/files/en-us/web/css/scrollbar-gutter/index.html
+++ b/files/en-us/web/css/scrollbar-gutter/index.html
@@ -37,7 +37,12 @@ scrollbar-gutter: always;
 scrollbar-gutter: always both;
 scrollbar-gutter: always force;
 scrollbar-gutter: always both force;
-</pre>
+
+/* Global values */
+scrollbar-gutter: inherit;
+scrollbar-gutter: initial;
+scrollbar-gutter: revert;
+scrollbar-gutter: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/scrollbar-width/index.html
+++ b/files/en-us/web/css/scrollbar-width/index.html
@@ -28,6 +28,7 @@ scrollbar-width: none;
 /* Global values */
 scrollbar-width: inherit;
 scrollbar-width: initial;
+scrollbar-width: revert;
 scrollbar-width: unset;
 </pre>
 

--- a/files/en-us/web/css/shape-image-threshold/index.html
+++ b/files/en-us/web/css/shape-image-threshold/index.html
@@ -33,6 +33,7 @@ shape-image-threshold: 0.7;
 /* Global values */
 shape-image-threshold: inherit;
 shape-image-threshold: initial;
+shape-image-threshold: revert;
 shape-image-threshold: unset;
 </pre>
 

--- a/files/en-us/web/css/shape-margin/index.html
+++ b/files/en-us/web/css/shape-margin/index.html
@@ -36,6 +36,7 @@ shape-margin: 60%;
 /* Global values */
 shape-margin: inherit;
 shape-margin: initial;
+shape-margin: revert;
 shape-margin: unset;
 </pre>
 

--- a/files/en-us/web/css/shape-outside/index.html
+++ b/files/en-us/web/css/shape-outside/index.html
@@ -47,6 +47,7 @@ shape-outside: linear-gradient(45deg, rgba(255, 255, 255, 0) 150px, red 150px);
 /* Global values */
 shape-outside: initial;
 shape-outside: inherit;
+shape-outside: revert;
 shape-outside: unset;
 </pre>
 

--- a/files/en-us/web/css/tab-size/index.html
+++ b/files/en-us/web/css/tab-size/index.html
@@ -26,6 +26,7 @@ tab-size: 2em;
 /* Global values */
 tab-size: inherit;
 tab-size: initial;
+tab-size: revert;
 tab-size: unset;
 </pre>
 

--- a/files/en-us/web/css/text-align-last/index.html
+++ b/files/en-us/web/css/text-align-last/index.html
@@ -30,6 +30,7 @@ text-align-last: justify;
 /* Global values */
 text-align-last: inherit;
 text-align-last: initial;
+text-align-last: revert;
 text-align-last: unset;
 </pre>
 

--- a/files/en-us/web/css/text-align/index.html
+++ b/files/en-us/web/css/text-align/index.html
@@ -38,6 +38,7 @@ text-align: -webkit-center;
 /* Global values */
 text-align: inherit;
 text-align: initial;
+text-align: revert;
 text-align: unset;
 </pre>
 

--- a/files/en-us/web/css/text-combine-upright/index.html
+++ b/files/en-us/web/css/text-combine-upright/index.html
@@ -27,6 +27,7 @@ text-combine-upright: digits 4;   /* fits up to 4 consecutive digits horizontall
 /* Global values */
 text-combine-upright: inherit;
 text-combine-upright: initial;
+text-combine-upright: revert;
 text-combine-upright: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-color/index.html
+++ b/files/en-us/web/css/text-decoration-color/index.html
@@ -40,6 +40,7 @@ text-decoration-color: transparent;
 /* Global values */
 text-decoration-color: inherit;
 text-decoration-color: initial;
+text-decoration-color: revert;
 text-decoration-color: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-line/index.html
+++ b/files/en-us/web/css/text-decoration-line/index.html
@@ -33,6 +33,7 @@ text-decoration-line: overline underline line-through;  /* Multiple decoration l
 /* Global values */
 text-decoration-line: inherit;
 text-decoration-line: initial;
+text-decoration-line: revert;
 text-decoration-line: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-skip-ink/index.html
+++ b/files/en-us/web/css/text-decoration-skip-ink/index.html
@@ -31,6 +31,7 @@ text-decoration-skip-ink: all;
 /* Global keywords */
 text-decoration-skip: inherit;
 text-decoration-skip: initial;
+text-decoration-skip-ink: revert;
 text-decoration-skip: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-skip/index.html
+++ b/files/en-us/web/css/text-decoration-skip/index.html
@@ -35,6 +35,7 @@ text-decoration-skip: objects edges box-decoration;
 /* Global values */
 text-decoration-skip: inherit;
 text-decoration-skip: initial;
+text-decoration-skip: revert;
 text-decoration-skip: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-style/index.html
+++ b/files/en-us/web/css/text-decoration-style/index.html
@@ -32,6 +32,7 @@ text-decoration-style: wavy;
 /* Global values */
 text-decoration-style: inherit;
 text-decoration-style: initial;
+text-decoration-style: revert;
 text-decoration-style: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration-thickness/index.html
+++ b/files/en-us/web/css/text-decoration-thickness/index.html
@@ -31,6 +31,7 @@ text-decoration-thickness: 10%;
 /* Global values */
 text-decoration-thickness: inherit;
 text-decoration-thickness: initial;
+text-decoration-thickness: revert;
 text-decoration-thickness: unset;
 </pre>
 

--- a/files/en-us/web/css/text-decoration/index.html
+++ b/files/en-us/web/css/text-decoration/index.html
@@ -30,6 +30,16 @@ browser-compat: css.properties.text-decoration
 
 <h2 id="Syntax">Syntax</h2>
 
+<pre class="brush: css">text-decoration: underline;
+text-decoration: overline red;
+text-decoration: none;
+
+/* Global values */
+text-decoration: inherit;
+text-decoration: initial;
+text-decoration: revert;
+text-decoration: unset;</pre>
+
 <p id="Values">The <code>text-decoration</code> property is specified as one or more space-separated values representing the various longhand text-decoration properties.</p>
 
 <h3 id="Values_2">Values</h3>

--- a/files/en-us/web/css/text-emphasis-color/index.html
+++ b/files/en-us/web/css/text-emphasis-color/index.html
@@ -30,6 +30,7 @@ text-emphasis-color: transparent;
 /* Global values */
 text-emphasis-color: inherit;
 text-emphasis-color: initial;
+text-emphasis-color: revert;
 text-emphasis-color: unset;
 </pre>
 

--- a/files/en-us/web/css/text-emphasis-position/index.html
+++ b/files/en-us/web/css/text-emphasis-position/index.html
@@ -28,6 +28,7 @@ text-emphasis-position: left under;
 /* Global values */
 text-emphasis-position: inherit;
 text-emphasis-position: initial;
+text-emphasis-postition: revert;
 text-emphasis-position: unset;
 </pre>
 

--- a/files/en-us/web/css/text-emphasis-style/index.html
+++ b/files/en-us/web/css/text-emphasis-style/index.html
@@ -36,6 +36,7 @@ text-emphasis-style: open sesame;
 /* Global values */
 text-emphasis-style: inherit;
 text-emphasis-style: initial;
+text-emphasis-style: revert;
 text-emphasis-style: unset;
 </pre>
 

--- a/files/en-us/web/css/text-emphasis/index.html
+++ b/files/en-us/web/css/text-emphasis/index.html
@@ -56,6 +56,7 @@ text-emphasis: filled sesame #555;
 /* Global values */
 text-emphasis: inherit;
 text-emphasis: initial;
+text-emphasis: revert;
 text-emphasis: unset;
 </pre>
 

--- a/files/en-us/web/css/text-indent/index.html
+++ b/files/en-us/web/css/text-indent/index.html
@@ -38,6 +38,7 @@ text-indent: 5em hanging each-line;
 /* Global values */
 text-indent: inherit;
 text-indent: initial;
+text-indent: revert;
 text-indent: unset;
 </pre>
 

--- a/files/en-us/web/css/text-justify/index.html
+++ b/files/en-us/web/css/text-justify/index.html
@@ -14,16 +14,19 @@ browser-compat: css.properties.text-justify
 
 <p>The <strong><code>text-justify</code></strong> CSS property sets what type of justification should be applied to text when {{cssxref("text-align")}}<code>: justify;</code> is set on an element.</p>
 
+<h2 id="Syntax">Syntax</h2>
+
 <pre class="brush: css no-line-numbers">text-justify: none;
 text-justify: auto;
 text-justify: inter-word;
 text-justify: inter-character;
 text-justify: distribute; /* Deprecated value */
-</pre>
 
-<h2 id="Syntax">Syntax</h2>
-
-<p>The <code>text-justify</code> property is specified as a single keyword chosen from the list of values below.</p>
+/* Global values */
+text-justify: inherit;
+text-justify: initial;
+text-justify: revert;
+text-justify: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/text-orientation/index.html
+++ b/files/en-us/web/css/text-orientation/index.html
@@ -27,6 +27,7 @@ text-orientation: use-glyph-orientation;
 /* Global values */
 text-orientation: inherit;
 text-orientation: initial;
+text-orientation: initial;
 text-orientation: unset;
 </pre>
 

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -27,7 +27,15 @@ white-space: nowrap;</pre>
 
 <p>The <code>text-overflow</code> property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line.</p>
 
-<p>Each value is specified as one of:</p>
+<pre class="brush: css">text-overflow: clip;
+text-overflow: ellipsis ellipsis;
+text-overflow: ellipsis " [..]";
+
+/* Global values */
+text-overflow: inherit;
+text-overflow: initial;
+text-overflow: revert;
+text-overflow: unset;</pre>
 
 <ul>
  <li>one of the keyword values: <code><a href="#clip">clip</a></code>, <code><a href="#ellipsis">ellipsis</a></code>, <code><a href="#fade">fade</a></code></li>

--- a/files/en-us/web/css/text-rendering/index.html
+++ b/files/en-us/web/css/text-rendering/index.html
@@ -30,6 +30,7 @@ text-rendering: geometricPrecision;
 /* Global values */
 text-rendering: inherit;
 text-rendering: initial;
+text-rendering: revert;
 text-rendering: unset;
 </pre>
 

--- a/files/en-us/web/css/text-shadow/index.html
+++ b/files/en-us/web/css/text-shadow/index.html
@@ -44,6 +44,7 @@ text-shadow: 5px 10px;
 /* Global values */
 text-shadow: inherit;
 text-shadow: initial;
+text-shadow: revert;
 text-shadow: unset;
 </pre>
 

--- a/files/en-us/web/css/text-size-adjust/index.html
+++ b/files/en-us/web/css/text-size-adjust/index.html
@@ -25,6 +25,7 @@ text-size-adjust: 80%;
 /* Global values */
 text-size-adjust: inherit;
 text-size-adjust: initial;
+text-size-adjust: revert;
 text-size-adjust: unset;
 </pre>
 

--- a/files/en-us/web/css/text-transform/index.html
+++ b/files/en-us/web/css/text-transform/index.html
@@ -58,6 +58,7 @@ text-transform: full-size-kana;
 /* Global values */
 text-transform: inherit;
 text-transform: initial;
+text-transform: revert;
 text-transform: unset;
 </pre>
 

--- a/files/en-us/web/css/text-underline-offset/index.html
+++ b/files/en-us/web/css/text-underline-offset/index.html
@@ -32,6 +32,7 @@ text-underline-offset: 20%;
 /* Global values */
 text-underline-offset: inherit;
 text-underline-offset: initial;
+text-underline-offset: revert;
 text-underline-offset: unset;
 </pre>
 

--- a/files/en-us/web/css/text-underline-position/index.html
+++ b/files/en-us/web/css/text-underline-position/index.html
@@ -30,6 +30,7 @@ text-underline-position: right under;
 /* Global values */
 text-underline-position: inherit;
 text-underline-position: initial;
+text-underline-position: revert;
 text-underline-position: unset;
 </pre>
 

--- a/files/en-us/web/css/top/index.html
+++ b/files/en-us/web/css/top/index.html
@@ -41,6 +41,7 @@ top: auto;
 /* Global values */
 top: inherit;
 top: initial;
+top: revert;
 top: unset;
 </pre>
 

--- a/files/en-us/web/css/touch-action/index.html
+++ b/files/en-us/web/css/touch-action/index.html
@@ -27,6 +27,7 @@ touch-action: manipulation;
 /* Global values */
 touch-action: inherit;
 touch-action: initial;
+touch-action: revert;
 touch-action: unset;
 </pre>
 

--- a/files/en-us/web/css/transform-box/index.html
+++ b/files/en-us/web/css/transform-box/index.html
@@ -25,6 +25,7 @@ transform-box: view-box;
 /* Global values */
 transform-box: inherit;
 transform-box: initial;
+transform-box: revert;
 transform-box: unset;
 </pre>
 

--- a/files/en-us/web/css/transform-origin/index.html
+++ b/files/en-us/web/css/transform-origin/index.html
@@ -67,6 +67,7 @@ transform-origin: bottom right 2cm;
 /* Global values */
 transform-origin: inherit;
 transform-origin: initial;
+transform-origin: revert;
 transform-origin: unset;
 </pre>
 

--- a/files/en-us/web/css/transform-style/index.html
+++ b/files/en-us/web/css/transform-style/index.html
@@ -29,6 +29,7 @@ transform-style: preserve-3d;
 /* Global values */
 transform-style: inherit;
 transform-style: initial;
+transform-style: revert;
 transform-style: unset;
 </pre>
 

--- a/files/en-us/web/css/transform/index.html
+++ b/files/en-us/web/css/transform/index.html
@@ -56,6 +56,7 @@ transform: perspective(500px) translate(10px, 0, 20px) rotateY(3deg);
 /* Global values */
 transform: inherit;
 transform: initial;
+transform: revert;
 transform: unset;
 </pre>
 

--- a/files/en-us/web/css/transition-delay/index.html
+++ b/files/en-us/web/css/transition-delay/index.html
@@ -34,6 +34,7 @@ transition-delay: 2s, 4ms;
 /* Global values */
 transition-delay: inherit;
 transition-delay: initial;
+transition-delay: revert;
 transition-delay: unset;
 </pre>
 

--- a/files/en-us/web/css/transition-duration/index.html
+++ b/files/en-us/web/css/transition-duration/index.html
@@ -28,6 +28,7 @@ transition-duration: 10s, 30s, 230ms;
 /* Global values */
 transition-duration: inherit;
 transition-duration: initial;
+transition-duration: revert;
 transition-duration: unset;
 </pre>
 

--- a/files/en-us/web/css/transition-property/index.html
+++ b/files/en-us/web/css/transition-property/index.html
@@ -38,6 +38,7 @@ transition-property: all, -moz-specific, sliding;
 /* Global values */
 transition-property: inherit;
 transition-property: initial;
+transition-property: revert;
 transition-property: unset;
 </pre>
 

--- a/files/en-us/web/css/transition-timing-function/index.html
+++ b/files/en-us/web/css/transition-timing-function/index.html
@@ -50,6 +50,7 @@ transition-timing-function: ease, step-start, cubic-bezier(0.1, 0.7, 1.0, 0.1);
 /* Global values */
 transition-timing-function: inherit;
 transition-timing-function: initial;
+transition-timing-function: revert;
 transition-timing-function: unset;</pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/transition/index.html
+++ b/files/en-us/web/css/transition/index.html
@@ -52,6 +52,7 @@ transition: all 0.5s ease-out;
 /* Global values */
 transition: inherit;
 transition: initial;
+transition: revert;
 transition: unset;
 </pre>
 

--- a/files/en-us/web/css/translate/index.html
+++ b/files/en-us/web/css/translate/index.html
@@ -28,7 +28,12 @@ translate: 50% 105px;
 
 /* Three values */
 translate: 50% 105px 5rem;
-</pre>
+
+/* Global values */
+translate: inherit;
+translate: initial;
+translate: revert;
+translate: unset;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/unicode-bidi/index.html
+++ b/files/en-us/web/css/unicode-bidi/index.html
@@ -17,6 +17,8 @@ browser-compat: css.properties.unicode-bidi
 
 <p class="warning"><strong>Note:</strong> This property is intended for Document Type Definition (DTD) designers. Web designers and similar authors <strong>should not</strong> override it.</p>
 
+<h2 id="Syntax">Syntax</h2>
+
 <pre class="brush: css">/* Keyword values */
 unicode-bidi: normal;
 unicode-bidi: embed;
@@ -24,12 +26,12 @@ unicode-bidi: isolate;
 unicode-bidi: bidi-override;
 unicode-bidi: isolate-override;
 unicode-bidi: plaintext;
+
 /* Global values */
 unicode-bidi: inherit;
 unicode-bidi: initial;
+unicode-bidi: revert;
 unicode-bidi: unset;</pre>
-
-<h2 id="Syntax">Syntax</h2>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/user-modify/index.html
+++ b/files/en-us/web/css/user-modify/index.html
@@ -24,6 +24,7 @@ user-modify: write-only;
 /* Global values */
 user-modify: inherit;
 user-modify: initial;
+user-modify: revert;
 user-modify: unset;
 </pre>
 

--- a/files/en-us/web/css/user-select/index.html
+++ b/files/en-us/web/css/user-select/index.html
@@ -25,6 +25,7 @@ user-select: all;
 /* Global values */
 user-select: inherit;
 user-select: initial;
+user-select: revert;
 user-select: unset;
 
 /* Mozilla-specific values */

--- a/files/en-us/web/css/vertical-align/index.html
+++ b/files/en-us/web/css/vertical-align/index.html
@@ -47,6 +47,7 @@ vertical-align: 20%;
 /* Global values */
 vertical-align: inherit;
 vertical-align: initial;
+vertical-align: revert;
 vertical-align: unset;
 </pre>
 

--- a/files/en-us/web/css/visibility/index.html
+++ b/files/en-us/web/css/visibility/index.html
@@ -29,6 +29,7 @@ visibility: collapse;
 /* Global values */
 visibility: inherit;
 visibility: initial;
+visibility: revert;
 visibility: unset;
 </pre>
 

--- a/files/en-us/web/css/white-space/index.html
+++ b/files/en-us/web/css/white-space/index.html
@@ -42,6 +42,7 @@ white-space: break-spaces;
 /* Global values */
 white-space: inherit;
 white-space: initial;
+white-space: revert;
 white-space: unset;
 </pre>
 

--- a/files/en-us/web/css/widows/index.html
+++ b/files/en-us/web/css/widows/index.html
@@ -21,6 +21,7 @@ widows: 3;
 /* Global values */
 widows: inherit;
 widows: initial;
+widows: revert;
 widows: unset;
 </pre>
 

--- a/files/en-us/web/css/width/index.html
+++ b/files/en-us/web/css/width/index.html
@@ -40,6 +40,7 @@ width: auto;
 /* Global values */
 width: inherit;
 width: initial;
+width: revert;
 width: unset;
 </pre>
 

--- a/files/en-us/web/css/will-change/index.html
+++ b/files/en-us/web/css/will-change/index.html
@@ -30,6 +30,7 @@ will-change: left, top;        /* Example of two &lt;animatable-feature&gt; */
 /* Global values */
 will-change: inherit;
 will-change: initial;
+will-change: revert;
 will-change: unset;
 </pre>
 

--- a/files/en-us/web/css/word-break/index.html
+++ b/files/en-us/web/css/word-break/index.html
@@ -27,6 +27,7 @@ word-break: break-word; /* deprecated */
 /* Global values */
 word-break: inherit;
 word-break: initial;
+word-break: revert;
 word-break: unset;
 </pre>
 

--- a/files/en-us/web/css/word-spacing/index.html
+++ b/files/en-us/web/css/word-spacing/index.html
@@ -33,6 +33,7 @@ word-spacing: 200%;
 /* Global values */
 word-spacing: inherit;
 word-spacing: initial;
+word-spacing: revert;
 word-spacing: unset;
 </pre>
 

--- a/files/en-us/web/css/writing-mode/index.html
+++ b/files/en-us/web/css/writing-mode/index.html
@@ -27,6 +27,7 @@ writing-mode: vertical-lr;
 /* Global values */
 writing-mode: inherit;
 writing-mode: initial;
+writing-mode: revert;
 writing-mode: unset;</pre>
 
 <p>The <code>writing-mode</code> property is specified as one of the values listed below. The flow direction in horizontal scripts is also affected by the <a href="https://www.w3.org/International/questions/qa-scripts.en">directionality of that script</a>, either left-to-right (<code>ltr</code>, like English and most other languages) or right-to-left (<code>rtl</code>, like Hebrew or Arabic).</p>

--- a/files/en-us/web/css/z-index/index.html
+++ b/files/en-us/web/css/z-index/index.html
@@ -36,6 +36,7 @@ z-index: -1; /* Negative values to lower the priority */
 /* Global values */
 z-index: inherit;
 z-index: initial;
+z-index: revert;
 z-index: unset;
 </pre>
 


### PR DESCRIPTION
Part of #3047 last batch of CSS properties, adds revert value plus syntax section to those missing it.
