### PR TITLE
Replace spec table with {{specifications}} for api/w* (part 1)

### DIFF
--- a/files/en-us/web/api/wakelock/index.html
+++ b/files/en-us/web/api/wakelock/index.html
@@ -36,20 +36,7 @@ browser-compat: api.WakeLock
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Screen Wake Lock','#the-wakelock-interface','WakeLock')}}</td>
-   <td>{{Spec2('Screen Wake Lock')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelock/request/index.html
+++ b/files/en-us/web/api/wakelock/request/index.html
@@ -76,20 +76,7 @@ requestWakeLock();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#the-request-method','request()')}}</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelocksentinel/index.html
+++ b/files/en-us/web/api/wakelocksentinel/index.html
@@ -85,20 +85,7 @@ wakeLockOffButton.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#the-wakelocksentinel-interface','WakeLockSentinel')}}</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelocksentinel/onrelease/index.html
+++ b/files/en-us/web/api/wakelocksentinel/onrelease/index.html
@@ -45,21 +45,7 @@ browser-compat: api.WakeLockSentinel.onrelease
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#the-onrelease-attribute','onrelease')}}
-			</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelocksentinel/release/index.html
+++ b/files/en-us/web/api/wakelocksentinel/release/index.html
@@ -47,20 +47,7 @@ browser-compat: api.WakeLockSentinel.release
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#the-release-method','release()')}}</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelocksentinel/released/index.html
+++ b/files/en-us/web/api/wakelocksentinel/released/index.html
@@ -44,20 +44,7 @@ await sentinel.release();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#dom-wakelocksentinel-released','released')}}</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/wakelocksentinel/type/index.html
+++ b/files/en-us/web/api/wakelocksentinel/type/index.html
@@ -49,21 +49,7 @@ requestWakeLock();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('Screen Wake Lock','#the-wakelocktype-enum','WakeLockType')}}
-			</td>
-			<td>{{Spec2('Screen Wake Lock')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/waveshapernode/curve/index.html
+++ b/files/en-us/web/api/waveshapernode/curve/index.html
@@ -39,20 +39,7 @@ distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-waveshapernode-curve', 'curve')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/index.html
@@ -68,20 +68,7 @@ browser-compat: api.WaveShaperNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#waveshapernode', 'WaveShaperNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/waveshapernode/oversample/index.html
+++ b/files/en-us/web/api/waveshapernode/oversample/index.html
@@ -59,20 +59,7 @@ browser-compat: api.WaveShaperNode.oversample
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-waveshapernode-oversample', 'oversample')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.html
@@ -48,20 +48,7 @@ browser-compat: api.WaveShaperNode.WaveShaperNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API','#dom-waveshapernode-waveshapernode','WaveShaperNode()')}}</td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
@@ -53,25 +53,7 @@ gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "beginQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBeginQuery.xhtml", "glBeginQuery")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
@@ -49,26 +49,7 @@ gl.drawArrays(gl.TRIANGLES, 0, 3);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "beginTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBeginTransformFeedback.xhtml",
-        "glBeginTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
@@ -50,25 +50,7 @@ browser-compat: api.WebGL2RenderingContext.bindBufferBase
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "bindBufferBase")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindBufferBase.xhtml", "glBindBufferBase")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
@@ -55,26 +55,7 @@ browser-compat: api.WebGL2RenderingContext.bindBufferRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "bindBufferRange")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindBufferRange.xhtml", "glBindBufferRange")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
@@ -42,25 +42,7 @@ gl.bindSampler(0, sampler);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "bindSampler")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindSampler.xhtml", "glBindSampler")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
@@ -42,26 +42,7 @@ gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "bindTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindTransformFeedback.xhtml",
-        "glBindTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.html
@@ -44,26 +44,7 @@ gl.bindVertexArray(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.17", "bindVertexArray")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindVertexArray.xhtml", "glBindVertexArray")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
@@ -61,26 +61,7 @@ browser-compat: api.WebGL2RenderingContext.blitFramebuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "blitFramebuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBlitFramebuffer.xhtml", "glBlitFramebuffer")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
@@ -66,25 +66,7 @@ gl.clearBufferfi(gl.DEPTH_STENCIL, 0, 1.0, 0);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.11", "clearBuffer[fiuv]()")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glClearBuffer.xhtml", "glClearBuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
@@ -57,25 +57,7 @@ var status = gl.clientWaitSync(sync, 0, 0);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.14", "clientWaitSync")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glClientWaitSync.xhtml", "glClientWaitSync")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
@@ -89,26 +89,7 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "compressedTexSubImage3D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCompressedTexSubImage3D.xhtml",
-        "glCompressedTexSubImage3D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
@@ -77,26 +77,7 @@ gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.ARRAY_BUFFER, 0, 0, length);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.3", "copyBufferSubData")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCopyBufferSubData.xhtml",
-        "glCopyBufferSubData")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
@@ -63,26 +63,7 @@ browser-compat: api.WebGL2RenderingContext.copyTexSubImage3D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "copyTexSubImage3D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCopyTexSubImage3D.xhtml",
-        "glCopyTexSubImage3D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.html
@@ -39,25 +39,7 @@ browser-compat: api.WebGL2RenderingContext.createQuery
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "createQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGenQueries.xhtml", "glGenQueries")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.html
@@ -38,25 +38,7 @@ browser-compat: api.WebGL2RenderingContext.createSampler
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "createSampler")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGenSamplers.xhtml", "glGenSamplers")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.html
@@ -38,26 +38,7 @@ browser-compat: api.WebGL2RenderingContext.createTransformFeedback
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "createTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGenTransformFeedbacks.xhtml",
-        "glGenTransformFeedbacks")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.html
@@ -44,26 +44,7 @@ gl.bindVertexArray(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.17", "createVertexArray")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGenVertexArrays.xhtml", "glGenVertexArrays")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.html
@@ -45,25 +45,7 @@ gl.deleteQuery(query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "deleteQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDeleteQueries.xhtml", "glDeleteQueries")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.html
@@ -45,25 +45,7 @@ gl.deleteSampler(sampler);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "deleteSampler")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDeleteSamplers.xhtml", "glDeleteSamplers")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.html
@@ -45,25 +45,7 @@ gl.deleteSync(sync);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "deleteSync")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDeleteSync.xhtml", "glDeleteSync")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.html
@@ -45,26 +45,7 @@ gl.deleteTransformFeedback(transformFeedback);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "deleteTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDeleteTransformFeedbacks.xhtml",
-        "glDeleteTransformFeedbacks")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.html
@@ -43,26 +43,7 @@ gl.deleteVertexArray(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.17", "deleteVertexArray")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDeleteVertexArrays.xhtml",
-        "glDeleteVertexArrays")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
@@ -69,26 +69,7 @@ browser-compat: api.WebGL2RenderingContext.drawArraysInstanced
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.9", "drawArraysInstanced")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDrawArraysInstanced.xhtml",
-        "glDrawArraysInstanced")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
@@ -56,25 +56,7 @@ browser-compat: api.WebGL2RenderingContext.drawBuffers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.11", "drawBuffers")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDrawBuffers.xhtml", "glDrawBuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
@@ -94,26 +94,7 @@ browser-compat: api.WebGL2RenderingContext.drawElementsInstanced
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.9", "drawElementsInstanced")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDrawElementsInstanced.xhtml",
-        "glDrawElementsInstanced")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
@@ -85,26 +85,7 @@ browser-compat: api.WebGL2RenderingContext.drawRangeElements
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.9", "drawRangeElements")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glDrawRangeElements.xhtml",
-        "glDrawRangeElements")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
@@ -53,25 +53,7 @@ gl.endQuery(gl.ANY_SAMPLES_PASSED);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "endQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBeginQuery.xhtml", "glEndQuery")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.html
@@ -39,26 +39,7 @@ gl.endTransformFeedback();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "endTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBeginTransformFeedback.xhtml",
-        "glEndTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
@@ -46,25 +46,7 @@ browser-compat: api.WebGL2RenderingContext.fenceSync
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.14", "fenceSync")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glFenceSync.xhtml", "glFenceSync")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
@@ -71,26 +71,7 @@ browser-compat: api.WebGL2RenderingContext.framebufferTextureLayer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "framebufferTextureLayer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glFramebufferTextureLayer.xhtml",
-        "glFramebufferTextureLayer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
@@ -40,26 +40,7 @@ browser-compat: api.WebGL2RenderingContext.getActiveUniformBlockName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "getActiveUniformBlockName")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetActiveUniformBlockName.xhtml",
-        "glGetActiveUniformBlockName")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
@@ -63,26 +63,7 @@ browser-compat: api.WebGL2RenderingContext.getActiveUniformBlockParameter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "getActiveUniformBlockParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetActiveUniformBlockiv.xhtml",
-        "glGetActiveUniformBlockiv")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
@@ -65,26 +65,7 @@ var uniformOffsets = gl.getActiveUniforms(program, uniformIndices, gl.UNIFORM_OF
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "getActiveUniforms")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetActiveUniformsiv.xhtml",
-        "glGetActiveUniformsiv")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
@@ -91,20 +91,7 @@ gl.getBufferSubData(gl.ARRAY_BUFFER, 0, arrBuffer);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.3", "getBufferSubData")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
@@ -43,26 +43,7 @@ gl.getFragDataLocation(program, 'fragColor');</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.7", "getFragDataLocation")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetFragDataLocation.xhtml",
-        "glGetFragDataLocation")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
@@ -55,25 +55,7 @@ browser-compat: api.WebGL2RenderingContext.getIndexedParameter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.2", "getIndexedParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGet.xhtml", "glGet")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
@@ -57,26 +57,7 @@ browser-compat: api.WebGL2RenderingContext.getInternalformatParameter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.5", "getInternalFormatParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetInternalformativ.xhtml",
-        "glGetInternalformativ")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
@@ -51,25 +51,7 @@ browser-compat: api.WebGL2RenderingContext.getQuery
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "getQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetQueryiv.xhtml", "glGetQueryiv")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
@@ -51,26 +51,7 @@ var result = gl.getQueryParameter(query, gl.QUERY_RESULT);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "getQueryParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetQueryObjectuiv.xhtml",
-        "glGetQueryObjectuiv")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
@@ -63,26 +63,7 @@ gl.getSamplerParameter(sampler, gl.TEXTURE_COMPARE_FUNC);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "getSamplerParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetSamplerParameter.xhtml",
-        "glGetSamplerParameter")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
@@ -54,25 +54,7 @@ gl.getSyncParameter(sync, gl.SYNC_STATUS);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.14", "getSyncParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetSynciv.xhtml", "glGetSynciv")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
@@ -42,26 +42,7 @@ browser-compat: api.WebGL2RenderingContext.getTransformFeedbackVarying
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "getTransformFeedbackVarying")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetTransformFeedbackVarying.xhtml",
-        "glGetTransformFeedbackVarying")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
@@ -47,26 +47,7 @@ var blockIndex = gl.getUniformBlockIndex(program, 'UBOData');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebGL2', "#3.7.16", "getUniformBlockIndex")}}</td>
-			<td>{{Spec2('WebGL2')}}</td>
-			<td>Initial definition for WebGL.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('OpenGL ES 3.0', "glGetUniformBlockIndex.xhtml",
-				"glGetUniformBlockIndex")}}</td>
-			<td>{{Spec2('OpenGL ES 3.0')}}</td>
-			<td>Man page of the (similar) OpenGL API.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
@@ -41,26 +41,7 @@ browser-compat: api.WebGL2RenderingContext.getUniformIndices
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "getUniformIndices")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetUniformIndices.xhtml",
-        "glGetUniformIndices")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/index.html
@@ -250,20 +250,7 @@ var gl = canvas.getContext('webgl2');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL2', "#3.7", "WebGL2RenderingContext")}}</td>
-   <td>{{Spec2('WebGL2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
@@ -61,26 +61,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateFramebuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "invalidateFramebuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glInvalidateFramebuffer.xhtml",
-        "glInvalidateFramebuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
@@ -74,26 +74,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateSubFramebuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "invalidateSubFramebuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glInvalidateSubFramebuffer.xhtml",
-        "glInvalidateSubFramebuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
@@ -46,25 +46,7 @@ gl.isQuery(query);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.12", "isQuery")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glIsQuery.xhtml", "glIsQuery")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
@@ -46,25 +46,7 @@ gl.isSampler(sampler);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.13", "isSampler")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glIsSampler.xhtml", "glIsSampler")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.html
@@ -46,25 +46,7 @@ gl.isSync(sync);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.14", "isSync")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glIsSync.xhtml", "glIsSync")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
@@ -47,26 +47,7 @@ gl.isTransformFeedback(transformFeedback);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "isTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glIsTransformFeedback.xhtml",
-        "glIsTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
@@ -45,25 +45,7 @@ gl.isVertexArray(vao);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.17", "isVertexArray")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glIsVertexArray.xhtml", "glIsVertexArray")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.html
@@ -42,26 +42,7 @@ gl.endTransformFeedback();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "pauseTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glPauseTransformFeedback.xhtml",
-        "glPauseTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
@@ -49,25 +49,7 @@ browser-compat: api.WebGL2RenderingContext.readBuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "readBuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glReadBuffer.xhtml", "glReadBuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
@@ -93,26 +93,7 @@ browser-compat: api.WebGL2RenderingContext.renderbufferStorageMultisample
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.5", "glRenderbufferStorageMultisample")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glRenderbufferStorageMultisample.xhtml",
-        "glRenderbufferStorageMultisample")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.html
@@ -42,26 +42,7 @@ gl.endTransformFeedback();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "resumeTransformFeedback")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glResumeTransformFeedback.xhtml",
-        "glResumeTransformFeedback")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
@@ -156,25 +156,7 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "texImage3D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Updated definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glTexImage3D.xhtml", "glTexImage3D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
@@ -97,25 +97,7 @@ browser-compat: api.WebGL2RenderingContext.texStorage2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "texStorage2D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glTexStorage2D.xhtml", "glTexStorage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
@@ -90,25 +90,7 @@ browser-compat: api.WebGL2RenderingContext.texStorage3D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "texStorage3D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glTexStorage3D.xhtml", "glTexStorage3D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
@@ -160,25 +160,7 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.6", "texSubImage3D")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glTexSubImage3D.xhtml", "glTexSubImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
@@ -51,26 +51,7 @@ gl.linkProgram(shaderProg);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.15", "transformFeedbackVaryings")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glTransformFeedbackVaryings.xhtml",
-        "glTransformFeedbackVaryings")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
@@ -67,25 +67,7 @@ void gl.uniform4uiv(location, data, optional srcOffset, optional srcLength);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.8", "uniform")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glUniform.xhtml", "glUniform")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
@@ -44,26 +44,7 @@ browser-compat: api.WebGL2RenderingContext.uniformBlockBinding
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.16", "uniformBlockBinding")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glUniformBlockBinding.xhtml",
-        "glUniformBlockBinding")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
@@ -57,25 +57,7 @@ void gl.uniformMatrix4fv(location, transpose, data, optional srcOffset, optional
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.8", "uniformMatrix")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glUniform.xhtml", "glUniformMatrix")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
@@ -51,26 +51,7 @@ browser-compat: api.WebGL2RenderingContext.vertexAttribDivisor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.9", "vertexAttribDivisor")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glVertexAttribDivisor.xhtml",
-        "glVertexAttribDivisor")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
@@ -50,25 +50,7 @@ void <var>gl</var>.vertexAttribI4uiv(<var>index</var>, <var>value</var>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.8", "vertexAttribI")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glVertexAttrib.xhtml", "glVertexAttribI")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
@@ -97,26 +97,7 @@ void main() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.8", "vertexAttribIPointer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glVertexAttribPointer.xhtml",
-        "glVertexAttribPointer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
@@ -48,25 +48,7 @@ gl.waitSync(sync, 0, gl.TIMEOUT_IGNORED);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.14", "waitSync")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glWaitSync.xhtml", "glWaitSync")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_color_buffer_float/index.html
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.html
@@ -50,20 +50,7 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA32F_EXT, 256, 256);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_color_buffer_float', "", "WEBGL_color_buffer_float")}}</td>
-   <td>{{Spec2('WEBGL_color_buffer_float')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.html
@@ -43,21 +43,7 @@ ext.getSupportedProfiles(); // ["ldr"]</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_compressed_texture_astc', '',
-        'WEBGL_compressed_texture_astc')}}</td>
-      <td>{{Spec2('WEBGL_compressed_texture_astc')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.html
@@ -174,20 +174,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_ASTC_12x12_KHR, 51
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_astc', "", "WEBGL_compressed_texture_astc")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_astc')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_atc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_atc/index.html
@@ -47,20 +47,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ATC_WEBGL, 512, 512
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_atc', "", "WEBGL_compressed_texture_atc")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_atc')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.html
@@ -59,20 +59,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA8_ETC2_EAC, 512, 51
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_etc', "", "WEBGL_compressed_texture_etc")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_etc')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
@@ -41,20 +41,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ETC1_WEBGL, 512, 51
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_etc1', "", "WEBGL_compressed_texture_etc1")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_etc1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
@@ -51,20 +51,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 5
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_pvrtc', "", "WEBGL_compressed_texture_pvrtc")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_pvrtc')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
@@ -53,20 +53,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_s3tc', "", "WEBGL_compressed_texture_s3tc")}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_s3tc')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
@@ -49,20 +49,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_compressed_texture_s3tc_srgb', '', 'WEBGL_compressed_texture_s3tc_srgb')}}</td>
-   <td>{{Spec2('WEBGL_compressed_texture_s3tc_srgb')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.html
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.html
@@ -48,20 +48,7 @@ console.log(renderer);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_debug_renderer_info', "", "WEBGL_debug_renderer_info")}}</td>
-   <td>{{Spec2('WEBGL_debug_renderer_info')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.html
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.html
@@ -57,21 +57,7 @@ console.log(src);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_debug_shaders', "",
-        "WEBGL_debug_shaders.getTranslatedShaderSource")}}</td>
-      <td>{{Spec2('WEBGL_debug_shaders')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_debug_shaders/index.html
+++ b/files/en-us/web/api/webgl_debug_shaders/index.html
@@ -31,20 +31,7 @@ browser-compat: api.WEBGL_debug_shaders
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_debug_shaders', "", "WEBGL_debug_shaders")}}</td>
-   <td>{{Spec2('WEBGL_debug_shaders')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_depth_texture/index.html
+++ b/files/en-us/web/api/webgl_depth_texture/index.html
@@ -57,20 +57,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 512, 512, 0, gl.DEPTH_COMPON
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_depth_texture', "", "WEBGL_depth_texture")}}</td>
-   <td>{{Spec2('WEBGL_depth_texture')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
@@ -77,25 +77,7 @@ browser-compat: api.WEBGL_draw_buffers.drawBuffersWEBGL
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_draw_buffers', '', 'WEBGL_draw_buffers')}}</td>
-      <td>{{Spec2('WEBGL_draw_buffers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', 'glDrawBuffers.xhtml', 'glDrawBuffers')}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_draw_buffers/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/index.html
@@ -116,20 +116,7 @@ void main(void) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_draw_buffers', '', 'WEBGL_draw_buffers')}}</td>
-   <td>{{Spec2('WEBGL_draw_buffers')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_lose_context/index.html
+++ b/files/en-us/web/api/webgl_lose_context/index.html
@@ -45,20 +45,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_lose_context', "", "WEBGL_lose_context")}}</td>
-   <td>{{Spec2('WEBGL_lose_context')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.html
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.html
@@ -44,20 +44,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_lose_context', "", "WEBGL_lose_context.loseContext")}}</td>
-      <td>{{Spec2('WEBGL_lose_context')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.html
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.html
@@ -44,20 +44,7 @@ gl.getExtension('WEBGL_lose_context').restoreContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_lose_context', "", "WEBGL_lose_context.loseContext")}}</td>
-      <td>{{Spec2('WEBGL_lose_context')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/index.html
@@ -125,16 +125,7 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WEBGL_multi_draw', "", "WEBGL_multi_draw")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
@@ -118,16 +118,7 @@ ext.multiDrawArraysInstancedWEBGL(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-   <tbody>
-      <tr>
-         <th scope="col">Specification</th>
-      </tr>
-      <tr>
-         <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
-      </tr>
-   </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
@@ -104,16 +104,7 @@ ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-   <tbody>
-      <tr>
-         <th scope="col">Specification</th>
-      </tr>
-      <tr>
-         <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
-      </tr>
-   </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
@@ -130,16 +130,7 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
@@ -117,16 +117,7 @@ ext.multiDrawElementsWEBGL(
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglactiveinfo/index.html
+++ b/files/en-us/web/api/webglactiveinfo/index.html
@@ -39,20 +39,7 @@ WebGLActiveInfo? getTransformFeedbackVarying(WebGLProgram? program, GLuint index
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.11", "WebGLActiveInfo")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglactiveinfo/name/index.html
+++ b/files/en-us/web/api/webglactiveinfo/name/index.html
@@ -23,20 +23,7 @@ activeUniform.name;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebGL", "#DOM-WebGLActiveInfo-name", "WebGLActiveInfo.name")}}</td>
-   <td>{{Spec2("WebGL")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglactiveinfo/size/index.html
+++ b/files/en-us/web/api/webglactiveinfo/size/index.html
@@ -23,20 +23,7 @@ activeUniform.size;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebGL", "#DOM-WebGLActiveInfo-size", "WebGLActiveInfo.size")}}</td>
-   <td>{{Spec2("WebGL")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglactiveinfo/type/index.html
+++ b/files/en-us/web/api/webglactiveinfo/type/index.html
@@ -23,20 +23,7 @@ activeUniform.type;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebGL", "#DOM-WebGLActiveInfo-type", "WebGLActiveInfo.type")}}</td>
-   <td>{{Spec2("WebGL")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglbuffer/index.html
+++ b/files/en-us/web/api/webglbuffer/index.html
@@ -33,20 +33,7 @@ var buffer = gl.createBuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.4", "WebGLBuffer")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglcontextevent/index.html
+++ b/files/en-us/web/api/webglcontextevent/index.html
@@ -50,20 +50,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.15", "WebGLContextEvent")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglcontextevent/statusmessage/index.html
+++ b/files/en-us/web/api/webglcontextevent/statusmessage/index.html
@@ -29,20 +29,7 @@ canvas.addEventListener('webglcontextcreationerror', function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebGL", "#5.15.1", "WebGLContextEvent.statusMessage")}}</td>
-   <td>{{Spec2("WebGL")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglframebuffer/index.html
+++ b/files/en-us/web/api/webglframebuffer/index.html
@@ -33,20 +33,7 @@ var buffer = gl.createFramebuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.5", "WebGLFramebuffer")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglprogram/index.html
+++ b/files/en-us/web/api/webglprogram/index.html
@@ -61,20 +61,7 @@ gl.drawArrays(gl.TRIANGLES, 0, 3);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.6", "WebGLProgram")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglquery/index.html
+++ b/files/en-us/web/api/webglquery/index.html
@@ -38,20 +38,7 @@ browser-compat: api.WebGLQuery
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL2', "#3.2", "WebGLQuery")}}</td>
-   <td>{{Spec2('WebGL2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderbuffer/index.html
@@ -33,20 +33,7 @@ var buffer = gl.createRenderbuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.7", "WebGLRenderbuffer")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/activetexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/activetexture/index.html
@@ -63,25 +63,7 @@ gl.getParameter(gl.ACTIVE_TEXTURE);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "activeTexture")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glActiveTexture.xml", "glActiveTexture")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.html
@@ -46,25 +46,7 @@ if ( !gl.getProgramParameter( program, gl.LINK_STATUS) ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "attachShader")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glAttachShader.xml", "glAttachShader")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>OpenGL man page.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
@@ -44,26 +44,7 @@ browser-compat: api.WebGLRenderingContext.bindAttribLocation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "bindAttribLocation")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBindAttribLocation.xml",
-        "glBindAttribLocation")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
@@ -88,46 +88,7 @@ gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.5", "bindBuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBindBuffer.xml", "glBindBuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.1", "bindBuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>
-        <p>Updated definition for WebGL 2.</p>
-
-        <p>Adds new <code>target</code> buffers:<br>
-          <code>gl.COPY_READ_BUFFER</code>,<br>
-          <code>gl.COPY_WRITE_BUFFER</code>,<br>
-          <code>gl.TRANSFORM_FEEDBACK_BUFFER</code>,<br>
-          <code>gl.UNIFORM_BUFFER</code>,<br>
-          <code>gl.PIXEL_PACK_BUFFER</code>,<br>
-          <code>gl.PIXEL_UNPACK_BUFFER</code>
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindBuffer.xhtml", "glBindBuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
@@ -78,37 +78,7 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "bindFramebuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBindFramebuffer.xml", "glBindFramebuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.1", "bindFrameBuffer")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Updated definition for WebGL 2.<br>
-        Adds: <code>gl.DRAW_FRAMEBUFFER</code> and <code>gl.READ_FRAMEBUFFER</code></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindFramebuffer.xhtml", "glBindFramebuffer")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
@@ -65,26 +65,7 @@ gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.7", "bindRenderbuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBindRenderbuffer.xml", "glBindRenderbuffer")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
@@ -73,36 +73,7 @@ gl.bindTexture(gl.TEXTURE_2D, texture);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "bindTexture")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBindTexture.xml", "glBindTexture")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.1", "bindTexture")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Updated definition for WebGL 2.<br>
-        Adds: <code>gl.TEXTURE_3D</code> and <code>gl.TEXTURE_2D_ARRAY</code></td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBindTexture.xhtml", "glBindTexture")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
@@ -52,25 +52,7 @@ browser-compat: api.WebGLRenderingContext.blendColor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "blendColor")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBlendColor.xml", "glBlendColor")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
@@ -85,30 +85,7 @@ gl.getParameter(gl.BLEND_EQUATION_ALPHA) === gl.FUNC_ADD;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "blendEquation")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBlendEquation.xml", "glBlendEquation")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBlendEquation.xml", "glBlendEquation")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
@@ -103,32 +103,7 @@ gl.getParameter(gl.BLEND_EQUATION_ALPHA) === gl.FUNC_ADD;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "blendEquationSeparate")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBlendEquationSeparate.xml",
-        "glBlendEquationSeparate")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBlendEquationSeparate.xhtml",
-        "glBlendEquationSeparate")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
@@ -174,28 +174,7 @@ gl.getParameter(gl.BLEND_SRC_RGB) == gl.SRC_COLOR;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "blendFunc")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.<br>
-        In WebGL, constant color and constant alpha cannot be used together as source and
-        destination factors in the blend function. See section 6.13. of the specification.
-      </td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBlendFunc.xml", "glBlendFunc")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
@@ -209,28 +209,7 @@ gl.getParameter(gl.BLEND_SRC_RGB) == gl.SRC_COLOR;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "blendFunc")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.<br>
-        In WebGL, constant color and constant alpha cannot be used together as source and
-        destination factors in the blend function. See section 6.13. of the specification.
-      </td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBlendFunc.xml", "glBlendFunc")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
@@ -158,47 +158,7 @@ var sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebGL', "#5.14.5", "bufferData")}}</td>
-			<td>{{Spec2('WebGL')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('OpenGL ES 2.0', "glBufferData.xml", "glBufferData")}}</td>
-			<td>{{Spec2('OpenGL ES 2.0')}}</td>
-			<td>Man page of the OpenGL API.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('OpenGL ES 3.0', "glBufferData.xhtml", "glBufferData")}}</td>
-			<td>{{Spec2('OpenGL ES 3.0')}}</td>
-			<td>Man page of the (similar) OpenGL ES 3 API.<br>
-				<br>
-				Adds new <code>target</code> buffers:<br>
-				<code>gl.COPY_READ_BUFFER</code>,<br>
-				<code>gl.COPY_WRITE_BUFFER</code>,<br>
-				<code>gl.TRANSFORM_FEEDBACK_BUFFER</code>,<br>
-				<code>gl.UNIFORM_BUFFER</code>,<br>
-				<code>gl.PIXEL_PACK_BUFFER</code>,<br>
-				<code>gl.PIXEL_UNPACK_BUFFER</code><br>
-				<br>
-				Adds new <code>usage</code> hints:<br>
-				<code>gl.STATIC_READ</code>,<br>
-				<code>gl.DYNAMIC_READ</code>,<br>
-				<code>gl.STREAM_READ</code>,<br>
-				<code>gl.STATIC_COPY</code>,<br>
-				<code>gl.DYNAMIC_COPY</code>,<br>
-				<code>gl.STREAM_COPY</code>.
-			</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
@@ -94,39 +94,7 @@ gl.bufferSubData(gl.ARRAY_BUFFER, 512, data);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.5", "bufferSubData")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glBufferSubData.xml", "glBufferSubData")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL ES 2 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glBufferSubData.xhtml", "glBufferSubData")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.<br>
-        <br>
-        Adds new <code>target</code> buffers:<br>
-        <code>gl.COPY_READ_BUFFER</code>,<br>
-        <code>gl.COPY_WRITE_BUFFER</code>,<br>
-        <code>gl.TRANSFORM_FEEDBACK_BUFFER</code>,<br>
-        <code>gl.UNIFORM_BUFFER</code>,<br>
-        <code>gl.PIXEL_PACK_BUFFER</code>,<br>
-        <code>gl.PIXEL_UNPACK_BUFFER</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.html
@@ -52,21 +52,7 @@ gl.canvas; // OffscreenCanvas</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#DOM-WebGLRenderingContext-canvas",
-        "WebGLRenderingContext.canvas")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
@@ -91,37 +91,7 @@ gl.checkFramebufferStatus(gl.FRAMEBUFFER);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "checkFramebufferStatus")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCheckFramebufferStatus.xml",
-        "glCheckFramebufferStatus")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.4", "checkFramebufferStatus")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Updated definition for WebGL 2.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCheckFramebufferStatus.xhtml",
-        "glCheckFramebufferStatus")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.html
@@ -68,25 +68,7 @@ gl.getParameter(gl.STENCIL_CLEAR_VALUE);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.11", "clear")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glClear.xml", "glClear")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
@@ -59,25 +59,7 @@ browser-compat: api.WebGLRenderingContext.clearColor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "clearColor")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glClearColor.xml", "glClearColor")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
@@ -49,25 +49,7 @@ browser-compat: api.WebGLRenderingContext.clearDepth
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "clearDepth")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glClearDepthf.xml", "glClearDepthf")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
@@ -48,25 +48,7 @@ browser-compat: api.WebGLRenderingContext.clearStencil
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "clearStencil")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glClearStencil.xml", "glClearStencil")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/colormask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/colormask/index.html
@@ -55,25 +55,7 @@ browser-compat: api.WebGLRenderingContext.colorMask
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "colorMask")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glColorMask.xml", "glColorMask")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.html
@@ -35,23 +35,7 @@ gl.commit();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#offscreencontext-commit', "the commit() method of
-        the OffscreenCanvas object's rendering context")}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
@@ -36,25 +36,7 @@ gl.compileShader(shader);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "compileShader")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCompileShader.xml", "glCompileShader")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>OpenGL man page.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
@@ -218,32 +218,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#COMPRESSEDTEXIMAGE2D", "compressedTexImage2D")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCompressedTexImage2D.xml",
-        "glCompressedTexImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCompressedTexImage2D.xhtml",
-        "glCompressedTexImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
@@ -195,33 +195,7 @@ gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 256, 256, 512, 512, ext.COMPRESSED_
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#COMPRESSEDTEXSUBIMAGE2D", "compressedTexSubImage2D")}}
-      </td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCompressedTexSubImage2D.xml",
-        "glCompressedTexSubImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glCompressedTexSubImage2D.xhtml",
-        "glCompressedTexSubImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
@@ -87,25 +87,7 @@ browser-compat: api.WebGLRenderingContext.copyTexImage2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "copyTexImage2D")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCopyTexImage2D.xml", "glCopyTexImage2D")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
@@ -74,26 +74,7 @@ browser-compat: api.WebGLRenderingContext.copyTexSubImage2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "copyTexSubImage2D")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCopyTexSubImage2D.xml", "glCopyTexSubImage2D")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createbuffer/index.html
@@ -39,25 +39,7 @@ var buffer = gl.createBuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.5", "createBuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGenBuffers.xml", "glGenBuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.html
@@ -39,25 +39,7 @@ var framebuffer = gl.createFramebuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "createFramebuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGenFramebuffers.xml", "glGenFramebuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createprogram/index.html
@@ -53,25 +53,7 @@ if ( !gl.getProgramParameter( program, gl.LINK_STATUS) ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "createProgram")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCreateProgram.xml", "glCreateProgram")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.html
@@ -40,26 +40,7 @@ var renderBuffer = gl.createRenderbuffer();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.7", "createRenderbuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGenRenderbuffers.xml", "glGenRenderbuffers")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.html
@@ -37,25 +37,7 @@ browser-compat: api.WebGLRenderingContext.createShader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "createShader")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCreateShader.xml", "glCreateShader")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>OpenGL man page.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/createtexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createtexture/index.html
@@ -44,25 +44,7 @@ var texture = gl.createTexture();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "createTexture")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGenTextures.xml", "glGenTextures")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/cullface/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cullface/index.html
@@ -59,25 +59,7 @@ gl.cullFace(gl.FRONT_AND_BACK);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "cullFace")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glCullFace.xml", "glCullFace")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.html
@@ -46,25 +46,7 @@ gl.deleteBuffer(buffer);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.5", "deleteBuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteBuffers.xml", "glDeleteBuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.html
@@ -46,26 +46,7 @@ gl.deleteFramebuffer(framebuffer);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "deleteFramebuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteFramebuffers.xml",
-        "glDeleteFramebuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.html
@@ -46,25 +46,7 @@ gl.deleteProgram(program);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "deleteProgram")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteProgram.xml", "glDeleteProgram")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.html
@@ -46,26 +46,7 @@ gl.deleteRenderbuffer(renderbuffer);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.7", "deleteRenderbuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteRenderbuffers.xml",
-        "glDeleteRenderbuffers")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteshader/index.html
@@ -42,25 +42,7 @@ browser-compat: api.WebGLRenderingContext.deleteShader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "deleteShader")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteShader.xml", "glDeleteShader")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.html
@@ -47,25 +47,7 @@ gl.deleteTexture(texture);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "deleteTexture")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDeleteTextures.xml", "glDeleteTextures")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
@@ -69,25 +69,7 @@ gl.depthFunc(gl.NEVER);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "depthFunc")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDepthFunc.xml", "glDepthFunc")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
@@ -46,25 +46,7 @@ browser-compat: api.WebGLRenderingContext.depthMask
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "depthMask")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDepthMask.xml", "glDepthMask")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
@@ -51,27 +51,7 @@ browser-compat: api.WebGLRenderingContext.depthRange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "depthRange")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition. Unlike OpenGL, WebGL requires <code>zNear</code> and
-        <code>zFar</code> values to be clamped to the range 0 to 1. Additionally,
-        <code>zNear</code> must be less than or equal to <code>zFar</code>.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDepthRangef.xml", "glDepthRangef")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/detachshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/detachshader/index.html
@@ -28,25 +28,7 @@ browser-compat: api.WebGLRenderingContext.detachShader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "detachShader")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDetachShader.xml", "glDetachShader")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>OpenGL man page.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.html
@@ -122,30 +122,7 @@ browser-compat: api.WebGLRenderingContext.disable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "disable")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDisable.xml", "glDisable")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glEnable.xhtml", "glDisable")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
@@ -39,26 +39,7 @@ browser-compat: api.WebGLRenderingContext.disableVertexAttribArray
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.10", "disableVertexAttribArray")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glEnableVertexAttribArray.xml",
-        "glDisableVertexAttribArray")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
@@ -70,25 +70,7 @@ browser-compat: api.WebGLRenderingContext.drawArrays
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.11", "drawArrays")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDrawArrays.xml", "glDrawArrays")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
@@ -83,25 +83,7 @@ browser-compat: api.WebGLRenderingContext.drawElements
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.11", "drawElements")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glDrawElements.xml", "glDrawElements")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.html
@@ -39,21 +39,7 @@ gl.drawingBufferHeight; // 150
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebGL", "#DOM-WebGLRenderingContext-drawingBufferHeight",
-        "WebGLRenderingContext.drawingBufferHeight")}}</td>
-      <td>{{Spec2("WebGL")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.html
@@ -39,21 +39,7 @@ gl.drawingBufferWidth; // 300
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebGL", "#DOM-WebGLRenderingContext-drawingBufferWidth",
-        "WebGLRenderingContext.drawingBufferWidth")}}</td>
-      <td>{{Spec2("WebGL")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.html
@@ -122,30 +122,7 @@ browser-compat: api.WebGLRenderingContext.enable
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "enable")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glEnable.xml", "glEnable")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glEnable.xhtml", "glEnable")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the OpenGL ES 3.0 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
@@ -126,26 +126,7 @@ gl.drawArrays(gl.TRIANGLES, 0, vertexCount);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.10", "enableVertexAttribArray")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glEnableVertexAttribArray.xml",
-        "glEnableVertexAttribArray")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/finish/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/finish/index.html
@@ -30,25 +30,7 @@ browser-compat: api.WebGLRenderingContext.finish
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.11", "finish")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glFinish.xml", "glFinish")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/flush/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/flush/index.html
@@ -30,25 +30,7 @@ browser-compat: api.WebGLRenderingContext.flush
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.11", "flush")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glFlush.xml", "glFlush")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
@@ -128,32 +128,7 @@ browser-compat: api.WebGLRenderingContext.framebufferRenderbuffer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "framebufferRenderbuffer")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glFramebufferRenderbuffer.xml",
-        "glFramebufferRenderbuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glFramebufferRenderbuffer.xhtml",
-        "glFramebufferRenderbuffer")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
@@ -156,32 +156,7 @@ browser-compat: api.WebGLRenderingContext.framebufferTexture2D
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.6", "framebufferTexture2D")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glFramebufferTexture2D.xml",
-        "glFramebufferTexture2D")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glFramebufferTexture2D.xhtml",
-        "glFramebufferTexture2D")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/frontface/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/frontface/index.html
@@ -44,25 +44,7 @@ browser-compat: api.WebGLRenderingContext.frontFace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.3", "frontFace")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glFrontFace.xml", "glFrontFace")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
@@ -57,31 +57,7 @@ browser-compat: api.WebGLRenderingContext.generateMipmap
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.8", "generateMipmap")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGenerateMipmap.xml", "glGenerateMipmap")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2.0 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGenerateMipmap.xhtml", "glGenerateMipmap")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3.0 API.<br>
-        Adds: <code>gl.TEXTURE_3D</code> and <code>gl.TEXTURE_2D_ARRAY</code></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
@@ -49,25 +49,7 @@ for (let i = 0; i &lt; numAttribs; ++i) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.10", "getActiveAttrib")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGetActiveAttrib.xml", "glGetActiveAttrib")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
@@ -143,26 +143,7 @@ for (let i = 0; i &lt; numUniforms; ++i) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.10", "getActiveUniform")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGetActiveUniform.xml", "glGetActiveUniform")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.html
@@ -45,26 +45,7 @@ gl.getAttachedShaders(program);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.9", "getAttachedShaders")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGetAttachedShaders.xml",
-        "glGetAttachedShaders")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
@@ -42,26 +42,7 @@ browser-compat: api.WebGLRenderingContext.getAttribLocation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.10", "getAttribLocation")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGetAttribLocation.xml", "glGetAttribLocation")}}
-      </td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Main page of the OpenGL API.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
@@ -87,54 +87,7 @@ browser-compat: api.WebGLRenderingContext.getBufferParameter
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL', "#5.14.5", "getBufferParameter")}}</td>
-      <td>{{Spec2('WebGL')}}</td>
-      <td>Initial definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 2.0', "glGetBufferParameteriv.xml",
-        "glGetBufferParameteriv")}}</td>
-      <td>{{Spec2('OpenGL ES 2.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 2 API.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebGL2', "#3.7.3", "getBufferParameter")}}</td>
-      <td>{{Spec2('WebGL2')}}</td>
-      <td>Updated definition for WebGL.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('OpenGL ES 3.0', "glGetBufferParameter.xhtml",
-        "glGetBufferParameter")}}</td>
-      <td>{{Spec2('OpenGL ES 3.0')}}</td>
-      <td>Man page of the (similar) OpenGL ES 3 API.<br>
-        <br>
-        Adds new <code>target</code> buffers:<br>
-        <code>gl.COPY_READ_BUFFER</code>,<br>
-        <code>gl.COPY_WRITE_BUFFER</code>,<br>
-        <code>gl.TRANSFORM_FEEDBACK_BUFFER</code>,<br>
-        <code>gl.UNIFORM_BUFFER</code>,<br>
-        <code>gl.PIXEL_PACK_BUFFER</code>,<br>
-        <code>gl.PIXEL_UNPACK_BUFFER</code><br>
-        <br>
-        Adds new <code>usage</code> hints:<br>
-        <code>gl.STATIC_READ</code>,<br>
-        <code>gl.DYNAMIC_READ</code>,<br>
-        <code>gl.STREAM_READ</code>,<br>
-        <code>gl.STATIC_COPY</code>,<br>
-        <code>gl.DYNAMIC_COPY</code>,<br>
-        <code>gl.STREAM_COPY</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
@@ -66,21 +66,7 @@ gl.getContextAttributes();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("WebGL", "#5.14.2", "WebGLRenderingContext.getContextAttributes")}}
-      </td>
-      <td>{{Spec2("WebGL")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/index.html
@@ -348,20 +348,7 @@ var gl = canvas.getContext('webgl');
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebGL', "#5.14", "WebGLRenderingContext")}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/w* (first part) to the {{Specifications}} macros. 

Only one page don't get a spec table anymore (but a message):
- `WEBGL_compressed_texture_atc` that is deprecated. I leave it that way

All other pages look fine.