### PR TITLE
Fix broken links on <label> page

### DIFF
--- a/files/en-us/web/html/element/label/index.html
+++ b/files/en-us/web/html/element/label/index.html
@@ -45,7 +45,7 @@ browser-compat: html.elements.label
 
 <dl>
  <dt>{{htmlattrdef("for")}}</dt>
- <dd>The {{htmlattrxref("id")}} of a <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form_labelable">labelable</a> form-related element in the same document as the <code>&lt;label&gt;</code> element. The first element in the document with an <code>id</code> matching the value of the <code>for</code> attribute is the <em>labeled control</em> for this label element if it is a <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a>. If it is not labelable then the <code>for</code> attribute has no effect. If there are other elements that also match the <code>id</code> value, later in the document, they are not considered.
+ <dd>The {{htmlattrxref("id")}} of a <a href="/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable">labelable</a> form-related element in the same document as the <code>&lt;label&gt;</code> element. The first element in the document with an <code>id</code> matching the value of the <code>for</code> attribute is the <em>labeled control</em> for this label element if it is a <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a>. If it is not labelable then the <code>for</code> attribute has no effect. If there are other elements that also match the <code>id</code> value, later in the document, they are not considered.
  <div class="note"><strong>Note</strong>: A <code>&lt;label&gt;</code> element can have both a <code>for</code> attribute and a contained control element, as long as the <code>for</code> attribute points to the contained control element.</div>
  </dd>
 </dl>
@@ -129,7 +129,7 @@ browser-compat: html.elements.label
   </tr>
   <tr>
    <th scope="row">Permitted content</th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content">Phrasing content</a>, but no descendant <code>label</code> elements. No <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form_labelable">labelable</a> elements other than the labeled control are allowed.</td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content">Phrasing content</a>, but no descendant <code>label</code> elements. No <a href="/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable">labelable</a> elements other than the labeled control are allowed.</td>
   </tr>
   <tr>
    <th scope="row">Tag omission</th>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Links to labelable elements' group were broken due to a case change on [Content categories page](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories).
