### PR TITLE
Adding the property pages for CSSCounterStyleRule

### DIFF
--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.html
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.html
@@ -1,0 +1,45 @@
+---
+title: CSSCounterStyleRule.additiveSymbols
+slug: Web/API/CSSCounterStyleRule/additiveSymbols
+tags:
+  - API
+  - Property
+  - Reference
+  - additiveSymbols
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.additiveSymbols
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>additiveSymbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface  gets and sets the value of the {{cssxref("@counter-style/additive-symbols","additive-symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let additiveSymbols = CSSCounterStyleRule.additiveSymbols;
+CSSCounterStyleRule.additiveSymbols = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>additiveSymbols</code> gives us the value " V 5, IV 4, I 1".</p>
+
+<pre class="brush: css">@counter-style additive-symbols-example {
+  system: additive;
+  additive-symbols: V 5, IV 4, I 1;
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].additiveSymbols); // " V 5, IV 4, I 1"</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.html
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.html
@@ -1,0 +1,47 @@
+---
+title: CSSCounterStyleRule.fallback
+slug: Web/API/CSSCounterStyleRule/fallback
+tags:
+  - API
+  - Property
+  - Reference
+  - fallback
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.fallback
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>fallback</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/fallback","fallback")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let fallback = CSSCounterStyleRule.fallback;
+CSSCounterStyleRule.fallback = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>fallback</code> gives us the value "disc".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+  fallback: disc;
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].fallback); // "disc" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.html
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.html
@@ -24,7 +24,7 @@ CSSCounterStyleRule.fallback = a;
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>fallback</code> gives us the value "disc".</p>
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>fallback</code> gives us the value "disc".</p>
 
 <pre class="brush: css">@counter-style box-corner {
   system: fixed;
@@ -43,5 +43,4 @@ console.log(myRules[0].fallback); // "disc" </pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/csscounterstylerule/index.html
+++ b/files/en-us/web/api/csscounterstylerule/index.html
@@ -10,11 +10,7 @@ browser-compat: api.CSSCounterStyleRule
 ---
 <p>{{APIRef("CSS Counter Styles")}}</p>
 
-<p>The <strong><code>CSSCounterStyleRule</code></strong> {{glossary("interface")}} represents an {{CSSxRef("@counter-style")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>.</p>
-
-<h2 id="Inheritance">Inheritance</h2>
-
-<p>This interface inherits from the following parent interfaces:</p>
+<p>The <strong><code>CSSCounterStyleRule</code></strong> interface represents an {{CSSxRef("@counter-style")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>.</p>
 
 <p>{{InheritanceDiagram}}</p>
 
@@ -24,27 +20,27 @@ browser-compat: api.CSSCounterStyleRule
 
 <dl>
  <dt>{{DOMxRef("CSSCounterStyleRule.name")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("&lt;counter-style-name&gt;")}} defined for the associated rule.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the <code>name</code> for the associated rule.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.system")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.symbols")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.additiveSymbols")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.negative")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.prefix")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.suffix")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.range")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.pad")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.speakAs")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
  <dt>{{DOMxRef("CSSCounterStyleRule.fallback")}}</dt>
- <dd>Is a {{DOMxRef("DOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
+ <dd>Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/csscounterstylerule/name/index.html
+++ b/files/en-us/web/api/csscounterstylerule/name/index.html
@@ -1,0 +1,47 @@
+---
+title: CSSCounterStyleRule.name
+slug: Web/API/CSSCounterStyleRule/name
+tags:
+  - API
+  - Property
+  - Reference
+  - name
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.name
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>name</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the <code>name</code> for the associated rule.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let name = CSSCounterStyleRule.name;
+CSSCounterStyleRule.name = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>name</code> gives us the custom ident "box-corner".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+  fallback: disc;
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].name); // "box-corner" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/negative/index.html
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.html
@@ -1,0 +1,47 @@
+---
+title: CSSCounterStyleRule.negative
+slug: Web/API/CSSCounterStyleRule/negative
+tags:
+  - API
+  - Property
+  - Reference
+  - negative
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.negative
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>negative</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/negative","negative")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let negative = CSSCounterStyleRule.negative;
+CSSCounterStyleRule.negative = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>negative</code> gives us the value "-".</p>
+
+<pre class="brush: css">@counter-style neg {
+  system: numeric;
+  symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
+  negative: "-";
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].negative); // "-" </pre>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/pad/index.html
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.html
@@ -24,7 +24,7 @@ CSSCounterStyleRule.pad = a;
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>pad</code> gives us the value "0".</p>
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>pad</code> gives us the value "0".</p>
 
 <pre class="brush: css">@counter-style box-corner {
   system: numeric;
@@ -42,5 +42,4 @@ console.log(myRules[0].pad); // "0" </pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/csscounterstylerule/pad/index.html
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.html
@@ -1,0 +1,46 @@
+---
+title: CSSCounterStyleRule.pad
+slug: Web/API/CSSCounterStyleRule/pad
+tags:
+  - API
+  - Property
+  - Reference
+  - pad
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.pad
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>pad</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/pad", "pad")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let pad = CSSCounterStyleRule.pad;
+CSSCounterStyleRule.pad = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>pad</code> gives us the value "0".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: numeric;
+  symbols: "0" "1" "2" "3" "4" "5";
+  pad: 2 "0";
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].pad); // "0" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.html
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.html
@@ -1,0 +1,46 @@
+---
+title: CSSCounterStyleRule.prefix
+slug: Web/API/CSSCounterStyleRule/prefix
+tags:
+  - API
+  - Property
+  - Reference
+  - prefix
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.prefix
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>prefix</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/prefix","prefix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let prefix = CSSCounterStyleRule.prefix;
+CSSCounterStyleRule.prefix = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>prefix</code> gives us the value "Chapter ".</p>
+
+<pre class="brush: css">@counter-style chapters {
+  system: numeric;
+  symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
+  prefix: 'Chapter ';
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].prefix); // "Chapter " </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/range/index.html
+++ b/files/en-us/web/api/csscounterstylerule/range/index.html
@@ -1,0 +1,44 @@
+---
+title: CSSCounterStyleRule.range
+slug: Web/API/CSSCounterStyleRule/range
+tags:
+  - API
+  - Property
+  - Reference
+  - range
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.range
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>range</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/range","range")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let range = CSSCounterStyleRule.range;
+CSSCounterStyleRule.range = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>range</code> gives us the value "2 4, 7 9".</p>
+
+<pre class="brush: css">@counter-style range-multi-example {
+  system: cyclic;
+  symbols: "\25A0" "\25A1";
+  range: 2 4, 7 9;
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].range); // "2 4, 7 9" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.html
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.html
@@ -1,0 +1,45 @@
+---
+title: CSSCounterStyleRule.speakAs
+slug: Web/API/CSSCounterStyleRule/speakAs
+tags:
+  - API
+  - Property
+  - Reference
+  - speakAs
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.speakAs
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>speakAs</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/speak-as","speak-as")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let speakAs = CSSCounterStyleRule.speakAs;
+CSSCounterStyleRule.speakAs = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>speakAs</code> gives us the value "bullets".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+  speak-as: "bullets";
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].speakAs); // "bullets" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.html
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.html
@@ -1,0 +1,47 @@
+---
+title: CSSCounterStyleRule.suffix
+slug: Web/API/CSSCounterStyleRule/suffix
+tags:
+  - API
+  - Property
+  - Reference
+  - suffix
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.suffix
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>suffix</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/suffix","suffix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let suffix = CSSCounterStyleRule.suffix;
+CSSCounterStyleRule.suffix = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>suffix</code> gives us the value ": ".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+  negative: "-";
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].suffix); // ": " </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.html
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.html
@@ -1,0 +1,47 @@
+---
+title: CSSCounterStyleRule.symbols
+slug: Web/API/CSSCounterStyleRule/symbols
+tags:
+  - API
+  - Property
+  - Reference
+  - symbols
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.symbols
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>symbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/symbols","symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let symbols = CSSCounterStyleRule.symbols;
+CSSCounterStyleRule.symbols = a;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>symbols</code> gives us the value "◰ ◳ ◲ ◱".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+  negative: "-";
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].symbols); // "◰ ◳ ◲ ◱" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/csscounterstylerule/system/index.html
+++ b/files/en-us/web/api/csscounterstylerule/system/index.html
@@ -1,0 +1,43 @@
+---
+title: CSSCounterStyleRule.system
+slug: Web/API/CSSCounterStyleRule/system
+tags:
+  - API
+  - Property
+  - Reference
+  - system
+  - CSSCounterStyleRule
+browser-compat: api.CSSCounterStyleRule.system
+---
+<div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
+
+<p class="summary">The <strong><code>system</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/system", "system")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let system = CSSCounterStyleRule.system;
+CSSCounterStyleRule.system = a;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSOMString")}}</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows a {{cssxref("@counter-style")}} rule. In JavaScript, <code>myRules[0]</code> is this <code>@counter-style</code> rule, returning <code>system</code> gives us the value "fixed".</p>
+
+<pre class="brush: css">@counter-style box-corner {
+  system: fixed;
+  symbols: ◰ ◳ ◲ ◱;
+  suffix: ': ';
+}</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].system); // "fixed" </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
I'm trying to make sure the things we've recently documented on the CSS side at MDN also get updated on the CSS API side, so this is the `CSSCounterStyleRule` property pages.

It looks like the BCD doesn't have the individual spec lines included, so I'll go add those next so that the spec tables show up.
