### PR TITLE
Minor clarity improvements in the page about TypedArray.slice()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -64,7 +64,7 @@ slice(start, end)
 
 <p>The <code>slice</code> method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the <code>slice</code> method returns is always a shallow copy.</p>
 
-<p>If a new element is added to either typed array, the other typed array is not affected.
+<p>If an element is changed in either typed array, the other typed array is not affected.
 </p>
 
 <h2 id="Examples">Examples</h2>
@@ -96,7 +96,7 @@ uint8.slice(0,1); // Uint8Array [ 1 ]
 
 <p>If you need to support truly obsolete JavaScript engines that don't support
   {{jsxref("Object.defineProperty")}}, it's best not to polyfill
-  <code>Array.prototype</code> methods at all, as you can't make them non-enumerable.</p>
+  <code><em>TypedArray</em>.prototype</code> methods at all, as you can't make them non-enumerable.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
I made two changes to the [page about <code>*TypedArray*.prototype.slice()</code>](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html).

1. Reworded a sentence from "add an element" to "change an element", because new elements can't be added to Typed Arrays
2. Replaced `Array.prototype` with <code>*TypedArray*.prototype</code>, as this page is about the latter.