### PR TITLE
Improve no specification message for the show event on Element

### DIFF
--- a/files/en-us/web/api/element/show_event/index.html
+++ b/files/en-us/web/api/element/show_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Element.show_event
 
 <p>The <strong><code>show</code></strong> event is fired when a {{domxref("Element/contextmenu_event", "contextmenu")}} event was fired on/bubbled to an element that has a <a href="/en-US/docs/Web/HTML/Global_attributes/contextmenu"><code>contextmenu</code> attribute</a>.</p>
 
+<div class="notecard warning">
+  <p>This event is on the progress of being removed from browsers. Do not write new code that rely on it.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -50,7 +54,7 @@ browser-compat: api.Element.show_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event is not on any standard track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/element/show_event/index.html
+++ b/files/en-us/web/api/element/show_event/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Element.show_event
 <p>The <strong><code>show</code></strong> event is fired when a {{domxref("Element/contextmenu_event", "contextmenu")}} event was fired on/bubbled to an element that has a <a href="/en-US/docs/Web/HTML/Global_attributes/contextmenu"><code>contextmenu</code> attribute</a>.</p>
 
 <div class="notecard warning">
-  <p>This event is on the progress of being removed from browsers. Do not write new code that rely on it.</p>
+  <p>This event is in progress of being removed from browsers. Do not write new code that relies on it.</p>
 </div>
 
 <table class="properties">
@@ -54,7 +54,7 @@ browser-compat: api.Element.show_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event is not on any standard track.</p>
+<p>This event is not on any standards track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

The `show` event on the interface `Event` is raised by very few browsers and no more on the standard track.

So I removed the macro, indicated that this is not on a standard track and added a note at the top indicating not to rely on it anymore

