### PR TITLE
Fix no-spec msg for SpeechGrammar() (and clean-up)

### DIFF
--- a/files/en-us/web/api/speechgrammar/index.html
+++ b/files/en-us/web/api/speechgrammar/index.html
@@ -21,7 +21,7 @@ browser-compat: api.SpeechGrammar
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{domxref("SpeechGrammar.SpeechGrammar()")}} {{non-standard_inline}}</dt>
+ <dt>{{domxref("SpeechGrammar.SpeechGrammar()", "SpeechGrammar()")}} {{non-standard_inline}}</dt>
  <dd>Creates a new <code>SpeechGrammar</code> object.</dd>
 </dl>
 

--- a/files/en-us/web/api/speechgrammar/speechgrammar/index.html
+++ b/files/en-us/web/api/speechgrammar/speechgrammar/index.html
@@ -1,5 +1,5 @@
 ---
-title: SpeechGrammar.SpeechGrammar()
+title: SpeechGrammar()
 slug: Web/API/SpeechGrammar/SpeechGrammar
 tags:
 - API
@@ -14,7 +14,7 @@ browser-compat: api.SpeechGrammar.SpeechGrammar
 ---
 <p>{{APIRef("Web Speech API")}}{{Non-standard_header}}</p>
 
-<p>The <code><strong>SpeechGrammar</strong></code> constructor of the
+<p>The <code><strong>SpeechGrammar()</strong></code> constructor of the
 	{{domxref("SpeechGrammar")}} interface creates a new <code>SpeechGrammar</code> object
 	instance.</p>
 
@@ -42,7 +42,7 @@ speechRecognitionList[1] = newGrammar; // should add the new SpeechGrammar objec
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This API has no official W3C or WHATWG specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

As it is clearly an experimental feature (not in the spec, behind a prefix) and the only on this interface, I just added the same message as in `Metadata`, with no further information.

Here I remove the {{Specifications}} macros and replace it by the text. I cleaned a bit the name of the ctor too, in that file and the interface page, to follow our convention.