### PR TITLE
Fix w3c link of get property

### DIFF
--- a/files/en-us/web/webdriver/commands/getelementproperty/index.html
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.html
@@ -85,7 +85,7 @@ bar
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName("WebDriver", "#dfn-get-element-attribute", "Get Element Property")}}</td>
+   <td>{{SpecName("WebDriver", "#dfn-get-element-property", "Get Element Property")}}</td>
    <td>{{Spec2("WebDriver")}}</td>
    <td>Initial definition</td>
   </tr>


### PR DESCRIPTION
The link was pointing to get attribute section, but there is a separate section for the get property: 

old: https://w3c.github.io/webdriver/#dfn-get-element-attribute
new: https://w3c.github.io/webdriver/#dfn-get-element-property
