### PR TITLE
Improve spec msgs for Metadata.*

### DIFF
--- a/files/en-us/web/api/metadata/index.html
+++ b/files/en-us/web/api/metadata/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Metadata
 ---
 <p>{{ APIRef("File System API") }}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
-<p>The <strong><code>Metadata</code></strong> interface is used by the File and Directory Entries API to contain information about a file system entry. This metadata includes the file's size and modification date and time.</p>
+<p>The <strong><code>Metadata</code></strong> interface is used by the <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory Entries API</a> to contain information about a file system entry. This metadata includes the file's size and modification date and time.</p>
 
 <div class="note">
 <p>This interface isn't available through the global scope; instead, you obtain a <code>Metadata</code> object describing a {{domxref("FileSystemEntry")}} using the method {{domxref("FileSystemEntry.getMetadata()")}}.</p>
@@ -31,8 +31,6 @@ browser-compat: api.Metadata
 </dl>
 
 <h2 id="Specifications">Specifications</h2>
-
-{{Specifications}}
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/metadata/modificationtime/index.html
+++ b/files/en-us/web/api/metadata/modificationtime/index.html
@@ -16,10 +16,10 @@ browser-compat: api.Metadata.modificationTime
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The read-only <strong><code>modificationTime</code></strong>
+<p>The read-only <strong><code>modificationTime</code></strong>
     property of the {{domxref("Metadata")}} interface is a {{jsxref("Date")}} object which
     specifies the date and time the file system entry (or the data referenced by the
-    entry) was last modified.</span>A file system entry is considered to have been
+    entry) was last modified. A file system entry is considered to have been
   modified if the metadata or the contents of the referenced file (or directory, or
   whatever other kind of file system entry might exist on the platform in use) has
   changed.</p>
@@ -52,6 +52,8 @@ browser-compat: api.Metadata.modificationTime
     }
   });
 }, handleError); </pre>
+
+<h2 id="Specifications">Specifications</h2>
 
 <p>This API has no official W3C or WHATWG specification.</p>
 

--- a/files/en-us/web/api/metadata/size/index.html
+++ b/files/en-us/web/api/metadata/size/index.html
@@ -16,9 +16,9 @@ browser-compat: api.Metadata.size
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The read-only <strong><code>size</code></strong> property of
+<p>The read-only <strong><code>size</code></strong> property of
     the {{domxref("Metadata")}} interface specifies the size, in bytes, of the referenced
-    file or other file system object on disk.</span></p>
+    file or other file system object on disk.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -44,6 +44,8 @@ browser-compat: api.Metadata.size
   });
 }, handleError);
 </pre>
+
+<h2 id="Specifications">Specifications</h2>
 
 <p>This API has no official W3C or WHATWG specification.</p>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Here I remove the {{Specifications}} macros and the text below was clear. I cleaned a bit the children (missing `<h2>`, old seosummary, …)