### PR TITLE
Clarify Atomics.isLockFree() description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.html
@@ -12,8 +12,10 @@ browser-compat: javascript.builtins.Atomics.isLockFree
 
 <p>The static
 	<code><strong>Atomics</strong></code><strong><code>.isLockFree()</code></strong>
-	method is used to determine whether to use locks or atomic operations. It returns
-	<code>true</code>, if the given size is one of the <a
+	method is used to determine whether the <code>Atomics</code> methods use locks 
+  or atomic hardware operations when applied to typed arrays with the given element 
+  byte size. 
+  It returns <code>false</code> if the given size is not one of the <a
 		href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT">BYTES_PER_ELEMENT</a>
 	property of integer TypedArray types.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

- The method isn’t used to determine whether anybody *needs to use* locks, 
  it is used to determine whether the *implementation* uses locks or not
- It does not have to return `true` for all valid BYTES_PER_ELEMENT values

> MDN URL of the main page changed

no

> Issue number (if there is an associated issue)

no

> Anything else that could help us review it

I appreciate MDN a lot and want to say thank you either way :)