### PR TITLE
change "ommision" to "omission" to fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -252,7 +252,7 @@ console.log([...new Set(numbers)])
 const mySet = new Set(text)  // Set(5) {'I', 'n', 'd', 'i', 'a'}
 mySet.size  // 5
 
-//case sensitive &amp; duplicate ommision
+//case sensitive &amp; duplicate omission
 new Set("Firefox")  // Set(7) { "F", "i", "r", "e", "f", "o", "x" }
 new Set("firefox")  // Set(6) { "f", "i", "r", "e", "o", "x" }
 </pre>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
I believe there was a misspelling of the word "omission".

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set

> Issue number (if there is an associated issue)
n/a