### PR TITLE
Adds HIDDevice

### DIFF
--- a/files/en-us/web/api/hiddevice/close/index.html
+++ b/files/en-us/web/api/hiddevice/close/index.html
@@ -1,0 +1,44 @@
+---
+title: HIDDevice.close()
+slug: Web/API/HIDDevice/close
+tags:
+  - API
+  - Method
+  - Reference
+  - close
+  - HIDDevice
+browser-compat: api.HIDDevice.close
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>close()</code></strong> method of the {{domxref("HIDDevice")}} interface closes the connection to the HID device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.close();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None</p>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("Promise")}} that resolves with <code>undefined</code> once the connection is closed.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example we close the HID device, once all data has been sent and received.</p>
+
+<pre class="brush: js">await device.close();</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/collections/index.html
+++ b/files/en-us/web/api/hiddevice/collections/index.html
@@ -19,15 +19,15 @@ browser-compat: api.HIDDevice.collections
 </pre>
 
 <h3>Value</h3>
-<p>An array of report formats. Each entry containing the following:</p>
+<p>An array of report formats. Each entry contains the following:</p>
 
 <dl>
   <dt><code>usagePage</code></dt>
-  <dd><p>An integer representing the Usage Page component of the HID usage associated with this collection. The Usage for a top level collection is used to identify the device type.</p>
-  <p>Standard HID Usage values can be found in the <a href="https://usb.org/document-library/hid-usage-tables-122">HID Usage Tables</a> document</p>
+  <dd><p>An integer representing the usage page component of the HID usage associated with this collection. The usage for a top level collection is used to identify the device type.</p>
+  <p>Standard HID usage values can be found in the <a href="https://usb.org/document-library/hid-usage-tables-122">HID Usage Tables</a> document</p>
   </dd>
   <dt><code>usage</code></dt>
-  <dd>An integer representing the Usage ID component of the HID usage associated with this collection.</dd>
+  <dd>An integer representing the usage ID component of the HID usage associated with this collection.</dd>
   <dt><code>type</code></dt>
   <dd>An 8-bit value representing the collection type. One of:
     <dl>
@@ -36,7 +36,7 @@ browser-compat: api.HIDDevice.collections
     </dl>
   </dd>
   <dt><code>children</code></dt>
-  <dd>An array of sub-collections which take the same format as a top-level collection.</dd>
+  <dd>An array of sub-collections which takes the same format as a top-level collection.</dd>
   <dt><code>inputReports</code></dt>
   <dd>An array of <code>inputReport</code> items.</dd>
   <dt><code>outputReports</code></dt>

--- a/files/en-us/web/api/hiddevice/collections/index.html
+++ b/files/en-us/web/api/hiddevice/collections/index.html
@@ -1,0 +1,81 @@
+---
+title: HIDDevice.collections
+slug: Web/API/HIDDevice/collections
+tags:
+  - API
+  - Property
+  - Reference
+  - collections
+  - HIDDevice
+browser-compat: api.HIDDevice.collections
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>collections</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns an array of report formats </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let collections = HIDDevice.collections;
+</pre>
+
+<h3>Value</h3>
+<p>An array of report formats. Each entry containing the following:</p>
+
+<dl>
+  <dt><code>usagePage</code></dt>
+  <dd><p>An integer representing the Usage Page component of the HID usage associated with this collection. The Usage for a top level collection is used to identify the device type.</p>
+  <p>Standard HID Usage values can be found in the <a href="https://usb.org/document-library/hid-usage-tables-122">HID Usage Tables</a> document</p>
+  </dd>
+  <dt><code>usage</code></dt>
+  <dd>An integer representing the Usage ID component of the HID usage associated with this collection.</dd>
+  <dt><code>type</code></dt>
+  <dd>An 8-bit value representing the collection type. One of:
+    <dl>
+      <dt><code>0x00</code></dt>
+      <dd>Physical</dd>
+    </dl>
+  </dd>
+  <dt><code>children</code></dt>
+  <dd>An array of sub-collections which take the same format as a top-level collection.</dd>
+  <dt><code>inputReports</code></dt>
+  <dd>An array of <code>inputReport</code> items.</dd>
+  <dt><code>outputReports</code></dt>
+  <dd>An array of <code>outputReport</code> items.</dd>
+  <dt><code>featureReports</code></dt>
+  <dd>An array of <code>featureReport</code> items.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example demonstrates how to access the various elements once the <code>collections</code> property has been returned. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+
+<pre class="brush: js">for (let collection of device.collections) {
+  // A HID collection includes usage, usage page, reports, and subcollections.
+  console.log(`Usage: ${collection.usage}`);
+  console.log(`Usage page: ${collection.usagePage}`);
+
+  for (let inputReport of collection.inputReports) {
+    console.log(`Input report: ${inputReport.reportId}`);
+    // Loop through inputReport.items
+  }
+
+  for (let outputReport of collection.outputReports) {
+    console.log(`Output report: ${outputReport.reportId}`);
+    // Loop through outputReport.items
+  }
+
+  for (let featureReport of collection.featureReports) {
+    console.log(`Feature report: ${featureReport.reportId}`);
+    // Loop through featureReport.items
+  }
+
+  // Loop through subcollections with collection.children
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/hiddevice/collections/index.html
+++ b/files/en-us/web/api/hiddevice/collections/index.html
@@ -29,20 +29,38 @@ browser-compat: api.HIDDevice.collections
   <dt><code>usage</code></dt>
   <dd>An integer representing the usage ID component of the HID usage associated with this collection.</dd>
   <dt><code>type</code></dt>
-  <dd>An 8-bit value representing the collection type. One of:
+  <dd>An 8-bit value representing the collection type, which describes a different relationship between the grouped items. One of:
     <dl>
       <dt><code>0x00</code></dt>
-      <dd>Physical</dd>
+      <dd>Physical (group of axes)</dd>
+      <dt><code>0x01</code></dt>
+      <dd>Application (mouse, keyboard)</dd>
+      <dt><code>0x02</code></dt>
+      <dd>Logical (interrelated data)</dd>
+      <dt><code>0x03</code></dt>
+      <dd>Report</dd>
+      <dt><code>0x04</code></dt>
+      <dd>Named array</dd>
+      <dt><code>0x05</code></dt>
+      <dd>Usage switch</dd>
+      <dt><code>0x06</code></dt>
+      <dd>Usage modified</dd>
+      <dt><code>0x07 to 0x7F</code></dt>
+      <dd>Reserved for future use</dd>
+      <dt><code>0x80 to 0xFF</code></dt>
+      <dd>Vendor-defined</dd>
     </dl>
+
+    <p>More information on these types can be found in the <a href="https://www.usb.org/document-library/device-class-definition-hid-111">Device Class Definition</a> document.</p>
   </dd>
   <dt><code>children</code></dt>
   <dd>An array of sub-collections which takes the same format as a top-level collection.</dd>
   <dt><code>inputReports</code></dt>
-  <dd>An array of <code>inputReport</code> items.</dd>
+  <dd>An array of <code>inputReport</code> items which represent individual input reports described in this collection.</dd>
   <dt><code>outputReports</code></dt>
-  <dd>An array of <code>outputReport</code> items.</dd>
+  <dd>An array of <code>outputReport</code> items which represent individual output reports described in this collection.</dd>
   <dt><code>featureReports</code></dt>
-  <dd>An array of <code>featureReport</code> items.</dd>
+  <dd>An array of <code>featureReport</code> items which represent individual feature reports described in this collection.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/hiddevice/index.html
+++ b/files/en-us/web/api/hiddevice/index.html
@@ -1,0 +1,97 @@
+---
+title: HIDDevice
+slug: Web/API/HIDDevice
+tags:
+  - API
+  - Interface
+  - Reference
+  - HIDDevice
+browser-compat: api.HIDDevice
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>HIDDevice</code></strong> interface of the {{domxref('WebHID API')}} represents a HID Device. It provides properties for accessing information about the device, methods for opening and closing the connection, and the sending and receiving of reports.</p>
+
+{{InheritanceDiagram}}
+
+<h2 id="Properties">Properties</h2>
+
+<p>This interface also inherits properties from {{domxref("EventTarget")}}.</p>
+
+<dl>
+  <dt>{{domxref("HIDDevice.opened")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns a {{jsxref("boolean")}}, true if the device has an open connection.</dd>
+  <dt>{{domxref("HIDDevice.vendorId")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the vendorId of the HID device.</dd>
+  <dt>{{domxref("HIDDevice.productId")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the productID of the HID device.</dd>
+  <dt>{{domxref("HIDDevice.productName")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns a {{domxref("DOMString","string")}} containing the product name of the HID device.</dd>
+  <dt>{{domxref("HIDDevice.collections")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an array of report formats for the HID device.</dd>
+</dl>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<dl>
+  <dt>{{domxref("HIDDevice.oninputreport")}}</dt>
+  <dd>An event handler that fires when a report is sent from the device.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p>This interface also inherits methods from {{domxref("EventTarget")}}.</p>
+
+<dl>
+  <dt>{{domxref("HIDDevice.open()")}}</dt>
+  <dd>Opens a connection to this HID device, and returns a {{jsxref("Promise")}} which resolves once the connection has been successful.</dd>
+  <dt>{{domxref("HIDDevice.close()")}}</dt>
+  <dd>Closes the connection to this HID device, and returns a {{jsxref("Promise")}} which resolves once the connection has been closed.</dd>
+  <dt>{{domxref("HIDDevice.sendReport()")}}</dt>
+  <dd>Sends an output report to this HID Device, and returns a {{jsxref("Promise")}} which resolves once the report has been sent.</dd>
+  <dt>{{domxref("HIDDevice.sendFeatureReport()")}}</dt>
+  <dd>Sends a feature report to this HID device, and returns a {{jsxref("Promise")}} which resolves once the report has been sent.</dd>
+  <dt>{{domxref("HIDDevice.receiveFeatureReport()")}}</dt>
+  <dd>Receives a feature report from this HID device in the form of a {{jsxref("Promise")}} which resolves with a {{jsxref("DataView")}}. This allows typed access to the contents of this message.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example demonstrates listening for an inputreport that will allow the application to detect which button is pressed on a Joy-Con Right device.</p>
+
+<pre class="brush: js">device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+
+  // Handle only the Joy-Con Right device and a specific report ID.
+  if (device.productId !== 0x2007 && reportId !== 0x3f) return;
+
+  const value = data.getUint8(0);
+  if (value === 0) return;
+
+  const someButtons = { 1: "A", 2: "X", 4: "B", 8: "Y" };
+  console.log(`User pressed button ${someButtons[value]}.`);
+});</pre>
+
+<p>In the following example <code>sendFeatureReport</code> is used to make a device blink.</p>
+
+<pre class="brush: js">const reportId = 1;
+for (let i = 0; i < 10; i++) {
+  // Turn off
+  await device.sendFeatureReport(reportId, Uint32Array.from([0, 0]));
+  await waitFor(100);
+  // Turn on
+  await device.sendFeatureReport(reportId, Uint32Array.from([512, 0]));
+  await waitFor(100);
+}</pre>
+
+<p>You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/index.html
+++ b/files/en-us/web/api/hiddevice/index.html
@@ -57,7 +57,7 @@ browser-compat: api.HIDDevice
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example demonstrates listening for an inputreport that will allow the application to detect which button is pressed on a Joy-Con Right device.</p>
+<p>The following example demonstrates listening for an <code>inputreport</code> event that will allow the application to detect which button is pressed on a Joy-Con Right device.</p>
 
 <pre class="brush: js">device.addEventListener("inputreport", event => {
   const { data, device, reportId } = event;

--- a/files/en-us/web/api/hiddevice/oninputreport/index.html
+++ b/files/en-us/web/api/hiddevice/oninputreport/index.html
@@ -22,7 +22,7 @@ HIDDevice.addEventListener('inputreport', function);</pre>
 
 <h2>Example</h2>
 
-<p>The following example demonstrates listening for an inputreport that will allow the application to detect which button is pressed on a Joy-Con Right device. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+<p>The following example demonstrates listening for an <code>inputreport</code> event that will allow the application to detect which button is pressed on a Joy-Con Right device. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
 
 <pre class="brush: js">device.addEventListener("inputreport", event => {
   const { data, device, reportId } = event;

--- a/files/en-us/web/api/hiddevice/oninputreport/index.html
+++ b/files/en-us/web/api/hiddevice/oninputreport/index.html
@@ -1,0 +1,46 @@
+---
+title: HIDDevice.oninputreport
+slug: Web/API/HIDDevice/oninputreport
+tags:
+  - API
+  - Property
+  - Reference
+  - oninputreport
+  - HIDDevice
+browser-compat: api.HIDDevice.oninputreport
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>oninputreport</code></strong> EventHandler of the {{domxref("HIDDevice")}} interface is an {{domxref("EventHandler")}} that processes inputreport events.</p>
+
+<p> The event fires when a new report is received from the HID device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.oninputreport = function;
+HIDDevice.addEventListener('inputreport', function);</pre>
+
+<h2>Example</h2>
+
+<p>The following example demonstrates listening for an inputreport that will allow the application to detect which button is pressed on a Joy-Con Right device. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+
+<pre class="brush: js">device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+
+  // Handle only the Joy-Con Right device and a specific report ID.
+  if (device.productId !== 0x2007 && reportId !== 0x3f) return;
+
+  const value = data.getUint8(0);
+  if (value === 0) return;
+
+  const someButtons = { 1: "A", 2: "X", 4: "B", 8: "Y" };
+  console.log(`User pressed button ${someButtons[value]}.`);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/hiddevice/open/index.html
+++ b/files/en-us/web/api/hiddevice/open/index.html
@@ -1,0 +1,56 @@
+---
+title: HIDDevice.open()
+slug: Web/API/HIDDevice/open
+tags:
+  - API
+  - Method
+  - Reference
+  - open
+  - HIDDevice
+browser-compat: api.HIDDevice.open
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>open()</code></strong> method of the {{domxref("HIDDevice")}} interface requests that the operating sytem opens the HID device.</p>
+
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>HID devices are not opened automatically. Therefore, a {{domxref("HIDDevice")}} returned by {{domxref("HID.getRequestDevice()")}} must be opened with this method before it is available to transfer data.</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.open();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("Promise")}} that resolves with <code>undefined</code> once the connection is opened.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>InvalidStateError</code></dt>
+  <dd>Thrown if the connection is already open.</dd>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if the attempt to open the connection fails for any reason.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example, we wait for the HID connection to open before attempting to send or receive data.</p>
+
+<pre class="brush: css">await device.open();</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/opened/index.html
+++ b/files/en-us/web/api/hiddevice/opened/index.html
@@ -1,0 +1,42 @@
+---
+title: HIDDevice.opened
+slug: Web/API/HIDDevice/opened
+tags:
+  - API
+  - Property
+  - Reference
+  - opened
+  - HIDDevice
+browser-compat: api.HIDDevice.opened
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>opened</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns true if the connection to the {{domxref("HIDDevice")}} is open and ready to transfer data.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let opened = HIDDevice.opened;</pre>
+
+<h3>Value</h3>
+<p>A {{jsxref("Boolean")}}, true if the connection is open.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example rerieves devices with {{domxref("HID.getDevices()")}} and logs the value of <code>opened</code> to the console.</p>
+
+<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+  let devices = await navigator.hid.getDevices();
+  devices.forEach(device => {
+    console.log(`HID: ${device.opened}`);
+  });
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/productid/index.html
+++ b/files/en-us/web/api/hiddevice/productid/index.html
@@ -1,0 +1,44 @@
+---
+title: HIDDevice.productId
+slug: Web/API/HIDDevice/productId
+tags:
+  - API
+  - Property
+  - Reference
+  - productId
+  - HIDDevice
+browser-compat: api.HIDDevice.productId
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>productId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product ID of the connected HID device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let productId = HIDDevice.productId;</pre>
+
+<h3>Value</h3>
+<p>An integer. If the device has no product ID, or the product ID cannot be accessed this will return <code>0</code>.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example rerieves devices with {{domxref("HID.getDevices()")}} and logs the value of <code>productId</code> to the console.</p>
+
+<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+  let devices = await navigator.hid.getDevices();
+  devices.forEach(device => {
+    console.log(`HID: ${device.productId}`);
+  });
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/productname/index.html
+++ b/files/en-us/web/api/hiddevice/productname/index.html
@@ -1,0 +1,44 @@
+---
+title: HIDDevice.productName
+slug: Web/API/HIDDevice/productName
+tags:
+  - API
+  - Property
+  - Reference
+  - productName
+  - HIDDevice
+browser-compat: api.HIDDevice.productName
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>productName</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product name of the connected HID device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let productName = HIDDevice.productName;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString","string")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example rerieves devices with {{domxref("HID.getDevices()")}} and logs the value of <code>productName</code> to the console.</p>
+
+<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+  let devices = await navigator.hid.getDevices();
+  devices.forEach(device => {
+    console.log(`HID: ${device.productName}`);
+  });
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
@@ -1,0 +1,56 @@
+---
+title: HIDDevice.receiveFeatureReport()
+slug: Web/API/HIDDevice/receiveFeatureReport
+tags:
+  - API
+  - Method
+  - Reference
+  - receiveFeatureReport
+  - HIDDevice
+browser-compat: api.HIDDevice.receiveFeatureReport
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>receiveFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface receives a feature report from the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
+
+<p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.receiveFeatureReport(reportId);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>reportId</code></dt>
+  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("Promise")}} which resolves with a {{domxref("DataView")}} object containing the feature report.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if receiving the report fails for any reason.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example a report is received from a device using a <code>reportId</code> of <code>1</code>.</p>
+
+<pre class="brush: js">const dataView = await device.receiveFeatureReport(1);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HIDDevice.receiveFeatureReport
 
 <dl>
   <dt><code>reportId</code></dt>
-  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+  <dd>An 8-bit report ID. If the HID device does not use report IDs, send <code>0</code>.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>
@@ -52,5 +52,4 @@ browser-compat: api.HIDDevice.receiveFeatureReport
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
@@ -1,0 +1,66 @@
+---
+title: HIDDevice.sendFeatureReport()
+slug: Web/API/HIDDevice/sendFeatureReport
+tags:
+  - API
+  - Method
+  - Reference
+  - sendFeatureReport
+  - HIDDevice
+browser-compat: api.HIDDevice.sendFeatureReport
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>sendFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends a feature report to the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
+
+<p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.sendFeatureReport(reportId, data);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>reportId</code></dt>
+  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+  <dt><code>data</code></dt>
+  <dd>Bytes as a {{domxref("BufferSource")}}.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("Promise")}} that resolves with <code>undefined</code> once the report has been sent.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if sending the report fails for any reason.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example <code>sendFeatureReport</code> is used to make a device blink. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+
+<pre class="brush: js">const reportId = 1;
+for (let i = 0; i < 10; i++) {
+  // Turn off
+  await device.sendFeatureReport(reportId, Uint32Array.from([0, 0]));
+  await waitFor(100);
+  // Turn on
+  await device.sendFeatureReport(reportId, Uint32Array.from([512, 0]));
+  await waitFor(100);
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HIDDevice.sendFeatureReport
 
 <dl>
   <dt><code>reportId</code></dt>
-  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+  <dd>An 8-bit report ID. If the HID device does not use report IDs, send <code>0</code>.</dd>
   <dt><code>data</code></dt>
   <dd>Bytes as a {{domxref("BufferSource")}}.</dd>
 </dl>
@@ -41,7 +41,7 @@ browser-compat: api.HIDDevice.sendFeatureReport
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following example <code>sendFeatureReport</code> is used to make a device blink. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+<p>In the following example <code>sendFeatureReport()</code> makes a device blink. You can see more examples and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
 
 <pre class="brush: js">const reportId = 1;
 for (let i = 0; i < 10; i++) {
@@ -62,5 +62,4 @@ for (let i = 0; i < 10; i++) {
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/hiddevice/sendreport/index.html
+++ b/files/en-us/web/api/hiddevice/sendreport/index.html
@@ -1,0 +1,64 @@
+---
+title: HIDDevice.sendReport()
+slug: Web/API/HIDDevice/sendReport
+tags:
+  - API
+  - Method
+  - Reference
+  - sendReport
+  - HIDDevice
+browser-compat: api.HIDDevice.sendReport
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>sendReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends an output report to the HID device.</p>
+
+<p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">HIDDevice.sendReport(reportId, data);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>reportId</code></dt>
+  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+  <dt><code>data</code></dt>
+  <dd>Bytes as a {{domxref("BufferSource")}}.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("Promise")}} that resolves with <code>undefined</code> once the report has been sent.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if sending the report fails for any reason.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The example below shows how to make a Joy-Con device rumble using output reports. You can see more examples, and live demos in the article <a href="https://web.dev/hid/">Connecting to uncommon HID devices</a>.</p>
+
+<pre class="brush: js">// First, send a command to enable vibration.
+// Magical bytes come from https://github.com/mzyy94/joycon-toolweb
+const enableVibrationData = [1, 0, 1, 64, 64, 0, 1, 64, 64, 0x48, 0x01];
+await device.sendReport(0x01, new Uint8Array(enableVibrationData));
+
+// Then, send a command to make the Joy-Con device rumble.
+// Actual bytes are available in the sample below.
+const rumbleData = [ /* ... */ ];
+await device.sendReport(0x10, new Uint8Array(rumbleData));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/hiddevice/sendreport/index.html
+++ b/files/en-us/web/api/hiddevice/sendreport/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HIDDevice.sendReport
 
 <dl>
   <dt><code>reportId</code></dt>
-  <dd>An 8-bit reportId. If the HID device does not use report IDs, send <code>0</code>.</dd>
+  <dd>An 8-bit report ID. If the HID device does not use report IDs, send <code>0</code>.</dd>
   <dt><code>data</code></dt>
   <dd>Bytes as a {{domxref("BufferSource")}}.</dd>
 </dl>
@@ -60,5 +60,4 @@ await device.sendReport(0x10, new Uint8Array(rumbleData));</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/hiddevice/vendorid/index.html
+++ b/files/en-us/web/api/hiddevice/vendorid/index.html
@@ -1,0 +1,44 @@
+---
+title: HIDDevice.vendorId
+slug: Web/API/HIDDevice/vendorId
+tags:
+  - API
+  - Property
+  - Reference
+  - vendorId
+  - HIDDevice
+browser-compat: api.HIDDevice.vendorId
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p class="summary">The <strong><code>vendorId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the vendor ID of the connected HID device. This identifies the vendor of the device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let vendorId = HIDDevice.vendorId;</pre>
+
+<h3>Value</h3>
+<p>An integer. If the device has no vendor ID, or the vendor ID cannot be accessed this will return <code>0</code>.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example rerieves devices with {{domxref("HID.getDevices()")}} and logs the value of <code>vendorId</code> to the console.</p>
+
+<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+  let devices = await navigator.hid.getDevices();
+  devices.forEach(device => {
+    console.log(`HID: ${device.vendorId}`);
+  });
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+


### PR DESCRIPTION
Adds the HIDDevice Interface.

Reviewer @jpmedley 

Notes:

1. The BCD data has been added for this in https://github.com/mdn/browser-compat-data/pull/11040 
2. When I looked at the spec there was pretty much no information about how any of this worked. I then found [this PR](https://github.com/WICG/webhid/pull/68) yesterday which contains all the algorithms. Therefore I've referenced this in terms of things like exceptions.
3. Examples came from the spec and https://web.dev/hid/ which I have linked to for further info.
