### PR TITLE
Convert spec table in CSS prefixed properties and at-rules

### DIFF
--- a/files/en-us/web/css/--_star_/index.html
+++ b/files/en-us/web/css/--_star_/index.html
@@ -78,22 +78,7 @@ browser-compat: css.properties.custom-property
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Variables", "#defining-variables", "--*")}}</td>
-   <td>{{Spec2("CSS3 Variables")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-webkit-line-clamp/index.html
+++ b/files/en-us/web/css/-webkit-line-clamp/index.html
@@ -80,22 +80,7 @@ browser-compat: css.properties.-webkit-line-clamp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Overflow", "#propdef--webkit-line-clamp", "-webkit-line-clamp")}}</td>
-   <td>{{Spec2("CSS3 Overflow")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-webkit-text-fill-color/index.html
+++ b/files/en-us/web/css/-webkit-text-fill-color/index.html
@@ -65,28 +65,7 @@ browser-compat: css.properties.-webkit-text-fill-color
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#the-webkit-text-fill-color', '-webkit-text-fill-color')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a class="external external-icon" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266--webkit-text-fill-color" hreflang="en" lang="en">Safari CSS Reference<br>
-    <small lang="en-US">'-webkit-text-fill-color' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-webkit-text-stroke-color/index.html
+++ b/files/en-us/web/css/-webkit-text-stroke-color/index.html
@@ -76,28 +76,7 @@ colorPicker.addEventListener("change", function(evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#the-webkit-text-stroke-color', '-webkit-text-stroke-color')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a class="external external-icon" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266--webkit-text-stroke-color" hreflang="en" lang="en">Safari CSS Reference<br>
-    <small lang="en-US">'-webkit-text-stroke-color' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial documentation</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-webkit-text-stroke-width/index.html
+++ b/files/en-us/web/css/-webkit-text-stroke-width/index.html
@@ -86,28 +86,7 @@ browser-compat: css.properties.-webkit-text-stroke-width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#the-webkit-text-stroke-width', '-webkit-text-stroke-width')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a class="external external-icon" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266--webkit-text-stroke-width" hreflang="en" lang="en">Safari CSS Reference<br>
-    <small lang="en-US">'-webkit-text-stroke-width' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial documentation</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-webkit-text-stroke/index.html
+++ b/files/en-us/web/css/-webkit-text-stroke/index.html
@@ -76,28 +76,7 @@ text-stroke: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#the-webkit-text-stroke', '-webkit-text-stroke')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a class="external external-icon" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-_webkit_text_stroke" hreflang="en" lang="en">Safari CSS Reference<br>
-    <small lang="en-US">'-webkit-text-stroke' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@charset/index.html
+++ b/files/en-us/web/css/@charset/index.html
@@ -57,22 +57,7 @@ browser-compat: css.at-rules.charset
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS2.1', 'syndata.html#x57', '@charset') }}</td>
-   <td>{{ Spec2('CSS2.1') }}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@color-profile/index.html
+++ b/files/en-us/web/css/@color-profile/index.html
@@ -61,20 +61,7 @@ browser-compat: css.at-rules.color-profile
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS4 Color', '#at-profile')}}</td>
-   <td>{{Spec2('CSS4 Color')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/additive-symbols/index.html
+++ b/files/en-us/web/css/@counter-style/additive-symbols/index.html
@@ -61,22 +61,7 @@ additive-symbols: 3 "0", 2 url(symbol.png);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-symbols', 'additive-symbols')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/fallback/index.html
+++ b/files/en-us/web/css/@counter-style/fallback/index.html
@@ -71,22 +71,7 @@ fallback: custom-gangnam-style;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-fallback', 'fallback')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/index.html
+++ b/files/en-us/web/css/@counter-style/index.html
@@ -130,22 +130,7 @@ ul {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#the-counter-style-rule', 'counter-style')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/negative/index.html
+++ b/files/en-us/web/css/@counter-style/negative/index.html
@@ -73,22 +73,7 @@ negative: "(" ")";   /* Surrounds value by '(' and ')' if it is negative */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-system', 'system')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/pad/index.html
+++ b/files/en-us/web/css/@counter-style/pad/index.html
@@ -70,22 +70,7 @@ browser-compat: css.at-rules.counter-style.pad
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#descdef-counter-style-pad', 'pad')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/prefix/index.html
+++ b/files/en-us/web/css/@counter-style/prefix/index.html
@@ -70,22 +70,7 @@ prefix: url(bullet.png);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#descdef-counter-style-prefix', 'prefix')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/range/index.html
+++ b/files/en-us/web/css/@counter-style/range/index.html
@@ -105,22 +105,7 @@ range: infinite 6, 10 infinite;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Counter Styles", "#counter-style-range", "range")}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/speak-as/index.html
+++ b/files/en-us/web/css/@counter-style/speak-as/index.html
@@ -97,22 +97,7 @@ speak-as: &lt;counter-style-name&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-speak-as', 'speak-as')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/suffix/index.html
+++ b/files/en-us/web/css/@counter-style/suffix/index.html
@@ -68,22 +68,7 @@ suffix: url(bullet.png);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#descdef-counter-style-suffix', 'suffix')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/symbols/index.html
+++ b/files/en-us/web/css/@counter-style/symbols/index.html
@@ -83,22 +83,7 @@ symbols: indic-numbers;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-symbols', 'symbols')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@counter-style/system/index.html
+++ b/files/en-us/web/css/@counter-style/system/index.html
@@ -375,22 +375,7 @@ ul {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Counter Styles', '#counter-style-system', 'system')}}</td>
-   <td>{{Spec2('CSS3 Counter Styles')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/ascent-override/index.html
+++ b/files/en-us/web/css/@font-face/ascent-override/index.html
@@ -55,22 +55,7 @@ ascent-override: 90%;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-ascent-override', 'ascent-override')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/descent-override/index.html
+++ b/files/en-us/web/css/@font-face/descent-override/index.html
@@ -55,22 +55,7 @@ descent-override: 90%;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-descent-override', 'descent-override')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-display/index.html
+++ b/files/en-us/web/css/@font-face/font-display/index.html
@@ -86,22 +86,7 @@ of the "short" and "extremely small" periods, respectively.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-display-desc', 'font-display')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-family/index.html
+++ b/files/en-us/web/css/@font-face/font-family/index.html
@@ -51,22 +51,7 @@ font-family: examplefont;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-family-desc', 'font-family')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-stretch/index.html
+++ b/files/en-us/web/css/@font-face/font-stretch/index.html
@@ -145,27 +145,7 @@ font-stretch: condensed ultra-condensed;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-prop-desc', 'font-stretch')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-prop-desc', 'font-stretch')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-style/index.html
+++ b/files/en-us/web/css/@font-face/font-style/index.html
@@ -77,27 +77,7 @@ font-style: oblique 30deg 50deg;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-prop-desc', 'font-style')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td>Adds oblique keyword with angle value</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-prop-desc', 'font-style')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-variant/index.html
+++ b/files/en-us/web/css/@font-face/font-variant/index.html
@@ -72,27 +72,7 @@ font-variant: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-prop-desc', 'font-variant')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-prop-desc', 'font-variant')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-variation-settings/index.html
+++ b/files/en-us/web/css/@font-face/font-variation-settings/index.html
@@ -53,22 +53,7 @@ font-variation-settings: "xhgt" 0.7;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-rend-desc', 'font-variation-settings')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/font-weight/index.html
+++ b/files/en-us/web/css/@font-face/font-weight/index.html
@@ -136,27 +136,7 @@ font-weight: 300 500;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-prop-desc', 'font-weight')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-prop-desc', 'font-weight')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -169,42 +169,7 @@ browser-compat: css.at-rules.font-face
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-    <td>{{SpecName('CSS5 Fonts', '#font-face-rule', '@font-face')}}</td>
-    <td>{{Spec2('CSS5 Fonts')}}</td>
-    <td>Adds the <code>size-adjust</code> descriptor.</td>
-   </tr>
-  <tr>
-    <td>{{SpecName('CSS4 Fonts', '#font-face-rule', '@font-face')}}</td>
-    <td>{{Spec2('CSS4 Fonts')}}</td>
-    <td>Definition in this version of the specification.</td>
-   </tr>
-  <tr>
-   <td>{{SpecName('WOFF2.0', '', 'WOFF2 font format')}}</td>
-   <td>{{Spec2('WOFF2.0')}}</td>
-   <td>Font format specification with new compression algorithm</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('WOFF1.0', '', 'WOFF font format')}}</td>
-   <td>{{Spec2('WOFF1.0')}}</td>
-   <td>Font format specification</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#font-face-rule', '@font-face')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/line-gap-override/index.html
+++ b/files/en-us/web/css/@font-face/line-gap-override/index.html
@@ -55,22 +55,7 @@ line-gap-override: 90%;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-line-gap-override', 'line-gap-override')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/size-adjust/index.html
+++ b/files/en-us/web/css/@font-face/size-adjust/index.html
@@ -56,22 +56,7 @@ browser-compat: css.at-rules.font-face.size-adjust
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Fonts', '#size-adjust-desc', 'size-adjust')}}</td>
-   <td>{{Spec2('CSS5 Fonts')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/src/index.html
+++ b/files/en-us/web/css/@font-face/src/index.html
@@ -72,22 +72,7 @@ src: local(font), url(path/to/font.svg) format("svg"),
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#src-desc', 'src')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-face/unicode-range/index.html
+++ b/files/en-us/web/css/@font-face/unicode-range/index.html
@@ -80,22 +80,7 @@ div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fonts', '#unicode-range-desc', 'unicode-range')}}</td>
-   <td>{{Spec2('CSS3 Fonts')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@font-feature-values/index.html
+++ b/files/en-us/web/css/@font-feature-values/index.html
@@ -65,22 +65,7 @@ browser-compat: css.at-rules.font-feature-values
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Fonts', '#font-feature-values', '@font-feature-values')}}</td>
-   <td>{{Spec2('CSS4 Fonts')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@import/index.html
+++ b/files/en-us/web/css/@import/index.html
@@ -58,43 +58,7 @@ browser-compat: css.at-rules.import
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Cascade", "#at-import", 'the <code>@import</code> rule')}}</td>
-   <td>{{Spec2("CSS4 Cascade")}}</td>
-   <td>Extended the syntax to support the {{CSSxRef("@supports")}} syntax.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Cascade', '#at-ruledef-import', '@import')}}</td>
-   <td>{{Spec2('CSS3 Cascade')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#media0', '@import')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Extended the syntax to support any media query and not only simple <a href="/en-US/docs/Web/CSS/@media#Media_types">media types</a>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'cascade.html#at-import', '@import')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Added support for {{CSSxRef("&lt;string&gt;")}} to denote the url of a stylesheet,<br>
-    and requirement to insert the <code>@import</code> rule at the beginning of the CSS document.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#the-cascade', '@import')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@keyframes/index.html
+++ b/files/en-us/web/css/@keyframes/index.html
@@ -117,22 +117,7 @@ browser-compat: css.at-rules.keyframes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Animations', '#keyframes', '@keyframes') }}</td>
-   <td>{{ Spec2('CSS3 Animations') }}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.html
+++ b/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.html
@@ -78,28 +78,7 @@ browser-compat: css.at-rules.media.-webkit-device-pixel-ratio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#css-media-queries-webkit-device-pixel-ratio', '-webkit-device-pixel-ratio')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a class="external external-icon" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3" hreflang="en" lang="en">Safari CSS Reference<br>
-    <small lang="en-US">'media query extensions' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial documentation</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.html
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.html
@@ -52,28 +52,7 @@ browser-compat: css.at-rules.media.-webkit-transform-3d
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#css-media-queries-webkit-transform-3d', '-webkit-transform-3d')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Initial standardization</td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3">Safari CSS Reference<br>
-    <small lang="en-US">'media query extensions' in that document.</small></a></td>
-   <td>Non-standard unofficial documentation</td>
-   <td>Initial documentation</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/any-hover/index.html
+++ b/files/en-us/web/css/@media/any-hover/index.html
@@ -46,22 +46,7 @@ browser-compat: css.at-rules.media.any-hover
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#descdef-media-any-hover', 'any-hover')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/any-pointer/index.html
+++ b/files/en-us/web/css/@media/any-pointer/index.html
@@ -78,22 +78,7 @@ browser-compat: css.at-rules.media.any-pointer
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#descdef-media-any-pointer', 'any-pointer')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/aspect-ratio/index.html
+++ b/files/en-us/web/css/@media/aspect-ratio/index.html
@@ -97,27 +97,7 @@ h.onchange=h.oninput=function(){
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#aspect-ratio', 'aspect-ratio')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#aspect-ratio', 'aspect-ratio')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/color-gamut/index.html
+++ b/files/en-us/web/css/@media/color-gamut/index.html
@@ -46,22 +46,7 @@ browser-compat: css.at-rules.media.color-gamut
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#color-gamut', 'color-gamut')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/color-index/index.html
+++ b/files/en-us/web/css/@media/color-index/index.html
@@ -57,27 +57,7 @@ browser-compat: css.at-rules.media.color-index
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#color-index', 'color-index')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>The value can now be negative, in which case it computes to false.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#color-index', 'color-index')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition. The value must be nonnegative.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/color/index.html
+++ b/files/en-us/web/css/@media/color/index.html
@@ -56,27 +56,7 @@ browser-compat: css.at-rules.media.color
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#color', 'color')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>The value can now be negative, in which case it computes to false.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#color', 'color')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition. The value must be nonnegative.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/device-aspect-ratio/index.html
+++ b/files/en-us/web/css/@media/device-aspect-ratio/index.html
@@ -35,27 +35,7 @@ browser-compat: css.at-rules.media.device-aspect-ratio
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Media Queries', '#device-aspect-ratio', 'device-aspect-ratio')}}</td>
-			<td>{{Spec2('CSS4 Media Queries')}}</td>
-			<td>Deprecated in Media Queries Level 4.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS3 Media Queries', '#device-aspect-ratio', 'device-aspect-ratio')}}</td>
-			<td>{{Spec2('CSS3 Media Queries')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/device-height/index.html
+++ b/files/en-us/web/css/@media/device-height/index.html
@@ -26,27 +26,7 @@ browser-compat: css.at-rules.media.device-height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#device-height', 'device-height')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Deprecated in Media Queries Level 4.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#device-height', 'device-height')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/device-width/index.html
+++ b/files/en-us/web/css/@media/device-width/index.html
@@ -26,27 +26,7 @@ browser-compat: css.at-rules.media.device-width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#device-width', 'device-width')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Deprecated in Media Queries Level 4.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#device-width', 'device-width')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/display-mode/index.html
+++ b/files/en-us/web/css/@media/display-mode/index.html
@@ -67,22 +67,7 @@ browser-compat: css.at-rules.media.display-mode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Manifest', '#the-display-mode-media-feature', 'display-mode')}}</td>
-   <td>{{Spec2('Manifest')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/forced-colors/index.html
+++ b/files/en-us/web/css/@media/forced-colors/index.html
@@ -116,22 +116,7 @@ browser-compat: css.at-rules.media.forced-colors
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#forced-colors', 'forced-colors')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/grid/index.html
+++ b/files/en-us/web/css/@media/grid/index.html
@@ -61,27 +61,7 @@ browser-compat: css.at-rules.media.grid
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#grid', 'grid')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#grid', 'grid')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/height/index.html
+++ b/files/en-us/web/css/@media/height/index.html
@@ -53,27 +53,7 @@ browser-compat: css.at-rules.media.height
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#height', 'height')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>The value can now be negative, in which case it computes to false.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#height', 'height')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition. The value must be nonnegative.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/hover/index.html
+++ b/files/en-us/web/css/@media/hover/index.html
@@ -44,22 +44,7 @@ browser-compat: css.at-rules.media.hover
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#hover', 'hover')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/index.html
+++ b/files/en-us/web/css/@media/index.html
@@ -107,47 +107,7 @@ browser-compat: css.at-rules.media
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#media-descriptor-table', '@media descriptors')}}</td>
-   <td>Reinstates <code>inverted-colors</code> and Custom Media Queries, which were removed from Level 4.<br>
-    Adds <code>prefers-reduced-motion</code>, <code>prefers-reduced-transparency</code>, <code>prefers-contrast</code>, and <code>prefers-color-scheme</code> media features.</td>
-   <td><a href="https://github.com/w3c/csswg-drafts/issues">CSS Working Group drafts GitHub issues</a></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Conditional', '#at-media', '@media')}}</td>
-   <td>Defines the basic syntax of the <code>@media</code> rule.</td>
-   <td><a href="https://github.com/w3c/csswg-drafts/issues">CSS Working Group drafts GitHub issues</a></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#media', '@media')}}</td>
-   <td>
-    <p>Adds <code>scripting</code>, <code>pointer</code>, <code>hover</code>, <code>update</code>, <code>overflow-block</code>, and <code>overflow-inline</code> media features.<br>
-     Deprecates all media types except for <code>screen</code>, <code>print</code>, <code>speech</code>, and <code>all</code>.<br>
-     Makes the syntax more flexible by adding, among other things, the <code>or</code> keyword.</p>
-   </td>
-   <td><a href="https://github.com/w3c/csswg-drafts/issues">CSS Working Group drafts GitHub issues</a></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#media0', '@media')}}</td>
-   <td></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'media.html#at-media-rule', '@media')}}</td>
-   <td>Initial definition.</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/inverted-colors/index.html
+++ b/files/en-us/web/css/@media/inverted-colors/index.html
@@ -57,22 +57,7 @@ browser-compat: css.at-rules.media.inverted-colors
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#inverted', 'inverted-colors')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/monochrome/index.html
+++ b/files/en-us/web/css/@media/monochrome/index.html
@@ -52,27 +52,7 @@ browser-compat: css.at-rules.media.monochrome
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#monochrome', 'monochrome')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>The value can now be negative, in which case it computes to false.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#monochrome', 'monochrome')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition. The value must be nonnegative.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/orientation/index.html
+++ b/files/en-us/web/css/@media/orientation/index.html
@@ -68,27 +68,7 @@ div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#orientation', 'orientation')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#orientation', 'orientation')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/overflow-block/index.html
+++ b/files/en-us/web/css/@media/overflow-block/index.html
@@ -49,22 +49,7 @@ browser-compat: css.at-rules.media.overflow-block
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#mf-overflow-block', 'overflow-block')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/overflow-inline/index.html
+++ b/files/en-us/web/css/@media/overflow-inline/index.html
@@ -49,22 +49,7 @@ browser-compat: css.at-rules.media.overflow-inline
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#mf-overflow-inline', 'overflow-inline')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/pointer/index.html
+++ b/files/en-us/web/css/@media/pointer/index.html
@@ -77,22 +77,7 @@ input[type="checkbox"]:checked {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#pointer', 'pointer')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.html
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.html
@@ -68,22 +68,7 @@ browser-compat: css.at-rules.media.prefers-color-scheme
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#descdef-media-prefers-color-scheme', 'prefers-color-scheme')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/prefers-contrast/index.html
+++ b/files/en-us/web/css/@media/prefers-contrast/index.html
@@ -56,22 +56,7 @@ browser-compat: css.at-rules.media.prefers-contrast
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#descdef-media-prefers-contrast', 'prefers-contrast')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/prefers-reduced-data/index.html
+++ b/files/en-us/web/css/@media/prefers-reduced-data/index.html
@@ -71,22 +71,7 @@ body {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#descdef-media-prefers-reduced-data', 'reduced-data')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.html
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.html
@@ -100,22 +100,7 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS5 Media Queries', '#descdef-media-prefers-reduced-motion', 'prefers-reduced-motion')}}</td>
-			<td>{{Spec2('CSS5 Media Queries')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/resolution/index.html
+++ b/files/en-us/web/css/@media/resolution/index.html
@@ -53,22 +53,7 @@ browser-compat: css.at-rules.media.resolution
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#resolution', 'resolution')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/scripting/index.html
+++ b/files/en-us/web/css/@media/scripting/index.html
@@ -65,22 +65,7 @@ browser-compat: css.at-rules.media.scripting
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS5 Media Queries', '#scripting', 'scripting')}}</td>
-   <td>{{Spec2('CSS5 Media Queries')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/shape/index.html
+++ b/files/en-us/web/css/@media/shape/index.html
@@ -64,7 +64,20 @@ browser-compat: css.at-rules.media.shape
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS Round Display', '#shape-media-feature', 'shape')}}</td>
+   <td>{{Spec2('CSS Round Display')}}</td>
+  </tr>
+ </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/shape/index.html
+++ b/files/en-us/web/css/@media/shape/index.html
@@ -64,20 +64,7 @@ browser-compat: css.at-rules.media.shape
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Round Display', '#shape-media-feature', 'shape')}}</td>
-   <td>{{Spec2('CSS Round Display')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/update-frequency/index.html
+++ b/files/en-us/web/css/@media/update-frequency/index.html
@@ -57,7 +57,22 @@ browser-compat: css.at-rules.media.update
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS4 Media Queries', '#update', 'update')}}</td>
+   <td>{{Spec2('CSS4 Media Queries')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/update-frequency/index.html
+++ b/files/en-us/web/css/@media/update-frequency/index.html
@@ -57,22 +57,7 @@ browser-compat: css.at-rules.media.update
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#update', 'update')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/width/index.html
+++ b/files/en-us/web/css/@media/width/index.html
@@ -53,27 +53,7 @@ browser-compat: css.at-rules.media.width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#width', 'width')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>The value can now be negative, in which case it computes to false.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Media Queries', '#width', 'width')}}</td>
-   <td>{{Spec2('CSS3 Media Queries')}}</td>
-   <td>Initial definition. The value must be nonnegative.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@namespace/index.html
+++ b/files/en-us/web/css/@namespace/index.html
@@ -62,22 +62,7 @@ svg|a {}
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Namespaces', '#declaration', '@namespace')}}</td>
-   <td>{{Spec2('CSS3 Namespaces')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@page/index.html
+++ b/files/en-us/web/css/@page/index.html
@@ -60,32 +60,7 @@ browser-compat: css.at-rules.page
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Logical Properties', '#page', ':recto and :verso')}}</td>
-   <td>{{Spec2('CSS Logical Properties')}}</td>
-   <td>Adds the <code>:recto</code> and <code>:verso</code> page selectors</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Paged Media', '#at-page-rule', '@page')}}</td>
-   <td>{{Spec2('CSS3 Paged Media')}}</td>
-   <td>No change from {{SpecName('CSS2.1')}}, though more CSS at-rules can be used inside a <code>@page</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'page.html#page-selectors', '@page')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@page/size/index.html
+++ b/files/en-us/web/css/@page/size/index.html
@@ -108,22 +108,7 @@ size: A4 portrait;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Paged Media', '#page-size-prop', 'size')}}</td>
-   <td>{{Spec2('CSS3 Paged Media')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@property/index.html
+++ b/files/en-us/web/css/@property/index.html
@@ -59,20 +59,7 @@ browser-compat: css.at-rules.property
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Properties and Values API', '#at-property-rule')}}</td>
-   <td>{{Spec2('CSS Properties and Values API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@property/inherits/index.html
+++ b/files/en-us/web/css/@property/inherits/index.html
@@ -69,20 +69,7 @@ browser-compat: css.at-rules.property.inherits
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Properties and Values API', '#inherits-descriptor', 'inherits')}}</td>
-   <td>{{Spec2('CSS Properties and Values API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@property/initial-value/index.html
+++ b/files/en-us/web/css/@property/initial-value/index.html
@@ -66,20 +66,7 @@ browser-compat: css.at-rules.property.initial-value
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Properties and Values API', '#initial-value-descriptor', 'initial-value')}}</td>
-   <td>{{Spec2('CSS Properties and Values API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@property/syntax/index.html
+++ b/files/en-us/web/css/@property/syntax/index.html
@@ -94,20 +94,7 @@ syntax: '*'; /* any valid token */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS Properties and Values API', '#the-syntax-descriptor', 'syntax')}}</td>
-   <td>{{Spec2('CSS Properties and Values API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@supports/index.html
+++ b/files/en-us/web/css/@supports/index.html
@@ -165,27 +165,7 @@ browser-compat: css.at-rules.supports
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Conditional", "#at-supports-ext", "@supports")}}</td>
-   <td>{{Spec2("CSS4 Conditional")}}</td>
-   <td>Adds the <code>selector()</code> function.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Conditional", "#at-supports", "@supports")}}</td>
-   <td>{{Spec2("CSS3 Conditional")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@viewport/index.html
+++ b/files/en-us/web/css/@viewport/index.html
@@ -96,27 +96,7 @@ browser-compat: css.at-rules.viewport
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Round Display", "#extending-viewport-rule", "@viewport")}}</td>
-   <td>{{Spec2("CSS Round Display")}}</td>
-   <td>Defined the {{cssxref("@viewport/viewport-fit", "viewport-fit")}} descriptor.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Device', '#atviewport-rule', '@viewport')}}</td>
-   <td>{{Spec2('CSS3 Device')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the CSS pseudo-classes to the `{{Specifications}}` macro.

I left 2 rules or descriptors, or prefixed properties with the old tables. They are recent additions to the standard and have no bcd entries (not supported anywhere I guess). The tables will be replaced when they get bcd:
- `shape` of the `@media` at-rule defined in CSS Round Display, and
- `update-frequency` of the `@media` at-rule defined in Media Queries (L4).

Also, `@color-profile` had a spec table with everything "Unknown" in it, so I kept it replaced.

All other pages look fine, which is really cool! 