### PR TITLE
Replace pagemacro with link to example in AudioTrack

### DIFF
--- a/files/en-us/web/api/audiotrack/index.html
+++ b/files/en-us/web/api/audiotrack/index.html
@@ -62,7 +62,7 @@ var tracks = el.audioTracks;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioTrack/label", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioTrack/label#example"><code>AudioTrack.label</code></a> for a simple example that shows how to get a array of track kinds and labels for a specified media element, filtered by kind.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

In `AudioTrack` replaces inclusion with link to `AudioTrack.label`