### PR TITLE
Fix Clipboard.read() and Clipboard.write()

### DIFF
--- a/files/en-us/web/api/clipboard/read/index.html
+++ b/files/en-us/web/api/clipboard/read/index.html
@@ -48,7 +48,7 @@ browser-compat: api.Clipboard.read
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Promise")}} that resolves with a {{domxref("DataTransfer")}} object
+<p>A {{jsxref("Promise")}} that resolves with a sequence of {{domxref("ClipboardItem")}} objects
   containing the clipboard's contents. The promise is rejected if permission to access the
   clipboard is not granted.</p>
 
@@ -63,23 +63,24 @@ browser-compat: api.Clipboard.read
 <pre class="brush: js">// First, ask the Permissions API if we have some kind of access to
 // the "clipboard-read" feature.
 
-navigator.permissions.query({name: "clipboard-read"}).then(result =&gt; {
-  // If permission to read the clipboard is granted or if the user will
-  // be prompted to allow it, we proceed.
-
-  if (result.state == "granted" || result.state == "prompt") {
-    navigator.clipboard.read().then(data =&gt; {
-      for (let i=0; i&lt;data.items.length; i++) {
-        if (data.items[i].type != "image/png") {
-          alert("Clipboard contains non-image data. Unable to access it.");
-        } else {
-          const blob = data.items[i].getType("image/png");
-          imgElem.src = URL.createObjectURL(blob);
+navigator.permissions.query({ name: "clipboard-read" }).then((result) =&gt {
+    // If permission to read the clipboard is granted or if the user will
+    // be prompted to allow it, we proceed.
+  
+    if (result.state == "granted" || result.state == "prompt") {
+      navigator.clipboard.read().then((data) =&gt {
+        for (let i = 0; i &lt data.length; i++) {
+          if (!data[i].types.includes("image/png")) {
+            alert("Clipboard contains non-image data. Unable to access it.");
+          } else {
+            data[i].getType("image/png").then((blob) =&gt {
+              imgElem.src = URL.createObjectURL(blob);
+            });
+          }
         }
-      }
-    });
-  }
-});
+      });
+    }
+  });
 </pre>
 
 <div class="note">

--- a/files/en-us/web/api/clipboard/write/index.html
+++ b/files/en-us/web/api/clipboard/write/index.html
@@ -58,22 +58,31 @@ browser-compat: api.Clipboard.write
 <p>This example function replaces the current contents of the clipboard with a specified
   string.</p>
 
-<pre class="brush: js">function setClipboard(text) {
-  let data = [new ClipboardItem({ "text/plain": text })];
+<pre class="brush: js">
+function setClipboard(text) {
+    var type = "text/plain";
+    var blob = new Blob([text], { type });
+    var data = [new ClipboardItem({ [type]: blob })];
 
-  navigator.clipboard.write(data).then(function() {
-    /* success */
-  }, function() {
-    /* failure */
-  });
+    navigator.clipboard.write(data).then(
+        function () {
+        /* success */
+        },
+        function () {
+        /* failure */
+        }
+    );
 }
 </pre>
 
-<p>The code begins by creating a new {{domxref("ClipboardItem")}} object into which the
-  text will be placed for sending to the clipboard. The key of the object passed to the
-  {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates
-  the content. The content could be a text or even a Blob (e.g. for copying images to the
-  clipboard). Then <code>write()</code> is called, specifying both a fulfillment function
+<p>The code begins by creating a new a {{domxref("Blob")}} object. This object is 
+  required to construct a {{domxref("ClipboardItem")}} object which is sent to the 
+  clipboard. The {{domxref("Blob")}} constructor takes in  the content we want to copy
+  and its type. This {{domxref("Blob")}} object can be derived from many sources e.g. a {{domxref("Canvas")}}.
+  <br />
+  <br />
+  Next, we create a new {{domxref("ClipboardItem")}} object into which the blob will be placed for sending to the clipboard. 
+  The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then <code>write()</code> is called, specifying both a fulfillment function
   and an error function.</p>
 
 <h3 id="Example_of_copying_canvas_contents_to_the_clipboard">Example of copying canvas


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The [specification](https://w3c.github.io/clipboard-apis/#dom-clipboard-read) (referred to in the Specifications section) defines `data` as a "sequence of ClipboardItems". The type property also does not exist. Furthermore, `getType()` returns a promise that resolves to the the blob data.

> Issue number (if there is an associated issue)

Fixes #6176 

> Anything else that could help us review it

Since this once functions has an incorrect example I suspect that a few related functions may also have incorrect documentation. I will investigate and create issues if I find anything. 
