### PR TITLE
Fixed typos in Accessibility Inspector documentation

### DIFF
--- a/files/en-us/tools/accessibility_inspector/index.html
+++ b/files/en-us/tools/accessibility_inspector/index.html
@@ -111,7 +111,7 @@ tags:
 
 <p><img alt="Accessibility inspector and page with checkbox Show tab order selected." src="accessibility-inspector-show_tab_order.png" style="border-style: solid; border-width: 1px;"></p>
 
-<p>All focussable items have a numbered marker and the currently focussed item is highlighted in a different color. In some cases the marker may be hidden by other elements, as is true for items 1 and 2 in the in the page below.<br>
+<p>All focussable items have a numbered marker and the currently focussed item is highlighted in a different color. In some cases the marker may be hidden by other elements, as is true for items 1 and 2 in the page below.<br>
  <img alt="A page where some of the markers for selection items are hidden" src="accessibility-inspector-hidden_items.png"><br>
  These become visible in the overlay when the item is the current item.</p>
 
@@ -133,7 +133,7 @@ tags:
  <li><strong>Text Labels</strong> — Check for <a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Text_labels_and_names">issues with missing text labels</a></li>
 </ul>
 
-<p>When you one of the menu items, Firefox scans your document for the type of issues you selected. Depending on the size and complexity of your document, this may take a few seconds. When the scan is complete, the left side of the Accessibility Inspector panel displays only the items that have that type of issue. In the right side of the panel, the <em>Checks</em> subpanel lists the specific issue with the selected node. For each type of issue, there is a <strong>Learn more</strong> link to further information on <em>MDN Web Docs</em> about the issue.</p>
+<p>When you select one of the menu items, Firefox scans your document for the type of issues you selected. Depending on the size and complexity of your document, this may take a few seconds. When the scan is complete, the left side of the Accessibility Inspector panel displays only the items that have that type of issue. In the right side of the panel, the <em>Checks</em> subpanel lists the specific issue with the selected node. For each type of issue, there is a <strong>Learn more</strong> link to further information on <em>MDN Web Docs</em> about the issue.</p>
 
 <p><br>
  <img alt="Accessibility Inspector - Showing the options when you select the Check for Issues button" src="accessibility-inspector-check_for_issues.png" style="border-style: solid; border-width: 1px;"></p>
@@ -192,7 +192,7 @@ tags:
 
 <h3 id="Accessibility_picker">Accessibility picker</h3>
 
-<p>Like the element picker button on the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Select_an_element#with_the_node_picker">Page Inspector</a>, the <em>Accessibility</em> tab's element picker button allows you to hover and select UI items on the current page  highlight objects in the accessibility tree.</p>
+<p>Like the element picker button on the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Select_an_element#with_the_node_picker">Page Inspector</a>, the <em>Accessibility</em> tab's element picker button allows you to hover and select UI items on the current page to highlight objects in the accessibility tree.</p>
 
 <p>The accessibility tab element picker looks slightly different from the Page Inspector HTML pane picker, as shown below:</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
There were three typos in the Accessibility Inspector documentation.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector

> Issue number (if there is an associated issue)
n/a

> Anything else that could help us review it
n/a