### PR TITLE
Update no-spec msg for SourceBuffer non-standard async methods

### DIFF
--- a/files/en-us/web/api/sourcebuffer/appendbufferasync/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendbufferasync/index.html
@@ -18,10 +18,10 @@ browser-compat: api.SourceBuffer.appendBufferAsync
 ---
 <div>{{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}</div>
 
-<p><span class="seoSummary">The <code><strong>appendBufferAsync()</strong></code> method
+<p>The <code><strong>appendBufferAsync()</strong></code> method
     of the {{domxref("SourceBuffer")}} interface begins the process of asynchronously
     appending media segment data from an {{jsxref("ArrayBuffer")}} or
-    {{domxref("ArrayBufferView")}} object to the <code>SourceBuffer</code>.</span> It
+    {{domxref("ArrayBufferView")}} object to the <code>SourceBuffer</code>. It
   returns a {{jsxref("Promise")}} which is fulfilled once the buffer has been appended.
 </p>
 
@@ -64,7 +64,7 @@ browser-compat: api.SourceBuffer.appendBufferAsync
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is not on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/sourcebuffer/removeasync/index.html
+++ b/files/en-us/web/api/sourcebuffer/removeasync/index.html
@@ -8,6 +8,7 @@ tags:
 - Media
 - Media Source Extensions
 - Method
+- Experimental
 - Non-standard
 - Reference
 - SourceBuffer
@@ -17,10 +18,10 @@ browser-compat: api.SourceBuffer.removeAsync
 ---
 <div>{{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}</div>
 
-<p><span class="seoSummary">The <code><strong>removeAsync()</strong></code> method of the
+<p>The <code><strong>removeAsync()</strong></code> method of the
     {{domxref("SourceBuffer")}} interface starts the process of asynchronously removing
     from the <code>SourceBuffer</code> media segments found within a specific time
-    range.</span> A {{jsxref("Promise")}} is returned, which is fulfilled when the buffers
+    range. A {{jsxref("Promise")}} is returned, which is fulfilled when the buffers
   in the specified time range have been removed.</p>
 
 <p>This method can only be called when {{domxref("SourceBuffer.updating", "updating")}} is
@@ -60,7 +61,7 @@ browser-compat: api.SourceBuffer.removeAsync
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is not on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with the `SourceBuffer.appendBufferAsync` and `SourceBuffer.removeAsync`.

- I removed the {{Specifications}} macro and replaced it with a basic text. 
- I fixed a tiny tag.

I removed some gremlins too.