### PR TITLE
Link to correct datasource for spec data

### DIFF
--- a/files/en-us/mdn/structures/specification_tables/index.html
+++ b/files/en-us/mdn/structures/specification_tables/index.html
@@ -72,8 +72,8 @@ tags:
  <li>The property or entity name to use in the tooltip; this, too, is used when linking to specific interfaces within a specification. Although this parameter is also optional, it is strongly recommended to add it and it should be set to the name of the concept.</li>
 </ol>
 
-<p>The names you may specify for specifications can be seen by looking at the <code>specList</code> object in the macro. If the specification you want to link to is not supported by the macro, propose a pull request that updates the <a href="https://github.com/mdn/kumascript/blob/master/macros/SpecData.json">SpecData</a> file.</p>
+<p>The names you may specify for specifications can be seen by looking at the <code>specList</code> object in the macro. If the specification you want to link to is not supported by the macro, propose a pull request that updates the <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/SpecData.json">SpecData</a> file.</p>
 
 <h3 id="Spec2"><code>\{{Spec2}}</code></h3>
 
-<p>The {{TemplateLink("spec2")}} macro creates and inserts a widget indicating the status of a specification into the "Status" column, given the name of a specification. It also gets its data from the <a href="https://github.com/mdn/kumascript/blob/master/macros/SpecData.json">SpecData</a> file. Again, if the specification you want to link to is not supported by the macro, propose a pull request.</p>
+<p>The {{TemplateLink("spec2")}} macro creates and inserts a widget indicating the status of a specification into the "Status" column, given the name of a specification. It also gets its data from the <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/SpecData.json">SpecData</a> file. Again, if the specification you want to link to is not supported by the macro, propose a pull request.</p>


### PR DESCRIPTION
The [repository that's currently linked to](https://github.com/mdn/kumascript) is marked as archived and now points at [these files](https://github.com/mdn/yari/blob/main/kumascript/macros/SpecData.json)

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was a dead link to a data source for spec statuses, I updated found the new location and updated the link.

> MDN URL of the main page changed

[https://developer.mozilla.org/en-US/docs/MDN/Structures/Specification_tables](https://developer.mozilla.org/en-US/docs/MDN/Structures/Specification_tables)

> Issue number (if there is an associated issue)

There isn't an associated issue.

> Anything else that could help us review it

I can't think of anything else, but please let me know if you have questions!
