### PR TITLE
Update no-spec msg for PerformanceTiming.*

### DIFF
--- a/files/en-us/web/api/performancetiming/connectend/index.html
+++ b/files/en-us/web/api/performancetiming/connectend/index.html
@@ -37,7 +37,8 @@ browser-compat: api.PerformanceTiming.connectEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.html
+++ b/files/en-us/web/api/performancetiming/connectstart/index.html
@@ -37,7 +37,8 @@ browser-compat: api.PerformanceTiming.connectStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.domainLookupEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.domainLookupStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.html
@@ -36,7 +36,8 @@ browser-compat: api.PerformanceTiming.domComplete
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
@@ -34,7 +34,8 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.html
@@ -43,7 +43,8 @@ browser-compat: api.PerformanceTiming.domInteractive
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/domloading/index.html
+++ b/files/en-us/web/api/performancetiming/domloading/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.domLoading
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.fetchStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/index.html
+++ b/files/en-us/web/api/performancetiming/index.html
@@ -39,43 +39,43 @@ browser-compat: api.PerformanceTiming
  <dd>When the prompt for unload terminates on the previous document in the same browsing context. If there is no previous document, this value will be the same as <code>PerformanceTiming.fetchStart</code>.</dd>
  <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.unloadEventStart")}} {{readonlyInline}}</dt>
  <dd>When the {{event("unload")}} event has been thrown, indicating the time at which the previous document in the window began to unload. If there is no previous document, or if the previous document or one of the needed redirects is not of the same origin, the value returned is <code>0</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.unloadEventEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.unloadEventEnd")}} {{readonlyInline}}</dt>
  <dd>When the {{event("unload")}} event handler finishes. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is <code>0</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.redirectStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.redirectStart")}} {{readonlyInline}}</dt>
  <dd>When the first HTTP redirect starts. If there is no redirect, or if one of the redirects is not of the same origin, the value returned is <code>0</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.redirectEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.redirectEnd")}} {{readonlyInline}}</dt>
  <dd>When the last HTTP redirect is completed, that is when the last byte of the HTTP response has been received. If there is no redirect, or if one of the redirects is not of the same origin, the value returned is <code>0</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.fetchStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.fetchStart")}} {{readonlyInline}}</dt>
  <dd>When the browser is ready to fetch the document using an HTTP request. This moment is <em>before</em> the check to any application cache.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domainLookupStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domainLookupStart")}} {{readonlyInline}}</dt>
  <dd>When the domain lookup starts. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as <code>PerformanceTiming.fetchStart</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domainLookupEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domainLookupEnd")}} {{readonlyInline}}</dt>
  <dd>When the domain lookup is finished. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as <code>PerformanceTiming.fetchStart</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.connectStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.connectStart")}} {{readonlyInline}}</dt>
  <dd>When the request to open a connection is sent to the network. If the transport layer reports an error and the connection establishment is started again, the last connection establishment start time is given. If a persistent connection is used, the value will be the same as <code>PerformanceTiming.fetchStart</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.connectEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.connectEnd")}} {{readonlyInline}}</dt>
  <dd>When the connection is opened network. If the transport layer reports an error and the connection establishment is started again, the last connection establishment end time is given. If a persistent connection is used, the value will be the same as <code>PerformanceTiming.fetchStart</code>. A connection is considered as opened when all secure connection handshake, or SOCKS authentication, is terminated.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.secureConnectionStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.secureConnectionStart")}} {{readonlyInline}}</dt>
  <dd>When the secure connection handshake starts. If no such connection is requested, it returns <code>0</code>.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.requestStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.requestStart")}} {{readonlyInline}}</dt>
  <dd>When the browser sent the request to obtain the actual document, from the server or from a cache. If the transport layer fails after the start of the request and the connection is reopened, this property will be set to the time corresponding to the new request.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.responseStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.responseStart")}} {{readonlyInline}}</dt>
  <dd>When the browser received the first byte of the response, from the server from a cache, or from a local resource.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.responseEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.responseEnd")}} {{readonlyInline}}</dt>
  <dd>When the browser received the last byte of the response, or when the connection is closed if this happened first, from the server, the cache, or from a local resource.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domLoading")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domLoading")}} {{readonlyInline}}</dt>
  <dd>When the parser started its work, that is when its {{domxref("Document.readyState")}} changes to <code>'loading'</code> and the corresponding {{event("readystatechange")}} event is thrown.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domInteractive")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domInteractive")}} {{readonlyInline}}</dt>
  <dd>When the parser finished its work on the main document, that is when its {{domxref("Document.readyState")}} changes to <code>'interactive'</code> and the corresponding {{event("readystatechange")}} event is thrown.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domContentLoadedEventStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domContentLoadedEventStart")}} {{readonlyInline}}</dt>
  <dd>Right before the parser sent the {{event("DOMContentLoaded")}} event, that is right after all the scripts that need to be executed right after parsing have been executed.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domContentLoadedEventEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domContentLoadedEventEnd")}} {{readonlyInline}}</dt>
  <dd>Right after all the scripts that need to be executed as soon as possible, in order or not, have been executed.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.domComplete")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.domComplete")}} {{readonlyInline}}</dt>
  <dd>When the parser finished its work on the main document, that is when its {{domxref("Document.readyState")}} changes to <code>'complete'</code> and the corresponding {{event("readystatechange")}} event is thrown.</dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.loadEventStart")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.loadEventStart")}} {{readonlyInline}}</dt>
  <dd>When the {{event("load")}} event was sent for the current document. If this event has not yet been sent, it returns <code>0.</code></dd>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.loadEventEnd")}} {{readonlyInline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.loadEventEnd")}} {{readonlyInline}}</dt>
  <dd>When the {{event("load")}} event handler terminated, that is when the load event is completed. If this event has not yet been sent, or is not yet completed, it returns <code>0.</code></dd>
 </dl>
 
@@ -84,13 +84,14 @@ browser-compat: api.PerformanceTiming
 <p><em>The <code>PerformanceTiming</code></em> <em>interface doesn't inherit any methods.</em></p>
 
 <dl>
- <dt>{{deprecated_inline}}  {{domxref("PerformanceTiming.toJSON()")}} {{non-Standard_Inline}}</dt>
+ <dt>{{deprecated_inline}} {{domxref("PerformanceTiming.toJSON()")}} {{non-Standard_Inline}}</dt>
  <dd>Returns a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON">JSON object</a> representing this <code>PerformanceTiming</code> object.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.html
@@ -36,7 +36,8 @@ browser-compat: api.PerformanceTiming.loadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.html
@@ -34,7 +34,8 @@ browser-compat: api.PerformanceTiming.loadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/navigationstart/index.html
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.html
@@ -36,7 +36,8 @@ browser-compat: api.PerformanceTiming.navigationStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectend/index.html
+++ b/files/en-us/web/api/performancetiming/redirectend/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.redirectEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.redirectStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/requeststart/index.html
+++ b/files/en-us/web/api/performancetiming/requeststart/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.requestStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/responseend/index.html
+++ b/files/en-us/web/api/performancetiming/responseend/index.html
@@ -35,7 +35,8 @@ browser-compat: api.PerformanceTiming.responseEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/responsestart/index.html
+++ b/files/en-us/web/api/performancetiming/responsestart/index.html
@@ -34,7 +34,8 @@ browser-compat: api.PerformanceTiming.responseStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
@@ -33,7 +33,8 @@ browser-compat: api.PerformanceTiming.secureConnectionStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.html
@@ -34,7 +34,8 @@ browser-compat: api.PerformanceTiming.unloadEventEnd
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.html
@@ -34,7 +34,8 @@ browser-compat: api.PerformanceTiming.unloadEventStart
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `PerformanceTiming.*` here.

I removed the {{Specifications}} macros and replaced it with a text. Same text in all pages (22 pages).