### PR TITLE
Improve no spec messages on CompositionEvent.*

### DIFF
--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
   method of the {{domxref("CompositionEvent")}} interface initializes the attributes of a
   <code>CompositionEvent</code> object instance.</p>
 
-<p class="notecard note">Nowadays, the correct way of creating a {{domxref("CompositionEvent")}} is to use
+<p class="notecard note">The correct way of creating a {{domxref("CompositionEvent")}} is to use
   the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.</p>
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -50,7 +50,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This method is not more on a standardization track. It is kept for compatibility purpose. Use the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.</p>
+<p>This method is no longer on a standardization track. It is kept for compatibility purposes. Use the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -16,6 +16,8 @@ browser-compat: api.CompositionEvent.initCompositionEvent
   method of the {{domxref("CompositionEvent")}} interface initializes the attributes of a
   <code>CompositionEvent</code> object instance.</p>
 
+<p class="notecard note">Nowadays, the correct way of creating a {{domxref("CompositionEvent")}} is to use
+  the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.</p>
 <h2 id="Syntax">Syntax</h2>
 
 <pre
@@ -48,7 +50,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method is not more on a standardization track. It is kept for compatibility purpose. Use the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/locale/index.html
+++ b/files/en-us/web/api/compositionevent/locale/index.html
@@ -31,7 +31,7 @@ is not guaranteed to be coherent.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This property was in early versions of different specifications. It is nowadays only kept for compatibility purpose and the way
+<p>This property was in early versions of different specifications. It is now only kept for compatibility purposes, and the way
 to set its value when creating a {{domxref("CompositionEvent")}} is <a href="https://github.com/w3c/uievents/issues/48">not well defined</a>.</p>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compositionevent/locale/index.html
+++ b/files/en-us/web/api/compositionevent/locale/index.html
@@ -16,6 +16,10 @@ browser-compat: api.CompositionEvent.locale
   {{domxref("CompositionEvent")}} interface returns the locale of current input method
   (for example, the keyboard layout locale if the composition is associated with IME).</p>
 
+<p class="notecard warning">Even for browsers supporting it, don't trust the value contained in this property.
+  Even if technically it is accessible, the way to set it up when creating a {{domxref("CompositionEvent")}}
+is not guaranteed to be coherent.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre
@@ -27,8 +31,8 @@ browser-compat: api.CompositionEvent.locale
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
-
+<p>This property was in early versions of different specifications. It is nowadays only kept for compatibility purpose and the way
+to set its value when creating a {{domxref("CompositionEvent")}} is <a href="https://github.com/w3c/uievents/issues/48">not well defined</a>.</p>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>


### PR DESCRIPTION
This is (the first) part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

`CompositionEvent.locale`: Removed the macro, indicated that this is not on a standard track, linked to a github issue on UIEvents showing how much of a mess it is.
`CompositionEvent.initCompositionEvent`: Removed the macro, made a somewhat generic info that `init*` methods are superseded by constructors.

