### PR TITLE
Reconcile `Document.createTreeWalker.createTreeWalker` option name with compat data

### DIFF
--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -16,7 +16,7 @@ browser-compat: api.Document.createTreeWalker
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>document</em>.createTreeWalker(<em>root</em>[, <em>whatToShow</em>[, <em>filter</em>[, <em>entityReferenceExpansion</em>]]]);
+<pre class="brush: js"><em>document</em>.createTreeWalker(<em>root</em>[, <em>whatToShow</em>[, <em>filter</em>[, <em>expandEntityReferences</em>]]]);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -123,7 +123,7 @@ browser-compat: api.Document.createTreeWalker
     <code>acceptNode</code>, which is called by the {{domxref("TreeWalker")}} to determine
     whether or not to accept a node that has passed the <code>whatToShow</code> check.
   </dd>
-  <dt><code>entityReferenceExpansion</code> {{optional_inline}} {{deprecated_inline}}</dt>
+  <dt><code>expandEntityReferences</code> {{optional_inline}} {{deprecated_inline}}</dt>
   <dd>A {{domxref("Boolean")}} flag indicating if when discarding an
     {{domxref("EntityReference")}} its whole sub-tree must be discarded at the same time.
   </dd>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

`Document.createTreeWalker()` has an option called, depending where you look, `entityReferenceExpansion` or `expandEntityReferences`. It's non-standard and deprecated, so there's no real authority to look to here. This PR makes things consistent with BCD.

This is a somewhat temporary measure though. It'll be fully irrelevant and eligible for removal in January 2022.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker

> Issue number (if there is an associated issue)

https://github.com/mdn/browser-compat-data/pull/11080

> Anything else that could help us review it
