### PR TITLE
Replace spec table with {{specifications}} for api/x*

### DIFF
--- a/files/en-us/web/api/xmldocument/index.html
+++ b/files/en-us/web/api/xmldocument/index.html
@@ -35,25 +35,7 @@ browser-compat: api.XMLDocument
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#xmldocument", "XMLDocument")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM4", "#xmldocument", "XMLDocument")}}</td>
-   <td>{{Spec2("DOM4")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/abort/index.html
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.html
@@ -57,20 +57,7 @@ if (OH_NOES_WE_NEED_TO_CANCEL_RIGHT_NOW_OR_ELSE) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-abort()-method')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/abort_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/abort_event/index.html
@@ -115,22 +115,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-abort')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/error_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/error_event/index.html
@@ -115,22 +115,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-error')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.html
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.html
@@ -109,23 +109,7 @@ request.onreadystatechange = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-getallresponseheaders()-method',
-        'getAllResponseHeaders()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.html
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.html
@@ -76,23 +76,7 @@ client.onreadystatechange = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("XMLHttpRequest", "#dom-xmlhttprequest-getresponseheader",
-        "getResponseHeader()")}}</td>
-      <td>{{Spec2("XMLHttpRequest")}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -142,22 +142,7 @@ browser-compat: api.XMLHttpRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>Live standard, latest version</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/load_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/load_event/index.html
@@ -115,22 +115,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-load')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
@@ -118,22 +118,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-loadend')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/loadstart_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/loadstart_event/index.html
@@ -118,22 +118,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-loadstart')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
+++ b/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
@@ -61,22 +61,7 @@ xhr.send();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#handler-xhr-onreadystatechange')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/open/index.html
+++ b/files/en-us/web/api/xmlhttprequest/open/index.html
@@ -57,22 +57,7 @@ browser-compat: api.XMLHttpRequest.open
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-open()-method', 'open()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.html
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.html
@@ -66,21 +66,7 @@ req.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-overridemimetype()-method',
-        'overrideMimeType()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.html
@@ -116,22 +116,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-progress')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.html
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.html
@@ -85,20 +85,7 @@ xhr.send(null);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#states')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.html
+++ b/files/en-us/web/api/xmlhttprequest/response/index.html
@@ -75,20 +75,7 @@ function load(url, callback) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-response-attribute')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.html
@@ -71,22 +71,7 @@ xhr.send(null);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-    <thead>
-        <tr>
-            <th scope="col">Specification</th>
-            <th scope="col">Status</th>
-            <th scope="col">Comment</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{SpecName('XMLHttpRequest', '#the-responsetext-attribute')}}</td>
-            <td>{{Spec2('XMLHttpRequest')}}</td>
-            <td>WHATWG living standard</td>
-        </tr>
-    </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.html
@@ -92,22 +92,7 @@ It can take the following values:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-responsetype-attribute')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.html
@@ -26,22 +26,7 @@ xhr.send(null);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-responseurl-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.html
@@ -83,22 +83,7 @@ xhr.send();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-responsexml-attribute', 'responseXML')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/send/index.html
+++ b/files/en-us/web/api/xmlhttprequest/send/index.html
@@ -123,22 +123,7 @@ xhr.send(&quot;foo=bar&amp;lorem=ipsum&quot;);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-send()-method', 'send()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.html
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.html
@@ -66,23 +66,7 @@ browser-compat: api.XMLHttpRequest.setRequestHeader
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#the-setrequestheader()-method',
-        'setRequestHeader()')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/status/index.html
+++ b/files/en-us/web/api/xmlhttprequest/status/index.html
@@ -48,22 +48,7 @@ xhr.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-status-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.html
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.html
@@ -51,20 +51,7 @@ xhr.send(null);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-statustext-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.html
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.html
@@ -41,20 +41,7 @@ xhr.send(null);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-timeout-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/timeout_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/timeout_event/index.html
@@ -54,22 +54,7 @@ client.send();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#event-xhr-timeout', 'timeout event')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -75,22 +75,7 @@ browser-compat: api.XMLHttpRequest.upload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-upload-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.html
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.html
@@ -36,20 +36,7 @@ xhr.send(null);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#the-withcredentials-attribute')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/index.html
@@ -37,20 +37,7 @@ browser-compat: api.XMLHttpRequestEventTarget
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>WHATWG living standard</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onabort/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onabort/index.html
@@ -45,20 +45,7 @@ xmlhttp.abort(); // This will invoke our onabort handler above
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest', '#handler-xhr-onabort')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>WHATWG living standard</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
@@ -46,20 +46,7 @@ xmlhttp.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest', '#handler-xhr-onerror')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>WHATWG living standard</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onload/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onload/index.html
@@ -44,20 +44,7 @@ xmlhttp.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('XMLHttpRequest', '#handler-xhr-onload')}}</td>
-			<td>{{Spec2('XMLHttpRequest')}}</td>
-			<td>WHATWG living standard</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onloadstart/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onloadstart/index.html
@@ -42,20 +42,7 @@ xmlhttp.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('XMLHttpRequest', '#handler-xhr-onloadstart')}}</td>
-      <td>{{Spec2('XMLHttpRequest')}}</td>
-      <td>WHATWG living standard</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onprogress/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onprogress/index.html
@@ -51,20 +51,7 @@ xmlhttp.send();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest', '#handler-xhr-onload')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td>WHATWG living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlserializer/index.html
+++ b/files/en-us/web/api/xmlserializer/index.html
@@ -69,20 +69,7 @@ document.body.insertAdjacentHTML('afterbegin', inp_xmls);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('DOM Parsing', '#the-xmlserializer-interface', 'XMLSerializer')}}</td>
-			<td>{{Spec2('DOM Parsing')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xmlserializer/serializetostring/index.html
+++ b/files/en-us/web/api/xmlserializer/serializetostring/index.html
@@ -97,21 +97,7 @@ browser-compat: api.XMLSerializer.serializeToString
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('DOM Parsing', '#dom-xmlserializer-serializetostring',
-        'serializeToString()')}}</td>
-      <td>{{Spec2('DOM Parsing')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.html
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.html
@@ -75,21 +75,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator-createExpression",
-        "XPathEvaluator.createExpression()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathevaluator/creatensresolver/index.html
+++ b/files/en-us/web/api/xpathevaluator/creatensresolver/index.html
@@ -42,21 +42,7 @@ browser-compat: api.XPathEvaluator.createNSResolver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator-createNSResolver",
-        "XPathEvaluator.createNSResolver()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.html
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.html
@@ -102,21 +102,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator-evaluate",
-        "XPathEvaluator.evaluate()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathevaluator/index.html
+++ b/files/en-us/web/api/xpathevaluator/index.html
@@ -55,20 +55,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathEvaluator", "XPathEvaluator")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathexception/code/index.html
+++ b/files/en-us/web/api/xpathexception/code/index.html
@@ -29,20 +29,7 @@ browser-compat: api.XPathException.code
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathException", "XPathException")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathexception/index.html
+++ b/files/en-us/web/api/xpathexception/index.html
@@ -47,20 +47,7 @@ browser-compat: api.XPathException
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathException", "XPathException")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathexpression/evaluate/index.html
+++ b/files/en-us/web/api/xpathexpression/evaluate/index.html
@@ -98,21 +98,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathExpression-evaluate",
-        "XPathExpression.evaluate()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathexpression/index.html
+++ b/files/en-us/web/api/xpathexpression/index.html
@@ -51,20 +51,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathExpression", "XPathExpression")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathnsresolver/index.html
+++ b/files/en-us/web/api/xpathnsresolver/index.html
@@ -27,20 +27,7 @@ browser-compat: api.XPathNSResolver
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathNSResolver", "XPathNSResolver")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.html
+++ b/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.html
@@ -36,21 +36,7 @@ browser-compat: api.XPathNSResolver.lookupNamespaceURI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathNSResolver-lookupNamespaceURI",
-        "XPathNSResolver.lookupNamespaceURI()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/booleanvalue/index.html
+++ b/files/en-us/web/api/xpathresult/booleanvalue/index.html
@@ -58,21 +58,7 @@ document.querySelector("output").textContent = result.booleanValue;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-booleanValue",
-        "XPathResult.booleanValue")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/index.html
+++ b/files/en-us/web/api/xpathresult/index.html
@@ -108,20 +108,7 @@ browser-compat: api.XPathResult
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult", "XPathResult")}}</td>
-   <td>{{Spec2("DOM3 XPath")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/invaliditeratorstate/index.html
+++ b/files/en-us/web/api/xpathresult/invaliditeratorstate/index.html
@@ -55,21 +55,7 @@ document.querySelector("output").textContent = result.invalidIteratorState ? "in
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-invalid-iterator-state",
-        "XPathResult.invalidIteratorState")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/iteratenext/index.html
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.html
@@ -66,21 +66,7 @@ document.querySelector("output").textContent = tagNames.join(", ");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-iterateNext",
-        "XPathResult.iterateNext()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/numbervalue/index.html
+++ b/files/en-us/web/api/xpathresult/numbervalue/index.html
@@ -58,21 +58,7 @@ document.querySelector("output").textContent = result.numberValue;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-numberValue",
-        "XPathResult.numberValue")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/resulttype/index.html
+++ b/files/en-us/web/api/xpathresult/resulttype/index.html
@@ -130,21 +130,7 @@ document.querySelector("output").textContent =
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-resultType",
-        "XPathResult.resultType")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/singlenodevalue/index.html
+++ b/files/en-us/web/api/xpathresult/singlenodevalue/index.html
@@ -61,21 +61,7 @@ document.querySelector("output").textContent = result.singleNodeValue.localName;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-singleNodeValue",
-        "XPathResult.singleNodeValue")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/snapshotitem/index.html
+++ b/files/en-us/web/api/xpathresult/snapshotitem/index.html
@@ -65,21 +65,7 @@ document.querySelector("output").textContent = tagNames.join(", ");
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-snapshotItem",
-        "XPathResult.snapshotItem()")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/snapshotlength/index.html
+++ b/files/en-us/web/api/xpathresult/snapshotlength/index.html
@@ -58,21 +58,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-snapshotLength",
-        "XPathResult.snapshotLength")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xpathresult/stringvalue/index.html
+++ b/files/en-us/web/api/xpathresult/stringvalue/index.html
@@ -58,21 +58,7 @@ document.querySelector("output").textContent = result.stringValue;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("DOM3 XPath", "xpath.html#XPathResult-stringValue",
-        "XPathResult.stringValue")}}</td>
-      <td>{{Spec2("DOM3 XPath")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
@@ -104,22 +104,7 @@ browser-compat: api.XRBoundedReferenceSpace.boundsGeometry
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrboundedreferencespace-boundsgeometry','boundsGeometry')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrboundedreferencespace/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/index.html
@@ -38,20 +38,7 @@ browser-compat: api.XRBoundedReferenceSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#xrboundedreferencespace-interface','XRBoundedReferenceSpace')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrenvironmentblendmode/index.html
+++ b/files/en-us/web/api/xrenvironmentblendmode/index.html
@@ -37,22 +37,7 @@ browser-compat: api.XREnvironmentBlendMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR AR Module","#xrenvironmentblendmode-enum","XREnvironmentBlendMode")}}</td>
-   <td>{{Spec2("WebXR AR Module")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xreye/index.html
+++ b/files/en-us/web/api/xreye/index.html
@@ -40,22 +40,7 @@ browser-compat: api.XREye
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#enumdef-xreye","XREye")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrframe/getpose/index.html
+++ b/files/en-us/web/api/xrframe/getpose/index.html
@@ -51,20 +51,7 @@ browser-compat: api.XRFrame.getPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrframe-getpose','XRFrame.getPose()')}}</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrframe/getviewerpose/index.html
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.html
@@ -76,21 +76,7 @@ if (viewerPose) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrframe-getviewerpose','XRFrame.getViewerPose()')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrframe/index.html
+++ b/files/en-us/web/api/xrframe/index.html
@@ -42,22 +42,7 @@ browser-compat: api.XRFrame
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrframe-interface","XRFrame")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrframe/session/index.html
+++ b/files/en-us/web/api/xrframe/session/index.html
@@ -34,22 +34,7 @@ browser-compat: api.XRFrame.session
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrframe-session","XRFrame.session")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrframerequestcallback/index.html
+++ b/files/en-us/web/api/xrframerequestcallback/index.html
@@ -35,24 +35,7 @@ browser-compat: api.XRFrameRequestCallback
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#callbackdef-xrframerequestcallback","XRFrameRequestCallback")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrhandedness/index.html
+++ b/files/en-us/web/api/xrhandedness/index.html
@@ -56,20 +56,7 @@ browser-compat: api.XRHandedness
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#enumdef-xrhandedness','XRHandedness')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrinputsource/gripspace/index.html
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.html
@@ -91,21 +91,7 @@ browser-compat: api.XRInputSource.gripSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrinputsource-gripspace','XRInputSource.gripSpace')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsource/handedness/index.html
+++ b/files/en-us/web/api/xrinputsource/handedness/index.html
@@ -53,21 +53,7 @@ browser-compat: api.XRInputSource.handedness
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrinputsource-handedness','XRInputSource.handedness')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsource/index.html
+++ b/files/en-us/web/api/xrinputsource/index.html
@@ -74,20 +74,7 @@ browser-compat: api.XRInputSource
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#xrinputsource-interface','XRInputSource')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsource/profiles/index.html
+++ b/files/en-us/web/api/xrinputsource/profiles/index.html
@@ -68,21 +68,7 @@ browser-compat: api.XRInputSource.profiles
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrinputsource-profiles','XRInputSource.profiles')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.html
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.html
@@ -53,22 +53,7 @@ browser-compat: api.XRInputSource.targetRayMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrinputsource-targetraymode','XRInputSource.handedness')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -90,22 +90,7 @@ browser-compat: api.XRInputSource.targetRaySpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrinputsource-targetrayspace','XRInputSource.targetRaySpace')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/entries/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/entries/index.html
@@ -81,23 +81,7 @@ for (let input of sources.entries()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebXR','#xrinputsourcearray','XRInputSourceArray')}} (See <a
-            href="#spec-iterables">[1]</a>)</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td><code>XRInputSourceArray</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p><a id="spec-iterables">[1]</a> See
   {{SectionOnPage("/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file",

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.html
@@ -100,23 +100,7 @@ inputSources.forEach((input) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebXR','#xrinputsourcearray','XRInputSourceArray')}} (See <a
-            href="#spec-iterables"></a>)</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td><code>XRInputSourceArray</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/index.html
@@ -64,22 +64,7 @@ if (sources.length &gt; 0) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebXR','#xrinputsourcearray-interface','XRInputSourceArray')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.html
@@ -67,23 +67,7 @@ browser-compat: api.XRInputSourceArray.keys
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebXR','#xrinputsourcearray','XRInputSourceArray')}} (See <a
-            href="#spec-iterables">[1]</a>)</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td><code>XRInputSourceArray</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p><a id="spec-iterables">[1]</a> See
   {{SectionOnPage("/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file",

--- a/files/en-us/web/api/xrinputsourcearray/length/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.html
@@ -63,24 +63,7 @@ if (sources.length === 0) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrinputsourcearray-length','XRInputSourceArray.length')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/values/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.html
@@ -66,23 +66,7 @@ browser-compat: api.XRInputSourceArray.values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('WebXR','#xrinputsourcearray','XRInputSourceArray')}} (See <a
-            href="#spec-iterables">[1]</a>)</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td><code>XRInputSourceArray</code> interface</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <p><a id="spec-iterables">[1]</a> See
   {{SectionOnPage("/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file",

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.html
@@ -79,23 +79,7 @@ browser-compat: api.XRInputSourceEvent.frame
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrinputsourceevent-frame","XRInputSourceEvent.frame")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceevent/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/index.html
@@ -85,22 +85,7 @@ browser-compat: api.XRInputSourceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrinputsourceevent","XRInputSourceEvent")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
@@ -61,24 +61,7 @@ browser-compat: api.XRInputSourceEvent.inputSource
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceevent-inputsource","XRInputSourceEvent.inputSource")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
@@ -63,22 +63,7 @@ browser-compat: api.XRInputSourceEvent.XRInputSourceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#xrinputsourceevent","XRInputSourceEvent")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceeventinit/frame/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/frame/index.html
@@ -79,24 +79,7 @@ if (event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceeventinit-frame","XRInputSourceEventInit.frame")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceeventinit/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/index.html
@@ -36,22 +36,7 @@ browser-compat: api.XRInputSourceEventInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#dictdef-xrinputsourceeventinit","XRInputSourceEventInit")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceeventinit/inputsource/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/inputsource/index.html
@@ -63,24 +63,7 @@ if (event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceeventinit-inputsource","XRInputSourceEventInit.inputSource")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
@@ -59,24 +59,7 @@ browser-compat: api.XRInputSourcesChangeEvent.added
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeevent-added","XRInputSourcesChangeEvent.added")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/index.html
@@ -76,22 +76,7 @@ function onInputSourcesChange(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrinputsourceschangeevent","XRInputSourcesChangeEvent")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
@@ -46,24 +46,7 @@ browser-compat: api.XRInputSourcesChangeEvent.removed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeevent-removed","XRInputSourcesChangeEvent.removed")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
@@ -41,24 +41,7 @@ browser-compat: api.XRInputSourcesChangeEvent.session
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeevent-session","XRInputSourcesChangeEvent.session")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
@@ -68,24 +68,7 @@ browser-compat: api.XRInputSourcesChangeEvent.XRInputSourcesChangeEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeevent-xrinputsourceschangeevent","XRInputSourcesChangeEvent()")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
@@ -53,24 +53,7 @@ browser-compat: api.XRInputSourcesChangeEventInit.added
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeeventinit-added","XRInputSourcesChangeEventInit.added")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/index.html
@@ -42,22 +42,7 @@ browser-compat: api.XRInputSourcesChangeEventInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#dictdef-xrinputsourceschangeeventinit","XRInputSourcesChangeEventInit")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/removed/index.html
@@ -51,24 +51,7 @@ browser-compat: api.XRInputSourcesChangeEventInit.removed
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeeventinit-removed","XRInputSourcesChangeEventInit.removed")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/session/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/session/index.html
@@ -49,24 +49,7 @@ browser-compat: api.XRInputSourcesChangeEventInit.session
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrinputsourceschangeeventinit-session","XRInputSourcesChangeEventInit.session")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/index.html
@@ -80,22 +80,7 @@ if (navigator.permissions) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('WebXR','#dictdef-xrpermissiondescriptor','XRPermissionDescriptor')}}</td>
-			<td>{{Spec2('WebXR')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/mode/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/mode/index.html
@@ -88,24 +88,7 @@ if (navigator.permissions) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrpermissiondescriptor-mode','XRPermissionDescriptor.mode')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/optionalfeatures/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/optionalfeatures/index.html
@@ -83,24 +83,7 @@ if (navigator.permissions) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrpermissiondescriptor-optionalfeatures','XRPermissionDescriptor.optionalFeatures')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/requiredfeatures/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/requiredfeatures/index.html
@@ -96,24 +96,7 @@ if (navigator.permissions) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrpermissiondescriptor-requiredfeatures','XRPermissionDescriptor.requiredFeatures')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissionstatus/granted/index.html
+++ b/files/en-us/web/api/xrpermissionstatus/granted/index.html
@@ -47,24 +47,7 @@ browser-compat: api.XRPermissionStatus.granted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrpermissionstatus-granted','XRPermissionStatus.granted')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpermissionstatus/index.html
+++ b/files/en-us/web/api/xrpermissionstatus/index.html
@@ -42,22 +42,7 @@ browser-compat: api.XRPermissionStatus
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebXR','#xrpermissionstatus','XRPermissionStatus')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpose/emulatedposition/index.html
+++ b/files/en-us/web/api/xrpose/emulatedposition/index.html
@@ -71,23 +71,7 @@ browser-compat: api.XRPose.emulatedPosition
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrpose-emulatedposition","XRPose.emulatedPosition")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpose/index.html
+++ b/files/en-us/web/api/xrpose/index.html
@@ -52,22 +52,7 @@ browser-compat: api.XRPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrpose-interface","XRPose")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrpose/transform/index.html
+++ b/files/en-us/web/api/xrpose/transform/index.html
@@ -67,22 +67,7 @@ browser-compat: api.XRPose.transform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrpose-transform","XRPose.transform")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
@@ -188,22 +188,7 @@ function rotateViewBy(dx, dy) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespace-getoffsetreferencespace','getOffsetReferenceSpace()')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/index.html
@@ -85,20 +85,7 @@ xrReferenceSpace = xrReferenceSpace.getOffsetReferenceSpace(offsetTransform);</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#xrreferencespace-interface','XRReferenceSpace')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespace/onreset/index.html
+++ b/files/en-us/web/api/xrreferencespace/onreset/index.html
@@ -50,20 +50,7 @@ browser-compat: api.XRReferenceSpace.onreset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrreferencespace-onreset','onreset')}}</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.html
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.html
@@ -98,20 +98,7 @@ browser-compat: api.XRReferenceSpace.reset_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#eventdef-xrreferencespace-reset','reset event')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/index.html
@@ -55,20 +55,7 @@ browser-compat: api.XRReferenceSpaceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#xrreferencespaceevent','XRReferenceSpaceEvent')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
@@ -40,22 +40,7 @@ browser-compat: api.XRReferenceSpaceEvent.referenceSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespaceevent-referencespace','XRReferenceSpaceEvent.referenceSpace')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.html
@@ -73,22 +73,7 @@ browser-compat: api.XRReferenceSpaceEvent.transform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespaceevent-transform','XRReferenceSpaceEvent.transform')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
@@ -59,22 +59,7 @@ browser-compat: api.XRReferenceSpaceEvent.XRReferenceSpaceEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespaceevent-xrreferencespaceevent','XRReferenceSpaceEvent()')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespaceeventinit/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/index.html
@@ -52,20 +52,7 @@ browser-compat: api.XRReferenceSpaceEventInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#dictdef-xrreferencespaceeventinit','XRReferenceSpaceEventInit')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
@@ -45,22 +45,7 @@ browser-compat: api.XRReferenceSpaceEventInit.referenceSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespaceeventinit-referencespace','XRReferenceSpaceEventInit.referenceSpace')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
@@ -47,22 +47,7 @@ browser-compat: api.XRReferenceSpaceEventInit.transform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrreferencespaceeventinit-transform','XRReferenceSpaceEventInit.transform')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrreferencespacetype/index.html
+++ b/files/en-us/web/api/xrreferencespacetype/index.html
@@ -79,22 +79,7 @@ browser-compat: api.XRReferenceSpaceType
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebXR','#enumdef-xrreferencespacetype','XRReferenceSpaceType')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.html
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.html
@@ -69,21 +69,7 @@ function setNewWebGLLayer(gl) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrrenderstate-baselayer','XRRenderState.baseLayer')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.html
@@ -33,20 +33,7 @@ browser-compat: api.XRRenderState.depthFar
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR Device API','#dom-xrrenderstate-depthfar','XRRenderState.depthFar')}}</td>
-      <td>{{Spec2('WebXR Device API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.html
@@ -33,20 +33,7 @@ browser-compat: api.XRRenderState.depthNear
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR Device API','#dom-xrrenderstate-depthnear','XRRenderState.depthNear')}}</td>
-      <td>{{Spec2('WebXR Device API')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstate/index.html
+++ b/files/en-us/web/api/xrrenderstate/index.html
@@ -38,22 +38,7 @@ browser-compat: api.XRRenderState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrrenderstate-interface","XRRenderState")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
@@ -28,22 +28,7 @@ browser-compat: api.XRRenderState.inlineVerticalFieldOfView
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrrenderstate-inlineVerticalFieldOfView','XRRenderState.inlineVerticalFieldOfView')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrenderstateinit/index.html
+++ b/files/en-us/web/api/xrrenderstateinit/index.html
@@ -44,22 +44,7 @@ browser-compat: api.XRRenderStateInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#dictdef-xrrenderstateinit","XRRenderStateInit")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/index.html
+++ b/files/en-us/web/api/xrrigidtransform/index.html
@@ -73,22 +73,7 @@ browser-compat: api.XRRigidTransform
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrrigidtransform-interface","XRRigidTransform")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/inverse/index.html
+++ b/files/en-us/web/api/xrrigidtransform/inverse/index.html
@@ -73,23 +73,7 @@ for (let view of pose.view) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrrigidtransform-inverse","XRRigidTransform.inverse")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.html
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.html
@@ -806,23 +806,7 @@ drawGLObject("magic-lamp", transform.matrix);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrrigidtransform-matrix","XRRigidTransform.matrix")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/orientation/index.html
+++ b/files/en-us/web/api/xrrigidtransform/orientation/index.html
@@ -56,24 +56,7 @@ browser-compat: api.XRRigidTransform.orientation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrrigidtransform-orientation","XRRigidTransform.orientation")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/position/index.html
+++ b/files/en-us/web/api/xrrigidtransform/position/index.html
@@ -96,24 +96,7 @@ function refSpaceCreated(refSpace) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrrigidtransform-position","XRRigidTransform.position")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.html
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.html
@@ -98,24 +98,7 @@ xrSession.requestReferenceSpace("local-floor")
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrrigidtransform-xrrigidtransform","XRRigidTransform()")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.html
@@ -97,24 +97,7 @@ function pauseXR() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrsession-cancelanimationframe","XRSession.cancelAnimationFrame")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/end/index.html
+++ b/files/en-us/web/api/xrsession/end/index.html
@@ -42,22 +42,7 @@ browser-compat: api.XRSession.end
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-end","XRSession.end")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/end_event/index.html
+++ b/files/en-us/web/api/xrsession/end_event/index.html
@@ -64,22 +64,7 @@ browser-compat: api.XRSession.end_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-end","end event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.html
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.html
@@ -53,22 +53,7 @@ browser-compat: api.XRSession.environmentBlendMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR AR Module","#xrenvironmentblendmode-enum","XRSession.environmentBlendMode")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/index.html
+++ b/files/en-us/web/api/xrsession/index.html
@@ -146,22 +146,7 @@ if (XR) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrsession-interface","XRSession")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/inputsources/index.html
+++ b/files/en-us/web/api/xrsession/inputsources/index.html
@@ -53,23 +53,7 @@ browser-compat: api.XRSession.inputSources
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-inputsources","XRSession.inputSources")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
@@ -55,22 +55,7 @@ browser-compat: api.XRSession.inputsourceschange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-inputsourceschange","inputsourceschange event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onend/index.html
+++ b/files/en-us/web/api/xrsession/onend/index.html
@@ -37,22 +37,7 @@ browser-compat: api.XRSession.onend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onend","XRSession.onend")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/oninputsourceschange/index.html
+++ b/files/en-us/web/api/xrsession/oninputsourceschange/index.html
@@ -38,22 +38,7 @@ browser-compat: api.XRSession.oninputsourceschange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#dom-xrsession-oninputsourceschange","XRSession.oninputsourceschange")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onselect/index.html
+++ b/files/en-us/web/api/xrsession/onselect/index.html
@@ -70,22 +70,7 @@ browser-compat: api.XRSession.onselect
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onselect","XRSession.onselect")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onselectend/index.html
+++ b/files/en-us/web/api/xrsession/onselectend/index.html
@@ -42,22 +42,7 @@ browser-compat: api.XRSession.onselectend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onselectend","XRSession.onselectend")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onselectstart/index.html
+++ b/files/en-us/web/api/xrsession/onselectstart/index.html
@@ -44,23 +44,7 @@ browser-compat: api.XRSession.onselectstart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onselectstart","XRSession.onselectstart")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueeze/index.html
+++ b/files/en-us/web/api/xrsession/onsqueeze/index.html
@@ -93,22 +93,7 @@ browser-compat: api.XRSession.onsqueeze
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onsqueeze","XRSession.onsqueeze")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueezeend/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezeend/index.html
@@ -81,23 +81,7 @@ browser-compat: api.XRSession.onsqueezeend
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onsqueezeend","XRSession.onsqueezeend")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueezestart/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezestart/index.html
@@ -66,23 +66,7 @@ browser-compat: api.XRSession.onsqueezestart
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-onsqueezestart","XRSession.onsqueezestart")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/onvisibilitychange/index.html
+++ b/files/en-us/web/api/xrsession/onvisibilitychange/index.html
@@ -42,24 +42,7 @@ browser-compat: api.XRSession.onvisibilitychange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrsession-onvisibilitychange","XRSession.onvisibilitychange")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/renderstate/index.html
+++ b/files/en-us/web/api/xrsession/renderstate/index.html
@@ -40,22 +40,7 @@ browser-compat: api.XRSession.renderState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsession-renderstate","XRSession.renderState")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.html
@@ -151,24 +151,7 @@ function onXRSessionEnded() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrsession-requestanimationframe","XRSession.requestAnimationFrame")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.html
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.html
@@ -62,22 +62,7 @@ browser-compat: api.XRSession.requestReferenceSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrsession-requestreferencespace','requestReferenceSpace()')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/select_event/index.html
+++ b/files/en-us/web/api/xrsession/select_event/index.html
@@ -79,22 +79,7 @@ browser-compat: api.XRSession.select_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-select","select event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.html
+++ b/files/en-us/web/api/xrsession/selectend_event/index.html
@@ -55,22 +55,7 @@ browser-compat: api.XRSession.selectend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-selectend","selectend event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/selectstart_event/index.html
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.html
@@ -104,22 +104,7 @@ xrSession.onselectend = onSelectionEvent;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-selectstart","selectstart event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/squeeze_event/index.html
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.html
@@ -82,22 +82,7 @@ browser-compat: api.XRSession.squeeze_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-squeeze","squeeze event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.html
@@ -56,22 +56,7 @@ browser-compat: api.XRSession.squeezeend_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-squeezeend","squeezeend event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.html
@@ -106,22 +106,7 @@ xrSession.onsqueezeend = onSqueezeEvent;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-squeezestart","squeezestart event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.html
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.html
@@ -91,24 +91,7 @@ browser-compat: api.XRSession.updateRenderState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrsession-updaterenderstate","XRSession.updateRenderState()")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.html
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.html
@@ -81,22 +81,7 @@ browser-compat: api.XRSession.visibilitychange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsession-visibilitychange","visibilitychange event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.html
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.html
@@ -57,24 +57,7 @@ browser-compat: api.XRSession.visibilityState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {{SpecName("WebXR","#dom-xrsession-visibilitystate","XRSession.visibilityState")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/index.html
@@ -75,22 +75,7 @@ browser-compat: api.XRSessionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrsessionevent","XRSessionEvent")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessionevent/session/index.html
+++ b/files/en-us/web/api/xrsessionevent/session/index.html
@@ -60,23 +60,7 @@ browser-compat: api.XRSessionEvent.session
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR", "#dom-xrsessionevent-session", "XRSessionEvent.session")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
@@ -64,23 +64,7 @@ browser-compat: api.XRSessionEvent.XRSessionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR", "#dom-xrsessionevent-xrsessionevent", "XRSessionEvent()
-        constructor")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessioneventinit/index.html
+++ b/files/en-us/web/api/xrsessioneventinit/index.html
@@ -39,22 +39,7 @@ browser-compat: api.XRSessionEventInit
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR", "#dictdef-xrsessioneventinit", "XRSessionEventInit")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessioneventinit/session/index.html
+++ b/files/en-us/web/api/xrsessioneventinit/session/index.html
@@ -45,23 +45,7 @@ browser-compat: api.XRSessionEventInit.session
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR", "#dom-xrsessioneventinit-session",
-        "XRSessionEventInit.session")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsessionmode/index.html
+++ b/files/en-us/web/api/xrsessionmode/index.html
@@ -47,27 +47,7 @@ browser-compat: api.XRSessionMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrsessionmode-enum","XRSessionMode")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebXR AR Module", "#dom-xrsessionmode-immersive-ar", "XRSessionMode: immersive-ar")}}</td>
-   <td>{{Spec2("WebXR AR Module")}}</td>
-   <td>The <code>immersive-ar</code> value added</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrspace/index.html
+++ b/files/en-us/web/api/xrspace/index.html
@@ -46,20 +46,7 @@ browser-compat: api.XRSpace
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebXR','#xrspace-interface','XRSpace')}}</td>
-			<td>{{Spec2('WebXR')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.html
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.html
@@ -80,22 +80,7 @@ browser-compat: api.XRSystem.devicechange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#eventdef-xrsystem-devicechange","devicechange event")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsystem/index.html
+++ b/files/en-us/web/api/xrsystem/index.html
@@ -90,22 +90,7 @@ function onButtonClicked() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR", "#xrsystem-interface", "XRSystem")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.html
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.html
@@ -100,23 +100,7 @@ function onButtonClicked() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsystem-issessionsupported","isSessionSupported()")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsystem/ondevicechange/index.html
+++ b/files/en-us/web/api/xrsystem/ondevicechange/index.html
@@ -41,22 +41,7 @@ browser-compat: api.XRSystem.ondevicechange
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsystem-ondevicechange","ondevicechange ")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.html
+++ b/files/en-us/web/api/xrsystem/requestsession/index.html
@@ -138,22 +138,7 @@ function onButtonClicked() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrsystem-requestsession","requestSession()")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrtargetraymode/index.html
+++ b/files/en-us/web/api/xrtargetraymode/index.html
@@ -73,20 +73,7 @@ browser-compat: api.XRTargetRayMode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#enumdef-xrtargetraymode','XRTargetRayMode')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrview/eye/index.html
+++ b/files/en-us/web/api/xrview/eye/index.html
@@ -89,22 +89,7 @@ for (let view of xrPose.views) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrview-eye","XRView.eye")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrview/index.html
+++ b/files/en-us/web/api/xrview/index.html
@@ -140,22 +140,7 @@ mat4.transpose(normalMatrix, normalMatrix);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrview-interface","XRView")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrview/projectionmatrix/index.html
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.html
@@ -49,23 +49,7 @@ browser-compat: api.XRView.projectionMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrview-projectionmatrix","XRView.projectionMatrix")}}
-      </td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrview/transform/index.html
+++ b/files/en-us/web/api/xrview/transform/index.html
@@ -116,22 +116,7 @@ for (let view of pose.views) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrview-transform","XRView.transform")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewerpose/index.html
+++ b/files/en-us/web/api/xrviewerpose/index.html
@@ -50,20 +50,7 @@ browser-compat: api.XRViewerPose
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#xrviewerpose-interface','XRViewerPose')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xrviewerpose/views/index.html
+++ b/files/en-us/web/api/xrviewerpose/views/index.html
@@ -86,20 +86,7 @@ if (pose) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrviewerpose-views','XRViewerPose.views')}}</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewport/height/index.html
+++ b/files/en-us/web/api/xrviewport/height/index.html
@@ -45,22 +45,7 @@ browser-compat: api.XRViewport.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrviewport-height","XRViewport.height")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewport/index.html
+++ b/files/en-us/web/api/xrviewport/index.html
@@ -68,22 +68,7 @@ gl.viewport(xrViewport.x, xrViewport.y, xrViewport.width, xrViewport.height);</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#xrviewport-interface","XRViewport")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewport/width/index.html
+++ b/files/en-us/web/api/xrviewport/width/index.html
@@ -45,22 +45,7 @@ browser-compat: api.XRViewport.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrviewport-width","XRViewport.width")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewport/x/index.html
+++ b/files/en-us/web/api/xrviewport/x/index.html
@@ -49,22 +49,7 @@ browser-compat: api.XRViewport.x
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrviewport-x","XRViewport.x")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrviewport/y/index.html
+++ b/files/en-us/web/api/xrviewport/y/index.html
@@ -54,22 +54,7 @@ browser-compat: api.XRViewport.y
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("WebXR","#dom-xrviewport-y","XRViewport.y")}}</td>
-      <td>{{Spec2("WebXR")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrvisibilitystate/index.html
+++ b/files/en-us/web/api/xrvisibilitystate/index.html
@@ -37,22 +37,7 @@ browser-compat: api.XRVisibilityState
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","enumdef-xrvisibilitystate","XRVisibilityState")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.html
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.html
@@ -76,21 +76,7 @@ if (!glLayer.antialias) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayer-antialias','XRWebGLLayer.antialias')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
@@ -118,21 +118,7 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayer-framebuffer','XRWebGLLayer.framebuffer')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
@@ -56,22 +56,7 @@ frameHeight = glLayer.framebufferHeight;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayer-framebufferheight','XRWebGLLayer.framebufferHeight')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
@@ -55,22 +55,7 @@ frameHeight = glLayer.framebufferHeight;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayer-framebufferwidth','XRWebGLLayer.framebufferWidth')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
@@ -160,20 +160,7 @@ browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayer-getnativeframebufferscalefactor','static XRWebGLLayer.getNativeFramebufferScaleFactor()')}}</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.html
@@ -100,22 +100,7 @@ browser-compat: api.XRWebGLLayer.getViewport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayer-getviewport','XRWebGLLayer.getViewport()')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
@@ -87,22 +87,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, glLayerOptions);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayer-ignoredepthvalues','XRWebGLLayer.ignoreDepthValues')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/index.html
@@ -91,20 +91,7 @@ if (pose) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('WebXR','#xrwebgllayer-interface','XRWebGLLayer')}}</td>
-			<td>{{Spec2('WebXR')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
@@ -85,20 +85,7 @@ browser-compat: api.XRWebGLLayer.XRWebGLLayer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayer-xrwebgllayer','XRWebGLLayer()')}}</td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/alpha/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/alpha/index.html
@@ -55,21 +55,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { alpha: <em>boolValue</em> });
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayerinit-alpha','XRWebGLLayerInit.alpha')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/antialias/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/antialias/index.html
@@ -81,22 +81,7 @@ if (glLayer) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayerinit-antialias','XRWebGLLayerInit.antialias')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/depth/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/depth/index.html
@@ -65,20 +65,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { depth: false });
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#dom-xrwebgllayerinit-depth','XRWebGLLayerInit.depth')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/framebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/framebufferscalefactor/index.html
@@ -63,20 +63,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { framebufferScaleFactor: <em>scal
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#dom-xrwebgllayerinit-framebufferscalefactor','XRWebGLLayerInit.framebufferScaleFactor')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/ignoredepthvalues/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/ignoredepthvalues/index.html
@@ -91,22 +91,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { ignoreDepthValues: <em>boolValue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('WebXR','#dom-xrwebgllayerinit-ignoredepthvalues','XRWebGLLayerInit.ignoreDepthValues')}}
-      </td>
-      <td>{{Spec2('WebXR')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/index.html
@@ -56,20 +56,7 @@ xrSession.updateRenderState({
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#dictdef-xrwebgllayerinit','XRWebGLLayerInit')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/stencil/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/stencil/index.html
@@ -50,20 +50,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { stencil: false });
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebXR','#dom-xrwebgllayerinit-stencil','XRWebGLLayerInit.stencil')}}</td>
-   <td>{{Spec2('WebXR')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the interface, properties & methods of api/w* (last part) to the {{Specifications}} macros. 

Only one page don't get a spec table anymore (but a message):
- `XRRenderState.*` and `XRSession.*` were missing `spec_url.` Added in mdn/browser-compat-data#11079.
- `XRReferenceSpaceEventInit`, `.transform`, `.referenceSpace`,`XRInputSourceEventInit`, `.frame`, `.inputSource`, as well as `XRSessionEventInit`, and `.session`, or `XRRenderStateInit` and `XRInputSourcesChangeEventInit`, `.session`, `.removed` and finally `.added` are dictionaries. They will be fixed when we deal with them. I leave them that way.
- `XRReferenceSpaceType`, `XRTargetRayMode`, `XRHandedness`, `XRVisibilityState` are enum/typedef. I leave them that way.
- `XPathException` and `XPathException.code` are deprecated and have no bcd. I leave it this way.
- `XPathResult`and children were missing `spec_url`. Added in mdn/browser-compat-data#11089
- `XMLSerializer.serializeToStream` was missing `spec_url`. Added in mdn/browser-compat-data#11132.
- `XPathNSResolver` and `XPathNSResolver.lookupNamespaceURI` are no more on the standard track and have no bcd.

All other pages look fine.