### PR TITLE
[Markdown] Replace tables with pre blocks

### DIFF
--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
@@ -120,24 +120,7 @@ public class WebSocket {
 
 <p>If we send "abcdef", we get these bytes:</p>
 
-<table>
- <tbody>
-  <tr>
-   <td>129</td>
-   <td>134</td>
-   <td>167</td>
-   <td>225</td>
-   <td>225</td>
-   <td>210</td>
-   <td>198</td>
-   <td>131</td>
-   <td>130</td>
-   <td>182</td>
-   <td>194</td>
-   <td>135</td>
-  </tr>
- </tbody>
-</table>
+<pre>129 134 167 225 225 210 198 131 130 182 194 135</pre>
 
 <p>- 129:</p>
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.html
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.html
@@ -169,21 +169,7 @@ if (Regex.IsMatch(data, "^GET")) {
 
 <p>If we send "MDN", we get these bytes:</p>
 
-<table>
- <tbody>
-  <tr>
-   <td>129</td>
-   <td>131</td>
-   <td>61</td>
-   <td>84</td>
-   <td>35</td>
-   <td>6</td>
-   <td>112</td>
-   <td>16</td>
-   <td>109</td>
-  </tr>
- </tbody>
-</table>
+<pre>129 131 61 84 35 6 112 16 109</pre>
 
 <p>Let's take a look at what these bytes mean.</p>
 


### PR DESCRIPTION
This is related to https://github.com/mdn/yari/issues/3783 in which I tried to find tables that might be badly affected by making `standard-table` the default style for our tables.

That issue found three tables that use tables for a particular formatting style, that should probably use something else:

https://developer.mozilla.org/en-US/docs/web/api/webglrenderingcontext/vertexattribpointer
https://developer.mozilla.org/en-US/docs/web/api/websockets_api/writing_a_websocket_server_in_java
https://developer.mozilla.org/en-US/docs/web/api/websockets_api/writing_websocket_server

I already replaced the first with an SVG diagram (https://github.com/mdn/content/pull/5123/files), and this PR replaces with other two with a `pre` block, which seemed like a simpler approach that worked just as well in this case.
