### PR TITLE
Make comment match actual function names

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
@@ -383,7 +383,7 @@ browser.tabs.executeScript({file: "/content_scripts/beastify.js"})
 
   /**
    * Listen for messages from the background script.
-   * Call "beastify()" or "reset()".
+   * Call "insertBeast()" or "removeExistingBeasts()".
   */
   browser.runtime.onMessage.addListener((message) =&gt; {
     if (message.command === "beastify") {


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Comment in content script doesn't match code.
