### PR TITLE
Revise the CSSOM entry in the Glossary

### DIFF
--- a/files/en-us/glossary/cssom/index.html
+++ b/files/en-us/glossary/cssom/index.html
@@ -6,15 +6,8 @@ tags:
   - CSSOM
   - DOM
   - Glossary
-  - Web Performance
 ---
-<p>The <strong>CSS Object Model (CSSOM)</strong> is a map of all CSS selectors and relevant properties for each selector in the form of a tree, with a root node, sibling, descendant, child, and other relationship. The CSSOM is very similar to the {{glossary('DOM', 'Document Object Model (DOM)')}}. Both of them are part of the critical rendering path which is a series of steps that must happen to properly render a website.</p>
-
-<p>The CSSOM, together with the DOM, to build the render tree, which is in turn used by the browser to layout and paint the web page.</p>
-
-<h3 id="CSSOM_API">CSSOM API</h3>
-
-<p>The <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a> is also a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify the CSS style dynamically.</p>
+<p>The <a href="/en-US/docs/Web/API/CSS_Object_Model"><strong>CSS Object Model (CSSOM)</strong></a> is a set of APIs for reading and modifying a document’s style-related (CSS) information. In other words, similar to the way in which the <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> enables a document’s structure and content to be read and modified from JavaScript, the CSSOM allows the document’s styling to be read and modified from JavaScript.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
This updates the CSSOM·entry·in·the·Glossary to more closely match what we have at https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model.  Otherwise, without this change, what we have in the Glossary for CSSOM isn’t really an improvement over what we have at API/CSS_Object_Model — and also contains grammar and style problems that would otherwise need fixing.

Fixes https://github.com/mdn/content/issues/6146