### PR TITLE
Add a missing word

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_alertdialog_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_alertdialog_role/index.html
@@ -30,7 +30,7 @@ tags:
  <li>The tab order inside the alert dialog must wrap.</li>
 </ul>
 
-<p>The difference with regular dialogs is that the <code>alertdialog</code> role should only used when an alert, error, or warning occurs. In other words, when a dialog's information and controls require the user's immediate attention <code>alertdialog</code> should be used instead of <code>dialog</code>. It is up to the developer to make this distinction though.</p>
+<p>The difference with regular dialogs is that the <code>alertdialog</code> role should only be used when an alert, error, or warning occurs. In other words, when a dialog's information and controls require the user's immediate attention <code>alertdialog</code> should be used instead of <code>dialog</code>. It is up to the developer to make this distinction though.</p>
 
 <p>Because of its urgent nature, alert dialogs must always be modal.</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

A word was missing.

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

The URL is: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role