### PR TITLE
Use `Array.prototype.unshift()` to replace `Array.prototype.reverse()` for keeping input order

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.html
@@ -80,11 +80,10 @@ function flatten(input) {
       // push back array items, won't modify the original input
       stack.push(...next);
     } else {
-      res.push(next);
+      // unshift value to keep input order
+      res.unshfit(next);
     }
   }
-  // reverse to restore input order
-  return res.reverse();
 }
 
 const arr = [1, 2, [3, 4, [5, 6]]];


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
Use `Array.prototype.unshift()` to keep the input order for simpler and performant example.


> Issue number (if there is an associated issue)
Nope.


> Anything else that could help us review it
Nope.