### PR TITLE
Update no-spec msg for PaymentCurrencyAmount.currencySystem

### DIFF
--- a/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
@@ -18,20 +18,20 @@ browser-compat: api.PaymentCurrencyAmount.currencySystem
 ---
 <p> {{APIRef("Payment Request API")}} {{Deprecated_Header}}</p>
 
-<div class="notecard warning">
-  <h4>Warning</h4>
-  <p>This property has been removed from the specification and should no longer be used;
-    the currency is now <em>always</em> specified using ISO 4127.</p>
-</div>
-
 <p>{{securecontext_header}}</p>
 
-<p><span class="seoSummary">The <em>obsolete</em> {{domxref("PaymentCurrencyAmount")}}
+<p>The <em>obsolete</em> {{domxref("PaymentCurrencyAmount")}}
     property <strong><code>currencySystem</code></strong> is a string which specifies the
     standard being used to specify the {{domxref("PaymentCurrencyAmount.currency",
     "currency")}} the {{domxref("PaymentCurrencyAmount.value", "value")}} is specified
     in.</span> For example, the default is <code>urn:iso:std:iso:4217</code>, which
   specifies that the standard used is {{interwiki("wikipedia", "ISO 4217")}}.</p>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This property has been removed from the specification and should no longer be used;
+    the currency is now <em>always</em> specified using ISO 4127.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -45,13 +45,13 @@ browser-compat: api.PaymentCurrencyAmount.currencySystem
   represented. The default, <code>urn:iso:std:iso:4217</code>, indicates the <a
     href="https://www.iso.org/iso-4217-currency-codes.html">ISO 4217</a> standard.</p>
 
-<p>This obsolete property was removed in the <a
-    href="https://www.w3.org/TR/2018/CR-payment-request-20180503">May 3, 2018 update</a>
-  of the Payment Request API specification.</p>
+
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was removed in the <a
+  href="https://www.w3.org/TR/2018/CR-payment-request-20180503">May 3, 2018 update</a>
+of the Payment Request API specification. This feature is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `PaymentCurrencyAmount.currencySystem` here.

I removed the {{Specifications}} macros and replaced it the text that was above (with a little addition). I also moved the note at the top to make it more visible.