### PR TITLE
MDN HTTP page templates for browser-compat

### DIFF
--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -2,44 +2,73 @@
 title: HTTP header page template
 slug: MDN/Structures/Page_types/HTTP_header_page_template
 tags:
+  - HTTP
   - HTTP Header
   - Reference
   - Template
-  - reference page
 browser-compat: path.to.feature.NameOfTheHeader
 ---
 <div>{{MDNSidebar}}</div>
 
-<div class="note">
-<h2 id="Remove_before_publishing">Remove before publishing</h2>
+<!-- Remove div below here before publishing -->
+<div class="notecard note">
+  <h2 id="Remove_before_publishing">Remove before publishing</h2>
+  
+  <h3 id="Page_front_matter">Page front matter</h3>
+  
+  <p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular header.</p>
+  
+  <pre>---
+  title: NameOfTheHeader
+  slug: Web/HTTP/Headers/NameOfTheHeader
+  tags:
+    - NameOfTheHeader
+    - HTTP
+    - HTTP Header
+    - Request header
+    - Response header
+    - Reference
+    - Experimental
+    - Deprecated
+  browser-compat: path.to.feature.NameOfTheHeader
+  ---</pre>
+  
+  <dl>
+  <dt><strong>Title</strong></dt>
+  <dd>Title heading displayed at top of page. Format as <em>NameOfTheHeader</em>. For example, the <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> header has a <em>title</em> of <code>Cache-Control</code>.</dd>
+  <dt>slug</dt>
+  <dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/HTTP/Headers/NameOfTheHeader</code>. For example, the <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> slug is <code>Web/HTTP/Headers/Cache-Control</code>.</dd>
+  <dt>tags</dt>
+  <dd>
+    <p>Always include the following tags: <strong>HTTP</strong>, <strong>Reference</strong>, <strong>HTTP Header</strong>, <em>NameOfTheHeader</em> (e.g. <strong>Cache-Control</strong>).</p>
+    <p>Include the following tags as appropriate:</p>
+    <ul>
+      <li>Type of request/response: <strong>Response header</strong>, <strong>Request header</strong>, <strong>Representation header</strong>, <strong>Payload header</strong>, <strong>Client hint</strong></li>
+      <li>Header status: <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</li>
+      <li>Any other tags that represent terms people might search for related to the technology. For example the <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> header includes the tag <strong>Caching</strong>.</li>
+    </ul>
+  </dd>
+  <dt>browser-compat</dt>
+  <dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheHeader</code> with the query string for the header in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility section (replacing the <code>\{{Compat}}</code> macro).</p>
+    
+    <p>Note that you may first need to create/update an entry for the HTTP header in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the header will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+  </dl>
+  
 
-<h3 id="Title_and_slug">Title and slug</h3>
+  <h3 id="Top_macros">Top macros</h3>
+  
+  <p>There are four macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
 
-<p>An HTTP header page should have a <em>title</em> and <em>slug</em> of <em>Name</em>Of<em>TheHTTPHeader</em>. For example, the <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> header has a <em>title</em> and <em>slug</em> of <em>Cache-Control</em>.</p>
-
-<h3 id="Top_macros">Top macros</h3>
-
-<p>There are four macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
-
-<ul>
- <li>\{{draft()}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
- <li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
- <li>\{{deprecated_header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
- <li>
-  <div>\{{httpsidebar}} — this generates the HTTP sidebar that every HTTP reference page has.</div>
- </li>
-</ul>
-
-<h3 id="Tags">Tags</h3>
-
-<p>In an HTTP header element subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>HTTP</strong>, <strong>Reference</strong>, <strong>HTTP Header</strong>, <em>the name of the HTTP Header</em> (e.g. <strong>Cache-Control</strong>), <strong>Response Header</strong>/<strong>Request header</strong>/<strong>Representation header</strong>, <strong>Caching</strong>/ or other header category as appropriate, <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<h3 id="Browser_compatibility">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>. Note that for HTML elements, most of the work has already been done — you just need to check that an entry is available.</p>
-
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
-</div>
+  <ul>
+   <li><code>\{{draft()}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+   <li><code>\{{SeeCompatTable}}</code> — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+   <li><code>\{{deprecated_header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+   <li>
+    <div><code>\{{httpsidebar}}</code> — this generates the HTTP sidebar that every HTTP reference page has.</div>
+   </li>
+  </ul>
+  </div>
+  <!-- Remove div above here before publishing -->
 
 <div>{{draft}}{{SeeCompatTable}}{{deprecated_header}}{{httpsidebar}}</div>
 
@@ -49,7 +78,7 @@ browser-compat: path.to.feature.NameOfTheHeader
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>Include header category (or categories), e.g. {{Glossary("Response header")}}</td>
+   <td>Include header category (or categories), e.g. {{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Client hints","Client hint")}}</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>
@@ -64,11 +93,13 @@ browser-compat: path.to.feature.NameOfTheHeader
 
 <h2 id="Syntax">Syntax</h2>
 
+<p>Fill in a syntax box, like the one below, according to the guidance in our <a href="/en-US/docs/MDN/Structures/Syntax_sections">syntax sections</a> article. If the header has a lot of available directives, feel free to include multiple syntax boxes, subsections and explanations as appropriate.</p>
+
+<pre class="brush: http">NameOfTheHeader: &lt;directive1&gt;
+NameOfTheHeader: &lt;directive1&gt;, &lt;directive2&gt;, …
+</pre>
+
 <p>The directives are case-insensitive and have an optional argument, that can use both token and quoted-string syntax. Multiple directives are comma-separated (delete information as appropriate).</p>
-
-<p>Fill in a syntax box, according to the guidance in our <a href="/en-US/docs/MDN/Structures/Syntax_sections">syntax sections</a> article.</p>
-
-<p>If the header has a lot of available directives, feel free to include multiple syntax boxes, subsections and explanations as appropriate.</p>
 
 <h2 id="Directives">Directives</h2>
 
@@ -83,9 +114,9 @@ browser-compat: path.to.feature.NameOfTheHeader
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a some examples that nicely show common use cases of the HTTP header.</p>
+<p>Fill in a some examples that show common use cases of the HTTP header (for example, a typical request and response sequence).</p>
 
-<pre class="brush: js">my code block</pre>
+<pre class="brush: http">my HTTP header example</pre>
 
 <p>And/or include a list of links to useful code samples that live elsewhere:</p>
 
@@ -121,6 +152,6 @@ browser-compat: path.to.feature.NameOfTheHeader
 <ul>
  <li>Include list of</li>
  <li>other links related to</li>
- <li>this Element that might</li>
+ <li>this header that might</li>
  <li>be useful</li>
 </ul>

--- a/files/en-us/mdn/structures/syntax_sections/index.html
+++ b/files/en-us/mdn/structures/syntax_sections/index.html
@@ -265,7 +265,7 @@ gainNode.gain.value = 0;</pre>
 
 <p>The "Syntax" section shows what a header's syntax will look like, using a syntax block styled using the "Syntax Box" style, including formal syntax to show exactly what directives can be included in the value, in what order, etc. For example, the {{HTTPHeader("If-None-Match")}} header's syntax block looks like this:</p>
 
-<pre class="brush: plain">If-None-Match: &lt;etag_value&gt;
+<pre class="brush: http">If-None-Match: &lt;etag_value&gt;
 If-None-Match: &lt;etag_value&gt;, &lt;etag_value&gt;, …
 If-None-Match: *</pre>
 
@@ -279,7 +279,7 @@ If-None-Match: *</pre>
 
 <p>Request method syntax is really simple, just containing a syntax block styled using the "Syntax Box" style that shows how the method syntax is structured. The syntax for the <a href="/en-US/docs/Web/HTTP/Methods/GET">GET method</a> looks like this:</p>
 
-<pre class="brush: plain">GET /index.html</pre>
+<pre class="brush: http">GET /index.html</pre>
 
 <h3 id="HTTP_response_status_codes">HTTP response status codes</h3>
 

--- a/files/en-us/web/http/headers/cache-control/index.html
+++ b/files/en-us/web/http/headers/cache-control/index.html
@@ -141,7 +141,7 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
 <dl>
  <dt>Good:</dt>
  <dd>
- <pre class="example-good brush: http no-line-numbers">Cache-Control: no-store</pre>
+ <pre class="example-good brush: http">Cache-Control: no-store</pre>
 
  <div class="notecard note">
  <p>The <code>no-store</code> directive will prevent a new resource being cached, but it will not prevent the cache from responding with a non-stale resource that was cached as the result of an earlier request. Setting <code>max-age=0</code> as well forces the cache to revalidate (clears the cache).</p>
@@ -152,7 +152,7 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
  </dd>
  <dt>Bad:</dt>
  <dd>
- <pre class="example-bad brush: http no-line-numbers">Cache-Control: private,no-cache,no-store,max-age=0,must-revalidate,pre-check=0,post-check=0</pre>
+ <pre class="example-bad brush: http">Cache-Control: private,no-cache,no-store,max-age=0,must-revalidate,pre-check=0,post-check=0</pre>
  </dd>
 </dl>
 
@@ -160,7 +160,7 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
 
 <p>For the files in the application that will not change, you can usually add aggressive caching by sending the response header below. This includes static files that are served by the application such as images, CSS files and JavaScript files, for example. In addition, see also the <code>Expires</code> header.</p>
 
-<pre class="brush: http no-line-numbers">Cache-Control: public, max-age=604800, immutable
+<pre class="brush: http">Cache-Control: public, max-age=604800, immutable
 </pre>
 
 <h3 id="Requiring_revalidation">Requiring revalidation</h3>
@@ -168,13 +168,13 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
 <p><code>no-cache</code> and <code>max-age=0, must-revalidate</code> indicates same meaning.<br>
  Clients can cache a resource but must revalidate each time before using it. This means HTTP request occurs each time though, it can skip downloading HTTP body if the content is valid.</p>
 
-<pre class="brush: http no-line-numbers">Cache-Control: no-cache</pre>
+<pre class="brush: http">Cache-Control: no-cache</pre>
 
-<pre class="brush: http no-line-numbers">Cache-Control: max-age=0, must-revalidate</pre>
+<pre class="brush: http">Cache-Control: max-age=0, must-revalidate</pre>
 
 <p><strong>Note</strong>: Following may serve stale resource if server is down or lose connectivity.</p>
 
-<pre class="brush: http no-line-numbers">Cache-Control: max-age=0</pre>
+<pre class="brush: http">Cache-Control: max-age=0</pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This updates the https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/HTTP_header_page_template with better information about how front-matter is used, in particular related to browser compat info. It also fixes some minor "fly by" issues in related topics.

- This follows on from https://github.com/mdn/content/pull/5780
- Also see https://github.com/mdn/content/pull/6217 (HTML Elements)