### PR TITLE
Minor editorial and grammar fixes for Credential APIs

### DIFF
--- a/files/en-us/web/api/credential/id/index.html
+++ b/files/en-us/web/api/credential/id/index.html
@@ -11,12 +11,12 @@ tags:
 - id
 browser-compat: api.Credential.id
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>id</code></strong> property of the
+<p>The <strong><code>id</code></strong> property of the
     {{domxref("Credential")}} interface returns a {{domxref("DOMString")}} containing the
     credential's identifier. This might be any one of a GUID, username, or email
-    address.</span></p>
+    address.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ browser-compat: api.Credential.id
 
 <h3 id="Value">Value</h3>
 
-<p>A a {{domxref("DOMString")}} containing the credential's identifier.</p>
+<p>A {{domxref("DOMString")}} containing the credential's identifier.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/credential/index.html
+++ b/files/en-us/web/api/credential/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Credential
 ---
 <div>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</div>
 
-<p>The <strong><code>Credential</code></strong> interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> provides information about an entity (usually a user) as a prerequisite to a trust decision.</p>
+<p>The <strong><code>Credential</code></strong> interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> provides information about an entity (usually a user) as a prerequisite to a trust decision.</p>
 
 <p><code>Credential</code> objects may be of 3 different types:</p>
 
@@ -26,9 +26,9 @@ browser-compat: api.Credential
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("Credential.id")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("Credential.id")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the credential's identifier. This might be any one of a GUID, username, or email address.</dd>
- <dt>{{domxref("Credential.type")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("Credential.type")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the credential's type. Valid values are <code>password</code>, <code>federated</code> and <code>public-key</code>. (For {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}} and {{domxref("PublicKeyCredential")}})</dd>
 </dl>
 

--- a/files/en-us/web/api/credential/type/index.html
+++ b/files/en-us/web/api/credential/type/index.html
@@ -10,12 +10,12 @@ tags:
 - credential management
 browser-compat: api.Credential.type
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>type</code></strong> property of the
-    {{domxref("Credential")}} interface returns a {{domxref("DOMString")}} containing the
+<p>The <strong><code>type</code></strong> property of the
+    {{domxref("Credential")}} interface returns a {{domxref("DOMString")}} containing the
     credential's type. Valid values are <code>password</code>, <code>federated</code> and
-    <code>public-key</code>.</span></p>
+    <code>public-key</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/credentialscontainer/create/index.html
+++ b/files/en-us/web/api/credentialscontainer/create/index.html
@@ -10,7 +10,7 @@ tags:
 - credential management
 browser-compat: api.CredentialsContainer.create
 ---
-<p>{{APIRef("Credential Management")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("Credential Management API")}}{{SeeCompatTable}}</p>
 
 <p>The <strong><code>create()</code></strong> method of the
   {{domxref("CredentialsContainer")}} interface returns a {{jsxref("Promise")}} that
@@ -18,7 +18,7 @@ browser-compat: api.CredentialsContainer.create
   <code>null</code> if no <code>Credential</code> object can be created.</p>
 
 <div class="note">
-  <p>This method is restricted to top-level contexts. Calls to it within an
+  <p>This method is restricted to top-level contexts. Calls to it within an
     <code>&lt;iframe&gt;</code> element will resolve without effect.</p>
 </div>
 
@@ -42,7 +42,7 @@ browser-compat: api.CredentialsContainer.create
           <li><code>id</code>: (required) {{domxref("USVString")}} Inherited from
             {{domxref("CredentialData")}}.</li>
           <li><code>name</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
-          <li><code>iconURL</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
+          <li><code>iconURL</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
           <li><code>password</code>: (required) {{domxref("USVString")}} TBD</li>
         </ul>
       </li>
@@ -53,13 +53,13 @@ browser-compat: api.CredentialsContainer.create
           <li><code>id</code>: (required) {{domxref("USVString")}} Inherited from
             {{domxref("CredentialData")}}.</li>
           <li><code>name</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
-          <li><code>iconURL</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
+          <li><code>iconURL</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
           <li><code>provider</code>: (required) {{domxref("USVString")}} TBD</li>
           <li><code>protocol</code>: {{optional_inline}} {{domxref("USVString")}} TBD</li>
         </ul>
       </li>
       <li><code>publicKey</code>: {{optional_inline}}
-        an {{domxref("PublicKeyCredentialCreationOptions")}} object that describes the
+        a {{domxref("PublicKeyCredentialCreationOptions")}} object that describes the
         options for creating a <a
           href="/en-US/docs/Web/API/Web_Authentication_API">WebAuthn</a> credential.</li>
     </ul>
@@ -68,9 +68,9 @@ browser-compat: api.CredentialsContainer.create
 
 <h3 id="Returns">Returns</h3>
 
-<p>A {{jsxref("Promise")}} that resolves with a {{domxref("Credential")}} instance, such
-  as {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}},
-  or {{domxref("PublicKeyCredential")}}.</p>
+<p>A {{jsxref("Promise")}} that resolves with a {{domxref("Credential")}} instance, such
+  as {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}},
+  or {{domxref("PublicKeyCredential")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/credentialscontainer/get/index.html
+++ b/files/en-us/web/api/credentialscontainer/get/index.html
@@ -11,10 +11,10 @@ tags:
 - credential management
 browser-compat: api.CredentialsContainer.get
 ---
-<p>{{APIRef("Credential Management")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("Credential Management API")}}{{SeeCompatTable}}</p>
 
 <p>The <strong><code>get()</code></strong> method of the
-  {{domxref("CredentialsContainer")}} interface returns a {{jsxref("Promise")}} to a
+  {{domxref("CredentialsContainer")}} interface returns a {{jsxref("Promise")}} to a
   single {{domxref("Credential")}} instance that matches the provided parameters. If no
   match is found the Promise will resolve to null.</p>
 
@@ -49,26 +49,26 @@ browser-compat: api.CredentialsContainer.get
     <ul>
       <li><code>password</code>: a {{jsxref("Boolean")}} indicating that returned
         {{domxref("Credential")}} instances should include user (as opposed to federated)
-        credentials. </li>
-      <li><code>federated</code>: A {{domxref("FederatedCredentialRequestOptions")}}
+        credentials.</li>
+      <li><code>federated</code>: A {{domxref("FederatedCredentialRequestOptions")}}
         object containing requirements for returned federated credentials. The available
         options are:
         <ul>
           <li><code>providers</code>: An array of {{domxref("DOMString")}} instances of
             identity providers to search for.</li>
-          <li><code>protocols</code> An array of {{domxref("DOMString")}} instances of
+          <li><code>protocols</code> An array of {{domxref("DOMString")}} instances of
             federation protocols to search for.</li>
         </ul>
       </li>
       <li><code>publicKey</code>: An {{domxref("PublicKeyCredentialRequestOptions")}}
         object containing requirements for returned <a
-          href="/en-US/docs/Web/API/Web_Authentication_API">WebAuthn</a> credentials. 
+          href="/en-US/docs/Web/API/Web_Authentication_API">WebAuthn</a> credentials.
       </li>
       <li><code>mediation</code>: A {{jsxref("String")}} indicating whether the user will
         be required to log on for every visit to the website. Valid values are
         <code>"silent"</code>, <code>"optional"</code>, or <code>"required"</code>.</li>
-      <li><code>unmediated</code>: {{deprecated_inline}} A {{jsxref("Boolean")}}
-        indicating the returned {{domxref("Credential")}} instance should not require user
+      <li><code>unmediated</code>: {{deprecated_inline}} A {{jsxref("Boolean")}}
+        indicating the returned {{domxref("Credential")}} instance should not require user
         mediation.</li>
       <li><code>signal</code>: An instance of {{domxref("AbortSignal")}} that can indicate
         that an ongoing <code>get()</code> operation should be halted. An aborted
@@ -81,7 +81,7 @@ browser-compat: api.CredentialsContainer.get
 
 <h3 id="Returns">Returns</h3>
 
-<p>A {{jsxref("Promise")}} that resolves with a {{domxref("Credential")}} instance that
+<p>A {{jsxref("Promise")}} that resolves with a {{domxref("Credential")}} instance that
   matches the provided parameters. If a single Credential cannot be unambiguously
   obtained, the Promise will resolve to null.</p>
 
@@ -91,15 +91,12 @@ browser-compat: api.CredentialsContainer.get
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
+<p>{{Compat}}</p>
 
-  <p>{{Compat}}</p>
+<h2 id="See_also">See also</h2>
 
-  <h2 id="See_also">See also</h2>
-
-  <ul>
-    <li>{{HTTPHeader("Feature-Policy")}} directive
-      {{HTTPHeader("Feature-Policy/publickey-credentials-get","publickey-credentials-get")}}
-    </li>
-  </ul>
-</div>
+<ul>
+  <li>{{HTTPHeader("Feature-Policy")}} directive
+    {{HTTPHeader("Feature-Policy/publickey-credentials-get","publickey-credentials-get")}}
+  </li>
+</ul>

--- a/files/en-us/web/api/credentialscontainer/index.html
+++ b/files/en-us/web/api/credentialscontainer/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CredentialsContainer
 ---
 <p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</p>
 
-<p>The <strong><code>CredentialsContainer</code></strong> interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> exposes methods to request credentials and notify the user agent when events such as successful sign in or sign out happen. This interface is accessible from {{domxref('Navigator.credentials')}}.</p>
+<p>The <strong><code>CredentialsContainer</code></strong> interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> exposes methods to request credentials and notify the user agent when events such as successful sign in or sign out happen. This interface is accessible from {{domxref('Navigator.credentials')}}.</p>
 
 <h2 id="Properties">Properties</h2>
 
@@ -28,13 +28,13 @@ browser-compat: api.CredentialsContainer
 
 <dl>
 	<dt>{{domxref("CredentialsContainer.create()")}}{{securecontext_inline}}</dt>
-	<dd>Returns a {{jsxref("Promise")}} that resolves with a new {{domxref("Credential")}} instance based on the provided options, or <code>null</code> if no <code>Credential</code> object can be created. In exceptional circumstances, the {{domxref("Promise")}} may reject.</dd>
+	<dd>Returns a {{jsxref("Promise")}} that resolves with a new {{domxref("Credential")}} instance based on the provided options, or <code>null</code> if no <code>Credential</code> object can be created. In exceptional circumstances, the {{domxref("Promise")}} may reject.</dd>
 	<dt>{{domxref("CredentialsContainer.get()")}}{{securecontext_inline}}</dt>
-	<dd>Returns a {{jsxref("Promise")}} that resolves with the {{domxref("Credential")}} instance that matches the provided parameters.</dd>
+	<dd>Returns a {{jsxref("Promise")}} that resolves with the {{domxref("Credential")}} instance that matches the provided parameters.</dd>
 	<dt>{{domxref("CredentialsContainer.preventSilentAccess()")}}{{securecontext_inline}}</dt>
-	<dd>Sets a flag that specifies whether automatic log in is allowed for future visits to the current origin, then returns an empty {{jsxref("Promise")}}. For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit. Earlier versions of the spec called this method <code>requireUserMediation()</code>. See {{anch("Browser compatibility")}} for support details.</dd>
+	<dd>Sets a flag that specifies whether automatic log in is allowed for future visits to the current origin, then returns an empty {{jsxref("Promise")}}. For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit. Earlier versions of the spec called this method <code>requireUserMediation()</code>. See {{anch("Browser compatibility")}} for support details.</dd>
 	<dt>{{domxref("CredentialsContainer.store()")}}{{securecontext_inline}}</dt>
-	<dd>Stores a set of credentials for a user, inside a provided {{domxref("Credential")}} instance and returns that instance in a {{jsxref("Promise")}}.</dd>
+	<dd>Stores a set of credentials for a user, inside a provided {{domxref("Credential")}} instance and returns that instance in a {{jsxref("Promise")}}.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
@@ -11,23 +11,23 @@ tags:
   - credential management
 browser-compat: api.CredentialsContainer.preventSilentAccess
 ---
-<p>{{APIRef("")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("Credential Management API")}}{{SeeCompatTable}}</p>
 
-<p><span class="seoSummary">The <strong><code>preventSilentAccess()</code></strong> method
+<p>The <strong><code>preventSilentAccess()</code></strong> method
     of the {{domxref("CredentialsContainer")}} interface sets a flag that specifies
     whether automatic log in is allowed for future visits to the current origin, then
-    returns an empty <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-      title="The Promise object represents the eventual completion (or failure) of an asynchronous operation, and its resulting value."><code>Promise</code></a>. </span>For
+    returns an empty <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+      title="The Promise object represents the eventual completion (or failure) of an asynchronous operation, and its resulting value."><code>Promise</code></a>. For
   example, you might call this, after a user signs out of a website to ensure that
   they aren't automatically signed in on the next site visit. Mediation varies by origin,
   and is an added check point of browser stored credentials, informing a user of an
-  account login status. This method is typically called after a user signs out of a
+  account login status. This method is typically called after a user signs out of a
   website, ensuring this user's login information is not automatically passed on the next
   site visit.</p>
 
-<p>Earlier versions of the spec called this method <code>requireUserMediation()</code>.
-  See <a href="/en-US/docs/Web/API/CredentialsContainer#browser_compatibility">Browser
-    compatibility</a> for support details.</p>
+<p>Earlier versions of the spec called this method<code>requireUserMediation()</code>.
+  The <a href="/en-US/docs/Web/API/CredentialsContainer#browser_compatibility">Browser
+    compatibility</a> section has support details.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/credentialscontainer/store/index.html
+++ b/files/en-us/web/api/credentialscontainer/store/index.html
@@ -11,15 +11,14 @@ tags:
 - credential management
 browser-compat: api.CredentialsContainer.store
 ---
-<p>{{APIRef("")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("Credential Management API")}}{{SeeCompatTable}}</p>
 
-<p><span class="seoSummary">The <strong><code>store()</code></strong> method of the
+<p>The <strong><code>store()</code></strong> method of the
     {{domxref("CredentialsContainer")}} stores a set of credentials for the user inside a
-    {{domxref("Credential")}} instance, returning this in a {{domxref("Promise")}}.</span>
-</p>
+    {{domxref("Credential")}} instance, returning this in a {{domxref("Promise")}}.</p>
 
 <div class="note">
-  <p>This method is restricted to top-level contexts. Calls to it within an
+  <p>This method is restricted to top-level contexts. Calls to it within an
     <code>&lt;iframe&gt;</code> element will resolve without effect.</p>
 </div>
 
@@ -32,12 +31,12 @@ browser-compat: api.CredentialsContainer.store
 
 <dl>
   <dt>Credentials</dt>
-  <dd>A valid {{domxref("Credential")}} instance.</dd>
+  <dd>A valid {{domxref("Credential")}} instance.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>
 
-<p>A {{domxref("Promise")}}, resolving to the passed {{domxref("Credential")}} instance.
+<p>A {{domxref("Promise")}}, resolving to the passed {{domxref("Credential")}} instance.
 </p>
 
 <h2 id="Example">Example</h2>
@@ -51,9 +50,9 @@ browser-compat: api.CredentialsContainer.store
 <pre class="brush: js">// Check if the browser supports password credentials (and the Credential Management API)
 if ("PasswordCredential" in window) {
   let credential = new PasswordCredential({
-    id: "example-username",
-    name: "John Doe", // In case of a login, the name comes from the server.
-    password: "correct horse battery staple"
+    id: "example-username",
+    name: "John Doe", // In case of a login, the name comes from the server.
+    password: "correct horse battery staple"
   });
 
   navigator.credentials.store(credential).then(() =&gt; {

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.html
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.html
@@ -1,5 +1,5 @@
 ---
-title: FederatedCredential
+title: FederatedCredential()
 slug: Web/API/FederatedCredential/FederatedCredential
 tags:
   - API
@@ -11,10 +11,10 @@ tags:
   - credential management
 browser-compat: api.FederatedCredential.FederatedCredential
 ---
-<p>{{APIRef("")}}{{Non-standard_header}}</p>
+<p>{{APIRef("Credential Management API")}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The <strong><code>FederatedCredential</code></strong>
-    constructor creates a new {{domxref("FederatedCredential")}} object.</span> In
+<p>The <strong><code>FederatedCredential()</code></strong>
+    constructor creates a new {{domxref("FederatedCredential")}} object. In
   supporting browsers, an instance of this class may be passed the <code>credential</code>
   received from the <code>init</code> object for global {{domxref('WindowOrWorkerGlobalScope.fetch')}}.</p>
 
@@ -26,7 +26,7 @@ browser-compat: api.FederatedCredential.FederatedCredential
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><em>init</em> </dt>
+  <dt><em>init</em></dt>
   <dd>Options are:
     <ul>
       <li><code>provider</code>: A {{domxref("USVString")}}; identifying the credential

--- a/files/en-us/web/api/federatedcredential/protocol/index.html
+++ b/files/en-us/web/api/federatedcredential/protocol/index.html
@@ -12,7 +12,7 @@ tags:
 - credential management
 browser-compat: api.FederatedCredential.protocol
 ---
-<div>{{SeeCompatTable}}{{APIRef("")}}{{securecontext_header}}</div>
+<div>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</div>
 
 <p>The <strong><code>protocol</code></strong> property of the
   {{domxref("FederatedCredential")}} interface returns a read-only

--- a/files/en-us/web/api/federatedcredential/provider/index.html
+++ b/files/en-us/web/api/federatedcredential/provider/index.html
@@ -11,7 +11,7 @@ tags:
 - credential management
 browser-compat: api.FederatedCredential.provider
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
 <p>The <strong><code>provider</code></strong> property of the
   {{domxref("FederatedCredential")}} interface returns a {{domxref("USVString")}}

--- a/files/en-us/web/api/passwordcredential/iconurl/index.html
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.html
@@ -11,21 +11,21 @@ tags:
 - credential management
 browser-compat: api.PasswordCredential.iconURL
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>iconURL</code></strong> read-only property
+<p>The <strong><code>iconURL</code></strong> read-only property
     of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
-    containing a URL pointing to an image for an icon. This image is intended for display
-    in a credential chooser. The URL must be accessible without authentication.</span></p>
+    containing a URL pointing to an image for an icon. This image is intended for display
+    in a credential chooser. The URL must be accessible without authentication.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>url</em> =<em>passwordCredential</em>.iconURL</pre>
+  class="brush: js"><em>url</em> = <em>passwordCredential</em>.iconURL</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("USVString")}} containing a URL.</p>
+<p>A {{domxref("USVString")}} containing a URL.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/index.html
@@ -12,7 +12,7 @@ browser-compat: api.PasswordCredential
 ---
 <p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</p>
 
-<p>The interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> provides information about a username/password pair. In supporting browsers an instance of this class may be passed in the <code>credential</code> member of the <code>init</code> object for global {{domxref('WindowOrWorkerGlobalScope.fetch')}}.</p>
+<p>The interface of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> provides information about a username/password pair. In supporting browsers an instance of this class may be passed in the <code>credential</code> member of the <code>init</code> object for global {{domxref('WindowOrWorkerGlobalScope.fetch')}}.</p>
 
 <div class="note">
 <p><strong>Note:</strong> This interface is restricted to top-level contexts and cannot be used from an {{HTMLElement("iframe")}}.</p>
@@ -31,10 +31,10 @@ browser-compat: api.PasswordCredential
 
 <dl>
  <dt>{{domxref("PasswordCredential.iconURL")}} {{readonlyinline}}{{securecontext_inline}}</dt>
- <dd>A {{domxref("USVString")}} containing a URL pointing to an image for an icon. This image is intended for display in a credential chooser. The URL must be accessible without authentication.</dd>
+ <dd>A {{domxref("USVString")}} containing a URL pointing to an image for an icon. This image is intended for display in a credential chooser. The URL must be accessible without authentication.</dd>
  <dt>{{domxref("PasswordCredential.name")}} {{readonlyinline}}{{securecontext_inline}}</dt>
  <dd>A {{domxref("USVString")}} containing a human-readable public name for display in a credential chooser.</dd>
- <dt>{{domxref("PasswordCredential.password")}} {{readonlyinline}}{{securecontext_inline}}</dt>
+ <dt>{{domxref("PasswordCredential.password")}}{{readonlyinline}}{{securecontext_inline}}</dt>
  <dd>A {{domxref("USVString")}} containing the password of the credential.</dd>
 </dl>
 

--- a/files/en-us/web/api/passwordcredential/name/index.html
+++ b/files/en-us/web/api/passwordcredential/name/index.html
@@ -11,21 +11,21 @@ tags:
 - credential management
 browser-compat: api.PasswordCredential.name
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>name</code></strong> read-only property of
+<p>The <strong><code>name</code></strong> read-only property of
     the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVSTring")}}
-    containing a human-readable public name for display in a credential chooser.</span>
+    containing a human-readable public name for display in a credential chooser.
 </p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>name</em> =<em>passwordCredential</em>.name</pre>
+  class="brush: js"><em>name</em> = <em>passwordCredential</em>.name</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("USVString")}} containing a name.</p>
+<p>A {{domxref("USVString")}} containing a name.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/passwordcredential/password/index.html
+++ b/files/en-us/web/api/passwordcredential/password/index.html
@@ -11,20 +11,20 @@ tags:
 - credential management
 browser-compat: api.PasswordCredential.password
 ---
-<p>{{SeeCompatTable}}{{APIRef("")}}</p>
+<p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>password</code></strong> read-only property
+<p>The <strong><code>password</code></strong> read-only property
     of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
-    containing the password of the credential.</span></p>
+    containing the password of the credential.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>password</em> =<em>passwordCredential</em>.password</pre>
+  class="brush: js"><em>password</em> = <em>passwordCredential</em>.password</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("USVString")}} containing a password.</p>
+<p>A {{domxref("USVString")}} containing a password.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.html
@@ -1,5 +1,5 @@
 ---
-title: PasswordCredential
+title: PasswordCredential()
 slug: Web/API/PasswordCredential/PasswordCredential
 tags:
   - API
@@ -10,10 +10,10 @@ tags:
   - credential management
 browser-compat: api.PasswordCredential.PasswordCredential
 ---
-<p>{{APIRef("")}}{{Non-standard_header}}</p>
+<p>{{APIRef("Credential Management API")}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The <strong><code>PasswordCredential</code></strong>
-    constructor creates a new {{domxref("PasswordCredential")}} object.</span> In
+<p>The <strong><code>PasswordCredential()</code></strong>
+    constructor creates a new {{domxref("PasswordCredential")}} object. In
   supporting browsers, an instance of this class may be passed the <code>credential</code>
   from the <code>init</code> object for global {{domxref('WindowOrWorkerGlobalScope.fetch')}}.</p>
 
@@ -27,7 +27,7 @@ var myCredential = new PasswordCredential(HTMLFormElement)</pre>
 <p>Either of the following:</p>
 
 <dl>
-  <dt><em>passwordCredentialData</em> </dt>
+  <dt><em>passwordCredentialData</em></dt>
   <dd>A PasswordCredentialData dictionary containing the following fields:
     <ul>
       <li><code>iconURL</code>: (Optional) the URL of a user's avatar image.</li>
@@ -37,15 +37,15 @@ var myCredential = new PasswordCredential(HTMLFormElement)</pre>
     </ul>
   </dd>
   <dt><em>htmlFormElement</em></dt>
-  <dd>A reference to an {{domxref("HTMLFormElement")}} with appropriate input fields. The
+  <dd>A reference to an {{domxref("HTMLFormElement")}} with appropriate input fields. The
     form should, at the very least, contain an id and password. It could also require a
     CSRF token.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
 
-<p>This example shows how to set up an {{domxref("HTMLFormElement")}} to caputure data
-  which we'll use to create a {{domxref("PasswordCredential")}} object.</p>
+<p>This example shows how to set up an {{domxref("HTMLFormElement")}} to caputure data
+  which we'll use to create a {{domxref("PasswordCredential")}} object.</p>
 
 <p>Starting with the form element.</p>
 
@@ -56,7 +56,7 @@ var myCredential = new PasswordCredential(HTMLFormElement)</pre>
 &lt;/form&gt;</pre>
 
 <p>Then, a reference to this form element, using it to create
-  a {{domxref("PasswordCredential")}} object, and storing it in the browser's password
+  a {{domxref("PasswordCredential")}} object, and storing it in the browser's password
   system.</p>
 
 <pre class="brush: js">var form = document.querySelector('#form');


### PR DESCRIPTION
I went a bit of rabbit hole here: initially I just wanted to fix two `<h2>` that weren't showing because of a useless `<div>`. (I detected this while checking the new spec table).

Finally:
- I added the missing sidebars
- Removed the gremlins
- Corrected a couple of grammar errors.

Nothing big.