### PR TITLE
Replace mentions of interface with dictionary for RTCRtpContributingSource.*

### DIFF
--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
@@ -16,7 +16,7 @@ browser-compat: api.RTCRtpContributingSource.audioLevel
 <div>{{APIRef("WebRTC API")}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>audioLevel</code></strong>
-    property of the {{domxref("RTCRtpContributingSource")}} interface indicates the audio
+    property of the {{domxref("RTCRtpContributingSource")}} dictionary contains the audio
     level contained in the last RTP packet played from the described source.</span>
   audioLevel will be the level value defined in [RFC6465] if the RFC 6465 header extension
   is present, and otherwise null.</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
@@ -20,7 +20,7 @@ browser-compat: api.RTCRtpContributingSource.rtpTimestamp
 <div>{{APIRef("WebRTC API")}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>rtpTimestamp</code></strong>
-    property of the {{domxref("RTCRtpContributingSource")}} interface returns a
+    property of the {{domxref("RTCRtpContributingSource")}} dictionary contains a
     {{domxref("DOMHighResTimeStamp")}} indicating the source-generated time at which the
     media contained int he packet was first sampled or obtained.</span></p>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCRtpContributingSource.source
 <div>{{APIRef("WebRTC API")}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>source</code></strong> property of
-    the {{domxref("RTCRtpContributingSource")}} interface returns the source identifier of
+    the {{domxref("RTCRtpContributingSource")}} dictionary contains the source identifier of
     a particular stream of RTP packets.</span> The value is the contributing source (CSRC)
   or synchronization source (SSRC) identifier, depending on whether the object is an
   <code>RTCRtpContributingSource</code> or {{domxref("RTCRtpSynchronizationSource")}},

--- a/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCRtpContributingSource.timestamp
 <div>{{APIRef("WebRTC API")}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>timestamp</code></strong> property
-    of the {{domxref("RTCRtpContributingSource")}} interface returns a
+    of the {{domxref("RTCRtpContributingSource")}} dictionary contains a
     {{domxref("DOMHighResTimeStamp")}} indicating the most recent time of playout of an
     RTP packet from the source.</span></p>
 


### PR DESCRIPTION
RTCRtpContributingSource is a dictionary not an interface.

Its members referred it as an interface, this PR fixes thiis.