### PR TITLE
Update no-spec msg for Screen.(un)lockorientation & co

### DIFF
--- a/files/en-us/web/api/screen/index.html
+++ b/files/en-us/web/api/screen/index.html
@@ -17,9 +17,9 @@ browser-compat: api.Screen
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{DOMxRef("Screen.availTop")}} {{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.availTop")}} {{Non-standard_Inline}}</dt>
  <dd>Specifies the y-coordinate of the first pixel that is not allocated to permanent or semipermanent user interface features.</dd>
- <dt>{{DOMxRef("Screen.availLeft")}} {{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.availLeft")}} {{Non-standard_Inline}}</dt>
  <dd>Returns the first available pixel available from the left side of the screen.</dd>
  <dt>{{DOMxRef("Screen.availHeight")}}</dt>
  <dd>Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows.</dd>
@@ -29,19 +29,19 @@ browser-compat: api.Screen
  <dd>Returns the color depth of the screen.</dd>
  <dt>{{DOMxRef("Screen.height")}}</dt>
  <dd>Returns the height of the screen in pixels.</dd>
- <dt>{{DOMxRef("Screen.left")}} {{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.left")}} {{Non-standard_Inline}}</dt>
  <dd>Returns the distance in pixels from the left side of the main screen to the left side of the current screen.</dd>
  <dt>{{DOMxRef("Screen.orientation")}}</dt>
  <dd>Returns the {{DOMxRef("ScreenOrientation")}} instance associated with this screen.</dd>
  <dt>{{DOMxRef("Screen.pixelDepth")}}</dt>
  <dd>Gets the bit depth of the screen.</dd>
- <dt>{{DOMxRef("Screen.top")}} {{deprecated_inline}}{{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.top")}} {{deprecated_inline}}{{Non-standard_Inline}}</dt>
  <dd>Returns the distance in pixels from the top side of the current screen.</dd>
  <dt>{{DOMxRef("Screen.width")}}</dt>
  <dd>Returns the width of the screen.</dd>
- <dt>{{DOMxRef("Screen.mozEnabled")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.mozEnabled")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
  <dd>Boolean. Setting to false will turn off the device's screen.</dd>
- <dt>{{DOMxRef("Screen.mozBrightness")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.mozBrightness")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
  <dd>Controls the brightness of a device's screen. A double between 0 and 1.0 is expected.</dd>
 </dl>
 
@@ -55,9 +55,9 @@ browser-compat: api.Screen
 <h2 id="Methods">Methods</h2>
 
 <dl>
- <dt>{{DOMxRef("Screen.lockOrientation")}}</dt>
+ <dt>{{DOMxRef("Screen.lockOrientation")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
  <dd>Lock the screen orientation (only works in fullscreen or for installed apps)</dd>
- <dt>{{DOMxRef("Screen.unlockOrientation")}}</dt>
+ <dt>{{DOMxRef("Screen.unlockOrientation")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
  <dd>Unlock the screen orientation (only works in fullscreen or for installed apps)</dd>
 </dl>
 

--- a/files/en-us/web/api/screen/lockorientation/index.html
+++ b/files/en-us/web/api/screen/lockorientation/index.html
@@ -120,7 +120,7 @@ if (screen.lockOrientationUniversal(["landscape-primary", "landscape-secondary"]
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+<p>This feature is not part of any specification. It is no longer on track to becoming a standard.</p>
 
 <p>Use {{domxref("ScreenOrientation.lock()")}} instead.</p>
 

--- a/files/en-us/web/api/screen/lockorientation/index.html
+++ b/files/en-us/web/api/screen/lockorientation/index.html
@@ -14,8 +14,11 @@ browser-compat: api.Screen.lockOrientation
 <p>{{APIRef("Screen Orientation API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>lockOrientation()</code></strong> method of the {{DOMxRef("Screen")}}
-  interface locks the screen into a specified orientation.
-  The {{DOMxRef("ScreenOrientation.lock()")}} method should be used instead.</p>
+  interface locks the screen into a specified orientation.</p>
+
+<div class="notecard warning">
+  This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.lock()")}} method instead.</p>
+</div>
 
 <div class="notecard note">
   <p><strong>Note:</strong> This method only works for installed Web apps or for Web pages
@@ -117,7 +120,9 @@ if (screen.lockOrientationUniversal(["landscape-primary", "landscape-secondary"]
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+
+<p>Use {{domxref("ScreenOrientation.lock()")}} instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/onorientationchange/index.html
+++ b/files/en-us/web/api/screen/onorientationchange/index.html
@@ -30,7 +30,9 @@ browser-compat: api.Screen.onorientationchange
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+
+<p>Use {{domxref("ScreenOrientation.onchange")}} instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/screen/onorientationchange/index.html
+++ b/files/en-us/web/api/screen/onorientationchange/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Screen.onorientationchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+<p>This feature is not part of any specification. It is no longer on track to becoming a standard.</p>
 
 <p>Use {{domxref("ScreenOrientation.onchange")}} instead.</p>
 

--- a/files/en-us/web/api/screen/unlockorientation/index.html
+++ b/files/en-us/web/api/screen/unlockorientation/index.html
@@ -49,7 +49,7 @@ if (unlockOrientation()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+<p>This feature is not part of any specification. It is no longer on track to becoming a standard.</p>
 
 <p>Use {{domxref("ScreenOrientation.unlock()")}} instead.</p>
 

--- a/files/en-us/web/api/screen/unlockorientation/index.html
+++ b/files/en-us/web/api/screen/unlockorientation/index.html
@@ -13,8 +13,12 @@ browser-compat: api.Screen.unlockOrientation
 <p>{{APIRef("Screen Orientation API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>Screen.unlockOrientation()</code></strong> method removes all the
-  previous screen locks set by the page/app. The {{DOMxRef("ScreenOrientation.unlock()")}}
-  method should be used instead.</p>
+  previous screen locks set by the page/app. The {{DOMxRef("ScreenOrientation.unlock()")}}
+  method should be used instead.</p>
+
+<div class="notecard warning">
+  This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.unlock()")}} method instead.</p>
+</div>
 
 <div class="notecard note">
   <p><strong>Note:</strong> This method only works for installed Web apps or for Web pages
@@ -45,7 +49,9 @@ if (unlockOrientation()) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+
+<p>Use {{domxref("ScreenOrientation.unlock()")}} instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `Screen.lockOrientation`, `Screen.unlockOrientation`, and `Screen.onorientationchange` here.

I removed the {{Specifications}} macros and replaced it with a basic text. I also added a text at the top of the pages, if it were missing, and marked the features as deprecated on the interface page. (+ some gremlin removal)