### PR TITLE
Add missing divs to Element»getBoundingClientRect() example

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.html
+++ b/files/en-us/web/api/element/getboundingclientrect/index.html
@@ -134,7 +134,11 @@ for (var key in rect) {
 <h4 id="Scrolling">Scrolling</h4>
 <p>This example demonstrates how bounding client rect is changing when document is scrolled.</p>
 
-<pre class="brush: html notranslate">&lt;div&gt;&lt;/div&gt;</pre>
+<pre class="brush: html notranslate">
+&lt;div&gt;&lt;/div&gt;
+    &lt;div id="example"&gt;&lt;/div&gt;
+    &lt;div id="controls"&gt;&lt;/div&gt;
+</pre>
 
 <pre class="brush: css notranslate">div#example {
   width: 400px;


### PR DESCRIPTION
The live demo of the scrolling example is missing two div elements for it to work.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Example doesn't work


> Issue number (if there is an associated issue)



> Anything else that could help us review it
