### PR TITLE
Convert spec table in CSS pseudo-elements

### DIFF
--- a/files/en-us/web/css/_doublecolon_after/index.html
+++ b/files/en-us/web/css/_doublecolon_after/index.html
@@ -129,37 +129,7 @@ span[data-descr]:focus::after {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-after', '::after')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>No significant changes to the previous specification.</td>
-  </tr>
-  <tr>
-   <td>{{Specname("CSS3 Animations", "", "animations on pseudo-element properties")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Allows animations on properties defined on pseudo-elements.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Selectors', '#gen-content', '::after')}}</td>
-   <td>{{Spec2('CSS3 Selectors')}}</td>
-   <td>Introduces the two-colon syntax.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'generate.html#before-after-content', '::after')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition, using the one-colon syntax.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_backdrop/index.html
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.html
@@ -53,22 +53,7 @@ dialog::backdrop {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('Fullscreen', '#::backdrop-pseudo-element', '::backdrop')}}</td>
-			<td>{{Spec2('Fullscreen')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_before/index.html
+++ b/files/en-us/web/css/_doublecolon_before/index.html
@@ -183,37 +183,7 @@ li[aria-current='step']::after {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-before', '::before')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>No significant changes to the previous specification.</td>
-  </tr>
-  <tr>
-   <td>{{Specname("CSS3 Animations", "", "")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td>Allows animations on properties defined on pseudo-elements.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Selectors', '#gen-content', '::before')}}</td>
-   <td>{{Spec2('CSS3 Selectors')}}</td>
-   <td>Introduces the two-colon syntax.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'generate.html#before-after-content', '::before')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition, using the one-colon syntax</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_cue-region/index.html
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.html
@@ -69,7 +69,20 @@ browser-compat: css.selectors.cue-region
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName("WebVTT", "#the-cue-region-pseudo-element", "the <code>::cue-region</code> pseudo-element")}}</td>
+   <td>{{Spec2("WebVTT")}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_cue-region/index.html
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.html
@@ -69,20 +69,7 @@ browser-compat: css.selectors.cue-region
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebVTT", "#the-cue-region-pseudo-element", "the <code>::cue-region</code> pseudo-element")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_cue/index.html
+++ b/files/en-us/web/css/_doublecolon_cue/index.html
@@ -81,22 +81,7 @@ browser-compat: css.selectors.cue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebVTT", "#the-cue-pseudo-element", "::cue")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.html
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.html
@@ -119,22 +119,7 @@ input[type=file]::file-selector-button:hover {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-  <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td>{{SpecName('CSS4 Pseudo-Elements', '#file-selector-button-pseudo', '::file-selector-button')}}</td>
-    <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-    <td>Initial definition.</td>
-  </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_first-letter/index.html
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.html
@@ -117,42 +117,7 @@ h2 + p::first-letter {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS4 Pseudo-Elements', '#first-letter-pseudo', '::first-letter')}}</td>
-   <td>{{ Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Generalizes allowed properties to typesetting, text decoration, inline layout properties, {{ cssxref("opacity") }}, and {{ cssxref("box-shadow") }}.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS3 Text Decoration', '#text-shadow-property', 'text-shadow with ::first-letter')}}</td>
-   <td>{{ Spec2('CSS3 Text Decoration')}}</td>
-   <td>Allows the use of {{cssxref("text-shadow")}} with <code>::first-letter</code>.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS3 Selectors', '#first-letter', '::first-letter') }}</td>
-   <td>{{ Spec2('CSS3 Selectors') }}</td>
-   <td>Introduction of the two-colon syntax. Definition of edge-case behavior, such as in list items or with specific languages (e.g., the Dutch digraph <code>IJ</code>).</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS2.1', 'selector.html#first-letter', '::first-letter') }}</td>
-   <td>{{ Spec2('CSS2.1') }}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS1', '#the-first-letter-pseudo-element', '::first-letter') }}</td>
-   <td>{{ Spec2('CSS1') }}</td>
-   <td>Initial definition, using the one-colon syntax.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_first-line/index.html
+++ b/files/en-us/web/css/_doublecolon_first-line/index.html
@@ -66,44 +66,7 @@ because it is not a block-level element.&lt;/span&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#first-line-pseudo', '::first-line')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Defines more strictly where <code>::first-letter</code> can occur.<br>
-    Generalizes allowed properties to typesetting, text decoration, and inline layout properties and {{cssxref("opacity")}}.<br>
-    Defines the inheritance of <code>::first-letter</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-shadow-property', 'text-shadow with ::first-line')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Allows the use of {{cssxref("text-shadow")}} with <code>::first-letter</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Selectors', '#first-line', '::first-line')}}</td>
-   <td>{{Spec2('CSS3 Selectors')}}</td>
-   <td>Introduction of the two-colon syntax.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'selector.html#first-line-pseudo', '::first-line')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#the-first-line-pseudo-element', '::first-line')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition, using the one-colon syntax.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.html
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.html
@@ -55,22 +55,7 @@ browser-compat: css.selectors.grammar-error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-grammar-error', '::grammar-error')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_marker/index.html
+++ b/files/en-us/web/css/_doublecolon_marker/index.html
@@ -64,27 +64,7 @@ browser-compat: css.selectors.marker
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#marker-pseudo', '::marker')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>No significant change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Lists', '#marker-pseudo', '::marker')}}</td>
-   <td>{{Spec2('CSS3 Lists')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_part/index.html
+++ b/files/en-us/web/css/_doublecolon_part/index.html
@@ -94,22 +94,7 @@ globalThis.customElements.define(template.id, class extends HTMLElement {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("CSS Shadow Parts", "#part", "::part")}}</td>
-			<td>{{Spec2("CSS Shadow Parts")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_placeholder/index.html
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.html
@@ -129,22 +129,7 @@ browser-compat: css.selectors.placeholder
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#placeholder-pseudo', '::placeholder')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_selection/index.html
+++ b/files/en-us/web/css/_doublecolon_selection/index.html
@@ -94,22 +94,7 @@ p::selection {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-selection', '::selection')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="note">
 <p><strong>Note:</strong> <code>::selection</code> was in drafts of CSS Selectors Level 3, but it was removed in the Candidate Recommendation phase because its was under-specified (especially with nested elements) and interoperability wasn't achieved <a href="http://lists.w3.org/Archives/Public/www-style/2008Oct/0268.html">(based on discussion in the W3C Style mailing list)</a>. It returned in <a href="http://dev.w3.org/csswg/css-pseudo-4/">Pseudo-Elements Level 4</a>.</p>

--- a/files/en-us/web/css/_doublecolon_slotted/index.html
+++ b/files/en-us/web/css/_doublecolon_slotted/index.html
@@ -86,22 +86,7 @@ browser-compat: css.selectors.slotted
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS Scope', '#slotted-pseudo', '::slotted') }}</td>
-   <td>{{ Spec2('CSS Scope') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.html
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.html
@@ -55,22 +55,7 @@ browser-compat: css.selectors.spelling-error
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-spelling-error', '::spelling-error')}}</td>
-   <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_target-text/index.html
+++ b/files/en-us/web/css/_doublecolon_target-text/index.html
@@ -36,22 +36,7 @@ browser-compat: css.selectors.target-text
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-    <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-target-text', '::target-text')}}</td>
-    <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
-    <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the CSS pseudo-classes to the `{{Specifications}}` macro.

I left 1 pseudo-elements with the old tables. They are recent additions to the standard and have no bcd entries (not supported anywhere I guess). The tables will be replaced when they get bcd:
- `::cue-region`

All other pages look fine, which is really cool! (I thought there were more pseudo-elements, but most of them are not on a standard track!)