### PR TITLE
Use YYYY-MM-DD capitals in <input type="datetime-local"> doc

### DIFF
--- a/files/en-us/web/html/element/input/datetime-local/index.html
+++ b/files/en-us/web/html/element/input/datetime-local/index.html
@@ -76,7 +76,7 @@ browser-compat: html.elements.input.input-datetime-local
 
 <p>{{ EmbedLiveSample('Value', 600, 60) }}</p>
 
-<p>One thing to note is that the displayed date and time formats differ from the actual <code>value</code>; the displayed date and time are formatted according to the user's locale as reported by their operating system, whereas the date/time <code>value</code> is always formatted <code>yyyy-MM-ddThh:mm</code>. When the above value submitted to the server, for example, it will look like <code>partydate=2017-06-01T08:30</code>.</p>
+<p>One thing to note is that the displayed date and time formats differ from the actual <code>value</code>; the displayed date and time are formatted according to the user's locale as reported by their operating system, whereas the date/time <code>value</code> is always formatted <code>YYYY-MM-DDThh:mm</code>. When the above value submitted to the server, for example, it will look like <code>partydate=2017-06-01T08:30</code>.</p>
 
 <div class="note">
 <p><strong>Note:</strong> Also bear in mind that if such data is submitted via HTTP <code><a href="/en-US/docs/Web/HTTP/Methods/GET">GET</a></code>, the colon character will need to be escaped for inclusion in the URL parameters, e.g. <code>partydate=2017-06-01T08%3A30</code>. See {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} for one way to do this.</p>
@@ -118,13 +118,13 @@ dateControl.value = '2017-06-01T08:30';</pre>
 
 <h3 id="attr-max"><code id="max">max</code></h3>
 
-<p>The latest date and time to accept. If the {{htmlattrxref("value", "input")}} entered into the element is later than this timestamp, the element fails <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>. If the value of the <code>max</code> attribute isn't a valid string which follows the format <code>yyyy-MM-ddThh:mm</code>, then the element has no maximum value.</p>
+<p>The latest date and time to accept. If the {{htmlattrxref("value", "input")}} entered into the element is later than this timestamp, the element fails <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>. If the value of the <code>max</code> attribute isn't a valid string which follows the format <code>YYYY-MM-DDThh:mm</code>, then the element has no maximum value.</p>
 
 <p>This value must specify a date string later than or equal to the one specified by the <code>min</code> attribute.</p>
 
 <h3 id="attr-min"><code id="min">min</code></h3>
 
-<p>The earliest date and time to accept; timestamps earlier than this will cause the element to fail <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>. If the value of the <code>min</code> attribute isn't a valid string which follows the format <code>yyyy-MM-ddThh:mm</code>, then the element has no minimum value.</p>
+<p>The earliest date and time to accept; timestamps earlier than this will cause the element to fail <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>. If the value of the <code>min</code> attribute isn't a valid string which follows the format <code>YYYY-MM-DDThh:mm</code>, then the element has no minimum value.</p>
 
 <p>This value must specify a date string earlier than or equal to the one specified by the <code>max</code> attribute.</p>
 
@@ -269,16 +269,16 @@ input:valid+span:after {
 
 <p>Non-supporting browsers gracefully degrade to a text input, but this creates problems both in terms of consistency of user interface (the presented control will be different), and data handling.</p>
 
-<p>The second problem is the most serious; as we mentioned earlier, with a <code>datetime-local</code> input, the actual value is always normalized to the format <code>yyyy-mm-ddThh:mm</code>. With a text input on the other hand, by default the browser has no recognition of what format the date should be in, and there are lots of different ways in which people write dates and times, for example:</p>
+<p>The second problem is the most serious; as we mentioned earlier, with a <code>datetime-local</code> input, the actual value is always normalized to the format <code>YYYY-MM-DDThh:mm</code>. With a text input on the other hand, by default the browser has no recognition of what format the date should be in, and there are lots of different ways in which people write dates and times, for example:</p>
 
 <ul>
- <li><code>ddmmyyyy</code></li>
- <li><code>dd/mm/yyyy</code></li>
- <li><code>mm/dd/yyyy</code></li>
- <li><code>dd-mm-yyyy</code></li>
- <li><code>mm-dd-yyyy</code></li>
- <li><code>mm-dd-yyyy hh:mm</code> (12 hour clock)</li>
- <li><code>mm-dd-yyyy HH:mm</code> (24 hour clock)</li>
+ <li><code>DDMMYYYY</code></li>
+ <li><code>DD/MM/YYYY</code></li>
+ <li><code>MM/DD/YYYY</code></li>
+ <li><code>DD-MM-YYYY</code></li>
+ <li><code>MM-DD-YYYY</code></li>
+ <li><code>MM-DD-YYYY hh:mm</code> (12 hour clock)</li>
+ <li><code>MM-DD-YYYY HH:mm</code> (24 hour clock)</li>
  <li>etc.</li>
 </ul>
 


### PR DESCRIPTION
As noted in https://github.com/mdn/content/issues/6161, lowercase `dd` in a date format string means “abbreviated name for the day of the week” — so what’s normally wanted instead is uppercase `DD`, which means “day of the month”. Similarly, lowercase `mm` means “minutes”, while uppercase `MM` is what’s needed for “months”. And year is normally uppercase `YYYY`, not lowercase `yyyy`. Fixes https://github.com/mdn/content/issues/6161.