### PR TITLE
Remove more empty <div>s

### DIFF
--- a/files/en-us/web/api/htmlelement/click/index.html
+++ b/files/en-us/web/api/htmlelement/click/index.html
@@ -62,5 +62,3 @@ function myFunction() {
     </ul>
   </li>
 </ul>
-
-<div id="eJOY__extension_root"></div>

--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.html
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.html
@@ -6,7 +6,6 @@ tags:
   - HTML5
   - Web-Based Protocol Handlers
 ---
-<div></div>
 
 <h2 id="Background">Background</h2>
 

--- a/files/en-us/web/css/text-emphasis-position/index.html
+++ b/files/en-us/web/css/text-emphasis-position/index.html
@@ -32,8 +32,6 @@ text-emphasis-postition: revert;
 text-emphasis-position: unset;
 </pre>
 
-<div class="note"></div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <h3 id="Values">Values</h3>


### PR DESCRIPTION
This is like https://github.com/mdn/content/pull/6138, some additional
things found with `git grep -E '<div[^>]*></div>'`.

There's no other eJOY__extension_root anywhere.
