### PR TITLE
Improve no spec msgs for CSSValue, CSSPrimitiveValue, CSSValueList

### DIFF
--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -10,7 +10,7 @@ tags:
 <p>{{DefaultAPISidebar("CSSOM")}}</p>
 
 <p class="summary">The <strong>CSS Object Model</strong> is a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.</p>
-<p>The values of CSS are represented untyped, that is using {{JSRef("String")}} objects.</p>
+<p>The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects.</p>
 
 <h2 id="Reference">Reference</h2>
 

--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -10,6 +10,7 @@ tags:
 <p>{{DefaultAPISidebar("CSSOM")}}</p>
 
 <p class="summary">The <strong>CSS Object Model</strong> is a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.</p>
+<p>The values of CSS are represented untyped, that is using {{JSRef("String")}} objects.</p>
 
 <h2 id="Reference">Reference</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
@@ -10,7 +10,7 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.getCounterValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getCounterValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get the <a
@@ -18,6 +18,16 @@ browser-compat: api.CSSPrimitiveValue.getCounterValue
   value. If this CSS value doesn't contain a counter value, a {{domxref("DOMException")}}
   is raised. Modification to the corresponding style property can be achieved using the
   {{domxref("Counter")}} interface.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -48,7 +58,10 @@ browser-compat: api.CSSPrimitiveValue.getCounterValue
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -9,12 +9,22 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.getFloatValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getFloatValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a float value in a specified
   unit. If this CSS value doesn't contain a float value or can't be converted into the
   specified unit, a {{domxref("DOMException")}} is raised.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -141,7 +151,10 @@ console.log(cssValue.getFloatValue(CSSPrimitiveValue.CSS_CM));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -9,13 +9,23 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.getRectValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getRectValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a rect value. If this CSS
   value doesn't contain a rect value, a {{domxref("DOMException")}} is raised.
   Modification to the corresponding style property can be achieved using the
   {{domxref("Rect")}} interface.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -52,7 +62,10 @@ console.log(cssValue.getRectValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -9,13 +9,23 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.getRGBColorValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getRGBColorValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get an RGB color value. If this
   CSS value doesn't contain a RGB color value, a {{domxref("DOMException")}} is raised.
   Modification to the corresponding style property can be achieved using the
   {{domxref("RGBColor")}} interface.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -52,7 +62,10 @@ console.log(cssValue.getRGBColorValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -9,11 +9,21 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.getStringValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getStringValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a string value. If this CSS
   value doesn't contain a string value, a {{domxref("DOMException")}} is raised.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -50,7 +60,10 @@ console.log(cssValue.getStringValue());</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -14,6 +14,16 @@ browser-compat: api.CSSPrimitiveValue
 
 <p>The <code><strong>CSSPrimitiveValue</strong></code> interface derives from the {{DOMxRef("CSSValue")}} interface and represents the current computed value of a CSS property.</p>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
+
 <p>This interface represents a single CSS value. It may be used to determine the value of a specific style property currently set in a block or to set a specific style property explicitly within the block. An instance of this interface might be obtained from the {{DOMxRef("CSSStyleDeclaration.getPropertyCSSValue()", "getPropertyCSSValue()")}} method of the {{DOMxRef("CSSStyleDeclaration")}} interface. A <code>CSSPrimitiveValue</code> object only occurs in a context of a CSS property.</p>
 
 <p>Conversions are allowed between absolute values (from millimeters to centimeters, from degrees to radians, and so on) but not between relative values. (For example, a pixel value cannot be converted to a centimeter value.) Percentage values can't be converted since they are relative to the parent value (or another property value). There is one exception for color percentage values: since a color percentage value is relative to the range 0-255, a color percentage value can be converted to a number (see also the {{DOMxRef("RGBColor")}} interface).</p>
@@ -163,7 +173,10 @@ browser-compat: api.CSSPrimitiveValue
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -10,10 +10,20 @@ tags:
   - primitiveValue
 browser-compat: api.CSSPrimitiveValue.primitiveType
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("CSSOM")}}</div>
 
 <p>The <code><strong>primitiveType</strong></code> read-only property of the
   {{domxref("CSSPrimitiveValue")}} interface represents the type of a CSS value.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -175,7 +185,10 @@ console.log(cssValue.primitiveType);
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -10,12 +10,22 @@ tags:
 - Deprecated
 browser-compat: api.CSSPrimitiveValue.setFloatValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>setFloatValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to set a float value. If the property
   attached to this value can't accept the specified unit or the float value, the value
   will be unchanged and a {{domxref("DOMException")}} will be raised.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -139,7 +149,10 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -10,12 +10,22 @@ tags:
   - Deprecated
 browser-compat: api.CSSPrimitiveValue.setStringValue
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>setStringValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to set a string value. If the
   property attached to this value can't accept the specified unit or the string value, the
   value will be unchanged and a {{domxref("DOMException")}} will be raised.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -83,7 +93,10 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
@@ -11,12 +11,20 @@ browser-compat: api.CSSStyleDeclaration.getPropertyCSSValue
 ---
 <p>{{ APIRef("CSSOM") }} {{deprecated_header}}</p>
 
-<p><span class="seoSummary">The <strong>CSSStyleDeclaration.getPropertyCSSValue()</strong>
+<p>The <strong>CSSStyleDeclaration.getPropertyCSSValue()</strong>
     method interface returns a {{domxref('CSSValue')}} containing the CSS value for a
-    property.</span> Note that it returns <code>null</code> if the property name is a
+    property. Note that it returns <code>null</code> if the property name is a
   shorthand property.</p>
 
-<p>You should use {{domxref("CSSStyleDeclaration.getPropertyValue()")}} instead.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>{{domxref("CSSStyleDeclaration.getPropertyValue()")}} of the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>{{domxref("Element.computedStyleMap()")}} of the modern <a href="/en-US/docs/Web/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -48,7 +56,10 @@ var rgbObj = style.getPropertyCSSValue('color').getRGBColorValue();
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -10,10 +10,20 @@ tags:
 - Deprecated
 browser-compat: api.CSSValue.cssText
 ---
-<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>cssText</strong></code> property of the {{domxref("CSSValue")}}
   interface represents the current computed CSS property value.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -33,11 +43,17 @@ console.log(cssValue.cssText);
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -11,11 +11,21 @@ tags:
 - Deprecated
 browser-compat: api.CSSValue.cssValueType
 ---
-<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>cssValueType</strong></code> read-only property of the
   {{domxref("CSSValue")}} interface represents the type of the current computed CSS
   property value.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -67,7 +77,10 @@ console.log(cssValue.cssValueType);
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -15,6 +15,16 @@ browser-compat: api.CSSValue
 
 <p>The <code><strong>CSSValue</strong></code> interface represents the current computed value of a CSS property.</p>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
+
 <h2 id="Properties">Properties</h2>
 
 <dl>
@@ -51,7 +61,10 @@ browser-compat: api.CSSValue
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -14,6 +14,16 @@ browser-compat: api.CSSValueList
 
 <p>The <code><strong>CSSValueList</strong></code> interface derives from the {{DOMxRef("CSSValue")}} interface and provides the abstraction of an ordered collection of CSS values.</p>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
+
 <p>Some properties allow an empty list in their syntax. In that case, these properties take the <code>none</code> identifier. So, an empty list means that the property has the value <code>none</code>.</p>
 
 <p>The items in the <code>CSSValueList</code> are accessible via an integral index, starting from 0.</p>
@@ -38,7 +48,10 @@ browser-compat: api.CSSValueList
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/item/index.html
+++ b/files/en-us/web/api/cssvaluelist/item/index.html
@@ -10,7 +10,7 @@ tags:
 - Deprecated
 browser-compat: api.CSSValueList.item
 ---
-<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>item()</strong></code> method of the {{domxref("CSSValueList")}}
   interface is used to retrieve a {{domxref("CSSValue")}} by ordinal index.</p>
@@ -18,6 +18,16 @@ browser-compat: api.CSSValueList.item
 <p>The order in this collection represents the order of the values in the CSS style
   property. If the index is greater than or equal to the number of values in the list,
   this method returns <code>null</code>.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -39,7 +49,10 @@ browser-compat: api.CSSValueList.item
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cssvaluelist/length/index.html
+++ b/files/en-us/web/api/cssvaluelist/length/index.html
@@ -12,12 +12,22 @@ tags:
 - Deprecated
 browser-compat: api.CSSValueList.length
 ---
-<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>length</strong></code> read-only property of the
   {{domxref("CSSValueList")}} interface represents the number of {{domxref("CSSValue")}}s
   in the list. The range of valid values of the indices is <code>0</code> to
   <code>length-1</code> inclusive.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+  not implement it.</p>
+  <p>To achieve your purpose, you can use:</p>
+  <ul>
+    <li>the untyped <a href="CSS_Object_Model">CSS Object Model</a>, widely supported, or</li>
+    <li>the modern <a href="CSS_Typed_OM_API">CSS Typed Object Model API</a>, less supported and considered experimental.</li>
+  </ul>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,7 +40,10 @@ browser-compat: api.CSSValueList.length
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was originally defined in the <a href="https://www.w3.org/TR/DOM-Level-2-Style">DOM Style Level 2</a> specification, but has been dropped from any
+  standardization effort since then.</p>
+
+<p>It has been superseded by a modern, but incompatible, <a href="/en-US/docs/Web/API/CSS_Typed_OM_API">CSS Typed Object Model API</a> that is now on the standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Here I dealt with the remnant (still supported by Safari!) of the typed API of the CSSOM: mostly `CSSValue`, `CSSPrimitiveValue`, `CSSValueList` and their children.

 - I added a note at the top, linking to the untyped part of CSSOM, as well as the new CSS Typed OM API.
 - I updated the sidebar to the CSSOM one (instead of the more generic and useless DOM one)
 - I replaced `{{Specification}}` by a link to the old spec and to an explanation that the only typed CSSOM API is the Houdini one (with a link to that API landing page).