### PR TITLE
Update no-spec msg for MouseEvent.initMouseEvent

### DIFF
--- a/files/en-us/web/api/mouseevent/initmouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.html
@@ -122,7 +122,7 @@ simulateClick();
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+<p>This feature is not part of any specification. It is no longer on track to becoming a standard.</p>
 
 <p>Use the {{domxref("MouseEvent.MouseEvent", "MouseEvent()")}} constructor instead.</p>
 

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.html
@@ -26,8 +26,7 @@ browser-compat: api.MouseEvent.initMouseEvent
 
 <p>Events initialized in this way must have been created with the {{domxref("Document.createEvent()") }} method.
   This method must be called to set the event
-  before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
-  dispatched, it doesn't do anything anymore.</p>
+  before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.</p>
 
 
 

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.html
@@ -16,18 +16,20 @@ browser-compat: api.MouseEvent.initMouseEvent
 <p>The <code><strong>MouseEvent.initMouseEvent()</strong></code> method initializes the
   value of a mouse event once it's been created (normally using the {{domxref("Document.createEvent()")}} method).</p>
 
-<p>Events initialized in this way must have been created with the {{domxref("Document.createEvent()") }} method.
-  This method must be called to set the event
-  before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
-  dispatched, it doesn't do anything anymore.</p>
+<div class="notecard warning">
 
-<div class="notecard note">
-  <h4>Note</h4>
   <p><strong>Do not use this method anymore as it is deprecated.</strong></p>
 
   <p>Instead use specific event constructors, like {{domxref("MouseEvent.MouseEvent", "MouseEvent()")}}.
   The page on <a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a> gives more information about the way to use these.</p>
 </div>
+
+<p>Events initialized in this way must have been created with the {{domxref("Document.createEvent()") }} method.
+  This method must be called to set the event
+  before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
+  dispatched, it doesn't do anything anymore.</p>
+
+
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -120,7 +122,9 @@ simulateClick();
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is no longer on the track of becoming a standard.</p>
+
+<p>Use the {{domxref("MouseEvent.MouseEvent", "MouseEvent()")}} constructor instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `MouseEvent.initMouseEvent` here.

I removed the {{Specifications}} macro and replaced it with a basic text. I also improved the message at the top to make it more visible.