### PR TITLE
Fix interactive SVG example in SVG <view> doc

### DIFF
--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -39,7 +39,8 @@ browser-compat: svg.elements.view
 
 <h3 id="SVG">SVG</h3>
 
-<pre class="brush: html">&lt;svg width="600" height="200" viewBox="0 0 600 200"
+<pre class="brush: svg">
+&lt;svg width="600" height="200" viewBox="0 0 600 200"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
   &lt;defs&gt;
@@ -66,9 +67,15 @@ browser-compat: svg.elements.view
   &lt;/a&gt;
 &lt;/svg&gt;</pre>
 
+<h3 id="HTML">HTML</h3>
+
+<pre class="brush: html">
+&lt;object data="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDYwMCAyMDAiDQogICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIg0KICAgIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgPGRlZnM%2BDQogICAgPHJhZGlhbEdyYWRpZW50IGlkPSJncmFkaWVudCI%2BDQogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjOGNmZmEwIiAvPg0KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjOGNhMGZmIiAvPg0KICAgIDwvcmFkaWFsR3JhZGllbnQ%2BDQogIDwvZGVmcz4NCg0KICA8Y2lyY2xlIHI9IjUwIiBjeD0iMTgwIiBjeT0iNTAiIHN0eWxlPSJmaWxsOnVybCgjZ3JhZGllbnQpIi8%2BDQoNCiAgPHZpZXcgaWQ9ImhhbGZTaXplVmlldyIgdmlld0JveD0iMCAwIDEyMDAgNDAwIi8%2BDQogIDx2aWV3IGlkPSJub3JtYWxTaXplVmlldyIgdmlld0JveD0iMCAwIDYwMCAyMDAiLz4NCiAgPHZpZXcgaWQ9ImRvdWJsZVNpemVWaWV3IiB2aWV3Qm94PSIwIDAgMzAwIDEwMCIvPg0KDQogIDxhIHhsaW5rOmhyZWY9IiNoYWxmU2l6ZVZpZXciPg0KICAgIDx0ZXh0IHg9IjUiIHk9IjIwIiBmb250LXNpemU9IjIwIj5oYWxmIHNpemU8L3RleHQ%2BDQogIDwvYT4NCiAgPGEgeGxpbms6aHJlZj0iI25vcm1hbFNpemVWaWV3Ij4NCiAgICA8dGV4dCB4PSI1IiB5PSI0MCIgZm9udC1zaXplPSIyMCI%2Bbm9ybWFsIHNpemU8L3RleHQ%2BDQogIDwvYT4NCiAgPGEgeGxpbms6aHJlZj0iI2RvdWJsZVNpemVWaWV3Ij4NCiAgICA8dGV4dCB4PSI1IiB5PSI2MCIgZm9udC1zaXplPSIyMCI%2BZG91YmxlIHNpemU8L3RleHQ%2BDQogIDwvYT4NCjwvc3ZnPg%3D%3D" type="image/svg+xml"&gt;&lt;/object&gt;
+</pre>
+
 <h3 id="Result">Result</h3>
 
-<p>{{EmbedLiveSample("Example", 600, 200)}}</p>
+<p>{{EmbedLiveSample("Example", "85ch", "240px")}}</p>
 
 <h2 id="DOM_Interface">DOM Interface</h2>
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/6131

---

It seems that interactive SVG features won’t work for an SVG image if the SVG markup is put directly into an HTML document — and instead, the SVG image needs to be embedded using an `object` or `iframe` element.