### PR TITLE
Fix code snippet language

### DIFF
--- a/files/en-us/web/html/element/section/index.html
+++ b/files/en-us/web/html/element/section/index.html
@@ -122,7 +122,7 @@ browser-compat: html.elements.section
 
 <p>Make sure to use some assistive technology and screenreader-friendly CSS to hide it, like so:</p>
 
-<pre class="brush: html">.hidden {
+<pre class="brush: css">.hidden {
   position: absolute;
   top: -9999px;
   left: -9999px;


### PR DESCRIPTION
Use class name `css` for CSS Code Snippet.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
 
The code snippet language is set as HTML when it should be CSS.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
