### PR TITLE
Update no-spec msg for Gamepad.displayId

### DIFF
--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -22,7 +22,7 @@ browser-compat: api.Gamepad.displayId
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>.</p>
-  <p>There is no direct replacement for this property. The {{domxref("Gamepad")}} object associated to an {{domxref("XRInputSource")}} can be obtained using the {{domxref("XRInputSource.gamepad")}} property.</p>
+  <p>There is no direct replacement for this property. The {{domxref("Gamepad")}} object associated with an {{domxref("XRInputSource")}} can be obtained using the {{domxref("XRInputSource.gamepad")}} property.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -46,7 +46,7 @@ browser-compat: api.Gamepad.displayId
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no more on any standards track.</p>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
 <p>As long as all browsers are not implementing the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to support them all <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -20,6 +20,11 @@ browser-compat: api.Gamepad.displayId
 
 <p>A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the {{domxref("VRDisplay.pose")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>.</p>
+  <p>There is no direct replacement for this property. The {{domxref("Gamepad")}} object associated to an {{domxref("XRInputSource")}} can be obtained using the {{domxref("XRInputSource.gamepad")}} property.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myDisplayId = gamepadInstance.displayId;</pre>
@@ -41,7 +46,8 @@ browser-compat: api.Gamepad.displayId
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no more on any standards track.</p>
+<p>As long as all browsers are not implementing the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to support them all <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -47,7 +47,7 @@ browser-compat: api.Gamepad.displayId
 <h2 id="Specifications">Specifications</h2>
 
 <p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
-<p>As long as all browsers are not implementing the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to support them all <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies some data is missing on mdn/browser-spec-data, without putting back an outdated table like before.

Here I deal with one WebVR property `Gamepad.displayId` that is not the most typical one as gamepads are excluded of the fundamental WebXR Display API specification, and:
 - I added a note at the top;
 - I replaced `{{Specification}}` with a more adequate text.

**There are a lot more pages (~70 pages) about WebVR on MDN and I would like to do something similar (but not a cut & paste: minor adaptations each time). Before proceeding with these pages, I would like a careful review of one adaptation (here!), so that I don't redo the work several times.**

@dontcallmedom , I think you are quite active on immersive-web, so I'm interested in your feedback (but not only yours).