### PR TITLE
Update no-spec msg for Text.replaceWholeText

### DIFF
--- a/files/en-us/web/api/text/replacewholetext/index.html
+++ b/files/en-us/web/api/text/replacewholetext/index.html
@@ -20,23 +20,26 @@ browser-compat: api.Text.replaceWholeText
   if one of the text nodes being replaced is read only.</p>
 
 <p>This method returns the text node which received the replacement text, or
-  <code>null</code> if the replacement text is an empty string.  The returned node is the
+  <code>null</code> if the replacement text is an empty string. The returned node is the
   current node unless the current node is read only, in which case the returned node is a
   newly created text node of the same type which has been inserted at the location of the
   replacement.</p>
+
+  <div class="notecard note">
+    <p><strong>Note:</strong> In order to achieve a similar effect in modern browsers,
+      consider using {{domxref("Node.textContent")}} or {{domxref("Element.innerHTML")}}.</p>
+  </div>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
   class="brush: js"><em>replacementNode</em> = <em>textnode</em>.replaceWholeText(content) </pre>
 
-<h2 id="Example">Example</h2>
-
-<p>See the example for the {{domxref("Text.wholeText")}} property.</p>
-
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was originally present in the DOM specification. It has been removed and this feature is no longer on track to become a standard.</p>
+
+<p>Instead, consider using algorithms based on {{domxref("Node.textContent")}} or {{domxref("Element.innerHTML")}}.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/text/wholetext/index.html
+++ b/files/en-us/web/api/text/wholetext/index.html
@@ -10,7 +10,7 @@ browser-compat: api.Text.wholeText
 ---
 <p>{{ apiref("DOM") }}</p>
 
-<p><span class="seoSummary">The <strong><code>Text.wholeText</code></strong> read-only property returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node.</span> The text is concatenated in document order.  This allows to specify any text node and obtain all adjacent text as a single string.</p>
+<p>The <strong><code>Text.wholeText</code></strong> read-only property returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node. The text is concatenated in document order. This allows to specify any text node and obtain all adjacent text as a single string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -48,24 +48,6 @@ browser-compat: api.Text.wholeText
 </pre>
 
 <p><code>wholeText</code> is just a property of text nodes that returns the string of data making up all the adjacent (i.e. not separated by an element boundary) text nodes combined.</p>
-
-<p>Now let’s return to our original problem. What we want is to be able to <em>replace</em> the whole text with new text. That’s where {{domxref("Text.replaceWholeText", "replaceWholeText()")}} comes in:</p>
-
-<pre class="brush: js">para.firstChild.replaceWholeText("Thru-hiking is great, but ");
-</pre>
-
-<p>We’re removing every adjacent text node (all the ones that constituted the whole text) but the one on which <code>replaceWholeText()</code> is called, and we’re changing the remaining one to the new text. What we have now is this:</p>
-
-<pre class="brush: html">&lt;p&gt;Thru-hiking is great, but &lt;a
-  href="https://en.wikipedia.org/wiki/Absentee_ballot"&gt;casting a
-  ballot&lt;/a&gt; is tricky.&lt;/p&gt;
-</pre>
-
-<p>Some uses of the whole-text functionality may be better served by using <code>Node.textContent</code>, or the longstanding {{domxref("Element.innerHTML")}}; that’s fine and probably clearer in most circumstances. If you have to work with mixed content within an element, as seen here, <code>wholeText</code> and <span class="internal"><code>replaceWholeText()</code></span> may be useful.</p>
-
-<div class="notecard warning">
-<p><span class="internal"><code>replaceWholeText()</code></span> <a href="/en-US/docs/Web/API/Text/replaceWholeText">is obsolete</a>.</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/text/wholetext/index.html
+++ b/files/en-us/web/api/text/wholetext/index.html
@@ -10,7 +10,7 @@ browser-compat: api.Text.wholeText
 ---
 <p>{{ apiref("DOM") }}</p>
 
-<p>The <strong><code>Text.wholeText</code></strong> read-only property returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node. The text is concatenated in document order. This allows to specify any text node and obtain all adjacent text as a single string.</p>
+<p>The <strong><code>Text.wholeText</code></strong> read-only property returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node. The text is concatenated in document order. This allows specifying any text node and obtaining all adjacent text as a single string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `Text.replaceWholeText()` here.

I removed the {{Specifications}} macros and replaced it by a text. I also added a note at the top.
I removed the example (that was a link to another page), and shortened the example on that page not to use the deprecated method.