### PR TITLE
Update no-spec msg for RTCRtpTransceiver.stopped and RTCSessionDescription()

### DIFF
--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
@@ -47,7 +47,7 @@ browser-compat: api.RTCRtpTransceiver.stopped
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
@@ -23,6 +23,12 @@ browser-compat: api.RTCRtpTransceiver.stopped
   method has been called or if a change to either the local or the remote description has
   caused the transceiver to be stopped for some reason.</p>
 
+<div class="Notecard note">
+  <p>This property is <em>deprecated</em> and will be removed in the future. Instead, look
+    at the value of {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}}.
+    Its value is <code>stopped</code> if the transceiver has stopped.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre
@@ -37,18 +43,11 @@ browser-compat: api.RTCRtpTransceiver.stopped
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<p>This property is <em>deprecated</em> and will be removed in the future. Instead, look
-  at the value of {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}}.
-  Its value is <code>stopped</code> if the transceiver has stopped.</p>
 
-<div class="notecard note">
-  <p><strong>Note:</strong> Currently only Firefox implements <code>stopped</code>, and
-    has not yet been updated to implement this change.</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
@@ -79,7 +79,7 @@ browser-compat: api.RTCSessionDescription.RTCSessionDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
@@ -79,7 +79,7 @@ browser-compat: api.RTCSessionDescription.RTCSessionDescription
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This feature is not part of any specification anymore. It is no longer on track to become a standard.</p>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with the `RTCRtpTransceiver.stopped` and `RTCSessionDescriptiion`.

- I removed the {{Specifications}} macro and replaced it with a basic text. 
- I moved near the top the main explaination why `stopped` has been deprecated.

I removed some gremlins too.