### PR TITLE
Restore “Getting ArrayBuffers or typed arrays from Base64” info

### DIFF
--- a/files/en-us/glossary/base64/index.html
+++ b/files/en-us/glossary/base64/index.html
@@ -16,37 +16,269 @@ tags:
 
 <p>Base64 encoding schemes are commonly used when there is a need to encode binary data that needs to be stored and transferred over media that are designed to deal with ASCII. This is to ensure that the data remain intact without modification during transport. Base64 is commonly used in a number of applications including email via <a href="https://en.wikipedia.org/wiki/MIME">MIME</a>, and storing complex data in <a href="/en-US/docs/Web/XML">XML</a>.</p>
 
-<p>One common application of base64 encoding on the web is to encode binary data  so it can be included in a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs">data: URL</a>.</p>
+<p>One common application of Base64 encoding on the web is to encode binary data  so it can be included in a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs">data: URL</a>.</p>
 
-<p>In JavaScript there are two functions respectively for decoding and encoding <em>base64</em> strings:</p>
+<p>In JavaScript there are two functions respectively for decoding and encoding Base64 strings:</p>
 
 <ul>
- <li><code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa">btoa()</a></code>: creates a base-64 encoded ASCII string from a "string" of binary data ("btoa" should be read as "binary to ASCII").</li>
- <li><code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob">atob()</a></code>: decodes a base64 encoded string("atob" should be read as "ASCII to binary").</li>
+ <li><code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa">btoa()</a></code>: creates a Base64-encoded ASCII string from a "string" of binary data ("btoa" should be read as "binary to ASCII").</li>
+ <li><code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob">atob()</a></code>: decodes a Base64-encoded string("atob" should be read as "ASCII to binary").</li>
 </ul>
 
 <p>The algorithm used by <code>atob()</code> and <code>btoa()</code> is specified in <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a>, section 4.</p>
 
 <p>Note that <code>btoa()</code> expects to be passed binary data, and will throw an exception if the given string contains any characters whose UTF-16 representation occupies more than one byte. For more details, see the documentation for <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa">btoa()</a></code>.</p>
 
-<h4 id="Encoded_size_increase">Encoded size increase</h4>
+<h2 id="Encoded_size_increase">Encoded size increase</h2>
 
 <p>Each Base64 digit represents exactly 6 bits of data. So, three 8-bits bytes of the input string/binary file (3×8 bits = 24 bits) can be represented by four 6-bit Base64 digits (4×6 = 24 bits).</p>
 
 <p>This means that the Base64 version of a string or file will be at least 133% the size of its source (a ~33% increase). The increase may be larger if the encoded data is small. For example, the string <code>"a"</code> with <code>length === 1</code> gets encoded to <code>"YQ=="</code> with <code>length === 4</code> — a 300% increase.</p>
 
-<h4 id="appendix_to_solution_1_decode_a_base64_string_to_uint8array_or_arraybuffer">Appendix to Solution: Decode a <em>Base64</em> string to <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">Uint8Array</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a></h4>
+<h2 id="the_unicode_problem">The "Unicode Problem"</h2>
 
-<p>The functions above let us also create <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">uint8Arrays</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">arrayBuffers</a> from <em>base64</em>-encoded strings:</p>
+<p>Since <a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a>s are 16-bit-encoded strings, in most browsers calling <code>window.btoa</code> on a Unicode string will cause a <code>Character Out Of Range</code> exception if a character exceeds the range of a 8-bit ASCII-encoded character. There are two possible methods to solve this problem:</p>
 
-<div ><pre><code><span>var</span> myArray <span >=</span> <span >base64DecToArr</span><span >(</span><span >"QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="</span><span >)</span><span >;</span> <span >// "Base 64 \u2014 Mozilla Developer Network" (as UTF-8)</span>
+<ul>
+ <li>the first one is to escape the whole string and then encode it;</li>
+ <li>the second one is to convert the UTF-16 <a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a> to an UTF-8 array of characters and then encode it.</li>
+</ul>
 
-  <span>var</span> myBuffer <span >=</span> <span >base64DecToArr</span><span >(</span><span >"QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="</span><span >)</span><span >.</span>buffer<span >;</span> <span >// "Base 64 \u2014 Mozilla Developer Network" (as UTF-8)</span>
+<p>Here are the two possible methods.</p>
 
-  <span >alert</span><span >(</span>myBuffer<span >.</span>byteLength<span >)</span><span >;</span></code></pre><button><span >Copy to Clipboard</span></button>
+<h3 id="solution_1_–_escaping_the_string_before_encoding_it">Solution #1 – escaping the string before encoding it</h3>
 
-</div>
+<pre class="brush:js">function utf8_to_b64( str ) {
+  return window.btoa(unescape(encodeURIComponent( str )));
+}
 
-<div><strong>Note:</strong> The function <code>base64DecToArr(sBase64[, <em>nBlockSize</em>])</code> returns an <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array"><code>uint8Array</code></a> of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the <code>nBlockSize</code> argument, which is the number of bytes which the <code>uint8Array.buffer.bytesLength</code> property must result to be a multiple of (<code>1</code> or omitted for ASCII, binary content, <a href="/en-US/docs/Web/API/DOMString/Binary">binary strings</a>, UTF-8-encoded strings; <code>2</code> for UTF-16 strings; <code>4</code> for UTF-32 strings).</div>
+function b64_to_utf8( str ) {
+  return decodeURIComponent(escape(window.atob( str )));
+}
 
-<p>For a more complete library, see <a href="/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a> (source code <a href="https://github.com/madmurphy/stringview.js">available on GitHub</a>).</p>
+// Usage:
+utf8_to_b64('✓ à la mode'); // "4pyTIMOgIGxhIG1vZGU="
+b64_to_utf8('4pyTIMOgIGxhIG1vZGU='); // "✓ à la mode"</pre>
+
+<p>This solution has been proposed by <a href="http://ecmanaut.blogspot.com/2006/07/encoding-decoding-utf8-in-javascript.html">Johan Sundström</a>.</p>
+
+<p>Another possible solution without utilizing the now deprecated 'unescape' and 'escape' functions.</p>
+
+<pre class="brush:js">function b64EncodeUnicode(str) {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+        return String.fromCharCode('0x' + p1);
+    }));
+}
+ b64EncodeUnicode('✓ à la mode'); // "4pyTIMOgIGxhIG1vZGU="
+</pre>
+
+<h3 id="solution_2_–_rewriting_atob_and_btoa_using_typedarrays_and_utf-8">Solution #2 – rewriting <code>atob()</code> and <code>btoa()</code> using <code>TypedArray</code>s and UTF-8</h3>
+
+<p><strong>Note:</strong> The following code is also useful to get an <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> from a Base64 string and/or viceversa (<a href="#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer">see below</a>).</p>
+
+<pre class="brush: js">"use strict";
+
+/*\
+|*|
+|*|  Base64 / binary data / UTF-8 strings utilities
+|*|
+|*|  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Base64_encoding_and_decoding
+|*|
+\*/
+
+/* Array of bytes to Base64 string decoding */
+
+function b64ToUint6 (nChr) {
+
+  return nChr &gt; 64 &amp;&amp; nChr &lt; 91 ?
+      nChr - 65
+    : nChr &gt; 96 &amp;&amp; nChr &lt; 123 ?
+      nChr - 71
+    : nChr &gt; 47 &amp;&amp; nChr &lt; 58 ?
+      nChr + 4
+    : nChr === 43 ?
+      62
+    : nChr === 47 ?
+      63
+    :
+      0;
+
+}
+
+function base64DecToArr (sBase64, nBlocksSize) {
+
+  var
+    sB64Enc = sBase64.replace(/[^A-Za-z0-9\+\/]/g, ""), nInLen = sB64Enc.length,
+    nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 &gt;&gt; 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 &gt;&gt; 2, taBytes = new Uint8Array(nOutLen);
+
+  for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx &lt; nInLen; nInIdx++) {
+    nMod4 = nInIdx &amp; 3;
+    nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) &lt;&lt; 6 * (3 - nMod4);
+    if (nMod4 === 3 || nInLen - nInIdx === 1) {
+      for (nMod3 = 0; nMod3 &lt; 3 &amp;&amp; nOutIdx &lt; nOutLen; nMod3++, nOutIdx++) {
+        taBytes[nOutIdx] = nUint24 &gt;&gt;&gt; (16 &gt;&gt;&gt; nMod3 &amp; 24) &amp; 255;
+      }
+      nUint24 = 0;
+
+    }
+  }
+
+  return taBytes;
+}
+
+/* Base64 string to array encoding */
+
+function uint6ToB64 (nUint6) {
+
+  return nUint6 &lt; 26 ?
+      nUint6 + 65
+    : nUint6 &lt; 52 ?
+      nUint6 + 71
+    : nUint6 &lt; 62 ?
+      nUint6 - 4
+    : nUint6 === 62 ?
+      43
+    : nUint6 === 63 ?
+      47
+    :
+      65;
+
+}
+
+function base64EncArr (aBytes) {
+
+  var nMod3 = 2, sB64Enc = "";
+
+  for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx &lt; nLen; nIdx++) {
+    nMod3 = nIdx % 3;
+    if (nIdx &gt; 0 &amp;&amp; (nIdx * 4 / 3) % 76 === 0) { sB64Enc += "\r\n"; }
+    nUint24 |= aBytes[nIdx] &lt;&lt; (16 &gt;&gt;&gt; nMod3 &amp; 24);
+    if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+      sB64Enc += String.fromCharCode(uint6ToB64(nUint24 &gt;&gt;&gt; 18 &amp; 63), uint6ToB64(nUint24 &gt;&gt;&gt; 12 &amp; 63), uint6ToB64(nUint24 &gt;&gt;&gt; 6 &amp; 63), uint6ToB64(nUint24 &amp; 63));
+      nUint24 = 0;
+    }
+  }
+
+  return sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) + (nMod3 === 2 ? '' : nMod3 === 1 ? '=' : '==');
+
+}
+
+/* UTF-8 array to DOMString and vice versa */
+
+function UTF8ArrToStr (aBytes) {
+
+  var sView = "";
+
+  for (var nPart, nLen = aBytes.length, nIdx = 0; nIdx &lt; nLen; nIdx++) {
+    nPart = aBytes[nIdx];
+    sView += String.fromCharCode(
+      nPart &gt; 251 &amp;&amp; nPart &lt; 254 &amp;&amp; nIdx + 5 &lt; nLen ? /* six bytes */
+        /* (nPart - 252 &lt;&lt; 30) may be not so safe in ECMAScript! So...: */
+        (nPart - 252) * 1073741824 + (aBytes[++nIdx] - 128 &lt;&lt; 24) + (aBytes[++nIdx] - 128 &lt;&lt; 18) + (aBytes[++nIdx] - 128 &lt;&lt; 12) + (aBytes[++nIdx] - 128 &lt;&lt; 6) + aBytes[++nIdx] - 128
+      : nPart &gt; 247 &amp;&amp; nPart &lt; 252 &amp;&amp; nIdx + 4 &lt; nLen ? /* five bytes */
+        (nPart - 248 &lt;&lt; 24) + (aBytes[++nIdx] - 128 &lt;&lt; 18) + (aBytes[++nIdx] - 128 &lt;&lt; 12) + (aBytes[++nIdx] - 128 &lt;&lt; 6) + aBytes[++nIdx] - 128
+      : nPart &gt; 239 &amp;&amp; nPart &lt; 248 &amp;&amp; nIdx + 3 &lt; nLen ? /* four bytes */
+        (nPart - 240 &lt;&lt; 18) + (aBytes[++nIdx] - 128 &lt;&lt; 12) + (aBytes[++nIdx] - 128 &lt;&lt; 6) + aBytes[++nIdx] - 128
+      : nPart &gt; 223 &amp;&amp; nPart &lt; 240 &amp;&amp; nIdx + 2 &lt; nLen ? /* three bytes */
+        (nPart - 224 &lt;&lt; 12) + (aBytes[++nIdx] - 128 &lt;&lt; 6) + aBytes[++nIdx] - 128
+      : nPart &gt; 191 &amp;&amp; nPart &lt; 224 &amp;&amp; nIdx + 1 &lt; nLen ? /* two bytes */
+        (nPart - 192 &lt;&lt; 6) + aBytes[++nIdx] - 128
+      : /* nPart &lt; 127 ? */ /* one byte */
+        nPart
+    );
+  }
+
+  return sView;
+
+}
+
+function strToUTF8Arr (sDOMStr) {
+
+  var aBytes, nChr, nStrLen = sDOMStr.length, nArrLen = 0;
+
+  /* mapping... */
+
+  for (var nMapIdx = 0; nMapIdx &lt; nStrLen; nMapIdx++) {
+    nChr = sDOMStr.charCodeAt(nMapIdx);
+    nArrLen += nChr &lt; 0x80 ? 1 : nChr &lt; 0x800 ? 2 : nChr &lt; 0x10000 ? 3 : nChr &lt; 0x200000 ? 4 : nChr &lt; 0x4000000 ? 5 : 6;
+  }
+
+  aBytes = new Uint8Array(nArrLen);
+
+  /* transcription... */
+
+  for (var nIdx = 0, nChrIdx = 0; nIdx &lt; nArrLen; nChrIdx++) {
+    nChr = sDOMStr.charCodeAt(nChrIdx);
+    if (nChr &lt; 128) {
+      /* one byte */
+      aBytes[nIdx++] = nChr;
+    } else if (nChr &lt; 0x800) {
+      /* two bytes */
+      aBytes[nIdx++] = 192 + (nChr &gt;&gt;&gt; 6);
+      aBytes[nIdx++] = 128 + (nChr &amp; 63);
+    } else if (nChr &lt; 0x10000) {
+      /* three bytes */
+      aBytes[nIdx++] = 224 + (nChr &gt;&gt;&gt; 12);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 6 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &amp; 63);
+    } else if (nChr &lt; 0x200000) {
+      /* four bytes */
+      aBytes[nIdx++] = 240 + (nChr &gt;&gt;&gt; 18);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 12 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 6 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &amp; 63);
+    } else if (nChr &lt; 0x4000000) {
+      /* five bytes */
+      aBytes[nIdx++] = 248 + (nChr &gt;&gt;&gt; 24);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 18 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 12 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 6 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &amp; 63);
+    } else /* if (nChr &lt;= 0x7fffffff) */ {
+      /* six bytes */
+      aBytes[nIdx++] = 252 + (nChr &gt;&gt;&gt; 30);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 24 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 18 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 12 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &gt;&gt;&gt; 6 &amp; 63);
+      aBytes[nIdx++] = 128 + (nChr &amp; 63);
+    }
+  }
+
+  return aBytes;
+
+}
+</pre>
+
+<h3 id="Tests">Tests</h3>
+
+<pre class="brush: js">/* Tests */
+
+var sMyInput = "Base 64 \u2014 Mozilla Developer Network";
+
+var aMyUTF8Input = strToUTF8Arr(sMyInput);
+
+var sMyBase64 = base64EncArr(aMyUTF8Input);
+
+alert(sMyBase64);
+
+var aMyUTF8Output = base64DecToArr(sMyBase64);
+
+var sMyOutput = UTF8ArrToStr(aMyUTF8Output);
+
+alert(sMyOutput);</pre>
+
+<h3 id="appendix_decode_a_base64_string_to_uint8array_or_arraybuffer">Appendix: Decode a Base64 string to Uint8Array or ArrayBuffer</h3>
+
+<p>These function let us to create also <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">uint8Arrays</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">arrayBuffers</a> from Base64-encoded strings:</p>
+
+<pre class="brush: js">
+// "Base 64 \u2014 Mozilla Developer Network"
+var myArray = base64DecToArr("QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw==");
+
+// "Base 64 \u2014 Mozilla Developer Network"
+var myBuffer = base64DecToArr("QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw==").buffer;
+
+alert(myBuffer.byteLength);</pre>
+
+<p><strong>Note:</strong> The function <code>base64DecToArr(sBase64[, <var>nBlocksSize</var>])</code> returns an <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array"><code>uint8Array</code></a> of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the <code>nBlocksSize</code> argument, which is the number of bytes of which the <code>uint8Array.buffer.bytesLength</code> property must result a multiple (<code>1</code> or omitted for ASCII, <a href="/en-US/docs/Web/API/DOMString/Binary">binary strings</a> or UTF-8-encoded strings, <code>2</code> for UTF-16 strings, <code>4</code> for UTF-32 strings).</p>

--- a/files/en-us/glossary/base64/index.html
+++ b/files/en-us/glossary/base64/index.html
@@ -34,3 +34,19 @@ tags:
 <p>Each Base64 digit represents exactly 6 bits of data. So, three 8-bits bytes of the input string/binary file (3×8 bits = 24 bits) can be represented by four 6-bit Base64 digits (4×6 = 24 bits).</p>
 
 <p>This means that the Base64 version of a string or file will be at least 133% the size of its source (a ~33% increase). The increase may be larger if the encoded data is small. For example, the string <code>"a"</code> with <code>length === 1</code> gets encoded to <code>"YQ=="</code> with <code>length === 4</code> — a 300% increase.</p>
+
+<h4 id="appendix_to_solution_1_decode_a_base64_string_to_uint8array_or_arraybuffer">Appendix to Solution: Decode a <em>Base64</em> string to <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">Uint8Array</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a></h4>
+
+<p>The functions above let us also create <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">uint8Arrays</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">arrayBuffers</a> from <em>base64</em>-encoded strings:</p>
+
+<div ><pre><code><span>var</span> myArray <span >=</span> <span >base64DecToArr</span><span >(</span><span >"QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="</span><span >)</span><span >;</span> <span >// "Base 64 \u2014 Mozilla Developer Network" (as UTF-8)</span>
+
+  <span>var</span> myBuffer <span >=</span> <span >base64DecToArr</span><span >(</span><span >"QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="</span><span >)</span><span >.</span>buffer<span >;</span> <span >// "Base 64 \u2014 Mozilla Developer Network" (as UTF-8)</span>
+
+  <span >alert</span><span >(</span>myBuffer<span >.</span>byteLength<span >)</span><span >;</span></code></pre><button><span >Copy to Clipboard</span></button>
+
+</div>
+
+<div><strong>Note:</strong> The function <code>base64DecToArr(sBase64[, <em>nBlockSize</em>])</code> returns an <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array"><code>uint8Array</code></a> of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the <code>nBlockSize</code> argument, which is the number of bytes which the <code>uint8Array.buffer.bytesLength</code> property must result to be a multiple of (<code>1</code> or omitted for ASCII, binary content, <a href="/en-US/docs/Web/API/DOMString/Binary">binary strings</a>, UTF-8-encoded strings; <code>2</code> for UTF-16 strings; <code>4</code> for UTF-32 strings).</div>
+
+<p>For a more complete library, see <a href="/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a> (source code <a href="https://github.com/madmurphy/stringview.js">available on GitHub</a>).</p>

--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -250,9 +250,8 @@ const normalArray = Array.prototype.slice.call(typedArray);</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Glossary/Base64#appendix.3a_decode_a_base64_string_to_uint8array_or_arraybuffer">Getting <code>ArrayBuffer</code>s or typed arrays from <em>Base64</em>-encoded strings</a></li>
- <li><a href="/en-US/docs/Code_snippets/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
+ <li><a href="/en-US/docs/Glossary/Base64#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer">Getting <code>ArrayBuffer</code>s or typed arrays from Base64-encoded strings</a></li>
  <li><a href="https://hacks.mozilla.org/2011/12/faster-canvas-pixel-manipulation-with-typed-arrays">Faster Canvas Pixel Manipulation with Typed Arrays</a></li>
- <li><a href="http://www.html5rocks.com/en/tutorials/webgl/typed_arrays">Typed Arrays: Binary Data in the Browser</a></li>
+ <li><a href="https://www.html5rocks.com/en/tutorials/webgl/typed_arrays">Typed Arrays: Binary Data in the Browser</a></li>
  <li><a href="/en-US/docs/Glossary/Endianness">Endianness</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays has a non-existent anchor and content:
https://developer.mozilla.org/en-US/docs/Glossary/Base64#appendix.3a_decode_a_base64_string_to_uint8array_or_arraybuffer

The en-US page does not seem to have an appendix and does not cover the topic described.
This content seems to be in https://developer.mozilla.org/zh-CN/docs/Glossary/Base64

> Issue number (if there is an associated issue)

This PR fixes issue #6032 


> Anything else that could help us review it

Go to /en-us/glossary/base64/index.html to see the changes and compare it with previous ones.