### PR TITLE
Update no-spec msg for HTMLImageElement.longDesc

### DIFF
--- a/files/en-us/web/api/htmlimageelement/longdesc/index.html
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.html
@@ -17,16 +17,15 @@ browser-compat: api.HTMLImageElement.longDesc
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
-<p><span
-    class="seoSummary">The <em>deprecated</em> property <code><strong>longDesc</strong></code> on
+<p>The <em>deprecated</em> property <code><strong>longDesc</strong></code> on
     the {{domxref("HTMLImageElement")}} interface specifies the URL of a text or HTML file
-    which contains a long-form description of the image.</span> This can be used to
+    which contains a long-form description of the image. This can be used to
   provide optional added details beyond the short description provided in the
   {{htmlattrxref("title")}} attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>descURL</em> = <em>htmlImageElement</em>.longDesc;
+<pre class="brush: js"><em>descURL</em> = <em>htmlImageElement</em>.longDesc;
 <em>htmlImageElement</em>.longDesc = <em>descURL</em>;
 </pre>
 
@@ -38,14 +37,14 @@ browser-compat: api.HTMLImageElement.longDesc
 
 <p>For example, if the image is a <a
     href="/en-US/docs/Web/Media/Formats/Image_types#png">PNG</a> of a flowchart.
-  The <code>longDesc</code> property could be used to provide an explanation of the flow
+  The <code>longDesc</code> property could be used to provide an explanation of the flow
   of control represented by the chart, using only text. This can be used by readers both
   as an explanation, but also as a substitute for visually-impaired users.</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<p>This property is <em>deprecated</em> and should no longer be used. Instead of
-  using <code>longDesc</code> to provide a link to a detailed description of an image,
+<p>This property is <em>deprecated</em> and should no longer be used. Instead of
+  using <code>longDesc</code> to provide a link to a detailed description of an image,
   encapsulate the image within a link using the {{HTMLElement("a")}} element.</p>
 
 <p>Consider the following older HTML:</p>
@@ -53,14 +52,14 @@ browser-compat: api.HTMLImageElement.longDesc
 <pre
   class="brush: html">&lt;img src="taco-tuesday.jpg" longDesc="image-descriptions/taco-tuesday.html"&gt;</pre>
 
-<p>Here, the <code>longDesc</code> is used to indicate that the user should be able to
-  access a detailed description of the image <code>taco-tuesday.jpg</code> in the HTML
-  file <code>image-descriptions/taco-tuesday.html</code>.</p>
+<p>Here, the <code>longDesc</code> is used to indicate that the user should be able to
+  access a detailed description of the image <code>taco-tuesday.jpg</code> in the HTML
+  file <code>image-descriptions/taco-tuesday.html</code>.</p>
 
 <p>This can be easily converted into modern HTML:</p>
 
 <pre class="brush: html">&lt;a href="image-descriptions/taco-tuesday.html"&gt;
-  &lt;img src="taco-tuesday.jpg"&gt;
+  &lt;img src="taco-tuesday.jpg"&gt;
 &lt;/a&gt;
 </pre>
 
@@ -69,7 +68,7 @@ browser-compat: api.HTMLImageElement.longDesc
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.html
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.html
@@ -68,7 +68,7 @@ browser-compat: api.HTMLImageElement.longDesc
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `HTMLImageElement.longDesc` here.

I removed the {{Specifications}} macro and replaced it with a basic text. I removed some gremlins too.