### PR TITLE
Remove charCodeAt ref from KeyboardEvent.key

### DIFF
--- a/files/en-us/web/api/keyboardevent/key/index.html
+++ b/files/en-us/web/api/keyboardevent/key/index.html
@@ -13,7 +13,7 @@ browser-compat: api.KeyboardEvent.key
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
-<p><span class="seoSummary">The {{domxref("KeyboardEvent")}} interface's <code><strong>key</strong></code> read-only property returns the value of the key pressed by the user, taking into consideration the state of modifier keys such as <kbd>Shift</kbd> as well as the keyboard locale and layout.</span> The Unicode value of the key pressed can be derived from it using {{jsxref("String.prototype.charCodeAt()", "charCodeAt()")}}. Its value is determined as follows:</p>
+<p><span class="seoSummary">The {{domxref("KeyboardEvent")}} interface's <code><strong>key</strong></code> read-only property returns the value of the key pressed by the user, taking into consideration the state of modifier keys such as <kbd>Shift</kbd> as well as the keyboard locale and layout.</span> Its value is determined as follows:</p>
 
 <div class="moreinfo pull-aside">
 <h4 id="Key_values">Key values</h4>


### PR DESCRIPTION
This is confusing since KeyboardEvent.key already contains the Unicode character string. KeyboardEvent.key is a string, not a number, thus cannot be passed to String.prototype.charCodeAt.