### PR TITLE
Replace spec table by macro in API overview pages (letter c)

### DIFF
--- a/files/en-us/web/api/canvas_api/index.html
+++ b/files/en-us/web/api/canvas_api/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>The {{domxref("Document.getElementById()")}} method gets a reference to the HTML <code>&lt;canvas&gt;</code> element. Next, the {{domxref("HTMLCanvasElement.getContext()")}} method gets that element's context—the thing onto which the drawing will be rendered.</p>
 
-<p>The actual drawing is done using the {{domxref("CanvasRenderingContext2D")}} interface. The {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} property makes the rectangle green. The {{domxref("CanvasRenderingContext2D.fillRect()", "fillRect()")}} method places its top-left corner at (10, 10), and gives it a size of 150 units wide by 100 tall.</p>
+<p>The actual drawing is done using the {{domxref("CanvasRenderingContext2D")}} interface. The {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} property makes the rectangle green. The {{domxref("CanvasRenderingContext2D.fillRect()", "fillRect()")}} method places its top-left corner at (10, 10), and gives it a size of 150 units wide by 100 tall.</p>
 
 <pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
@@ -110,22 +110,7 @@ ctx.fillRect(10, 10, 150, 100);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#2dcontext', 'the 2D rendering context')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("html.elements.canvas")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channel_messaging_api/index.html
+++ b/files/en-us/web/api/channel_messaging_api/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Channel_messaging_concepts_and_usage">Channel messaging concepts and usage</h2>
 
-<p>A message channel is created using the {{domxref("MessageChannel.MessageChannel", "MessageChannel()")}} constructor. Once created, the two ports of the channel can be accessed through the {{domxref("MessageChannel.port1")}} and {{domxref("MessageChannel.port2")}} properties (which both return {{domxref("MessagePort")}} objects.) The app that created the channel uses <code>port1</code>, and the app at the other end of the port uses <code>port2</code> — you send a message to <code>port2</code>, and transfer the port over to the other browsing context using {{domxref("window.postMessage")}} along with two arguments (the message to send, and the object to transfer ownership of, in this case the port itself.)</p>
+<p>A message channel is created using the {{domxref("MessageChannel.MessageChannel", "MessageChannel()")}} constructor. Once created, the two ports of the channel can be accessed through the {{domxref("MessageChannel.port1")}} and {{domxref("MessageChannel.port2")}} properties (which both return {{domxref("MessagePort")}} objects.) The app that created the channel uses <code>port1</code>, and the app at the other end of the port uses <code>port2</code> — you send a message to <code>port2</code>, and transfer the port over to the other browsing context using {{domxref("window.postMessage")}} along with two arguments (the message to send, and the object to transfer ownership of, in this case the port itself.)</p>
 
 <p>When these transferable objects are transferred, they are no longer usable on the context they previously belonged to. A port, after it is sent, can no longer be used by the original context.</p>
 
@@ -46,20 +46,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'web-messaging.html#channel-messaging', 'Channel messaging')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.MessageChannel")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.html
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.html
@@ -19,9 +19,9 @@ tags:
 
 <h2 id="Use_cases">Use cases</h2>
 
-<p>Channel messaging is mainly useful in cases where you've got a social site that embeds capabilities from other sites into its main interface via IFrames, such as games, address book, or an audio player with personalized music choices. When these act as standalone units, things are ok, but the difficulty comes when you want interaction between the main site and the IFrames, or the different IFrames. For example, what if you wanted to add a contact to the address book from the main site, add high scores from your game into your main profile, or add new background music choices from the audio player onto the game? Such things are not so easy using conventional web technology, because of the security models the web uses. You have to think about whether the origins trust one another, and how the messages are passed.</p>
+<p>Channel messaging is mainly useful in cases where you've got a social site that embeds capabilities from other sites into its main interface via iframes, such as games, address book, or an audio player with personalized music choices. When these act as standalone units, things are ok, but the difficulty comes when you want interaction between the main site and the IFrames, or the different IFrames. For example, what if you wanted to add a contact to the address book from the main site, add high scores from your game into your main profile, or add new background music choices from the audio player onto the game? Such things are not so easy using conventional web technology, because of the security models the web uses. You have to think about whether the origins trust one another, and how the messages are passed.</p>
 
-<p>Message channels on the other hand can provide a secure channel that allows you to pass data between different browsing contexts. </p>
+<p>Message channels on the other hand can provide a secure channel that allows you to pass data between different browsing contexts.</p>
 
 <div class="note">
 <p><strong>Note</strong>: For more information and ideas, the <a href="https://html.spec.whatwg.org/multipage/comms.html#ports-as-the-basis-of-an-object-capability-model-on-the-web">Ports as the basis of an object-capability model on the Web</a> section of the spec is a useful read.</p>
@@ -39,7 +39,7 @@ tags:
 
 <h2 id="Creating_the_channel">Creating the channel</h2>
 
-<p>In the main page of the demo, we have a simple form with a text input for entering messages to be sent to an {{htmlelement("iframe")}}. We also have a paragraph which we will use later on to display confirmation messages that we will receive back from the {{htmlelement("iframe")}}.</p>
+<p>In the main page of the demo, we have a simple form with a text input for entering messages to be sent to an {{htmlelement("iframe")}}. We also have a paragraph which we will use later on to display confirmation messages that we will receive back from the {{htmlelement("iframe")}}.</p>
 
 <pre class="brush: js">var input = document.getElementById('message-input');
 var output = document.getElementById('message-output');
@@ -75,19 +75,19 @@ function onMessage(e) {
   input.value = '';
 }</pre>
 
-<p>We start off by creating a new message channel by using the {{domxref( "MessageChannel.MessageChannel","MessageChannel()")}} constructor.</p>
+<p>We start off by creating a new message channel by using the {{domxref( "MessageChannel.MessageChannel","MessageChannel()")}} constructor.</p>
 
-<p>When the IFrame has loaded, we register an <code>onclick</code> handler for our button and an <code>onmessage</code> handler for {{domxref("MessageChannel.port1")}}. Finally we transfer {{domxref("MessageChannel.port2")}} to the IFrame using the {{domxref("window.postMessage")}} method.</p>
+<p>When the IFrame has loaded, we register an <code>onclick</code> handler for our button and an <code>onmessage</code> handler for {{domxref("MessageChannel.port1")}}. Finally we transfer {{domxref("MessageChannel.port2")}} to the IFrame using the {{domxref("window.postMessage")}} method.</p>
 
-<p>Let's explore how the <code>iframe.contentWindow.postMessage</code> line works in a bit more detail. It takes three arguments:</p>
+<p>Let's explore how the <code>iframe.contentWindow.postMessage</code> line works in a bit more detail. It takes three arguments:</p>
 
 <ol>
- <li>The message being sent. For this initial port transfering this message could be an empty string but in this example it is set to <code>'init'</code>.</li>
+ <li>The message being sent. For this initial port transfering this message could be an empty string but in this example it is set to <code>'init'</code>.</li>
  <li>The origin the message is to be sent to. <code>*</code> means "any origin".</li>
  <li>An object, the ownership of which is transferred to the receiving browsing context. In this case, we are transferring {{domxref("MessageChannel.port2")}} to the IFrame, so it can be used to communicate with the main page.</li>
 </ol>
 
-<p>When our button is clicked, we prevent the form from submitting as normal and then send the value entered in our text input to the IFrame via the {{domxref("MessageChannel")}}.</p>
+<p>When our button is clicked, we prevent the form from submitting as normal and then send the value entered in our text input to the IFrame via the {{domxref("MessageChannel")}}.</p>
 
 <h2 id="Receiving_the_port_and_message_in_the_IFrame">Receiving the port and message in the IFrame</h2>
 
@@ -114,11 +114,11 @@ function onMessage(e) {
 }
 </pre>
 
-<p>When the initial message is received from the main page via the {{domxref("window.postMessage")}} method, we run the <code>initPort</code> function. This saves the transferred port and register an <code>onmessage</code> handler that will be called each time a message is passed through our {{domxref("MessageChannel")}}.</p>
+<p>When the initial message is received from the main page via the {{domxref("window.postMessage")}} method, we run the <code>initPort</code> function. This saves the transferred port and register an <code>onmessage</code> handler that will be called each time a message is passed through our {{domxref("MessageChannel")}}.</p>
 
 <p>When a message is received from the main page we create a list item and insert it in the unordered list, setting the {{domxref("Node.textContent","textContent")}} of the list item equal to the event's <code>data</code> attribute (this contains the actual message).</p>
 
-<p>Next, we post a confirmation message back to the main page via the message channel by calling {{domxref("MessagePort.postMessage")}} on {{domxref("MessageChannel.port2")}} that was initially transferred to the IFrame. </p>
+<p>Next, we post a confirmation message back to the main page via the message channel by calling {{domxref("MessagePort.postMessage")}} on {{domxref("MessageChannel.port2")}} that was initially transferred to the iframe.</p>
 
 <h2 id="Receiving_the_confirmation_in_the_main_page">Receiving the confirmation in the main page</h2>
 
@@ -130,24 +130,11 @@ function onMessage(e) {
   input.value = '';
 }</pre>
 
-<p>When a message is received back from the IFrame confirming that the original message was received successfully, this outputs the confirmation to a paragraph and empties the text input ready for the next message to be sent.</p>
+<p>When a message is received back from the IFrame confirming that the original message was received successfully, this outputs the confirmation to a paragraph and empties the text input ready for the next message to be sent.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'web-messaging.html#channel-messaging', 'Channel messaging')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.MessageChannel")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/clipboard_api/index.html
+++ b/files/en-us/web/api/clipboard_api/index.html
@@ -17,7 +17,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p>The <strong>Clipboard API</strong> provides the ability to respond to clipboard commands (cut, copy, and paste) as well as to asynchronously read from and write to the system clipboard. Access to the contents of the clipboard is gated behind the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>: The <code>clipboard-write</code> permission is granted automatically to pages when they are in the active tab. The <code>clipboard-read</code> permission must be requested, which you can do by trying to read data from the clipboard.</p>
+<p>The <strong>Clipboard API</strong> provides the ability to respond to clipboard commands (cut, copy, and paste) as well as to asynchronously read from and write to the system clipboard. Access to the contents of the clipboard is gated behind the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>: The <code>clipboard-write</code> permission is granted automatically to pages when they are in the active tab. The <code>clipboard-read</code> permission must be requested, which you can do by trying to read data from the clipboard.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (not exposed via {{domxref("WorkerNavigator")}}).</p>
@@ -47,20 +47,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Clipboard API')}}</td>
-   <td>{{Spec2('Clipboard API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.Clipboard")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compression_streams_api/index.html
+++ b/files/en-us/web/api/compression_streams_api/index.html
@@ -40,20 +40,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Compression Streams')}}</td>
-    <td>{{Spec2('Compression Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications("api.CompressionStream")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/console_api/index.html
+++ b/files/en-us/web/api/console_api/index.html
@@ -48,20 +48,7 @@ console.log(myString)</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Console API')}}</td>
-   <td>{{Spec2('Console API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.Console")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/constraint_validation/index.html
+++ b/files/en-us/web/api/constraint_validation/index.html
@@ -116,30 +116,7 @@ nameInput.addEventListener('invalid', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'forms.html#the-constraint-validation-api', 'constraint validation API') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'sec-forms.html#the-constraint-validation-api', 'constraint validation API') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from the previous snapshot {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#the-constraint-validation-api', 'constraint validation API') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>First snapshot of  {{SpecName('HTML WHATWG')}} containing this interface.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.ValidityState")}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -96,20 +96,7 @@ async function getContacts() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Contact Picker API')}}</td>
-   <td>{{Spec2('Contact Picker API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.ContactsManager")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/content_index_api/index.html
+++ b/files/en-us/web/api/content_index_api/index.html
@@ -195,20 +195,7 @@ const contentIndexItems = self.registration.index.getAll();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Content Index API')}}</td>
-   <td>{{Spec2('Content Index API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.ContentIndex")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/cookie_store_api/index.html
+++ b/files/en-us/web/api/cookie_store_api/index.html
@@ -39,20 +39,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Cookie Store API')}}</td>
-   <td>{{Spec2('Cookie Store API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.CookieStore")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/credential_management_api/index.html
+++ b/files/en-us/web/api/credential_management_api/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Credential_management_concepts_and_usage">Credential management concepts and usage</h2>
 
-<p>This API lets websites interact with a user agent’s password system directly so that websites can deal in a uniform way with site credentials and user agents can provide better assistance with the management of their credentials. For example, user agents have a particularly hard time dealing with federated identity providers or esoteric sign-in mechanisms.</p>
+<p>This API lets websites interact with a user agent's password system directly so that websites can deal in a uniform way with site credentials and user agents can provide better assistance with the management of their credentials. For example, user agents have a particularly hard time dealing with federated identity providers or esoteric sign-in mechanisms.</p>
 
 <p>To address these problems, the Credential Management API provides ways for a website to store and retrieve different types of credentials. This gives users capabilities such as seeing the federated account they used to sign on to a site, or resuming a session without the explicit sign-in flow of an expired session.</p>
 
@@ -45,25 +45,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Credential Management')}}</td>
-   <td>{{Spec2('Credential Management')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebAuthn')}}</td>
-   <td>{{Spec2('WebAuthn')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.Credential")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_counter_styles/index.html
+++ b/files/en-us/web/api/css_counter_styles/index.html
@@ -19,20 +19,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Counter Styles")}}</td>
-   <td>{{Spec2("CSS3 Counter Styles")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.CSSCounterStyleRule")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_font_loading_api/index.html
+++ b/files/en-us/web/api/css_font_loading_api/index.html
@@ -33,22 +33,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Font Loading')}}</td>
-   <td>{{Spec2('CSS3 Font Loading')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.FontFace")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_painting_api/guide/index.html
+++ b/files/en-us/web/api/css_painting_api/guide/index.html
@@ -47,7 +47,7 @@ tags:
   }
 });</pre>
 
-<p>In this class example we have defined a single context option with the <code>contextOptions()</code> function: we returned a simple object stating alpha transparency is allowed.</p>
+<p>In this class example we have defined a single context option with the <code>contextOptions()</code> function: we returned a simple object stating alpha transparency is allowed.</p>
 
 <p>We have then used the <code>paint()</code> function to paint to our canvas.</p>
 
@@ -99,7 +99,7 @@ tags:
 
 <h2 id="PaintSize">PaintSize</h2>
 
-<p>In the example above, we created a 20x200 unit box, painted 15 units from the top of the element  it is the same regardless of the size of the element. If the text is small, the yellow box looks like a huge underline. If the text is huge, the box might look like an bar above the first three letters. It would be better if the background image was relative to the size of the element — we can use the element's <code>paintSize</code> property to ensure the background image is proportional to the size of the element's box model size.</p>
+<p>In the example above, we created a 20x200 unit box, painted 15 units from the top of the element it is the same regardless of the size of the element. If the text is small, the yellow box looks like a huge underline. If the text is huge, the box might look like an bar above the first three letters. It would be better if the background image was relative to the size of the element — we can use the element's <code>paintSize</code> property to ensure the background image is proportional to the size of the element's box model size.</p>
 
 <p><img alt="The background is 50% of the height and 60% of the width of the element" src="mycoolheadersized.png"></p>
 

--- a/files/en-us/web/api/css_painting_api/index.html
+++ b/files/en-us/web/api/css_painting_api/index.html
@@ -167,7 +167,7 @@ li:nth-of-type(3n+1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications("api.PaintWorklet")}}
+{{Specifications("api.PaintWorkletGlobalScope")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_painting_api/index.html
+++ b/files/en-us/web/api/css_painting_api/index.html
@@ -29,7 +29,7 @@ tags:
 
 <dl>
  <dt>{{domxref('PaintWorklet')}}</dt>
- <dd>Programmatically generates an image where a CSS property expects a file. Access this interface through <a href="/en-US/docs/Web/API/CSS/paintWorklet" title="paintWorklet is a static, read-only property of the CSS interface that provides access to the PaintWorklet, which programmatically generates an image where a CSS property expects a file. "><code>CSS.paintWorklet</code></a>.</dd>
+ <dd>Programmatically generates an image where a CSS property expects a file. Access this interface through <a href="/en-US/docs/Web/API/CSS/paintWorklet" title="paintWorklet is a static, read-only property of the CSS interface that provides access to the PaintWorklet, which programmatically generates an image where a CSS property expects a file."><code>CSS.paintWorklet</code></a>.</dd>
  <dt>{{domxref('PaintWorkletGlobalScope')}}</dt>
  <dd>The global execution context of the <code>paintWorklet</code>.</dd>
  <dt>{{domxref('PaintRenderingContext2D')}}</dt>
@@ -49,7 +49,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>To draw directly into an element's background using JavaScript in our CSS, we define a paint worklet using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function, tell the document to include the worklet using the paintWorklet addModule() method, then include the image we created using the CSS <code><a href="/en-US/docs/Web/CSS/paint()">paint()</a></code>  function.</p>
+<p>To draw directly into an element's background using JavaScript in our CSS, we define a paint worklet using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function, tell the document to include the worklet using the paintWorklet addModule() method, then include the image we created using the CSS <code><a href="/en-US/docs/Web/CSS/paint()">paint()</a></code> function.</p>
 
 <p>We create our PaintWorklet called 'hollowHighlights' using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function:</p>
 
@@ -119,26 +119,26 @@ tags:
 <p>We then include the paintWorklet:</p>
 
 <pre class="brush: html hidden">&lt;ul&gt;
-    &lt;li&gt;item 1&lt;/li&gt;
-    &lt;li&gt;item 2&lt;/li&gt;
-    &lt;li&gt;item 3&lt;/li&gt;
-    &lt;li&gt;item 4&lt;/li&gt;
-    &lt;li&gt;item 5&lt;/li&gt;
-    &lt;li&gt;item 6&lt;/li&gt;
-    &lt;li&gt;item 7&lt;/li&gt;
-    &lt;li&gt;item 8&lt;/li&gt;
-    &lt;li&gt;item 9&lt;/li&gt;
-    &lt;li&gt;item 10&lt;/li&gt;
-    &lt;li&gt;item 11&lt;/li&gt;
-    &lt;li&gt;item 12&lt;/li&gt;
-    &lt;li&gt;item 13&lt;/li&gt;
-    &lt;li&gt;item 14&lt;/li&gt;
-    &lt;li&gt;item 15&lt;/li&gt;
-    &lt;li&gt;item 16&lt;/li&gt;
-    &lt;li&gt;item 17&lt;/li&gt;
-    &lt;li&gt;item 18&lt;/li&gt;
-    &lt;li&gt;item 19&lt;/li&gt;
-    &lt;li&gt;item 20&lt;/li&gt;
+    &lt;li&gt;item 1&lt;/li&gt;
+    &lt;li&gt;item 2&lt;/li&gt;
+    &lt;li&gt;item 3&lt;/li&gt;
+    &lt;li&gt;item 4&lt;/li&gt;
+    &lt;li&gt;item 5&lt;/li&gt;
+    &lt;li&gt;item 6&lt;/li&gt;
+    &lt;li&gt;item 7&lt;/li&gt;
+    &lt;li&gt;item 8&lt;/li&gt;
+    &lt;li&gt;item 9&lt;/li&gt;
+    &lt;li&gt;item 10&lt;/li&gt;
+    &lt;li&gt;item 11&lt;/li&gt;
+    &lt;li&gt;item 12&lt;/li&gt;
+    &lt;li&gt;item 13&lt;/li&gt;
+    &lt;li&gt;item 14&lt;/li&gt;
+    &lt;li&gt;item 15&lt;/li&gt;
+    &lt;li&gt;item 16&lt;/li&gt;
+    &lt;li&gt;item 17&lt;/li&gt;
+    &lt;li&gt;item 18&lt;/li&gt;
+    &lt;li&gt;item 19&lt;/li&gt;
+    &lt;li&gt;item 20&lt;/li&gt;
 &lt;/ul&gt;</pre>
 
 <pre class="brush: js">  CSS.paintWorklet.addModule('https://mdn.github.io/houdini-examples/cssPaint/intro/worklets/hilite.js');
@@ -167,20 +167,7 @@ li:nth-of-type(3n+1) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Painting API')}}</td>
-   <td>{{Spec2('CSS Painting API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.PaintWorklet")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_properties_and_values_api/guide/index.html
+++ b/files/en-us/web/api/css_properties_and_values_api/guide/index.html
@@ -21,10 +21,10 @@ tags:
 <p>The following will register a {{cssxref('--*', 'CSS custom properties')}}, <code>--my-prop</code>, using {{domxref('CSS.registerProperty')}}, as a color, give it a default value, and have it not inherit its value:</p>
 
 <pre class="brush: js">window.CSS.registerProperty({
-  name: '--my-prop',
-  syntax: '&lt;color&gt;',
-  inherits: false,
-  initialValue: '#c0ffee',
+  name: '--my-prop',
+  syntax: '&lt;color&gt;',
+  inherits: false,
+  initialValue: '#c0ffee',
 });
 </pre>
 
@@ -33,9 +33,9 @@ tags:
 <p>The same registration can take place in CSS. The following will register a {{cssxref('--*', 'CSS custom properties')}}, <code>--my-prop</code>, using {{cssxref('@property')}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>, as a color, give it a default value, and have it not inherit its value:</p>
 
 <pre class="brush: css">@property --my-prop {
-  syntax: '&lt;color&gt;';
-  inherits: false;
-  initial-value: #c0ffee;
+  syntax: '&lt;color&gt;';
+  inherits: false;
+  initial-value: #c0ffee;
 }</pre>
 
 <h2 id="Using_registered_custom_properties">Using registered custom properties</h2>
@@ -45,25 +45,25 @@ tags:
 <p>In this example, the custom property <code>--registered</code> has been registered using the syntax <code>&lt;color&gt;</code> and then used in a linear gradient. That property is then transitioned on hover or focus to a different color. Notice that with the registered property the transition works, but that it doesn't with the unregistered property!</p>
 
 <pre class="brush: css">.registered {
-  --registered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--registered));
-  transition: --registered 1s ease-in-out;
+  --registered: #c0ffee;
+  background-image: linear-gradient(to right, #fff, var(--registered));
+  transition: --registered 1s ease-in-out;
 }
 
 .registered:hover,
 .registered:focus {
-  --registered: #b4d455;
+  --registered: #b4d455;
 }
 
 .unregistered {
-  --unregistered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--unregistered));
-  transition: --unregistered 1s ease-in-out;
+  --unregistered: #c0ffee;
+  background-image: linear-gradient(to right, #fff, var(--unregistered));
+  transition: --unregistered 1s ease-in-out;
 }
 
 .unregistered:hover,
 .unregistered:focus {
-  --unregistered: #b4d455;
+  --unregistered: #b4d455;
 }</pre>
 
 <div class="hidden" id="registered">
@@ -72,41 +72,41 @@ tags:
 </pre>
 
 <pre class="brush: css">.registered {
-  --registered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--registered));
-  transition: --registered 1s ease-in-out;
+  --registered: #c0ffee;
+  background-image: linear-gradient(to right, #fff, var(--registered));
+  transition: --registered 1s ease-in-out;
 }
 
 .registered:hover,
 .registered:focus {
-  --registered: #b4d455;
+  --registered: #b4d455;
 }
 
 .unregistered {
-  --unregistered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--unregistered));
-  transition: --unregistered 1s ease-in-out;
+  --unregistered: #c0ffee;
+  background-image: linear-gradient(to right, #fff, var(--unregistered));
+  transition: --unregistered 1s ease-in-out;
 }
 
 .unregistered:hover,
 .unregistered:focus {
-  --unregistered: #b4d455;
+  --unregistered: #b4d455;
 }
 
 button {
-  height: 40vh;
-  display: block;
-  width: 100%;
-  font-size: 3vw;
+  height: 40vh;
+  display: block;
+  width: 100%;
+  font-size: 3vw;
 }
 
 </pre>
 
 <pre class="brush: js">window.CSS.registerProperty({
-  name: '--registered',
-  syntax: '&lt;color&gt;',
-  inherits: false,
-  initialValue: 'red',
+  name: '--registered',
+  syntax: '&lt;color&gt;',
+  inherits: false,
+  initialValue: 'red',
 });</pre>
 </div>
 

--- a/files/en-us/web/api/css_properties_and_values_api/index.html
+++ b/files/en-us/web/api/css_properties_and_values_api/index.html
@@ -38,20 +38,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Properties and Values API')}}</td>
-			<td>{{Spec2('CSS Properties and Values API')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications("api.CSS.registerProperty")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_typed_om_api/guide/index.html
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.html
@@ -53,9 +53,9 @@ for (const [prop, val] of defaultComputedStyles) {
 	stylesList.appendChild(cssValue);
 }</pre>
 
-<p>The <code>computedStyleMap()</code> method returns a {{domxref('StylePropertyMapReadOnly')}} object containing the <code><a href="/en-US/docs/Web/API/StylePropertyMapReadOnly/size">size</a></code> property, which indicates how many properties are in the map. We iterate through the style map, creating a  <code><a href="/en-US/docs/Web/HTML/Element/dt">&lt;dt&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/dd">&lt;dd&gt;</a></code> for each property and value respectively.</p>
+<p>The <code>computedStyleMap()</code> method returns a {{domxref('StylePropertyMapReadOnly')}} object containing the <code><a href="/en-US/docs/Web/API/StylePropertyMapReadOnly/size">size</a></code> property, which indicates how many properties are in the map. We iterate through the style map, creating a <code><a href="/en-US/docs/Web/HTML/Element/dt">&lt;dt&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/dd">&lt;dd&gt;</a></code> for each property and value respectively.</p>
 
-<p>In  <a href="/en-US/docs/Web/API/Element/computedStyleMap#browser_compatibility">browsers that support <code>computedStyleMap()</code></a>, you'll see a list of all the CSS properties and values. In other browsers, you'll just see a link.</p>
+<p>In <a href="/en-US/docs/Web/API/Element/computedStyleMap#browser_compatibility">browsers that support <code>computedStyleMap()</code></a>, you'll see a list of all the CSS properties and values. In other browsers, you'll just see a link.</p>
 
 <p>{{EmbedLiveSample("example1", 120, 300)}}</p>
 
@@ -113,7 +113,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 <p>{{EmbedLiveSample("example2", 120, 300)}}</p>
 </div>
 
-<p>We included {{cssxref('border-left-color')}} to demonstrate that, had we included all the properties, every value that defaults to <code><a href="/en-US/docs/Web/CSS/color_value">currentcolor</a></code> (including {{cssxref('caret-color')}}, {{cssxref('outline-color')}}, {{cssxref('text-decoration-color')}}, {{cssxref('column-rule-color')}}, etc.) would return <code>rgb(255, 0, 0)</code>. The link has inherited <code>font-weight: bold;</code> from the paragraph's styles, listing it as <code>font-weight: 700</code>.  Custom properties, like our <code>--color: red</code> , are properties. As such, they are accessible via <code>get()</code>.</p>
+<p>We included {{cssxref('border-left-color')}} to demonstrate that, had we included all the properties, every value that defaults to <code><a href="/en-US/docs/Web/CSS/color_value">currentcolor</a></code> (including {{cssxref('caret-color')}}, {{cssxref('outline-color')}}, {{cssxref('text-decoration-color')}}, {{cssxref('column-rule-color')}}, etc.) would return <code>rgb(255, 0, 0)</code>. The link has inherited <code>font-weight: bold;</code> from the paragraph's styles, listing it as <code>font-weight: 700</code>. Custom properties, like our <code>--color: red</code> , are properties. As such, they are accessible via <code>get()</code>.</p>
 
 <p>You'll note that custom properties retain the value as written in the stylesheet, whereas computed styles will be listed as the computed value — {{cssxref('color')}} was listed as an <a href="/en-US/docs/Web/CSS/color_value"><code>rgb()</code> </a>value and the {{cssxref('font-weight')}} returned was <code>700</code> even though we use a {{cssxref('&lt;color&gt;', 'named color')}} and the <code>bold</code> keyword.</p>
 
@@ -141,7 +141,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
     &lt;/tr&gt;
 &lt;/table&gt;</pre>
 
-<p>For each property of interest, we list the name of the property, use <code>.get(propertyName).value</code> to return the value, and, if the object returned by the <code>get()</code> is a <code>CSSUnitValue</code>, list the unit type we retrieve with <code>.get(propertyName).unit</code>.</p>
+<p>For each property of interest, we list the name of the property, use <code>.get(propertyName).value</code> to return the value, and, if the object returned by the <code>get()</code> is a <code>CSSUnitValue</code>, list the unit type we retrieve with <code>.get(propertyName).unit</code>.</p>
 
 <pre class="brush: js">// get the element we're inspecting
 const myElement = document.querySelector('p');
@@ -240,7 +240,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <p>You'll note the {{cssxref('&lt;length&gt;')}} unit returned is <code>px</code>, the {{cssxref('&lt;percentage&gt;')}} unit returned is <code>percent</code>, the {{cssxref('&lt;time&gt;')}} unit is <code>s</code> for 'seconds', and the unitless {{cssxref('&lt;number&gt;')}} unit is <code>number</code>.</p>
 
-<p>We didn't declare a {{cssxref('width')}} or a {{cssxref('height')}} for the paragraph, both of which default to <code>auto</code> and therefore return a <code><a href="/en-US/docs/Web/API/CSSKeywordValue">CSSKeywordValue</a></code> instead of a <code><a href="/en-US/docs/Web/API/CSSUnitValue">CSSUnitValue</a></code>. <code>CSSKeywordValue</code>s do not have a unit property, so in these cases our <code>get().unit</code> returns <code>undefined</code>. </p>
+<p>We didn't declare a {{cssxref('width')}} or a {{cssxref('height')}} for the paragraph, both of which default to <code>auto</code> and therefore return a <code><a href="/en-US/docs/Web/API/CSSKeywordValue">CSSKeywordValue</a></code> instead of a <code><a href="/en-US/docs/Web/API/CSSUnitValue">CSSUnitValue</a></code>. <code>CSSKeywordValue</code>s do not have a unit property, so in these cases our <code>get().unit</code> returns <code>undefined</code>.</p>
 
 <p>Had the <code>width</code> or <code>height</code> been defined in a <code>&lt;length&gt;</code> or <code>&lt;percent&gt;</code>, the <code><a href="/en-US/docs/Web/API/CSSUnitValue">CSSUnitValue</a></code> unit would have been <code>px</code> or <code>percent</code> respectively.</p>
 
@@ -267,7 +267,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <ul>
  <li>{{domxref("CSSStyleValue.parse()")}}</li>
- <li>{{domxref("CSSStyleValue.parseAll()")}} </li>
+ <li>{{domxref("CSSStyleValue.parseAll()")}}</li>
 </ul>
 
 <p>As noted above, <code>StylePropertyMapReadOnly.get('--customProperty')</code> returns a {{domxref('CSSUnparsedValue')}}. We can parse <code>CSSUnparsedValue</code> object instances with the inherited {{domxref('CSSStyleValue.parse()')}} and {{domxref('CSSStyleValue.parseAll()')}} methods.</p>
@@ -311,7 +311,7 @@ const allComputedStyles = button.computedStyleMap();
 let btnWidth = allComputedStyles.get('width')
 
 console.log( btnWidth ); // CSSMathSum
-console.log( btnWidth.values ); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
+console.log( btnWidth.values ); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
 console.log( btnWidth.operator ); // 'sum'
 
 // CSSTransformValue
@@ -319,10 +319,10 @@ let transform = allComputedStyles.get('transform');
 
 console.log( transform );        // CSSTransformValue {0: CSSScale, 1: CSSTranslate, length: 2, is2D: true}
 console.log( transform.length ); // 1
-console.log( transform[0] );     // CSSScale {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, is2D: true}
-console.log( transform[0].x );   // CSSUnitValue {value: 0.95, unit: "number"}
-console.log( transform[0].y );   // CSSUnitValue {value: 0.95, unit: "number"}
-console.log( transform[0].z );   // CSSUnitValue {value: 1, unit: "number"}
+console.log( transform[0] );     // CSSScale {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, is2D: true}
+console.log( transform[0].x );   // CSSUnitValue {value: 0.95, unit: "number"}
+console.log( transform[0].y );   // CSSUnitValue {value: 0.95, unit: "number"}
+console.log( transform[0].z );   // CSSUnitValue {value: 1, unit: "number"}
 console.log( transform.is2D );   // true
 
 // CSSImageValue
@@ -362,13 +362,13 @@ console.log( parsedUnit.value );
 <pre class="brush: js">// CSSUnparsedValue
 let unit = allComputedStyles.get('--unit');
 
-console.log( unit )    // CSSUnparsedValue {0: " 1.2rem", length: 1}
+console.log( unit )    // CSSUnparsedValue {0: " 1.2rem", length: 1}
 console.log (unit[0] ) // " 1.2rem" </pre>
 
-<p>When we invoke <code>get()</code>, a custom property of type <code>CSSUnparsedValue</code> is returned. Note the space before the <code> 1.2rem</code>.  To get a unit and value, we need a <code>CSSUnitValue</code>, which we can retrieve using the <code>CSSStyleValue.parse()</code> method on the <code>CSSUnparsedValue</code>.</p>
+<p>When we invoke <code>get()</code>, a custom property of type <code>CSSUnparsedValue</code> is returned. Note the space before the <code> 1.2rem</code>. To get a unit and value, we need a <code>CSSUnitValue</code>, which we can retrieve using the <code>CSSStyleValue.parse()</code> method on the <code>CSSUnparsedValue</code>.</p>
 
 <pre class="brush: js">let parsedUnit = CSSNumericValue.parse( unit );
-console.log( parsedUnit );        // CSSUnitValue {value: 1.2, unit: "rem"}
+console.log( parsedUnit );        // CSSUnitValue {value: 1.2, unit: "rem"}
 console.log( parsedUnit.unit );   // "rem"
 console.log( parsedUnit.value );  // 1.2</pre>
 
@@ -383,28 +383,28 @@ console.log( parsedUnit.value );  // 1.2</pre>
 <pre class="brush: js">let btnWidth = allComputedStyles.get('width')
 
 console.log( btnWidth );             // CSSMathSum
-console.log( btnWidth.values );      // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
+console.log( btnWidth.values );      // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
 console.log( btnWidth.operator );    // 'sum'</pre>
 
 <h3 id="CSSTransformValue_with_CSSScale">CSSTransformValue with CSSScale</h3>
 
-<p>The <code><a href="/en-US/docs/Web/CSS/CSS_Display">display: inline-block;</a></code> also enables transforming. In our CSS we have <code>transform: scale(0.95);</code>, which is a {{cssxref('transform')}} function. </p>
+<p>The <code><a href="/en-US/docs/Web/CSS/CSS_Display">display: inline-block;</a></code> also enables transforming. In our CSS we have <code>transform: scale(0.95);</code>, which is a {{cssxref('transform')}} function.</p>
 
 <pre class="brush: js">let transform = allComputedStyles.get('transform');
 
 console.log( transform );        // CSSTransformValue {0: CSSScale, 1: CSSTranslate, length: 2, is2D: true}
 console.log( transform.length ); // 1
-console.log( transform[0] );     // CSSScale {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, is2D: true}
-console.log( transform[0].x );   // CSSUnitValue {value: 0.95, unit: "number"}
-console.log( transform[0].y );      // CSSUnitValue {value: 0.95, unit: "number"}
-console.log( transform[0].z );   // CSSUnitValue {value: 1, unit: "number"}
+console.log( transform[0] );     // CSSScale {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, is2D: true}
+console.log( transform[0].x );   // CSSUnitValue {value: 0.95, unit: "number"}
+console.log( transform[0].y );      // CSSUnitValue {value: 0.95, unit: "number"}
+console.log( transform[0].z );   // CSSUnitValue {value: 1, unit: "number"}
 console.log( transform.is2D );   // true</pre>
 
 <p>When we <code>get()</code> the <code>transform</code> property, we get a {{domxref('CSSTransformValue')}}. We can query the length (or number) of transform functions with the .<code>length</code> property.</p>
 
 <p>Seen as we have a length of <code>1</code>, which represents a single transform function, we log the first object and get a <code>CSSScale</code> object. We get <code>CSSUnitValues</code> when we query the <code>x</code>, <code>y</code>, and <code>z</code> scaling. The readonly <code>CSSScale.is2D</code> property is <code>true</code> in this scenario.</p>
 
-<p>Had we added <code>translate()</code>, <code>skew()</code>, and <code>rotate()</code> transform functions, the length would have been <code>4</code>, each with their own <code>x</code>, <code>y</code>, <code>z</code> values, and each with an <code>.is2D</code> property. For example, had we included <code>transform: translate3d(1px, 1px, 3px)</code>, the <code>.get('transform')</code> would have returned a <code>CSSTranslate</code> with <code>CSSUnitValues</code> for <code>x</code>, <code>y</code>, and <code>z</code>, and the readonly .i<code>s2D</code> property would have been <code>false</code>.</p>
+<p>Had we added <code>translate()</code>, <code>skew()</code>, and <code>rotate()</code> transform functions, the length would have been <code>4</code>, each with their own <code>x</code>, <code>y</code>, <code>z</code> values, and each with an <code>.is2D</code> property. For example, had we included <code>transform: translate3d(1px, 1px, 3px)</code>, the <code>.get('transform')</code> would have returned a <code>CSSTranslate</code> with <code>CSSUnitValues</code> for <code>x</code>, <code>y</code>, and <code>z</code>, and the readonly .i<code>s2D</code> property would have been <code>false</code>.</p>
 
 <h3 id="CSSImageValue">CSSImageValue</h3>
 
@@ -415,9 +415,9 @@ console.log( transform.is2D );   // true</pre>
 console.log( bgImage );             // CSSImageValue
 console.log( bgImage.toString() );  // url("magicwand.png")</pre>
 
-<p>When we <code>get()</code> the <code>'background-image'</code>, a {{domxref('CSSImageValue')}} is returned. While we used the CSS {{cssxref('background')}} shorthand property, the inherited {{domxref('Object.prototype.toString()')}} method, shows we returned only the image, '<code>url("magicwand.png")'</code>.</p>
+<p>When we <code>get()</code> the <code>'background-image'</code>, a {{domxref('CSSImageValue')}} is returned. While we used the CSS {{cssxref('background')}} shorthand property, the inherited {{domxref('Object.prototype.toString()')}} method, shows we returned only the image, '<code>url("magicwand.png")'</code>.</p>
 
-<p>Notice that the value returned is the absolute path to the image — this is returned even if the original <code>url()</code> value was relative. Had the background image been a gradient or multiple background images,  <code>.get('background-image') </code>would have returned a <code>CSSStyleValue</code>. The <code>CSSImageValue</code> is returned only if there is a single image, and only if that single image declaration is a URL.</p>
+<p>Notice that the value returned is the absolute path to the image — this is returned even if the original <code>url()</code> value was relative. Had the background image been a gradient or multiple background images, <code>.get('background-image') </code>would have returned a <code>CSSStyleValue</code>. The <code>CSSImageValue</code> is returned only if there is a single image, and only if that single image declaration is a URL.</p>
 
 <h3 id="Summary">Summary</h3>
 

--- a/files/en-us/web/api/css_typed_om_api/index.html
+++ b/files/en-us/web/api/css_typed_om_api/index.html
@@ -22,9 +22,9 @@ tags:
 <p>The {{domxref('CSSStyleValue')}} interface of the CSS Typed Object Model API is the base class of all CSS values accessible through the Typed OM API. An instance of this class may be used anywhere a string is expected.</p>
 
 <dl>
-	<dt> {{domxref('CSSStyleValue.parse()', 'CSSStyleValue.parse(property, cssText)')}}  </dt>
+	<dt>{{domxref('CSSStyleValue.parse()', 'CSSStyleValue.parse(property, cssText)')}}</dt>
 	<dd>The parse() method of the CSSStyleValue interface allows a CSSNumericValue to be constructed from a CSS string. It sets a specific CSS property to the specified values and returns the first value as a CSSStyleValue object.</dd>
-	<dt> {{domxref('CSSStyleValue.parseAll()')}}</dt>
+	<dt>{{domxref('CSSStyleValue.parseAll()')}}</dt>
 	<dd>The parseAll() method of the CSSStyleValue interface sets all occurrences of a specific CSS property to the specified value and returns an array of CSSStyleValue objects, each containing one of the supplied values.</dd>
 </dl>
 
@@ -119,20 +119,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS Typed OM')}}</td>
-			<td>{{Spec2('CSS Typed OM')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications("api.CSSStyleValue")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Part of #1146: source the spec data from {{Specifications}} in API overview pages (letter c).

(I fixed some gremlins at the same time)