### PR TITLE
Remove question about MDN URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,8 +2,10 @@
 
 > What was wrong/why is this fix needed? (quick summary only)
 
-> MDN URL of the main page changed
+
 
 > Issue number (if there is an associated issue)
+
+
 
 > Anything else that could help us review it


### PR DESCRIPTION
The URLs become clear when the PR review companion comments. And if a PR touches some other file that don't relate to specific pages, the question (still) doesn't make sense. 

Also, I added a lot more space between each question because if you don't have 1 empty line between each question and each answer, they get globbered together.

