### PR TITLE
Removes shortcut string from rel links

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
@@ -189,7 +189,7 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."&gt;
 <ol>
  <li>Saving it in the same directory as the site's index page, saved in <code>.ico</code> format (most browsers will support favicons in more common formats like <code>.gif</code> or <code>.png</code>, but using the ICO format will ensure it works as far back as Internet Explorer 6.)</li>
  <li>Adding the following line into your HTML's {{HTMLElement("head")}} block to reference it:
-  <pre class="brush: html">&lt;link rel="shortcut icon" href="favicon.ico" type="image/x-icon"&gt;</pre>
+  <pre class="brush: html">&lt;link rel="icon" href="favicon.ico" type="image/x-icon"&gt;</pre>
  </li>
 </ol>
 
@@ -208,7 +208,7 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."&gt;
 &lt;!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --&gt;
 &lt;link rel="apple-touch-icon-precomposed" href="https://developer.mozilla.org/static/img/favicon57.png"&gt;
 &lt;!-- basic favicon --&gt;
-&lt;link rel="shortcut icon" href="https://developer.mozilla.org/static/img/favicon32.png"&gt;</pre>
+&lt;link rel="icon" href="https://developer.mozilla.org/static/img/favicon32.png"&gt;</pre>
 
 <p>The comments explain what each icon is used for — these elements cover things like providing a nice high resolution icon to use when the website is saved to an iPad's home screen.</p>
 

--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -346,7 +346,7 @@ tags:
   &lt;!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --&gt;
   &lt;link rel="apple-touch-icon-precomposed" href="/static/img/favicon57.de33179910ae.png"&gt;
   &lt;!-- basic favicon --&gt;
-  &lt;link rel="shortcut icon" href="/static/img/favicon32.7f3da72dcea1.png"&gt;</pre>
+  &lt;link rel="icon" href="/static/img/favicon32.7f3da72dcea1.png"&gt;</pre>
 	</dd>
 </dl>
 

--- a/files/en-us/web/html/link_types/index.html
+++ b/files/en-us/web/html/link_types/index.html
@@ -115,9 +115,14 @@ browser-compat: html.elements.link.rel
     <br>
     If there are multiple <code>&lt;link rel="icon"&gt;</code>s, the browser uses their {{HTMLAttrxRef("media","link")}}, {{HTMLAttrxRef("type","link")}}, and {{HTMLAttrxRef("sizes","link")}} attributes to select the most appropriate icon. If several icons are equally appropriate, the last one is used. If the most appropriate icon is later found to be inappropriate, for example because it uses an unsupported format, the browser proceeds to the next-most appropriate, and so on.<br>
     <br>
-    <strong>Note:</strong> Apple's iOS does not use this link type, nor the {{HTMLAttrxRef("sizes","link")}} attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder. Instead it uses the non-standard <a class="external external-icon" href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4"><code>apple-touch-icon</code></a> and <a class="external external-icon" href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6"><code>apple-touch-startup-image</code></a> respectively.<br>
-    <br>
-    The <code>shortcut</code> link type is often seen before <code>icon</code>, but this link type is non-conforming, ignored and <strong>web authors must not use it anymore</strong>.</td>
+    <div class="notecard note">
+      <p><strong>Note:</strong> Apple's iOS does not use this link type, nor the {{HTMLAttrxRef("sizes","link")}} attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder. Instead it uses the non-standard <a class="external external-icon" href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4"><code>apple-touch-icon</code></a> and <a class="external external-icon" href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6"><code>apple-touch-startup-image</code></a> respectively.</p>
+    </div>
+    
+    <div class="notecard warning">
+      <p><strong>Warning:</strong> The <code>shortcut</code> link type is often seen before <code>icon</code>, but this link type is non-conforming, ignored and <strong>web authors must not use it anymore</strong>.</p>
+    </div>
+    </td>
    <td>{{HTMLElement("link")}}</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}</td>
   </tr>

--- a/files/en-us/web/progressive_web_apps/app_structure/index.html
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.html
@@ -84,7 +84,7 @@ tags:
 	&lt;meta name="theme-color" content="#B12A34"&gt;
 	&lt;meta name="viewport" content="width=device-width, initial-scale=1"&gt;
 	&lt;meta property="og:image" content="icons/icon-512.png"&gt;
-	&lt;link rel="shortcut icon" href="favicon.ico"&gt;
+	&lt;link rel="icon" href="favicon.ico"&gt;
 	&lt;link rel="stylesheet" href="style.css"&gt;
 	&lt;link rel="manifest" href="js13kpwa.webmanifest"&gt;
 	&lt;script src="data/games.js" defer&gt;&lt;/script&gt;

--- a/files/en-us/web/progressive_web_apps/structural_overview/index.html
+++ b/files/en-us/web/progressive_web_apps/structural_overview/index.html
@@ -108,7 +108,7 @@ tags:
 	&lt;meta name="theme-color" content="#B12A34"&gt;
 	&lt;meta name="viewport" content="width=device-width, initial-scale=1"&gt;
 	&lt;meta property="og:image" content="icons/icon-512.png"&gt;
-	&lt;link rel="shortcut icon" href="favicon.ico"&gt;
+	&lt;link rel="icon" href="favicon.ico"&gt;
 	&lt;link rel="stylesheet" href="style.css"&gt;
 	&lt;link rel="manifest" href="js13kpwa.webmanifest"&gt;
 	&lt;script src="data/games.js" defer&gt;&lt;/script&gt;


### PR DESCRIPTION
Fixes #6209

The use of `shortcut` in `<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">` is 'strongly deprecated'. This removes all instances of this and also makes the note where it is mentioned more visible. 