### PR TITLE
Fix typo in “Device pixel” glossary entry

### DIFF
--- a/files/en-us/glossary/device_pixel/index.html
+++ b/files/en-us/glossary/device_pixel/index.html
@@ -13,7 +13,7 @@ tags:
   - width
 ---
 
-<p>A "pixel" is a single physical "light bulb" on a display that is capable of displaying a full color independent of its neighbours. Computer screens displaying their content in pixels. This physical pixel is also called a "device pixel".</p>
+<p>A "pixel" is a single physical "light bulb" on a display that is capable of displaying a full color independent of its neighbours. Computer screens display their content in pixels. This physical pixel is also called a "device pixel".</p>
 
 <p>In contrast to the device pixel the {{Glossary("CSS pixel","CSS pixel")}} is a unit of length which roughly corresponds to the width or height of a single dot. The CSS pixel is defined as the physical size of a single pixel at a pixel density of 96 DPI, located an arm's length away from the viewer's eyes. A CSS pixel is therefore equivalent to many device pixels.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The sentence "Computer screens displaying their content in pixels." doesn't seem grammatically correct. 


> Issue number (if there is an associated issue)
N/A


> Anything else that could help us review it
