### PR TITLE
use {{Specifications}} instead of hardcoded table

### DIFF
--- a/files/en-us/web/css/offset-path/index.html
+++ b/files/en-us/web/css/offset-path/index.html
@@ -149,24 +149,7 @@ offset-path: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>&lt;body&gt;</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Motion Path Level 1', '#offset-path-property', 'offset-path')}}</td>
-   <td>{{Spec2('Motion Path Level 1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The Yari builder tries to extract the specifications table, but what was there (after the `<h2 id="Specifications">Specifications</h2>`) didn't come from `{{Specifications}}` but instead from old legacy HTML. 

> Issue number (if there is an associated issue)

https://github.com/mdn/yari/issues/4059

> Anything else that could help us review it

This is a quick fix that doesn't really prevent this from happening again. Perhaps that page isn't yet ready for `{{Specifications}}`.