### PR TITLE
Convert spec table in CSS properties (from t to z)

### DIFF
--- a/files/en-us/web/css/tab-size/index.html
+++ b/files/en-us/web/css/tab-size/index.html
@@ -92,22 +92,7 @@ tab-size: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#tab-size-property', 'tab-size')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/table-layout/index.html
+++ b/files/en-us/web/css/table-layout/index.html
@@ -81,22 +81,7 @@ td {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS2.1', 'tables.html#width-layout', 'table-layout')}}</td>
-			<td>{{Spec2('CSS2.1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-align-last/index.html
+++ b/files/en-us/web/css/text-align-last/index.html
@@ -84,22 +84,7 @@ text-align-last: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#text-align-last-property', 'text-align-last')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-align/index.html
+++ b/files/en-us/web/css/text-align/index.html
@@ -160,42 +160,7 @@ text-align: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Logical Properties', '#text-align', 'text-align')}}</td>
-   <td>{{Spec2('CSS Logical Properties')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS4 Text', '#alignment', 'text-align')}}</td>
-   <td>{{Spec2('CSS4 Text')}}</td>
-   <td>Added the <code>&lt;string&gt;</code> value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#text-align-property', 'text-align')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Added the <code>start</code>, <code>end</code>, and <code>match-parent</code> values. Changed the unnamed initial value to <code>start</code> (which it was).</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'text.html#alignment-prop', 'text-align')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#text-align', 'text-align')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-combine-upright/index.html
+++ b/files/en-us/web/css/text-combine-upright/index.html
@@ -98,27 +98,7 @@ text-combine-upright: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Writing Modes", "#propdef-text-combine-upright", "text-combine-upright")}}</td>
-   <td>{{Spec2("CSS4 Writing Modes")}}</td>
-   <td>Add <code>digits</code> value</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Writing Modes", "#propdef-text-combine-upright", "text-combine-upright")}}</td>
-   <td>{{Spec2("CSS3 Writing Modes")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-color/index.html
+++ b/files/en-us/web/css/text-decoration-color/index.html
@@ -93,22 +93,7 @@ s {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS3 Text Decoration', '#text-decoration-color-property', 'text-decoration-color') }}</td>
-			<td>{{ Spec2('CSS3 Text Decoration') }}</td>
-			<td>Initial definition. The {{cssxref("text-decoration")}} property is now a shorthand to define multiple related properties.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-line/index.html
+++ b/files/en-us/web/css/text-decoration-line/index.html
@@ -83,22 +83,7 @@ text-decoration-line: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-decoration-line-property', 'text-decoration-line')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Initial definition. The {{cssxref("text-decoration")}} property is now a shorthand to define multiple related properties.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-skip-ink/index.html
+++ b/files/en-us/web/css/text-decoration-skip-ink/index.html
@@ -88,22 +88,7 @@ text-decoration-skip: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Text Decoration", "#text-decoration-skip-ink-property", "text-decoration-skip-ink")}}</td>
-   <td>{{Spec2("CSS4 Text Decoration")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-skip/index.html
+++ b/files/en-us/web/css/text-decoration-skip/index.html
@@ -92,22 +92,7 @@ text-decoration-skip: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Text Decoration", "#text-decoration-skipping", "text-decoration-skip")}}</td>
-   <td>{{Spec2("CSS4 Text Decoration")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-style/index.html
+++ b/files/en-us/web/css/text-decoration-style/index.html
@@ -94,22 +94,7 @@ text-decoration-style: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Text Decoration', '#text-decoration-style-property', 'text-decoration-style') }}</td>
-   <td>{{ Spec2('CSS3 Text Decoration') }}</td>
-   <td>Initial definition. The {{cssxref("text-decoration")}} property is now a shorthand to define multiple related properties.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-decoration-thickness/index.html
+++ b/files/en-us/web/css/text-decoration-thickness/index.html
@@ -92,22 +92,7 @@ text-decoration-thickness: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Text Decoration', '#text-decoration-width-property', 'text-decoration-width')}}</td>
-   <td>{{Spec2('CSS4 Text Decoration')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <div class="notecard note">
 <p><strong>Note</strong>: The property used to be called <code>text-decoration-width</code>, but was updated in 2019 to <code>text-decoration-thickness</code>.</p>

--- a/files/en-us/web/css/text-decoration/index.html
+++ b/files/en-us/web/css/text-decoration/index.html
@@ -113,37 +113,7 @@ text-decoration: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Text Decoration')}}</td>
-			<td>{{Spec2('CSS4 Text Decoration')}}</td>
-			<td>Adds {{cssxref("text-decoration-thickness")}}; note that this isn't yet officially part of the shorthand — this is as yet unspecified.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS3 Text Decoration', '#text-decoration-property', 'text-decoration')}}</td>
-			<td>{{Spec2('CSS3 Text Decoration')}}</td>
-			<td>Transformed into a shorthand property. Added support for the value of {{cssxref('text-decoration-style')}}.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS2.1', 'text.html#lining-striking-props', 'text-decoration')}}</td>
-			<td>{{Spec2('CSS2.1')}}</td>
-			<td>No significant changes.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS1', '#text-decoration', 'text-decoration')}}</td>
-			<td>{{Spec2('CSS1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-emphasis-color/index.html
+++ b/files/en-us/web/css/text-emphasis-color/index.html
@@ -75,22 +75,7 @@ text-emphasis-color: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-emphasis-color-property', 'text-emphasis')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-emphasis-position/index.html
+++ b/files/en-us/web/css/text-emphasis-position/index.html
@@ -124,22 +124,7 @@ em rt {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS3 Text Decoration', '#text-emphasis-position-property', 'text-emphasis')}}</td>
-			<td>{{Spec2('CSS3 Text Decoration')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-emphasis-style/index.html
+++ b/files/en-us/web/css/text-emphasis-style/index.html
@@ -83,22 +83,7 @@ text-emphasis-style: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-emphasis-style-property', 'text-emphasis')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-emphasis/index.html
+++ b/files/en-us/web/css/text-emphasis/index.html
@@ -115,22 +115,7 @@ text-emphasis: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-emphasis-property', 'text-emphasis')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-indent/index.html
+++ b/files/en-us/web/css/text-indent/index.html
@@ -163,32 +163,7 @@ p + p {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#text-indent-property', 'text-indent')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Adds the <code>hanging</code> and <code>each-line</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'text.html#indentation-prop', 'text-indent')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>The behavior with <code>display: inline-block</code> and anonymous block boxes is explicitly defined.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#text-indent', 'text-indent')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-justify/index.html
+++ b/files/en-us/web/css/text-justify/index.html
@@ -96,22 +96,7 @@ text-justify: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#text-justify-property', 'text-justify')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-orientation/index.html
+++ b/files/en-us/web/css/text-orientation/index.html
@@ -75,22 +75,7 @@ text-orientation: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Writing Modes', '#text-orientation', 'text-orientation')}}</td>
-   <td>{{Spec2('CSS3 Writing Modes')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -204,27 +204,7 @@ for (let para of paras) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://drafts.csswg.org/css-overflow-4/#text-overflow">CSS Overflow Module Level 4</a></td>
-   <td></td>
-   <td>Added the values <code>&lt;string&gt;</code> and <code>fade</code> and the <code>fade()</code> function</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Overflow', '#text-overflow', 'text-overflow')}}</td>
-   <td>{{Spec2('CSS3 Overflow')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <p>A previous version of this interface reached the <em>Candidate Recommendation</em> status. As some not-listed-at-risk features needed to be removed, the spec was demoted to the <em>Working Draft</em> level, explaining why browsers implemented this property unprefixed, though not at the CR state.</p>
 

--- a/files/en-us/web/css/text-rendering/index.html
+++ b/files/en-us/web/css/text-rendering/index.html
@@ -113,27 +113,7 @@ text-rendering: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('SVG2', 'painting.html#TextRenderingProperty', 'text-rendering')}}</td>
-   <td>{{Spec2('SVG2')}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'painting.html#TextRenderingProperty', 'text-rendering')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-shadow/index.html
+++ b/files/en-us/web/css/text-shadow/index.html
@@ -109,22 +109,7 @@ text-shadow: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-shadow-property', 'text-shadow')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>The CSS property <code>text-shadow</code> was <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/text.html#text-shadow-props">improperly defined in CSS2</a> and dropped in CSS2 (Level 1). The CSS Text Module Level 3 spec refined the syntax. Later it was moved to <a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Module Level 3</a>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-size-adjust/index.html
+++ b/files/en-us/web/css/text-size-adjust/index.html
@@ -69,22 +69,7 @@ text-size-adjust: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Text Size Adjust", "#adjustment-control", "text-size-adjust")}}</td>
-   <td>{{Spec2("CSS Text Size Adjust")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-transform/index.html
+++ b/files/en-us/web/css/text-transform/index.html
@@ -333,32 +333,7 @@ strong { width: 100%; float: right; }</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#text-transform', 'text-transform')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>From {{SpecName('CSS2.1', 'text.html#caps-prop', 'text-transform')}}, extends letters to any Unicode character in the Number or Letter general category. Modifies the behavior of <code>capitalize</code> to apply to the first letter of the word, ignoring initial punctuations or symbols. Adds the <code>full-width</code> and <code>full-size-kana</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'text.html#caps-prop', 'text-transform')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>From {{SpecName('CSS1', '#text-transform', 'text-transform')}}, extends letters to non-latin bi-cameral scripts</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#text-transform', 'text-transform')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-underline-offset/index.html
+++ b/files/en-us/web/css/text-underline-offset/index.html
@@ -79,22 +79,7 @@ text-underline-offset: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Text Decoration', '#underline-offset', 'text-underline-offset')}}</td>
-			<td>{{Spec2('CSS4 Text Decoration')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/text-underline-position/index.html
+++ b/files/en-us/web/css/text-underline-position/index.html
@@ -117,22 +117,7 @@ tellus ac erat posuere.&lt;/p&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text Decoration', '#text-underline-position-property', 'text-underline-position')}}</td>
-   <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/time-percentage/index.html
+++ b/files/en-us/web/css/time-percentage/index.html
@@ -54,27 +54,7 @@ browser-compat: css.types.time-percentage
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Values', '#mixed-percentages', '&lt;time-percentage&gt;')}}</td>
-   <td>{{Spec2('CSS4 Values')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Values', '#mixed-percentages', '&lt;time-percentage&gt;')}}</td>
-   <td>{{Spec2('CSS3 Values')}}</td>
-   <td>Defines <code>&lt;time-percentage&gt;</code>. Adds <code>calc()</code></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/time/index.html
+++ b/files/en-us/web/css/time/index.html
@@ -56,32 +56,7 @@ browser-compat: css.types.time
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Values','#time','&lt;time&gt;')}}</td>
-			<td>{{Spec2('CSS4 Values')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS3 Values','#time','&lt;time&gt;')}}</td>
-			<td>{{Spec2('CSS3 Values')}}</td>
-			<td>Normative definition of <code>s</code> and <code>ms</code>.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS2.1','aural.html#times','&lt;time&gt;')}}</td>
-			<td>{{Spec2('CSS2.1')}}</td>
-			<td>Informal definition of <code>s</code> and <code>ms</code>.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/top/index.html
+++ b/files/en-us/web/css/top/index.html
@@ -100,27 +100,7 @@ div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Positioning', '#propdef-top', 'top')}}</td>
-   <td>{{Spec2('CSS3 Positioning')}}</td>
-   <td>Adds behavior for sticky positioning.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visuren.html#propdef-top', 'top')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-box/index.html
+++ b/files/en-us/web/css/transform-box/index.html
@@ -105,22 +105,7 @@ transform-box: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transforms', '#transform-box', 'transform-box')}}</td>
-   <td>{{Spec2('CSS3 Transforms')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/index.html
+++ b/files/en-us/web/css/transform-function/index.html
@@ -258,27 +258,7 @@ selectElem.addEventListener('change', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Transforms 2', '#transform-functions', '&lt;transform-function&gt;')}}</td>
-   <td>{{Spec2('CSS Transforms 2')}}</td>
-   <td>Added 3D transform functions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Transforms', '#transform-functions', '&lt;transform-function&gt;')}}</td>
-   <td>{{Spec2('CSS3 Transforms')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/matrix()/index.html
+++ b/files/en-us/web/css/transform-function/matrix()/index.html
@@ -252,22 +252,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-matrix", "matrix()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/matrix3d()/index.html
+++ b/files/en-us/web/css/transform-function/matrix3d()/index.html
@@ -281,22 +281,7 @@ body {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("CSS Transforms 2", "#funcdef-matrix3d", "matrix3d()")}}</td>
-			<td>{{Spec2("CSS Transforms 2")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/perspective()/index.html
+++ b/files/en-us/web/css/transform-function/perspective()/index.html
@@ -202,22 +202,7 @@ p + div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-perspective", "perspective()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/rotate()/index.html
+++ b/files/en-us/web/css/transform-function/rotate()/index.html
@@ -344,22 +344,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-rotate", "rotate()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/rotate3d()/index.html
+++ b/files/en-us/web/css/transform-function/rotate3d()/index.html
@@ -334,22 +334,7 @@ div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-rotate3d", "rotate3d()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/rotatex()/index.html
+++ b/files/en-us/web/css/transform-function/rotatex()/index.html
@@ -215,22 +215,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-rotatex", "rotateX()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/rotatey()/index.html
+++ b/files/en-us/web/css/transform-function/rotatey()/index.html
@@ -215,22 +215,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-rotatey", "rotateY()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/rotatez()/index.html
+++ b/files/en-us/web/css/transform-function/rotatez()/index.html
@@ -216,22 +216,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-rotatez", "rotateZ()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/scale()/index.html
+++ b/files/en-us/web/css/transform-function/scale()/index.html
@@ -307,22 +307,7 @@ scale(<var>sx</var>, <var>sy</var>)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-scale", "scale()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/scale3d()/index.html
+++ b/files/en-us/web/css/transform-function/scale3d()/index.html
@@ -219,22 +219,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-scale3d", "scale3d()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/scalex()/index.html
+++ b/files/en-us/web/css/transform-function/scalex()/index.html
@@ -251,22 +251,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-scalex", "scaleX()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/scaley()/index.html
+++ b/files/en-us/web/css/transform-function/scaley()/index.html
@@ -253,22 +253,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-scaley", "scaleY()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/scalez()/index.html
+++ b/files/en-us/web/css/transform-function/scalez()/index.html
@@ -199,22 +199,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-scalez", "scaleZ()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/skew()/index.html
+++ b/files/en-us/web/css/transform-function/skew()/index.html
@@ -313,22 +313,7 @@ div {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-skew", "skew()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/skewx()/index.html
+++ b/files/en-us/web/css/transform-function/skewx()/index.html
@@ -259,22 +259,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-skewx", "skewX()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/skewy()/index.html
+++ b/files/en-us/web/css/transform-function/skewy()/index.html
@@ -253,22 +253,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-skewy", "skewY()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/translate()/index.html
+++ b/files/en-us/web/css/transform-function/translate()/index.html
@@ -273,22 +273,7 @@ transform: translate(30%, 50%);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS3 Transforms', '#funcdef-transform-translate', 'translate()')}}</td>
-      <td>{{Spec2('CSS3 Transforms')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/translate3d()/index.html
+++ b/files/en-us/web/css/transform-function/translate3d()/index.html
@@ -179,22 +179,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS Transforms 2", "#funcdef-translate3d", "translate3d()")}}</td>
-      <td>{{Spec2("CSS Transforms 2")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/translatex/index.html
+++ b/files/en-us/web/css/transform-function/translatex/index.html
@@ -235,22 +235,7 @@ transform: translateX(50%);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-translatex", "translateX()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/translatey()/index.html
+++ b/files/en-us/web/css/transform-function/translatey()/index.html
@@ -167,22 +167,7 @@ transform: translateY(50%);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("CSS3 Transforms", "#funcdef-transform-translatey", "translateY()")}}</td>
-      <td>{{Spec2("CSS3 Transforms")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-function/translatez()/index.html
+++ b/files/en-us/web/css/transform-function/translatez()/index.html
@@ -178,22 +178,7 @@ browser-compat: css.types.transform-function
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('CSS Transforms 2', '#transform-functions', 'transform')}}</td>
-      <td>{{Spec2('CSS Transforms 2')}}</td>
-      <td>Adds 3D transform functions to the CSS Transforms standard.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform-style/index.html
+++ b/files/en-us/web/css/transform-style/index.html
@@ -145,22 +145,7 @@ checkbox.addEventListener('change', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Transforms 2', '#transform-style-property', 'transform-style')}}</td>
-   <td>{{Spec2('CSS Transforms 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transform/index.html
+++ b/files/en-us/web/css/transform/index.html
@@ -121,27 +121,7 @@ transform: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Transforms 2', '#transform-functions', 'transform')}}</td>
-   <td>{{Spec2('CSS Transforms 2')}}</td>
-   <td>Adds 3D transform functions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Transforms', '#transform-property', 'transform')}}</td>
-   <td>{{Spec2('CSS3 Transforms')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transition-delay/index.html
+++ b/files/en-us/web/css/transition-delay/index.html
@@ -128,22 +128,7 @@ changeButton.addEventListener("click", change);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS3 Transitions', '#transition-delay-property', 'transition-delay')}}</td>
-			<td>{{Spec2('CSS3 Transitions')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transition-duration/index.html
+++ b/files/en-us/web/css/transition-duration/index.html
@@ -119,22 +119,7 @@ changeButton.addEventListener("click", change);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS3 Transitions', '#transition-duration-property', 'transition-duration') }}</td>
-			<td>{{ Spec2('CSS3 Transitions') }}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transition-property/index.html
+++ b/files/en-us/web/css/transition-property/index.html
@@ -90,22 +90,7 @@ transition-property: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS3 Transitions', '#transition-property-property', 'transition-property')}}</td>
-			<td>{{Spec2('CSS3 Transitions')}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transition-timing-function/index.html
+++ b/files/en-us/web/css/transition-timing-function/index.html
@@ -248,22 +248,7 @@ var intervalID = window.setInterval(updateTransition, 10000);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS3 Transitions', '#transition-timing-function-property', 'transition-timing-function') }}</td>
-			<td>{{ Spec2('CSS3 Transitions') }}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/transition/index.html
+++ b/files/en-us/web/css/transition/index.html
@@ -110,22 +110,7 @@ transition: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS3 Transitions', '#transition-shorthand-property', 'transition') }}</td>
-			<td>{{ Spec2('CSS3 Transitions') }}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/translate/index.html
+++ b/files/en-us/web/css/translate/index.html
@@ -103,22 +103,7 @@ div:hover .translate {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Transforms 2', '#individual-transforms', 'individual transforms')}}</td>
-   <td>{{Spec2('CSS Transforms 2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <p>{{CSSInfo}}</p>
 

--- a/files/en-us/web/css/translate/index.html
+++ b/files/en-us/web/css/translate/index.html
@@ -105,8 +105,6 @@ div:hover .translate {
 
 {{Specifications}}
 
-<p>{{CSSInfo}}</p>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/css/translation-value/index.html
+++ b/files/en-us/web/css/translation-value/index.html
@@ -135,22 +135,7 @@ selectElem.addEventListener('change', () =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Transforms', '#transform-functions', 'The Transform Functions')}}</td>
-   <td>{{Spec2('CSS3 Transforms')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/type_selectors/index.html
+++ b/files/en-us/web/css/type_selectors/index.html
@@ -62,37 +62,7 @@ example|h1 { color: blue }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Selectors', '#type-selectors', 'Type (tag name) selector')}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Selectors', '#type-selectors', 'type selectors')}}</td>
-   <td>{{Spec2('CSS3 Selectors')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'selector.html#type-selectors', 'type selectors')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#basic-concepts', 'type selectors')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/unicode-bidi/index.html
+++ b/files/en-us/web/css/unicode-bidi/index.html
@@ -85,27 +85,7 @@ unicode-bidi: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Writing Modes', '#unicode-bidi', 'unicode-bidi')}}</td>
-   <td>{{Spec2('CSS3 Writing Modes')}}</td>
-   <td>Added <code>plaintext</code>, <code>isolate</code>, and <code>isolate-override</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visuren.html#propdef-unicode-bidi', 'unicode-bidi')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/universal_selectors/index.html
+++ b/files/en-us/web/css/universal_selectors/index.html
@@ -80,32 +80,7 @@ example|* { color: blue }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Selectors', '#the-universal-selector', 'universal selector')}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>No changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Selectors', '#universal-selector', 'universal selector')}}</td>
-   <td>{{Spec2('CSS3 Selectors')}}</td>
-   <td>Defines behavior regarding namespaces and adds hint that omitting the selector is allowed within pseudo-elements</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'selector.html#universal-selector', 'universal selector')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/unset/index.html
+++ b/files/en-us/web/css/unset/index.html
@@ -88,27 +88,7 @@ p {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS4 Cascade', '#inherit-initial', 'unset') }}</td>
-   <td>{{ Spec2('CSS4 Cascade') }}</td>
-   <td>No changes from Level 3.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS3 Cascade', '#inherit-initial', 'unset') }}</td>
-   <td>{{ Spec2('CSS3 Cascade') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -168,37 +168,7 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 Values', '#urls', 'url()')}}</td>
-			<td>{{Spec2('CSS4 Values')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS3 Values', '#urls', 'url()')}}</td>
-			<td>{{Spec2('CSS3 Values')}}</td>
-			<td>No significant change from CSS Level 2 (Revision 1).</td>
-		</tr>
-		<tr>
-			<td>{{Specname('CSS2.1', 'syndata.html#uri', 'uri()')}}</td>
-			<td>{{Spec2('CSS2.1')}}</td>
-			<td>No significant change from CSS Level 1.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('CSS1', '#url', 'url()')}}</td>
-			<td>{{Spec2('CSS1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/user-select/index.html
+++ b/files/en-us/web/css/user-select/index.html
@@ -121,22 +121,7 @@ user-select: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS4 UI', '#propdef-user-select', 'user-select')}}</td>
-			<td>{{Spec2('CSS4 UI')}}</td>
-			<td>Initial definition. Also defines <code>-webkit-user-select</code> as a deprecated alias of <code>user-select</code>.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/var()/index.html
+++ b/files/en-us/web/css/var()/index.html
@@ -76,22 +76,7 @@ body {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Variables', '#using-variables', 'var()')}}</td>
-   <td>{{Spec2('CSS3 Variables')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/vertical-align/index.html
+++ b/files/en-us/web/css/vertical-align/index.html
@@ -228,27 +228,7 @@ td {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visudet.html#propdef-vertical-align', 'vertical-align')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Adds the {{cssxref("&lt;length&gt;")}} value and allows it to be applied to elements with a {{cssxref("display")}} type of <code>table-cell</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#vertical-align', 'vertical-align')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/visibility/index.html
+++ b/files/en-us/web/css/visibility/index.html
@@ -141,32 +141,7 @@ td {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Ruby', '#hiding', 'visibility')}}</td>
-   <td>{{Spec2('CSS3 Ruby')}}</td>
-   <td>Defines the <code>collapse</code> value as it applies to ruby annotations.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Flexbox', '#visibility-collapse', 'visibility')}}</td>
-   <td>{{Spec2('CSS3 Flexbox')}}</td>
-   <td>Defines the <code>collapse</code> value as it applies to flex items.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visufx.html#visibility', 'visibility')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/white-space/index.html
+++ b/files/en-us/web/css/white-space/index.html
@@ -236,27 +236,7 @@ select.addEventListener("change", function(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Text", "#propdef-white-space", "white-space")}}</td>
-   <td>{{Spec2("CSS3 Text")}}</td>
-   <td>Precisely defines the breaking algorithms.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "text.html#white-space-prop", "white-space")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/widows/index.html
+++ b/files/en-us/web/css/widows/index.html
@@ -82,32 +82,7 @@ p:first-child {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fragmentation', '#widows-orphans', 'widows')}}</td>
-   <td>{{Spec2('CSS3 Fragmentation')}}</td>
-   <td>Extends <code>widows</code> to apply to any type of fragment, including pages, regions, or columns.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#filling-columns', 'widows')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Recommendations to consider <code>widows</code> in relation to columns.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'page.html#break-inside', 'widows')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/width/index.html
+++ b/files/en-us/web/css/width/index.html
@@ -153,37 +153,7 @@ width: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Sizing', '#width-height-keywords', 'width')}}</td>
-   <td>{{Spec2('CSS4 Sizing')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Sizing', '#width-height-keywords', 'width')}}</td>
-   <td>{{Spec2('CSS3 Sizing')}}</td>
-   <td>Added the <code>max-content</code>, <code>min-content</code>, <code>fit-content</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visudet.html#the-width-property', 'width')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Precises on which element it applies to.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#width', 'width')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/will-change/index.html
+++ b/files/en-us/web/css/will-change/index.html
@@ -114,22 +114,7 @@ function removeHint() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Will Change', '#will-change', 'will-change')}}</td>
-   <td>{{Spec2('CSS Will Change')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/word-break/index.html
+++ b/files/en-us/web/css/word-break/index.html
@@ -115,22 +115,7 @@ word-break: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#word-break-property', 'word-break')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/word-spacing/index.html
+++ b/files/en-us/web/css/word-spacing/index.html
@@ -88,32 +88,7 @@ word-spacing: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Text', '#propdef-word-spacing', 'word-spacing')}}</td>
-   <td>{{Spec2('CSS3 Text')}}</td>
-   <td>Replaces the previous values with a <code>&lt;spacing-limit&gt;</code> value that defines the same thing, plus the <code>&lt;percentage&gt;</code> value. Allows up to three values describing the optimum, minimum, and maximum value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'text.html#propdef-word-spacing', 'word-spacing')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#word-spacing', 'word-spacing')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/writing-mode/index.html
+++ b/files/en-us/web/css/writing-mode/index.html
@@ -186,27 +186,7 @@ th {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("CSS4 Writing Modes", "#block-flow", "writing-mode")}}</td>
-			<td>{{Spec2("CSS4 Writing Modes")}}</td>
-			<td>Add <code>sideways-lr</code> and <code>sideways-rl</code></td>
-		</tr>
-		<tr>
-			<td>{{SpecName("CSS3 Writing Modes", "#block-flow", "writing-mode")}}</td>
-			<td>{{Spec2("CSS3 Writing Modes")}}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/z-index/index.html
+++ b/files/en-us/web/css/z-index/index.html
@@ -112,22 +112,7 @@ z-index: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visuren.html#z-index', 'z-index')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the CSS properties (from t to z) to the `{{Specifications}}` macro.

All pages look fine, which is really cool! 