### PR TITLE
Rename element.attachShadow parameter to just init

### DIFF
--- a/files/en-us/web/api/element/attachshadow/index.html
+++ b/files/en-us/web/api/element/attachshadow/index.html
@@ -49,13 +49,13 @@ browser-compat: api.Element.attachShadow
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <var>shadowroot</var> = <var>element</var>.attachShadow(<var>shadowRootInit</var>);
+<pre class="brush: js">var <var>shadowroot</var> = <var>element</var>.attachShadow(<var>init</var>);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>shadowRootInit</code></dt>
+  <dt><code>init</code></dt>
   <dd>A <code>ShadowRootInit</code> dictionary, which can contain the following fields:
     <dl>
       <dt><code>mode</code></dt>


### PR DESCRIPTION
Matching the spec:
https://dom.spec.whatwg.org/#dom-element-attachshadow

The ShadowRootInit dictionary reference is left, and isn't wrong.
