### PR TITLE
Add note about Safari 14 on macOS desktop not being compatible

### DIFF
--- a/files/en-us/learn/performance/multimedia/index.html
+++ b/files/en-us/learn/performance/multimedia/index.html
@@ -82,7 +82,11 @@ tags:
 <p>Other formats improve on JPEG's capabilities in regards to compression, but are not available on every browser: </p>
 
 <ul>
- <li><a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a> — Excellent choice for both images and animated images. WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. (but not progressive display.). Supported by all major browsers except Safari.</li>
+ <li><a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a> — Excellent choice for both images and animated images. WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. (but not progressive display.). Supported by all major browsers except Safari 14 on macOS desktop.
+  <div class="notecard note">
+    <p><strong>Note:</strong> Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
+  </div>
+  </li>
  <li><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> — Good choice for both images and animated images due to high performance and royalty free image format (even more efficient that WebP, but not as widely supported). It is now supported on Chrome, Opera and Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>). See also <a href="https://avif-converter.online">an online tool to convert previous image formats to AVIF</a>.</li>
  <li><strong>JPEG-XR</strong> — created by Microsoft and only available in Internet Explorer and EdgeHTML based Edge. Doesn't support progressive display and the image decoding is not hardware accelerated and therefore resource-intensive on the browser's main thread. Progressive JPEG above-the-fold is that they render progressively (hence the name), meaning the user sees a low-resolution version that gains clarity as the image downloads, rather than the image loading at full resolution top-to-bottom or even only rendering once completely downloaded.</li>
  <li><strong>JPEG2000</strong> — once to be successor to JPEG but only supported in Safari. Doesn't support progressive display either.</li>


### PR DESCRIPTION
Fixes #6201

Despite the official note Safari 14 is not compatible with webp on macOS desktop. This is noted at the end of https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#webp

This moves that same note into the learn topic https://developer.mozilla.org/en-US/docs/Learn/Performance/Multimedia#the_most_optimal_format

So basically now it says supported on all major browsers except this one browser in the current version.