### PR TITLE
Fixed Typo

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
@@ -57,7 +57,7 @@ oReq.send();</pre>
 <div class="note"><strong>Note:</strong> The constructor function
   <code>XMLHttpRequest</code> isn't limited to only XML documents. It starts with
   <strong>"XML"</strong> because when it was created the main format that was originally
-  used for Asynchronous Data Exchange were XML</div>
+  used for Asynchronous Data Exchange was XML</div>
 
 <h2 id="Handling_responses">Handling responses</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
@@ -54,10 +54,12 @@ oReq.send();</pre>
   }}, synchronous requests on the main thread have been deprecated due to the negative
   effects to the user experience.</div>
 
-<div class="note"><strong>Note:</strong> The constructor function
+<div class="notecard note">
+  <p><strong>Note:</strong> The constructor function
   <code>XMLHttpRequest</code> isn't limited to only XML documents. It starts with
   <strong>"XML"</strong> because when it was created the main format that was originally
-  used for Asynchronous Data Exchange was XML.</div>
+  used for Asynchronous Data Exchange was XML.</p>
+</div>
 
 <h2 id="Handling_responses">Handling responses</h2>
 
@@ -89,7 +91,7 @@ oReq.send();</pre>
     XML code changes slightly, the method will likely fail.</li>
 </ol>
 
-<div class="note">
+<div class="notecard note">
   <p><strong>Note:</strong> <code>XMLHttpRequest</code> can now interpret HTML for you
     using the {{domxref("XMLHttpRequest.responseXML", "responseXML")}} property. Read the
     article about <a href="/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest">HTML

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
@@ -57,7 +57,7 @@ oReq.send();</pre>
 <div class="note"><strong>Note:</strong> The constructor function
   <code>XMLHttpRequest</code> isn't limited to only XML documents. It starts with
   <strong>"XML"</strong> because when it was created the main format that was originally
-  used for Asynchronous Data Exchange was XML</div>
+  used for Asynchronous Data Exchange was XML.</div>
 
 <h2 id="Handling_responses">Handling responses</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Typo in the doc

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest

> Issue number (if there is an associated issue)

Fixes #6088 
