### PR TITLE
Update no-spec msg for ScriptProcessorNode

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
@@ -17,10 +17,7 @@ browser-compat: api.BaseAudioContext.createScriptProcessor
   creates a {{domxref("ScriptProcessorNode")}} used for direct audio processing.</p>
 
 <div class="note">
-  <p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this
-    feature has been marked as deprecated, and was replaced by <a
-      href="https://webaudio.github.io/web-audio-api/#audioworklet">AudioWorklet</a> (see
-    {{domxref("AudioWorkletNode")}}).</p>
+  <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -99,43 +96,43 @@ console.log(scriptNode.bufferSize);
 // load in an audio track via XHR and decodeAudioData
 
 function getData() {
-  request = new XMLHttpRequest();
-  request.open('GET', 'viper.ogg', true);
-  request.responseType = 'arraybuffer';
-  request.onload = function() {
-    var audioData = request.response;
+  request = new XMLHttpRequest();
+  request.open('GET', 'viper.ogg', true);
+  request.responseType = 'arraybuffer';
+  request.onload = function() {
+    var audioData = request.response;
 
-    audioCtx.decodeAudioData(audioData, function(buffer) {
-    myBuffer = buffer;
-    source.buffer = myBuffer;
-  },
-    function(e){"Error with decoding audio data" + e.err});
-  }
-  request.send();
+    audioCtx.decodeAudioData(audioData, function(buffer) {
+      myBuffer = buffer;
+      source.buffer = myBuffer;
+    },
+    function(e){"Error with decoding audio data" + e.err});
+  }
+  request.send();
 }
 
 // Give the node a function to process audio events
 scriptNode.onaudioprocess = function(audioProcessingEvent) {
   // The input buffer is the song we loaded earlier
-  var inputBuffer = audioProcessingEvent.inputBuffer;
+  var inputBuffer = audioProcessingEvent.inputBuffer;
 
-  // The output buffer contains the samples that will be modified and played
-  var outputBuffer = audioProcessingEvent.outputBuffer;
+  // The output buffer contains the samples that will be modified and played
+  var outputBuffer = audioProcessingEvent.outputBuffer;
 
-  // Loop through the output channels (in this case there is only one)
-  for (var channel = 0; channel &lt; outputBuffer.numberOfChannels; channel++) {
-    var inputData = inputBuffer.getChannelData(channel);
-    var outputData = outputBuffer.getChannelData(channel);
+  // Loop through the output channels (in this case there is only one)
+  for (var channel = 0; channel &lt; outputBuffer.numberOfChannels; channel++) {
+    var inputData = inputBuffer.getChannelData(channel);
+    var outputData = outputBuffer.getChannelData(channel);
 
-    // Loop through the 4096 samples
-    for (var sample = 0; sample &lt; inputBuffer.length; sample++) {
-      // make output equal to the same as the input
-      outputData[sample] = inputData[sample];
+    // Loop through the 4096 samples
+    for (var sample = 0; sample &lt; inputBuffer.length; sample++) {
+      // make output equal to the same as the input
+      outputData[sample] = inputData[sample];
 
-      // add noise to each output sample
-      outputData[sample] += ((Math.random() * 2) - 1) * 0.2;
-    }
-  }
+      // add noise to each output sample
+      outputData[sample] += ((Math.random() * 2) - 1) * 0.2;
+    }
+  }
 }
 
 getData();
@@ -143,20 +140,22 @@ getData();
 // wire up play button
 playButton.onclick = function() {
   source.connect(scriptNode);
-  scriptNode.connect(audioCtx.destination);
-  source.start();
+  scriptNode.connect(audioCtx.destination);
+  source.start();
 }
 
 // When the buffer source stops playing, disconnect everything
 source.onended = function() {
   source.disconnect(scriptNode);
-  scriptNode.disconnect(audioCtx.destination);
+  scriptNode.disconnect(audioCtx.destination);
 }
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Since the August 29 2014 <a href="https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor">Web Audio API specification</a> publication, this feature has been deprecated. It is no longer on track to become a standard.</p>
+
+<p>It was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.html
+++ b/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.html
@@ -5,12 +5,16 @@ tags:
   - ScriptProcessorNode
   - Web Audio API
   - audioprocess
-  - events
+  - event
 browser-compat: api.ScriptProcessorNode.audioprocess_event
 ---
 <div>{{APIRef("Web Audio API")}}{{deprecated_header}}</div>
 
-<p>The audioprocess event of the {{domxref("ScriptProcessorNode")}} interface is fired when an input buffer of a script processor is ready to be processed.</p>
+<p>The audioprocess event of the {{domxref("ScriptProcessorNode")}} interface is fired when an input buffer of a script processor is ready to be processed.</p>
+
+<div class="note">
+  <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
+</div>
 
 <table class="properties">
  <tbody>
@@ -70,7 +74,9 @@ browser-compat: api.ScriptProcessorNode.audioprocess_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Since the August 29 2014 <a href="https://www.w3.org/TR/webaudio/#ScriptProcessorNode">Web Audio API specification</a> publication, this feature has been deprecated. It is no longer on track to become a standard.</p>
+
+<p>It was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.html
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.html
@@ -10,14 +10,13 @@ tags:
   - bufferSize
 browser-compat: api.ScriptProcessorNode.bufferSize
 ---
-<p>{{APIRef("Web Audio API")}}</p>
-
-<div class="notecard note">
-  <p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="/en-US/docs/Web/API/Web_Audio_API#audio_workers">Audio Workers</a>.</p>
-</div>
-
+<p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
 <p>The <code>bufferSize</code> property of the {{domxref("ScriptProcessorNode")}} interface returns an integer representing both the input and output buffer size, in sample-frames. Its value can be a power of 2 value in the range <code>256</code>–<code>16384</code>.</p>
+
+<div class="note">
+  <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -35,7 +34,9 @@ console.log(scriptNode.bufferSize);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Since the August 29 2014 <a href="https://www.w3.org/TR/webaudio/#ScriptProcessorNode">Web Audio API specification</a> publication, this feature has been deprecated. It is no longer on track to become a standard.</p>
+
+<p>It was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/index.html
+++ b/files/en-us/web/api/scriptprocessornode/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ScriptProcessorNode
 <p>The <code>ScriptProcessorNode</code> interface allows the generation, processing, or analyzing of audio using JavaScript.</p>
 
 <div class="note">
-<p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and was replaced by <a href="https://webaudio.github.io/web-audio-api/#audioworklet">AudioWorklet</a> (see {{domxref("AudioWorkletNode")}}).</p>
+  <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 </div>
 
 <p>The <code>ScriptProcessorNode</code> interface is an {{domxref("AudioNode")}} audio-processing module that is linked to two buffers, one containing the input audio data, one containing the processed output audio data. An event, implementing the {{domxref("AudioProcessingEvent")}} interface, is sent to the object each time the input buffer contains new data, and the event handler terminates when it has filled the output buffer with data.</p>
@@ -80,7 +80,9 @@ browser-compat: api.ScriptProcessorNode
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Since the August 29 2014 <a href="https://www.w3.org/TR/webaudio/#ScriptProcessorNode">Web Audio API specification</a> publication, this feature has been deprecated. It is no longer on track to become a standard.</p>
+
+<p>It was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
@@ -10,14 +10,14 @@ tags:
   - onaudioprocess
 browser-compat: api.ScriptProcessorNode.onaudioprocess
 ---
-<p>{{APIRef("Web Audio API")}}</p>
+<p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
+
+<p>The <code>onaudioprocess</code> event handler of the {{domxref("ScriptProcessorNode")}} interface represents the {{event("Event_handlers", "event handler")}} to be called for the <code>audioprocess</code> event that is dispatched to <code>ScriptProcessorNode</code> node types. An event of type {{domxref("AudioProcessingEvent")}} will be dispatched to the event handler.</p>
 
 <div class="note">
-<p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="/en-US/docs/Web/API/Web_Audio_API#audio_workers">Audio Workers</a>.</p>
+  <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 </div>
 
-<div>
-<p>The <code>onaudioprocess</code> event handler of the {{domxref("ScriptProcessorNode")}} interface represents the {{event("Event_handlers", "event handler")}} to be called for the <code>audioprocess</code> event that is dispatched to <code>ScriptProcessorNode</code> node types. An event of type {{domxref("AudioProcessingEvent")}} will be dispatched to the event handler.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -32,7 +32,9 @@ scriptNode.onaudioprocess = function() { ... }</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>Since the August 29 2014 <a href="https://www.w3.org/TR/webaudio/#ScriptProcessorNode">Web Audio API specification</a> publication, this feature has been deprecated. It is no longer on track to become a standard.</p>
+
+<p>It was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `ScriptProcessorNode.*` (and `BaseAudioContext.createScriptProcessorNode()`) here.

I removed the {{Specifications}} macro and replaced it with a basic text. I also improved the message at the top to make it more visible.