### PR TITLE
remove use of mdn.mozillademos.org

### DIFF
--- a/files/en-us/games/techniques/crisp_pixel_art_look/index.html
+++ b/files/en-us/games/techniques/crisp_pixel_art_look/index.html
@@ -82,7 +82,7 @@ image.onload = function () {
     // draw the image into the canvas
     ctx.drawImage(image, 0, 0);
 }
-image.src = 'https://mdn.mozillademos.org/files/12640/cat.png';</pre>
+image.src = 'cat.png';</pre>
 
 <p>This code used together produces the following result:</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Lots of samples use the deprecated https://mdn.mozillademos.org/files/... URLs.

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

See existing ongoing work: https://github.com/mdn/content/pulls?q=is%3Apr+is%3Aclosed+mdn.mozillademos.org