### PR TITLE
Drop link to non-existent “Monitoring text content changes” section

### DIFF
--- a/files/en-us/web/api/mutationobserver/observe/index.html
+++ b/files/en-us/web/api/mutationobserver/observe/index.html
@@ -90,9 +90,7 @@ browser-compat: api.MutationObserver.observe
       <dt>{{domxref("MutationObserverInit.characterDataOldValue",
         "characterDataOldValue")}} {{optional_inline}}</dt>
       <dd>Set to <code>true</code> to record the previous value of a node's text whenever
-        the text changes on nodes being monitored. For details and an example, see
-        {{SectionOnPage("/en-US/docs/Web/API/MutationObserver", "Monitoring text content
-        changes")}}. The default value is <code>false</code>.</dd>
+        the text changes on nodes being monitored. The default value is <code>false</code>.</dd>
     </dl>
   </dd>
 </dl>
@@ -117,7 +115,7 @@ browser-compat: api.MutationObserver.observe
         (indicating that attribute changes are not to be monitored), but
         <code>attributeOldValue</code> is <code>true</code> and/or
         <code>attributeFilter</code> is present.</li>
-      <li>The {{domxref("MutaitonObserverInit.characterDataOldValue",
+      <li>The {{domxref("MutationObserverInit.characterDataOldValue",
         "characterDataOldValue")}} option is <code>true</code> but
         {{domxref("MutationObserverInit.characterData")}} is <code>false</code>
         (indicating that character changes are not to be monitored).</li>

--- a/files/en-us/web/api/mutationobserverinit/index.html
+++ b/files/en-us/web/api/mutationobserverinit/index.html
@@ -38,7 +38,7 @@ browser-compat: api.MutationObserverInit
 	<dt>{{domxref("MutationObserverInit.characterData", "characterData")}} {{optional_inline}}</dt>
 	<dd>Set to <code>true</code> to monitor the specified target node (and, if <code>subtree</code> is <code>true</code>, its descendants) for changes to the character data contained within the node or nodes. The default value is <code>true</code> if <code>characterDataOldValue</code> is specified, otherwise the default value is <code>false</code>.</dd>
 	<dt>{{domxref("MutationObserverInit.characterDataOldValue", "characterDataOldValue")}} {{optional_inline}}</dt>
-	<dd>Set to <code>true</code> to record the previous value of a node's text whenever the text changes on nodes being monitored. For details and an example, see {{SectionOnPage("/en-US/docs/Web/API/MutationObserver", "Monitoring text content changes")}}. The default value is <code>false</code>.</dd>
+	<dd>Set to <code>true</code> to record the previous value of a node's text whenever the text changes on nodes being monitored. The default value is <code>false</code>.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
I can find no record that the `MutationObserver` article ever actually had a “Monitoring text content changes” section, and no record that existed anywhere else in MDN at any time.

Fixes https://github.com/mdn/content/issues/6150