### PR TITLE
Give additional examples of how to create a MediaStream

### DIFF
--- a/files/en-us/web/api/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/index.html
@@ -12,7 +12,7 @@ browser-compat: api.MediaStream
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
-<p><span class="seoSummary">The <strong><code>MediaStream</code></strong> interface represents a stream of media content. A stream consists of several <strong>tracks</strong> such as video or audio tracks. Each track is specified as an instance of {{domxref("MediaStreamTrack")}}.</span>You can obtain a MediaStream object either by using the constructor or by calling {{domxref("MediaDevices.getUserMedia()")}}.</p>
+<p><span class="seoSummary">The <strong><code>MediaStream</code></strong> interface represents a stream of media content. A stream consists of several <strong>tracks</strong> such as video or audio tracks. Each track is specified as an instance of {{domxref("MediaStreamTrack")}}.</span>You can obtain a MediaStream object either by using the constructor or by calling functions such as {{domxref("MediaDevices.getUserMedia()")}}, {{domxref("MediaDevices.getDisplayMedia()")}}, or {{domxref("HTMLCanvasElement.captureStream()")}}.</p>
 
 <p>Some user agents subclass this interface to provide more precise information or functionality, like in {{domxref("CanvasCaptureMediaStreamTrack")}}.</p>
 

--- a/files/en-us/web/api/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/index.html
@@ -12,7 +12,9 @@ browser-compat: api.MediaStream
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
-<p><span class="seoSummary">The <strong><code>MediaStream</code></strong> interface represents a stream of media content. A stream consists of several <strong>tracks</strong> such as video or audio tracks. Each track is specified as an instance of {{domxref("MediaStreamTrack")}}.</span>You can obtain a MediaStream object either by using the constructor or by calling functions such as {{domxref("MediaDevices.getUserMedia()")}}, {{domxref("MediaDevices.getDisplayMedia()")}}, or {{domxref("HTMLCanvasElement.captureStream()")}}.</p>
+<p>The <strong><code>MediaStream</code></strong> interface represents a stream of media content. A stream consists of several <strong>tracks</strong>, such as video or audio tracks. Each track is specified as an instance of {{domxref("MediaStreamTrack")}}.</p>
+
+<p>You can obtain a <code>MediaStream</code> object either by using the constructor or by calling functions such as {{domxref("MediaDevices.getUserMedia()")}}, {{domxref("MediaDevices.getDisplayMedia()")}}, or {{domxref("HTMLCanvasElement.captureStream()")}}.</p>
 
 <p>Some user agents subclass this interface to provide more precise information or functionality, like in {{domxref("CanvasCaptureMediaStreamTrack")}}.</p>
 


### PR DESCRIPTION
The current introductory prose makes it sound like there are only two 
ways to create a MediaStream, when there are really others.  This change 
adds two more ways to the list, and also makes the list less firm that 
it's complete.  (I'm not sure whether the ways listed following this 
edit are all the ways that exist today, but even if they are, that seems 
like it may not continue to be true.)