### PR TITLE
Add sidebar to guide page about CSS Typed Object Model API

### DIFF
--- a/files/en-us/web/api/css_typed_om_api/guide/index.html
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.html
@@ -7,6 +7,8 @@ tags:
   - Houdini
   - Learn
 ---
+<div>{{DefaultAPISidebar("CSS Typed Object Model API")}}</div>
+
 <p>The <strong><a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a></strong> exposes CSS values as typed JavaScript objects to allow their performant manipulation.</p>
 
 <p>Converting <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a> value strings into meaningfully-typed JavaScript representations and back (via {{domxref("HTMLElement.style")}} can incur a significant performance overhead.</p>


### PR DESCRIPTION
The Guide has no sidebar. This is fixing it.

Note the sidebars on CSS Typed OM API-related articles are not displayed on MDN Web Docs, because of a bug in GroupData.json. mdn/yari#4054 will fix it and make the sidebars in CSS Typed Object Model API appear in the relevant articles, including the guide modified here.