### PR TITLE
Adds a note about video formats

### DIFF
--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -50,6 +50,11 @@ browser-compat: html.elements.img
 
 <div class="notecard note">
 	<h4>Tip</h4>
+	<p>Safari 11.1 added the ability to use a video format, as an animated gif replacement. No other browser supports this. See the <a href="https://crbug.com/791658">Chromium bug</a>, and <a href="http://bugzil.la/895131">Firefox bug</a> for more information.</p>
+</div>
+
+<div class="notecard note">
+	<h4>Note</h4>
 	<p>See <a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a> for more comprehensive information about image formats supported by web browsers. This includes image formats that are supported but not recommended for web content (e.g. ICO, BMP, etc.)</p>
 </div>
 


### PR DESCRIPTION
Fixes #1777 by adding a note about video as used as a format for `<img>` elements.