### PR TITLE
Update Old links at "Demos of open web technologies"

### DIFF
--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -64,8 +64,8 @@ tags:
 
 <ul>
  <li><a href="https://ondras.github.io/fireworks-webgl/">Web Audio Fireworks</a></li>
- <li>IoQuake3 (<a href="https://github.com/klaussilveira/ioquake3.js">source code</a>)</li>
- <li>Escher puzzle (<a href="https://github.com/micahbolen/demoscene">source code</a>)</li>
+ <li><a href="https://webglsamples.org/aquarium/aquarium.html">Aquarium</a></li>
+ <li><a href="https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html">Dynamic cubemap</a></li>
  <li><a href="https://collinhover.github.io/kaiopua/">Kai 'Opua</a> (<a href="https://github.com/collinhover/kaiopua">source code</a>)</li>
 </ul>
 

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -79,15 +79,10 @@ tags:
 <h2 id="CSS">CSS</h2>
 
 <ul>
- <li><a href="http://www.csszengarden.com/">CSS Zen Garden</a></li>
  <li><a href="https://codepen.io/SoftwareRVG/pen/OXkOWj/">CSS floating logo "mozilla"</a></li>
- <li><a href="https://felixniklas.com/paperfold/">Paperfold</a></li>
  <li><a href="https://ondras.github.io/blockout/">CSS Blockout</a></li>
  <li><a href="https://ondras.zarovi.cz/demos/rubik/">Rubik's cube</a></li>
- <li>Planetarium (<a href="https://github.com/littleworkshop/planetarium">source code</a>)</li>
  <li><a href="https://codepen.io/equinusocio/full/qjyXPP/">Loader with blend modes</a></li>
- <li><a href="https://codepen.io/equinusocio/full/KNYOxJ/">Text reveal with clip-path</a></li>
- <li><a href="https://codepen.io/equinusocio/full/jEVNeJ/">Luminiscent vial</a></li>
  <li><a href="https://dmytsv.github.io/sass-spa/index.html#home">CSS-based single page application</a> (<a href="https://github.com/dmytsv/sass-spa">source code</a>)</li>
 </ul>
 

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -135,5 +135,5 @@ tags:
  <li><a href="https://ondras.github.io/photo/">Photo editor</a></li>
  <li><a href="https://ondras.github.io/coral/">Coral generator</a></li>
  <li><a href="https://nerget.com/rayjs-mt/rayjs.html">Raytracer</a></li>
- <li><a href="https://palerdot.github.io/hotcold/">HotCold Touch Typing</a></li>
+ <li><a href="https://mdn.github.io/fibonacci-worker/">Fibonacci</a></li>
 </ul>

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -37,10 +37,7 @@ tags:
 
 <ul>
  <li><a href="https://starkravingfinkle.org/projects/demo/svg-bubblemenu-in-html.xml">Bubblemenu</a> (visual effects and interaction)</li>
- <li><a href="https://starkravingfinkle.org/blog/2007/07/firefox-3-svg-foreignobject/">HTML transformations</a> using <code>foreignObject</code> (visual effects and transforms)</li>
- <li><a href="http://www.lutanho.net/svgvml3d/platonic.html">3D objects demo</a> (interactive)</li>
  <li><a href="http://www.themaninblue.com/experiment/Blobular/">Blobular</a> (interactive)</li>
- <li><a href="http://www.double.co.nz/video_test/video.svg">Video embedded in SVG</a> (or use the <a href="http://www.double.co.nz/video_test/video_svg.tar.bz2">local download</a>)</li>
  <li><a href="https://summerstyle.github.io/summer/">Summer HTML image map creator</a> (<a href="https://github.com/summerstyle/summer">source code</a>)</li>
 </ul>
 

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -77,6 +77,7 @@ tags:
 
 <ul>
  <li><a href="https://impress.github.io/impress.js">Impress.js</a> (<a href="https://github.com/impress/impress.js">source code</a>)</li>
+ <li><a href="https://ohiodave.com/tests/css2d/flickr.html">Flickr Polaroid Stack</a></li>
 </ul>
 
 <h2 id="Games">Games</h2>

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -115,11 +115,11 @@ tags:
 <h3 id="Web_Audio_API">Web Audio API</h3>
 
 <ul>
- <li><a href="https://ondras.github.io/fireworks-webgl/">Web Audio Fireworks</a></li>
- <li><a href="https://ondras.github.io/oscope/">oscope.js - JavaScript oscilloscope</a></li>
- <li><a href="https://h3ndrk.github.io/html5-web-audio-showcase/">HTML5 Web Audio Showcase</a> (<a href="https://github.com/NIPE-SYSTEMS/html5-web-audio-showcase">source code</a>)</li>
- <li><a href="https://wayou.github.io/HTML5_Audio_Visualizer/">HTML5 Audio Visualizer</a> (<a href="https://github.com/Wayou/HTML5_Audio_Visualizer">source code</a>)</li>
- <li><a href="https://carlosrafaelgn.com.br/GraphicalFilterEditor/">Graphical Filter Editor and Visualizer</a> (<a href="https://github.com/carlosrafaelgn/GraphicalFilterEditor">source code</a>)</li>
+ <li><a href="https://mdn.github.io/webaudio-examples/audiocontext-states/">Audio Context states demo</a></li>
+ <li><a href="https://mdn.github.io/webaudio-examples/audio-analyser/">Audio analyser - graphical visualization of an audio signal</a></li>
+ <li><a href="https://mdn.github.io/webaudio-examples/iirfilter-node/">IIR filter node</a></li>
+ <li><a href="https://mdn.github.io/webaudio-examples/multi-track/">Multi track</a></li>
+ <li><a href="https://mdn.github.io/webaudio-examples/stereo-panner-node/">Stereo-panner-node</a></li>
 </ul>
 
 <h3 id="File_API">File API</h3>

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -48,14 +48,8 @@ tags:
 
 <ul>
  <li><a href="https://vimeo.com/172328210">Video 3D Animation "mozilla constantly evolving"</a></li>
- <li><a href="https://vimeo.com/173851395">Video 3D animation "Floating Dance"</a></li>
- <li><a href="http://www.double.co.nz/video_test/test1.html">Streaming Anime, Movie Trailer and Interview</a></li>
- <li><a href="http://www.double.co.nz/video_test/test2.html">Billy's Browser Firefox Flick</a></li>
- <li><a href="http://www.double.co.nz/video_test/test3.html">Virtual Barber Shop</a></li>
- <li><a href="http://www.double.co.nz/video_test/test4.html">Transformers Movie Trailer</a></li>
- <li><a href="http://www.double.co.nz/video_test/test5.html">A Scanner Darkly Movie Trailer</a> (with built in controls)</li>
- <li><a href="http://www.double.co.nz/video_test/events.html">Events firing and volume control</a></li>
- <li><a href="http://www.double.co.nz/video_test/video.svg">Dragable and sizable videos</a></li>
+ <li><a href="https://vimeo.com/173851395">Video 3D Animation "Floating Dance"</a></li>
+ <li><a href="https://vimeo.com/560300715">Video 3D Animation "The Gravel Institute: Monopoly</a></li>
 </ul>
 
 <h2 id="3D_Graphics">3D Graphics</h2>

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -24,11 +24,7 @@ tags:
 <ul>
  <li><a href="https://www.blobsallad.se/">Blob Sallad: an interactive blob using JavaScript and canvas</a> (<a href="http://blobsallad.se/article/">code demos)</a></li>
  <li><a href="https://mdn.github.io/canvas-raycaster/index.html">3D RayCaster</a></li>
- <li><a href="https://processingjs.org/exhibition/">processing.js</a></li>
- <li><a href="https://p5js.org/">p5js</a></li>
- <li><a href="http://gyu.que.jp/jscloth/">3D on 2D Canvas</a></li>
  <li><a href="https://viliusle.github.io/miniPaint/">miniPaint: Image editor</a> (<a href="https://github.com/viliusle/miniPaint">source code</a>)</li>
-
  <li><a href="https://zenphoton.com">Zen Photon Garden </a>(<a href="https://github.com/scanlime/zenphoton">source code</a>)</li>
  <li><a href="https://maximumroulette.com/">Multi touch in canvas demo</a> (<a href="https://github.com/zlatnaspirala/multi-touch-canvas-handler">source code</a>)</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->
This PR fixes and eliminates some outdated links at <a href="https://developer.mozilla.org/en-US/docs/Web/Demos_of_open_web_technologies">open web</a>.

 Issue number (if there is an associated issue)
Fixes #2764 

