### PR TITLE
Replace “host” with “hostname” in Origin glossary entry

### DIFF
--- a/files/en-us/glossary/origin/index.html
+++ b/files/en-us/glossary/origin/index.html
@@ -7,7 +7,7 @@ tags:
   - WebMechanics
   - origin
 ---
-<p>Web content's <strong>origin</strong> is defined by the <em>scheme</em> (protocol), <em>host</em> (domain), and <em>port</em> of the {{Glossary("URL")}} used to access it. Two objects have the same origin only when the scheme, host, and port all match.</p>
+<p>Web content's <strong>origin</strong> is defined by the <em>scheme</em> (protocol), <em>hostname</em> (domain), and <em>port</em> of the {{Glossary("URL")}} used to access it. Two objects have the same origin only when the scheme, hostname, and port all match.</p>
 
 <p>Some operations are restricted to same-origin content, and this restriction can be lifted using {{Glossary("CORS")}}.</p>
 
@@ -18,7 +18,7 @@ tags:
   <tr>
    <td style="width: 50%;"><code>http://example.com/app1/index.html</code><br>
     <code>http://example.com/app2/index.html</code></td>
-   <td style="width: 50%;">same origin because same scheme (<code>http</code>) and host (<code>example.com</code>)</td>
+   <td style="width: 50%;">same origin because same scheme (<code>http</code>) and hostname (<code>example.com</code>)</td>
   </tr>
   <tr>
    <td style="width: 50%;"><code>http://Example.com:80</code><br>
@@ -41,7 +41,7 @@ tags:
    <td style="width: 50%;"><code>http://example.com</code><br>
     <code>http://www.example.com</code><br>
     <code>http://myapp.example.com</code></td>
-   <td style="width: 50%;">different hosts</td>
+   <td style="width: 50%;">different hostnames</td>
   </tr>
   <tr>
    <td style="width: 50%;"><code>http://example.com</code><br>


### PR DESCRIPTION
The term “host” is ambiguous, because as pointed out in https://github.com/mdn/content/issues/6148, “host” can mean “fully qualified domain name plus port”. But “hostname” in unambiguous, because it’s clearly understood to just mean “fully qualified domain name” — without the port.

So to avoid that any ambiguity in the Origin glossary entry, this change replaces “host” with “hostname” throughout.

Fixes https://github.com/mdn/content/issues/6148