### PR TITLE
Fix typo in mouseleave event documentation

### DIFF
--- a/files/en-us/web/api/element/mouseleave_event/index.html
+++ b/files/en-us/web/api/element/mouseleave_event/index.html
@@ -46,9 +46,9 @@ browser-compat: api.Element.mouseleave_event
 
 <p>One <code>mouseleave</code> event is sent to each element of the hierarchy when leaving them. Here four events are sent to the four elements of the hierarchy when the pointer moves from the text to an area outside of the most outer div represented here.</p>
 
-<h4>Behavior of <code>mouseover</code> events:</h4>
+<h4>Behavior of <code>mouseout</code> events:</h4>
 
-<img class="default internal" src="mouseout.png"><
+<img class="default internal" src="mouseout.png">
 
 <p>One single <code>mouseout</code> event is sent to the deepest element of the DOM tree, then it bubbles up the hierarchy until it is canceled by a handler or reaches the root.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Looks like a copy paste error in https://github.com/mdn/content/pull/5681