### PR TITLE
Update device client hint information

### DIFF
--- a/files/en-us/web/http/headers/content-dpr/index.html
+++ b/files/en-us/web/http/headers/content-dpr/index.html
@@ -41,7 +41,7 @@ browser-compat: http.headers.Content-DPR
 <div class="notecard note">
   <p><strong>Note:</strong></p>
     <ul>
-      <li><code>Content-DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+      <li><code>Content-DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>. The <a href="https://wicg.github.io/responsive-image-client-hints">Responsive Image Client Hints</a> spec proposes to replace this header by specifying intrinsic resolution/dimensions in EXIF metadata.</li>
     </ul>
 </div>
 

--- a/files/en-us/web/http/headers/content-dpr/index.html
+++ b/files/en-us/web/http/headers/content-dpr/index.html
@@ -1,0 +1,80 @@
+---
+title: Content-DPR
+slug: Web/HTTP/Headers/Content-DPR
+tags:
+  - Content-DPR
+  - Client hints
+  - HTTP
+  - HTTP Header
+  - Response header
+  - Deprecated
+  - Non-standard
+  - Exerimental
+browser-compat: http.headers.Content-DPR
+---
+<div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
+
+<p>The <strong><code>Content-DPR</code></strong> response header is used to confirm the <em>image</em> device to pixel ratio in requests where the screen {{HTTPHeader("DPR")}} <a href="/en-US/docs/Glossary/Client_hints">client hint</a> was used to select an image resource.</p>
+
+
+<table class="properties">
+  <tbody>
+   <tr>
+    <th scope="row">Header type</th>
+    <td>{{Glossary("Response header")}}, {{Glossary("Client hints","Client hint")}}</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("Forbidden header name")}}</th>
+    <td>no</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+    <td>no</td>
+   </tr>
+  </tbody>
+ </table>
+
+<p>If the {{HTTPHeader("DPR")}} client hint is used to select an image the server must specify <code>Content-DPR</code> in the response. If the value in <code>Content-DPR</code> is different from the {{HTTPHeader("DPR")}} value in the request (i.e. image DPR is not the same as screen DPR) then the client must use the <code>Content-DPR</code> for determining intrinsic image size and scaling the image.</p>
+
+<p>If the <code>Content-DPR</code> header appears more than once in a message the last occurrence is used.</p>
+ 
+<div class="notecard note">
+  <p><strong>Note:</strong></p>
+    <ul>
+      <li><code>Content-DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+    </ul>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: http">Content-DPR: &lt;number&gt;</pre>
+
+<h2 id="Directives">Directives</h2>
+
+<dl>
+ <dt><code> &lt;number&gt;</code></dt>
+ <dd>The image device pixel ratio, calculated according to the following formula:
+  <pre>Content-DPR = [Selected image resource size] / ([Width] / [DPR])</pre>
+</dd>
+</dl>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+ <li>Device client hints
+  <ul>
+    <li>{{HTTPHeader("Device-Memory")}}</li>
+    <li>{{HTTPHeader("DPR")}}</li>
+    <li>{{HTTPHeader("Viewport-Width")}}</li>
+    <li>{{HTTPHeader("Width")}}</li>
+   </ul>
+ </li>
+ <li>{{HTTPHeader("Accept-CH")}}</li>
+ <li><a href="/en-US/docs/Web/HTTP/Caching#varying_responses">HTTP Caching > Varying responses</a> and {{HTTPHeader("Vary")}}</li>
+</ul>

--- a/files/en-us/web/http/headers/content-dpr/index.html
+++ b/files/en-us/web/http/headers/content-dpr/index.html
@@ -58,6 +58,9 @@ browser-compat: http.headers.Content-DPR
 </dd>
 </dl>
 
+<h2 id="Examples">Examples</h2>
+
+<p>See the <a href="/en-US/docs/Web/HTTP/Headers/DPR#examples"><code>DPR</code></a> header example.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-dpr/index.html
+++ b/files/en-us/web/http/headers/content-dpr/index.html
@@ -54,7 +54,7 @@ browser-compat: http.headers.Content-DPR
 <dl>
  <dt><code> &lt;number&gt;</code></dt>
  <dd>The image device pixel ratio, calculated according to the following formula:
-  <pre>Content-DPR = [Selected image resource size] / ([Width] / [DPR])</pre>
+  <br> Content-DPR = <em>Selected image resource size</em> / (<em>Width</em> / <em>DPR</em>)
 </dd>
 </dl>
 

--- a/files/en-us/web/http/headers/device-memory/index.html
+++ b/files/en-us/web/http/headers/device-memory/index.html
@@ -11,9 +11,9 @@ tags:
   - Experimental
 browser-compat: http.headers.Device-Memory
 ---
-<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}</div>
 
-<p>The <strong><code>Device-Memory</code></strong> header is a <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a> header that works like <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> header which represents the approximate amount of RAM client device has.</p>
+<p>The <strong><code>Device-Memory</code></strong> {{Glossary("Client hints","device client hint")}} request header field indicates the approximate amount of available RAM on the client device. The header is part of the <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</p>
 
 <table class="properties">
   <tbody>
@@ -25,31 +25,37 @@ browser-compat: http.headers.Device-Memory
     <th scope="row">{{Glossary("Forbidden header name")}}</th>
     <td>no</td>
    </tr>
-   <tr>
-    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
-    <td>no</td>
-   </tr>
   </tbody>
  </table>
 
-<div>{{securecontext_header}}</div>
+ <p>The amount of device RAM can be used as a fingerprinting variable, so values for the header are intentionally coarse to reduce the potential for its misuse.</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> Client Hints are accessible only on secure origins (via TLS). Server has to opt in to receive <code>Device-Memory</code> header from the client by sending {{HTTPHeader("Accept-CH")}} and {{HTTPHeader("Accept-CH-Lifetime")}} response headers.</p>
+  <p><strong>Note:</strong></p>
+    <ul>
+      <li>Client Hints are accessible only on secure origins (via TLS).</li>
+      <li>A server has to opt in to receive the <code>Device-Memory</code> header from the client, by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>Servers that opt in to the <code>Device-Memory</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
+    </ul>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The amount of device RAM can be used as a fingerprinting variable, so values for the header are intentionally coarse to reduce the potential for its misuse. The header takes on the following values: <code>0.25</code>, <code>0.5</code>, <code>1</code>, <code>2</code>, <code>4</code>, <code>8</code>.</p>
-
 <pre class="brush: http">Device-Memory: &lt;number&gt;</pre>
+
+<h2 id="Directives">Directives</h2>
+
+<dl>
+ <dt><code> &lt;number&gt;</code></dt>
+ <dd>The approximate amount of device RAM. Possible values are: <code>0.25</code>, <code>0.5</code>, <code>1</code>, <code>2</code>, <code>4</code>, <code>8</code>.</dd>
+</dl>
+
 
 <h2 id="Examples">Examples</h2>
 
-<p>Server first needs to opt in to receive <code>Device-Memory</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Device-Memory</code> and {{HTTPHeader("Accept-CH-Lifetime")}}.</p>
+<p>Server first needs to opt in to receive <code>Device-Memory</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Device-Memory</code>.</p>
 
 <pre class="brush: http">Accept-CH: Device-Memory
-Accept-CH-Lifetime: 86400
 </pre>
 
 <p>Then on subsequent requests the client might send <code>Device-Memory</code> header back:</p>
@@ -67,9 +73,17 @@ Accept-CH-Lifetime: 86400
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a></li>
+  <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+  <li><a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a></li>
+  <li>{{DOMxRef("Navigator.deviceMemory")}}</li>
+ <li>Device client hints
+  <ul>
+    <li>{{HTTPHeader("Content-DPR")}}</li>
+    <li>{{HTTPHeader("DPR")}}</li>
+    <li>{{HTTPHeader("Viewport-Width")}}</li>
+    <li>{{HTTPHeader("Width")}}</li>
+   </ul>
+ </li>
  <li>{{HTTPHeader("Accept-CH")}}</li>
- <li>{{HTTPHeader("Accept-CH-Lifetime")}}</li>
- <li>{{HTTPHeader("Vary")}}</li>
- <li>{{DOMxRef("Navigator.deviceMemory")}}</li>
+ <li><a href="/en-US/docs/Web/HTTP/Caching#varying_responses">HTTP Caching > Varying responses</a> and {{HTTPHeader("Vary")}}</li>
 </ul>

--- a/files/en-us/web/http/headers/device-memory/index.html
+++ b/files/en-us/web/http/headers/device-memory/index.html
@@ -53,7 +53,7 @@ browser-compat: http.headers.Device-Memory
 
 <h2 id="Examples">Examples</h2>
 
-<p>Server first needs to opt in to receive <code>Device-Memory</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Device-Memory</code>.</p>
+<p>The server first needs to opt in to receive <code>Device-Memory</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Device-Memory</code>.</p>
 
 <pre class="brush: http">Accept-CH: Device-Memory
 </pre>

--- a/files/en-us/web/http/headers/device-memory/index.html
+++ b/files/en-us/web/http/headers/device-memory/index.html
@@ -28,8 +28,6 @@ browser-compat: http.headers.Device-Memory
   </tbody>
  </table>
 
- <p>The amount of device RAM can be used as a fingerprinting variable, so values for the header are intentionally coarse to reduce the potential for its misuse.</p>
-
 <div class="notecard note">
   <p><strong>Note:</strong></p>
     <ul>
@@ -50,6 +48,7 @@ browser-compat: http.headers.Device-Memory
  <dd>The approximate amount of device RAM. Possible values are: <code>0.25</code>, <code>0.5</code>, <code>1</code>, <code>2</code>, <code>4</code>, <code>8</code>.</dd>
 </dl>
 
+<p>The amount of device RAM can be used as a fingerprinting variable, so values for the header are intentionally coarse to reduce the potential for its misuse.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -62,9 +62,15 @@ browser-compat: http.headers.DPR
 
 <pre class="brush: http">Accept-CH: DPR</pre>
 
-<p>Then on subsequent requests the client might send <code>DPR</code> header back:</p>
+<p>Then on subsequent requests the client might send <code>DPR</code> header to the server:</p>
 
-<pre class="brush: http">DPR: 2.0</pre>
+<pre class="brush: http">DPR: 2.0
+</pre>
+
+<p>If a request with the <code>DPR</code> header (as shown above) is for an image resource, then the server response must include the {{HTTPHeader("Content-DPR")}} header:</p>
+
+<pre class="brush: http">Content-DPR: 2.0
+</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -68,9 +68,20 @@ browser-compat: http.headers.DPR
 
 <p>{{Compat}}</p>
 
+
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+ <li>Device client hints
+  <ul>
+    <li>{{HTTPHeader("Device-Memory")}}</li>
+    <li>{{HTTPHeader("Viewport-Width")}}</li>
+    <li>{{HTTPHeader("Width")}}</li>
+   </ul>
+ </li>
  <li>{{HTTPHeader("Accept-CH")}}</li>
- <li>{{HTTPHeader("Vary")}}</li>
+ <li><a href="/en-US/docs/Web/HTTP/Caching#varying_responses">HTTP Caching > Varying responses</a> and {{HTTPHeader("Vary")}}</li>
 </ul>
+ 
+

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -39,6 +39,7 @@ browser-compat: http.headers.DPR
       <li>Client Hints are accessible only on secure origins (via TLS).</li>
       <li>As for all client hints, a server has to opt in to receive <code>DPR</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
       <li>Servers that opt in to the <code>DPR</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
+      <li><code>DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
     </ul>
 </div>
 
@@ -62,10 +63,6 @@ browser-compat: http.headers.DPR
 <p>Then on subsequent requests the client might send <code>DPR</code> header back:</p>
 
 <pre class="brush: http">DPR: 2.0</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -31,7 +31,7 @@ browser-compat: http.headers.DPR
  
 <p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset">srcset</a> attribute to allow user agents to select a preferred image.</p>
 
-<p>When <code>DPR</code> is used in to determine what resource is returned in from a request, the server must include the {{HTTPHeader("Content-DPR")}} header in the <em>response</em>. The client must also use the result of this header in any layout calculations rather than the <code>DPR</code> value specified in the request.</p>
+<p>If a server uses the <code>DPR</code> hint to choose which resource is sent in a response, the response must include the {{HTTPHeader("Content-DPR")}} header. The client must use the value in <code>Content-DPR</code> for layout if it differs from the value in the request's <code>DPR</code> header.</p>
 
 <p>If the <code>DPR</code> header appears more than once in a message the last occurence is used.</p>
  

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -14,7 +14,7 @@ browser-compat: http.headers.DPR
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.</p>
+<p>The <strong><code>DPR</code></strong> <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> request header provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.</p>
 
 <table class="properties">
   <tbody>
@@ -39,9 +39,9 @@ browser-compat: http.headers.DPR
   <p><strong>Note:</strong></p>
     <ul>
       <li>Client Hints are accessible only on secure origins (via TLS).</li>
-      <li>As for all client hints, a server has to opt in to receive <code>DPR</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>A server has to opt in to receive the <code>DPR</code> header from the client, by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
       <li>Servers that opt in to the <code>DPR</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
-      <li><code>DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+      <li><code>DPR</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>. The proposed replacement is <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-dpr"><code>Sec-CH-DPR</code></a> (Responsive Image Client Hints).</li>
     </ul>
 </div>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -14,7 +14,7 @@ browser-compat: http.headers.DPR
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every CSS pixel.</p>
+<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.</p>
 
 <table class="properties">
   <tbody>
@@ -29,11 +29,11 @@ browser-compat: http.headers.DPR
   </tbody>
  </table>
  
-<p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset">srcset</a> attribute to allow user agents to select a preferred image.</p>
+<p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset"><code>srcset</code></a> attribute to allow user agents to select a preferred image.</p>
 
 <p>If a server uses the <code>DPR</code> hint to choose which resource is sent in a response, the response must include the {{HTTPHeader("Content-DPR")}} header. The client must use the value in <code>Content-DPR</code> for layout if it differs from the value in the request's <code>DPR</code> header.</p>
 
-<p>If the <code>DPR</code> header appears more than once in a message the last occurence is used.</p>
+<p>If the <code>DPR</code> header appears more than once in a message the last occurrence is used.</p>
  
 <div class="notecard note">
   <p><strong>Note:</strong></p>

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -28,10 +28,12 @@ browser-compat: http.headers.DPR
    </tr>
   </tbody>
  </table>
-
- <p>If the <code>DPR</code> header appears more than once in a message the last occurence is used.</p>
  
 <p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset">srcset</a> attribute to allow user agents to select a preferred image.</p>
+
+<p>When <code>DPR</code> is used in to determine what resource is returned in from a request, the server must include the {{HTTPHeader("Content-DPR")}} header in the <em>response</em>. The client must also use the result of this header in any layout calculations rather than the <code>DPR</code> value specified in the request.</p>
+
+<p>If the <code>DPR</code> header appears more than once in a message the last occurence is used.</p>
  
 <div class="notecard note">
   <p><strong>Note:</strong></p>
@@ -75,6 +77,7 @@ browser-compat: http.headers.DPR
   <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
  <li>Device client hints
   <ul>
+    <li>{{HTTPHeader("Content-DPR")}}</li>
     <li>{{HTTPHeader("Device-Memory")}}</li>
     <li>{{HTTPHeader("Viewport-Width")}}</li>
     <li>{{HTTPHeader("Width")}}</li>

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -14,7 +14,7 @@ browser-compat: http.headers.DPR
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every CSS pixel.</p>
+<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every CSS pixel.</p>
 
 <table class="properties">
   <tbody>
@@ -29,7 +29,7 @@ browser-compat: http.headers.DPR
   </tbody>
  </table>
 
- <p>If the DPR header appears more than once in a message the last occurence is used.</p>
+ <p>If the <code>DPR</code> header appears more than once in a message the last occurence is used.</p>
  
 <p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset">srcset</a> attribute to allow user agents to select a preferred image.</p>
  

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -14,7 +14,7 @@ browser-compat: http.headers.DPR
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> header which represents the client device pixel ratio, which is the number of physical device pixels corresponding to every CSS pixel.</p>
+<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">client hint</a> header that provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every CSS pixel.</p>
 
 <table class="properties">
   <tbody>
@@ -26,32 +26,42 @@ browser-compat: http.headers.DPR
     <th scope="row">{{Glossary("Forbidden header name")}}</th>
     <td>no</td>
    </tr>
-   <tr>
-    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
-    <td>no</td>
-   </tr>
   </tbody>
  </table>
 
+ <p>If the DPR header appears more than once in a message the last occurence is used.</p>
+ 
+<p>The hint is useful when selecting image sources that best correspond to a screen's pixel density. This is similar to the role played by <code>x</code> descriptors in the <code>&lt;img&gt;</code> <a href="/en-US/docs/Web/HTML/Element/img#attr-srcset">srcset</a> attribute to allow user agents to select a preferred image.</p>
+ 
 <div class="notecard note">
-<p><strong>Note:</strong> Client Hints are accessible only on secure origins (via TLS). Server has to opt in to receive <code>DPR</code> header from the client by sending {{HTTPHeader("Accept-CH")}} and {{HTTPHeader("Accept-CH-Lifetime")}} response headers.</p>
+  <p><strong>Note:</strong></p>
+    <ul>
+      <li>Client Hints are accessible only on secure origins (via TLS).</li>
+      <li>As for all client hints, a server has to opt in to receive <code>DPR</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>Servers that opt in to the <code>DPR</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
+    </ul>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: http">DPR: &lt;number&gt;</pre>
 
+<h2 id="Directives">Directives</h2>
+
+<dl>
+ <dt><code> &lt;number&gt;</code></dt>
+ <dd>The client device pixel ratio.</dd>
+</dl>
+
 <h2 id="Examples">Examples</h2>
 
-<p>Server first needs to opt in to receive <code>DPR</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>DPR</code> and {{HTTPHeader("Accept-CH-Lifetime")}}.</p>
+<p>A server must first opt in to receive the <code>DPR</code> header by sending the response header {{HTTPHeader("Accept-CH")}} containing the directive <code>DPR</code>.</p>
 
-<pre class="brush: http">Accept-CH: DPR
-Accept-CH-Lifetime: 86400
-</pre>
+<pre class="brush: http">Accept-CH: DPR</pre>
 
 <p>Then on subsequent requests the client might send <code>DPR</code> header back:</p>
 
-<pre class="brush: http">DPR: 1.0</pre>
+<pre class="brush: http">DPR: 2.0</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -65,6 +75,5 @@ Accept-CH-Lifetime: 86400
 
 <ul>
  <li>{{HTTPHeader("Accept-CH")}}</li>
- <li>{{HTTPHeader("Accept-CH-Lifetime")}}</li>
  <li>{{HTTPHeader("Vary")}}</li>
 </ul>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -95,7 +95,7 @@ tags:
   <dt>{{HTTPHeader("Content-DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>
   <dd>Response header used to confirm the image device to pixel ratio in requests where the {{HTTPHeader("DPR")}} client hint was used to select an image resource.</dd>
   <dt>{{HTTPHeader("Device-Memory")}} {{deprecated_inline}}{{experimental_inline}}</dt>
-  <dd>Approximate amount of available client RAM memory. This is part of <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</dd>
+  <dd>Approximate amount of available client RAM memory. This is part of the <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</dd>
   <dt>{{HTTPHeader("DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>
   <dd>Client device pixel ratio (DPR), which is the number of physical device pixels corresponding to every CSS pixel.</dd>
   <dt>{{HTTPHeader("Viewport-Width")}} {{deprecated_inline}}{{experimental_inline}}</dt>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -92,14 +92,16 @@ tags:
 <h3 id="device_client_hints">Device client hints</h3>
 
 <dl>
-  <dt>{{HTTPHeader("Device-Memory")}} {{experimental_inline}}</dt>
-  <dd>Approximate amount of available client RAM memory. Technically a part of <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</dd>
-  <dt>{{HTTPHeader("DPR")}} {{deprecated_inline}}</dt>
+  <dt>{{HTTPHeader("Content-DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>
+  <dd>Response header used to confirm the image device to pixel ratio in requests where{{HTTPHeader("DPR")}} was used to select an image resource.</dd>
+  <dt>{{HTTPHeader("Device-Memory")}} {{deprecated_inline}}{{experimental_inline}}</dt>
+  <dd>Approximate amount of available client RAM memory. This is part of <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</dd>
+  <dt>{{HTTPHeader("DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>
   <dd>Client device pixel ratio (DPR), which is the number of physical device pixels corresponding to every CSS pixel.</dd>
-  <dt>{{HTTPHeader("Viewport-Width")}} {{experimental_inline}}</dt>
+  <dt>{{HTTPHeader("Viewport-Width")}} {{deprecated_inline}}{{experimental_inline}}</dt>
   <dd>A number that indicates the layout viewport width in CSS pixels. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</dd>
-  <dt>{{HTTPHeader("Width")}} {{experimental_inline}}</dt>
-  <dd>The <code>Width</code> request header field is a number that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value). The <code>Width</code> header field can be omitted if the desired resource width is not known at the time of the request or the resource does not have a display width. If <code>Width</code> occurs in a message more than once, the last value overrides all previous occurrences.</dd>
+  <dt>{{HTTPHeader("Width")}} {{deprecated_inline}}{{experimental_inline}}</dt>
+  <dd>The <code>Width</code> request header field is a number that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image).</dd>
  </dl>
 
 

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -93,7 +93,7 @@ tags:
 
 <dl>
   <dt>{{HTTPHeader("Content-DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>
-  <dd>Response header used to confirm the image device to pixel ratio in requests where{{HTTPHeader("DPR")}} was used to select an image resource.</dd>
+  <dd>Response header used to confirm the image device to pixel ratio in requests where the {{HTTPHeader("DPR")}} client hint was used to select an image resource.</dd>
   <dt>{{HTTPHeader("Device-Memory")}} {{deprecated_inline}}{{experimental_inline}}</dt>
   <dd>Approximate amount of available client RAM memory. This is part of <a href="/en-US/docs/Web/API/Device_Memory_API">Device Memory API</a>.</dd>
   <dt>{{HTTPHeader("DPR")}} {{deprecated_inline}}{{experimental_inline}}</dt>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -97,7 +97,7 @@ tags:
   <dt>{{HTTPHeader("DPR")}} {{deprecated_inline}}</dt>
   <dd>Client device pixel ratio (DPR), which is the number of physical device pixels corresponding to every CSS pixel.</dd>
   <dt>{{HTTPHeader("Viewport-Width")}} {{experimental_inline}}</dt>
-  <dd>A number that indicates the layout viewport width in CSS pixels. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value). If <code>Viewport-Width</code> occurs in a message more than once, the last value overrides all previous occurrences.</dd>
+  <dd>A number that indicates the layout viewport width in CSS pixels. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</dd>
   <dt>{{HTTPHeader("Width")}} {{experimental_inline}}</dt>
   <dd>The <code>Width</code> request header field is a number that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value). The <code>Width</code> header field can be omitted if the desired resource width is not known at the time of the request or the resource does not have a display width. If <code>Width</code> occurs in a message more than once, the last value overrides all previous occurrences.</dd>
  </dl>

--- a/files/en-us/web/http/headers/viewport-width/index.html
+++ b/files/en-us/web/http/headers/viewport-width/index.html
@@ -1,0 +1,85 @@
+---
+title: Viewport-Width
+slug: Web/HTTP/Headers/Viewport-Width
+tags:
+  - Viewport-Width
+  - Client hints
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Deprecated
+  - Non-standard
+  - Exerimental
+browser-compat: http.headers.Viewport-Width
+---
+<div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
+
+<p>The <strong><code>Viewport-Width</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).</p>
+
+<table class="properties">
+  <tbody>
+   <tr>
+    <th scope="row">Header type</th>
+    <td>{{Glossary("Request header")}}, {{Glossary("Client hints","Client hint")}}</td>
+   </tr>
+   <tr>
+    <th scope="row">{{Glossary("Forbidden header name")}}</th>
+    <td>no</td>
+   </tr>
+  </tbody>
+ </table>
+ 
+<p>The hint can be used with other screen-specific hints to deliver images optimized for a specific screen size, or to omit resources that are not needed for a particular screen width.</p>
+
+<p>If the <code>Viewport-Width</code> header appears more than once in a message the last occurrence is used.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong></p>
+    <ul>
+      <li>Client Hints are accessible only on secure origins (via TLS).</li>
+      <li>As for all client hints, a server has to opt in to receive <code>Viewport-Width</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>Servers that opt in to the <code>Viewport-Width</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
+      <li><code>Viewport-Width</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+    </ul>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: http">Viewport-Width: &lt;number&gt;</pre>
+
+<h2 id="Directives">Directives</h2>
+
+<dl>
+ <dt><code> &lt;number&gt;</code></dt>
+ <dd>The width of the user's viewport in {{Glossary("CSS pixel","CSS pixels")}}, rounded up to the nearest integer.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>A server must first opt in to receive the <code>Viewport-Width</code> header by sending the response header {{HTTPHeader("Accept-CH")}} containing the directive <code>Viewport-Width</code>.</p>
+
+<pre class="brush: http">Accept-CH: Viewport-Width</pre>
+
+<p>Then on subsequent requests the client might send <code>Viewport-Width</code> header back:</p>
+
+<pre class="brush: http">Viewport-Width: 320</pre>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+ <li>Device client hints
+  <ul>
+    <li>{{HTTPHeader("Content-DPR")}}</li>
+    <li>{{HTTPHeader("Device-Memory")}}</li>
+    <li>{{HTTPHeader("DPR")}}</li>
+    <li>{{HTTPHeader("Width")}}</li>
+   </ul>
+ </li>
+ <li>{{HTTPHeader("Accept-CH")}}</li>
+ <li><a href="/en-US/docs/Web/HTTP/Caching#varying_responses">HTTP Caching > Varying responses</a> and {{HTTPHeader("Vary")}}</li>
+</ul>

--- a/files/en-us/web/http/headers/viewport-width/index.html
+++ b/files/en-us/web/http/headers/viewport-width/index.html
@@ -14,7 +14,7 @@ browser-compat: http.headers.Viewport-Width
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>Viewport-Width</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> header that provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).</p>
+<p>The <strong><code>Viewport-Width</code></strong> <a href="/en-US/docs/Glossary/Client_hints">device client hint</a> request header provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).</p>
 
 <table class="properties">
   <tbody>
@@ -37,9 +37,9 @@ browser-compat: http.headers.Viewport-Width
   <p><strong>Note:</strong></p>
     <ul>
       <li>Client Hints are accessible only on secure origins (via TLS).</li>
-      <li>As for all client hints, a server has to opt in to receive <code>Viewport-Width</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>A server has to opt in to receive the <code>Viewport-Width</code> header from the client, by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
       <li>Servers that opt in to the <code>Viewport-Width</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
-      <li><code>Viewport-Width</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+      <li><code>Viewport-Width</code> was removed from the original client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>. The proposed replacement is <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width"><code>Sec-CH-Viewport-Width</code></a> (Responsive Image Client Hints).</li>
     </ul>
 </div>
 

--- a/files/en-us/web/http/headers/width/index.html
+++ b/files/en-us/web/http/headers/width/index.html
@@ -11,12 +11,9 @@ tags:
   - Experimental
 browser-compat: http.headers.Width
 ---
-<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-
-<p>The <strong><code>Width</code></strong> request header field is a {{Glossary("Client hints","client hint header")}} that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</p>
-
-<p>If the desired resource width is not known at the time of the request or the resource does not have a display width, the <code>Width</code> header field can be omitted. If <code>Width</code> occurs in a message more than once, the last value overrides all previous occurrences</p>
+<p>The <strong><code>Width</code></strong> request header field is a {{Glossary("Client hints","device client hint")}} header that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</p>
 
 <table class="properties">
   <tbody>
@@ -28,17 +25,36 @@ browser-compat: http.headers.Width
     <th scope="row">{{Glossary("Forbidden header name")}}</th>
     <td>no</td>
    </tr>
-   <tr>
-    <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
-    <td>no</td>
-   </tr>
   </tbody>
  </table>
 
+<p>The hint is particularly useful because it allows the client to request a resource that is optimal for both the screen and the layout: taking into account both the density-corrected width of the screen and the image's extrinsic size within the layout.</p>
+
+<p>If the desired resource width is not known at the time of the request or the resource does not have a display width, the <code>Width</code> header field can be omitted.</p>
+
+<p>If the <code>Width</code> header appears more than once in a message the last occurrence is used.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong></p>
+    <ul>
+      <li>Client Hints are accessible only on secure origins (via TLS).</li>
+      <li>As for all client hints, a server has to opt in to receive <code>Width</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>Servers that opt in to the <code>Width</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
+      <li><code>Width</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+    </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: http">Width: &lt;number&gt;</pre>
+
+<h2 id="Directives">Directives</h2>
+
+<dl>
+ <dt><code> &lt;number&gt;</code></dt>
+ <dd>The width of the resource in physical pixels, rounded up to the nearest integer.</dd>
+</dl>
+
 
 <h2 id="Examples">Examples</h2>
 
@@ -50,10 +66,6 @@ browser-compat: http.headers.Width
 
 <pre class="brush: http">Width: 1920</pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<p>{{Specifications}}</p>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
@@ -61,7 +73,15 @@ browser-compat: http.headers.Width
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+ <li>Device client hints
+  <ul>
+    <li>{{HTTPHeader("Content-DPR")}}</li>
+    <li>{{HTTPHeader("Device-Memory")}}</li>
+    <li>{{HTTPHeader("DPR")}}</li>
+    <li>{{HTTPHeader("Viewport-Width")}}</li>
+   </ul>
+ </li>
  <li>{{HTTPHeader("Accept-CH")}}</li>
- <li>{{HTTPHeader("Vary")}}</li>
- <li><a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints">Adapting to Users with Client Hints</a> (developer.google.com)</li>
+ <li><a href="/en-US/docs/Web/HTTP/Caching#varying_responses">HTTP Caching > Varying responses</a> and {{HTTPHeader("Vary")}}</li>
 </ul>

--- a/files/en-us/web/http/headers/width/index.html
+++ b/files/en-us/web/http/headers/width/index.html
@@ -9,11 +9,12 @@ tags:
   - HTTP Header
   - Request header
   - Experimental
+  - Deprecated
 browser-compat: http.headers.Width
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}</div>
 
-<p>The <strong><code>Width</code></strong> request header field is a {{Glossary("Client hints","device client hint")}} header that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image). The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</p>
+<p>The <strong><code>Width</code></strong> {{Glossary("Client hints","device client hint")}} request header field indicates the desired resource width in physical pixels — the intrinsic size of an image. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).</p>
 
 <table class="properties">
   <tbody>
@@ -38,9 +39,9 @@ browser-compat: http.headers.Width
   <p><strong>Note:</strong></p>
     <ul>
       <li>Client Hints are accessible only on secure origins (via TLS).</li>
-      <li>As for all client hints, a server has to opt in to receive <code>Width</code> header from the client by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
+      <li>A server has to opt in to receive the <code>Width</code> header from the client, by sending the {{HTTPHeader("Accept-CH")}} response header.</li>
       <li>Servers that opt in to the <code>Width</code> client hint will typically also specify it in the {{HTTPHeader("Vary")}} header. This informs caches that the server may send different responses based on the header value in a request.</li>
-      <li><code>Width</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>.</li>
+      <li><code>Width</code> was removed from the client hints specification in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07">draft-ietf-httpbis-client-hints-07</a>. The proposed replacement is <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-width"><code>Sec-CH-Width</code></a> (Responsive Image Client Hints).</li>
     </ul>
 </div>
 

--- a/files/en-us/web/http/headers/width/index.html
+++ b/files/en-us/web/http/headers/width/index.html
@@ -59,7 +59,7 @@ browser-compat: http.headers.Width
 
 <h2 id="Examples">Examples</h2>
 
-<p>Server first needs to opt in to receive the <code>Width</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Width</code>.</p>
+<p>The server first needs to opt in to receive the <code>Width</code> header by sending the response headers {{HTTPHeader("Accept-CH")}} containing <code>Width</code>.</p>
 
 <pre class="brush: http">Accept-CH: Width</pre>
 


### PR DESCRIPTION
This updates [DPR](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR) HTTP header with directives section, and additional info from the last spec [I can find in which it was mentioned](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-06#page-6) (in the next version there is info that says headers were removed to their own specs, but I cannot yet find.

It also adds info about using Vary, and what happens if the value appears multiple times in response. That's from the spec.

I removed info about Accept-CH-Lifetime from this page, as that header is deprecated.

This is part of addressing #1408 and follows on from #5883.
- BCD work to test if all client hints should have the secure header tagging here: https://github.com/mdn/browser-compat-data/pull/11144
- BCD work to mark headers deprecated here: https://github.com/mdn/browser-compat-data/pull/11186

@Elchi3 Feel free to review/merge this. If you don't, I'll continue to add the other device client hints docs until done. But hoping for sanity check. Note, I'm also after advice on how to find the spec for this.