### PR TITLE
Update no-spec msg for HTMLBaseFontElement

### DIFF
--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -16,7 +16,7 @@ browser-compat: api.HTMLBaseFontElement
 <p>The <code>&lt;basefont&gt;</code> element has been deprecated in HTML4 and removed in HTML5. This latest specification requires that this element implements {{domxref("HTMLUnknownElement")}} rather than <code>HTMLBaseFontElement</code>.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> Use functionalities of <a href="/en-US/docs/Web/CSS/CSS_Fonts">CSS Fonts</a> instead.</p>
+  <p><strong>Note:</strong> Use <a href="/en-US/docs/Web/CSS/CSS_Fonts">CSS Fonts</a> features instead.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -38,7 +38,7 @@ browser-compat: api.HTMLBaseFontElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Present up to HTML 3.2, this was deprecated in HTML 4 and removed in HTML 5. No modern browsers support it and this feature is no longer on track to become a standard.</p>
+<p>This feature was present in the HTML specification up through HTML 3.2, but was deprecated in HTML 4, and then removed — and so is not in the current HTML specification. No modern browsers support it and this feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -38,7 +38,7 @@ browser-compat: api.HTMLBaseFontElement
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Present up to HTML 3.2, this was deprecated in HTML 4 and removed in HTML 5. No modern browsers support it and this is not on any standards track.</p>
+<p>Present up to HTML 3.2, this was deprecated in HTML 4 and removed in HTML 5. No modern browsers support it and this feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -15,6 +15,10 @@ browser-compat: api.HTMLBaseFontElement
 
 <p>The <code>&lt;basefont&gt;</code> element has been deprecated in HTML4 and removed in HTML5. This latest specification requires that this element implements {{domxref("HTMLUnknownElement")}} rather than <code>HTMLBaseFontElement</code>.</p>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> Use functionalities of <a href="/en-US/docs/Web/CSS/CSS_Fonts">CSS Fonts</a> instead.</p>
+</div>
+
 <h2 id="Properties">Properties</h2>
 
 <p><em>Inherits properties from its parent, {{domxref("HTMLElement")}}.</em></p>
@@ -34,7 +38,7 @@ browser-compat: api.HTMLBaseFontElement
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Present up to HTML 3.2, this was deprecated in HTML 4 and removed in HTML 5. No modern browsers support it and this is not on any standards track.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Here I dealt with `HTMBaseFontElement`.