### PR TITLE
Pagemacro examplefix

### DIFF
--- a/files/en-us/web/api/element/mousedown_event/index.html
+++ b/files/en-us/web/api/element/mousedown_event/index.html
@@ -48,7 +48,7 @@ browser-compat: api.Element.mousedown_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/Element/mousemove_event", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/Element/mousemove_event#examples"><code>mousemove_event</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/element/mouseup_event/index.html
+++ b/files/en-us/web/api/element/mouseup_event/index.html
@@ -43,7 +43,7 @@ browser-compat: api.Element.mouseup_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/Element/mousemove_event", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/Element/mousemove_event#examples"><code>mousemove_event</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/gainnode/gain/index.html
+++ b/files/en-us/web/api/gainnode/gain/index.html
@@ -27,13 +27,13 @@ gainNode.gain.value = 0.5;
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: Though the <code>AudioParam</code> returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createGain","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createGain#example"><code>BaseAudioContext.createGain()</code></a> for example code showing how to use an <code>AudioContext</code> to create a <code>GainNode</code>, which is then used to mute and unmute the audio by changing the gain property value.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -64,7 +64,7 @@ browser-compat: api.GainNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createGain","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createGain#example"><code>BaseAudioContext.createGain()</code></a> for example code showing how to use an <code>AudioContext</code> to create a <code>GainNode</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.html
@@ -54,7 +54,7 @@ browser-compat: api.HTMLImageElement.naturalWidth
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/HTMLImageElement/naturalHeight", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/HTMLImageElement/naturalHeight#example"><code>HTMLImageElement.naturalHeight</code></a> for example code that displays an image in both its natural "density-adjusted" size, and in its rendered size as altered by the page's CSS and other factors.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlimageelement/y/index.html
+++ b/files/en-us/web/api/htmlimageelement/y/index.html
@@ -19,8 +19,7 @@ browser-compat: api.HTMLImageElement.y
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-    class="brush: js">let <em>imageY</em> = <em>htmlImageElement</em>.y;</pre>
+<pre class="brush: js">let <em>imageY</em> = <em>htmlImageElement</em>.y;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -48,7 +47,7 @@ browser-compat: api.HTMLImageElement.y
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/HTMLImageElement/x", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/HTMLImageElement/x#example"><code>HTMLImageElement.x</code></a> for example code that demonstrates the use of the <code>HTMLImageElement.y</code> (and <code>HTMLImageElement.x</code>).</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

In a bunch of examples (see commits) it replaces page macros inclusion with a link to the original examples.
