### PR TITLE
Fixing a bunch of links in the animation property and shorthands pages

### DIFF
--- a/files/en-us/web/css/animation-delay/index.html
+++ b/files/en-us/web/css/animation-delay/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-delay
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-delay</code></strong> <a href="/en-US/docs/CSS">CSS</a> property specifies the amount of time to wait from applying the animation to an element before beginning to perform the animation. The animation can start later, immediately from its beginning, or immediately and partway through the animation.</p>
+<p>The <strong><code>animation-delay</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property specifies the amount of time to wait from applying the animation to an element before beginning to perform the animation. The animation can start later, immediately from its beginning, or immediately and partway through the animation.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-delay.html")}}</div>
 
@@ -46,7 +46,7 @@ animation-delay: unset;
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -88,7 +88,7 @@ animation-delay: unset;
 
 <p>{{EmbedLiveSample("Examples","100%","250")}}</p>
 
-<p>See <a href="/en-US/docs/CSS/CSS_animations">CSS animations</a> for examples.</p>
+<p>See <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations">CSS animations</a> for examples.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -101,6 +101,6 @@ animation-delay: unset;
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/CSS/Tutorials/Using_CSS_animations" title="Tutorial about CSS animations">Using CSS animations</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations" title="Tutorial about CSS animations">Using CSS animations</a></li>
  <li>JavaScript {{domxref("AnimationEvent")}} API</li>
 </ul>

--- a/files/en-us/web/css/animation-direction/index.html
+++ b/files/en-us/web/css/animation-direction/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-direction
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-direction</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets whether an animation should play forward, backward, or alternate back and forth between playing the sequence forward and backward.</p>
+<p>The <strong><code>animation-direction</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets whether an animation should play forward, backward, or alternate back and forth between playing the sequence forward and backward.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-direction.html")}}</div>
 
@@ -50,7 +50,7 @@ animation-direction: unset;
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/animation-duration/index.html
+++ b/files/en-us/web/css/animation-duration/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-duration
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-duration</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets the length of time that an animation takes to complete one cycle.</p>
+<p>The <strong><code>animation-duration</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the length of time that an animation takes to complete one cycle.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-duration.html")}}</div>
 
@@ -46,7 +46,7 @@ animation-duration: unset;
 </div>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/animation-fill-mode/index.html
+++ b/files/en-us/web/css/animation-fill-mode/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-fill-mode
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-fill-mode</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets how a CSS animation applies styles to its target before and after its execution.</p>
+<p>The <strong><code>animation-fill-mode</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets how a CSS animation applies styles to its target before and after its execution.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-fill-mode.html")}}</div>
 
@@ -42,7 +42,7 @@ animation-fill-mode: unset;
  <dt><code>none</code></dt>
  <dd>The animation will not apply any styles to the target when it's not executing. The element will instead be displayed using any other CSS rules applied to it. This is the default value.</dd>
  <dt><code>forwards</code></dt>
- <dd>The target will retain the computed values set by the last <a href="/en-US/docs/CSS/@keyframes">keyframe</a> encountered during execution. The last keyframe depends on the value of {{cssxref("animation-direction")}} and {{cssxref("animation-iteration-count")}}:
+ <dd>The target will retain the computed values set by the last <a href="/en-US/docs/Web/CSS/@keyframes">keyframe</a> encountered during execution. The last keyframe depends on the value of {{cssxref("animation-direction")}} and {{cssxref("animation-iteration-count")}}:
  <table class="standard-table">
   <thead>
    <tr>
@@ -86,7 +86,7 @@ animation-fill-mode: unset;
  </table>
  </dd>
  <dt><code>backwards</code></dt>
- <dd>The animation will apply the values defined in the first relevant <a href="/en-US/docs/CSS/@keyframes">keyframe</a> as soon as it is applied to the target, and retain this during the {{cssxref("animation-delay")}} period. The first relevant keyframe depends on the value of {{cssxref("animation-direction")}}:
+ <dd>The animation will apply the values defined in the first relevant <a href="/en-US/docs/Web/CSS/@keyframes">keyframe</a> as soon as it is applied to the target, and retain this during the {{cssxref("animation-delay")}} period. The first relevant keyframe depends on the value of {{cssxref("animation-direction")}}:
  <table class="standard-table">
   <thead>
    <tr>
@@ -111,7 +111,7 @@ animation-fill-mode: unset;
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -159,7 +159,7 @@ animation-fill-mode: unset;
 
 <p>{{EmbedLiveSample('Examples',700,300)}}</p>
 
-<p>See <a href="/en-US/docs/CSS/CSS_animations">CSS animations</a> for more examples.</p>
+<p>See <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations">CSS animations</a> for more examples.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/animation-iteration-count/index.html
+++ b/files/en-us/web/css/animation-iteration-count/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - CSS Property Animations
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-iteration-count
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-iteration-count</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets the number of times an animation sequence should be played before stopping.</p>
+<p>The <strong><code>animation-iteration-count</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the number of times an animation sequence should be played before stopping.</p>
 
 <p>If multiple values are specified, each time the animation is played the next value in the list is used, cycling back to the first value after the last one is used.</p>
 
@@ -49,7 +49,7 @@ animation-iteration-count: unset;</pre>
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/animation-name/index.html
+++ b/files/en-us/web/css/animation-name/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-name
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-name</code></strong> <a href="/en-US/docs/CSS">CSS</a> property specifies the names of one or more {{cssxref("@keyframes")}} at-rules describing the animation or animations to apply to the element.</p>
+<p>The <strong><code>animation-name</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property specifies the names of one or more {{cssxref("@keyframes")}} at-rules describing the animation or animations to apply to the element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-name.html")}}</div>
 
@@ -45,7 +45,7 @@ animation-name: unset;</pre>
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/animation-play-state/index.html
+++ b/files/en-us/web/css/animation-play-state/index.html
@@ -6,12 +6,12 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-play-state
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-play-state</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets whether an animation is running or paused.</p>
+<p>The <strong><code>animation-play-state</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets whether an animation is running or paused.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-play-state.html")}}</div>
 
@@ -43,7 +43,7 @@ animation-play-state: unset;
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/animation-timing-function/index.html
+++ b/files/en-us/web/css/animation-timing-function/index.html
@@ -6,7 +6,7 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.animation-timing-function
 ---
 <div>{{CSSRef}}</div>
@@ -101,7 +101,7 @@ animation-timing-function: unset;
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
+<p><strong>Note</strong>: When you specify multiple comma-separated values on an <code>animation-*</code> property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values">Setting multiple animation property values</a>.</p>
 </div>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -254,7 +254,7 @@ animation-timing-function: unset;
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations" title="CSS developer guide about CSS animations">Using CSS animations</a></li>
- <li>{{cssxref('timing-function')}}</li>
+ <li>{{cssxref('easing-function')}}</li>
  <li>JavaScript {{domxref("AnimationEvent")}} API</li>
- <li><a href="http://cubic-bezier.com">cubic-bezier.com</a></li>
+ <li><a href="https://cubic-bezier.com">cubic-bezier.com</a></li>
 </ul>

--- a/files/en-us/web/css/animation/index.html
+++ b/files/en-us/web/css/animation/index.html
@@ -6,7 +6,7 @@ tags:
   - CSS Animations
   - CSS Property
   - Reference
-  - 'recipe:css-shorthand-property'
+  - recipe:css-shorthand-property
 browser-compat: css.properties.animation
 ---
 <div>{{CSSRef}}</div>
@@ -26,7 +26,7 @@ animation: slidein 3s linear 1s;
 animation: slidein 3s;
 </pre>
 
-<p>A <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_transitions#Which_CSS_properties_are_animatable">description of which properties are animatable</a> is available; it's worth noting that this description is also valid for <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_transitions">CSS transitions</a>.</p>
+<p>A <a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions#which_css_properties_are_animatable">description of which properties are animatable</a> is available; it's worth noting that this description is also valid for <a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transitions</a>.</p>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 
@@ -90,7 +90,7 @@ animation: slidein 3s;
 	<li><a href="https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity">Designing Safer Web Animation For Motion Sensitivity · An A List Apart Article</a></li>
 	<li><a href="https://css-tricks.com/introduction-reduced-motion-media-query/">An Introduction to the Reduced Motion Media Query | CSS-Tricks</a></li>
 	<li><a href="https://webkit.org/blog/7551/responsive-design-for-motion/">Responsive Design for Motion | WebKit</a></li>
-	<li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.2_%E2%80%94_Enough_Time_Provide_users_enough_time_to_read_and_use_content">MDN Understanding WCAG, Guideline 2.2 explanations</a></li>
+	<li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#guideline_2.2_%e2%80%94_enough_time_provide_users_enough_time_to_read_and_use_content">MDN Understanding WCAG, Guideline 2.2 explanations</a></li>
 	<li><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-pause.html">Understanding Success Criterion 2.2.2 | W3C Understanding WCAG 2.0</a></li>
 </ul>
 
@@ -147,7 +147,7 @@ animation: slidein 3s;
 
 <p>{{EmbedLiveSample('Cylon_Eye')}}</p>
 
-<p>See <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Examples">Using CSS animations</a> for additional examples.</p>
+<p>See <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#examples">Using CSS animations</a> for additional examples.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Spotted a bunch of link flaws in this set of pages. 
