### PR TITLE
Update no-spec msg for *.expandEntityReferences

### DIFF
--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -36,7 +36,8 @@ expand = nodeIterator.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range Specification</a>, but removed from later DOM versions.
+  This feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -36,7 +36,7 @@ expand = nodeIterator.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range Specification</a>, but removed from later DOM versions.
+<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range</a>, but is absent in the current DOM specification.
   This feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -36,7 +36,7 @@ expand = treeWalker.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range Specification</a>, but removed from later DOM versions.
+<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range</a>, but is absent in the current DOM specification.
   This feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -36,7 +36,8 @@ expand = treeWalker.expandEntityReferences;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was originally a part of <a href="https://www.w3.org/TR/DOM-Level-2-Traversal-Range/">DOM Level 2 Traversal and Range Specification</a>, but removed from later DOM versions.
+  This feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `TreeWalker.replaceWholeText()` and `NodeIterator.replaceWholeText()` here.

Given that the most useful info I found about dropping them was

<img width="446" alt="Screenshot 2021-06-21 at 16 37 39" src="https://user-images.githubusercontent.com/1466293/122786080-35978200-d2b4-11eb-8123-726fcb03b5f4.png">

I opted for a simple update: I removed the {{Specifications}} macro and replaced it by a text explaining it has been drop from the DOM standard.