### PR TITLE
change currentcolor to currentColor

### DIFF
--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -858,17 +858,17 @@ browser-compat: css.types.color
 <p><strong>Historical note:</strong> <code>transparent</code> wasn't a true color in CSS Level 2 (Revision 1). It was a special keyword that could be used instead of a regular <code>&lt;color&gt;</code> value on two CSS properties: {{Cssxref("background")}} and {{Cssxref("border")}}. It was essentially added to allow developers to override an inherited solid color. With the advent of alpha channels in CSS Colors Level 3, <code>transparent</code> was redefined as a true color. It can now be used wherever a <code>&lt;color&gt;</code> value can be used.</p>
 </div>
 
-<h3 id="currentcolor_keyword"><code id="currentColor">currentcolor</code> keyword</h3>
+<h3 id="currentcolor_keyword"><code id="currentColor">currentColor</code> keyword</h3>
 
-<p>The <code>currentcolor</code> keyword represents the value of an element's {{Cssxref("color")}} property. This lets you use the <code>color</code> value on properties that do not receive it by default.</p>
+<p>The <code>currentColor</code> keyword represents the value of an element's {{Cssxref("color")}} property. This lets you use the <code>color</code> value on properties that do not receive it by default.</p>
 
-<p>If <code>currentcolor</code> is used as the value of the <code>color</code> property, it instead takes its value from the inherited value of the <code>color</code> property.</p>
+<p>If <code>currentColor</code> is used as the value of the <code>color</code> property, it instead takes its value from the inherited value of the <code>color</code> property.</p>
 
-<h4 id="currentcolor_example">currentcolor example</h4>
+<h4 id="currentcolor_example">currentColor example</h4>
 
-<pre class="brush: html">&lt;div style="color:blue; border: 1px dashed currentcolor;"&gt;
+<pre class="brush: html">&lt;div style="color:blue; border: 1px dashed currentColor;"&gt;
   The color of this text is blue.
-  &lt;div style="background:currentcolor; height:9px;"&gt;&lt;/div&gt;
+  &lt;div style="background:currentColor; height:9px;"&gt;&lt;/div&gt;
   This block is surrounded by a blue border.
 &lt;/div&gt;</pre>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
`currentcolor` is not the correct keyword.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
