### PR TITLE
Pagemacro more example fixes

### DIFF
--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.html
@@ -58,7 +58,7 @@ browser-compat: api.MediaElementAudioSourceNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createMediaElementSource","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext/createMediaElementSource#example"><code>AudioContext.createMediaElementSource()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/index.html
@@ -68,7 +68,7 @@ browser-compat: api.MediaSessionActionDetails
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/MediaSessionAction", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/MediaSessionAction#examples"><code>MediaSessionAction</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
@@ -64,7 +64,7 @@ browser-compat: api.MediaStreamAudioDestinationNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createMediaStreamDestination","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext.createMediaStreamDestination#examples"><code>AudioContext.createMediaStreamDestination()</code></a> for example code that creates a <code>MediaStreamAudioDestinationNode</code> and uses it as a source for audio to be recorded.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
@@ -32,7 +32,7 @@ var myStream = destination.stream;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createMediaStreamDestination","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext/createMediaStreamDestination#examples"><code>AudioContext.createMediaStreamDestination()</code></a> for example code that creates a <code>MediaStreamAudioDestinationNode</code> and uses its <code>stream</code> property as a source for audio to be recorded.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/index.html
@@ -38,7 +38,7 @@ browser-compat: api.PeriodicWave
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPeriodicWave","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext/createPeriodicWave#example"><code>AudioContext.createPeriodicWave()</code></a> for simple example code that shows how to create a <code>PeriodicWave</code> object containing a simple sine wave.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/scrolltooptions/behavior/index.html
+++ b/files/en-us/web/api/scrolltooptions/behavior/index.html
@@ -35,7 +35,7 @@ browser-compat: api.ScrollToOptions.behavior
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/ScrollToOptions","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/ScrollToOptions#examples"><code>ScrollToOptions</code></a> for an example.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/scrolltooptions/left/index.html
+++ b/files/en-us/web/api/scrolltooptions/left/index.html
@@ -27,7 +27,7 @@ browser-compat: api.ScrollToOptions.left
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/ScrollToOptions","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/ScrollToOptions#examples"><code>ScrollToOptions</code></a> for an example.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/scrolltooptions/top/index.html
+++ b/files/en-us/web/api/scrolltooptions/top/index.html
@@ -27,7 +27,7 @@ browser-compat: api.ScrollToOptions.top
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/ScrollToOptions","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/ScrollToOptions#examples"><code>ScrollToOptions</code></a> for an example.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

In a bunch of examples (see commits) it replaces page macros inclusion with a link to the original examples.