### PR TITLE
removing outdated support notes

### DIFF
--- a/files/en-us/web/css/background-position/index.html
+++ b/files/en-us/web/css/background-position/index.html
@@ -185,12 +185,6 @@ div {
 
 <p>{{Compat}}</p>
 
-<h3 id="Quantum_CSS_notes">Quantum CSS notes</h3>
-
-<ul>
- <li>Gecko has a bug meaning that <code>background-position</code> can't be {{cssxref("transition","transitioned")}} between two values containing different numbers of {{cssxref("&lt;position&gt;")}} values, for example <code>background-position: 10px 10px;</code> and <code>background-position: 20px 20px, 30px 30px;</code> (see {{bug(1390446)}}). Firefox's new parallel CSS engine (also known as <a href="https://wiki.mozilla.org/Quantum">Quantum CSS</a> or <a href="https://wiki.mozilla.org/Quantum/Stylo">Stylo</a>, planned for release in Firefox 57) fixes this.</li>
-</ul>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/en-us/web/css/gradient/radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/radial-gradient()/index.html
@@ -144,10 +144,6 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <div>{{Compat}}</div>
 
-<h3 id="Quantum_CSS_notes">Quantum CSS notes</h3>
-
-<p>Gecko used to have a long-standing bug whereby radial gradients like <code>radial-gradient(circle gold,red)</code> would work, even though they shouldn't because of the missing comma between <code>circle</code> and <code>gold</code>. Also, {{cssxref("calc()")}} expressions were rejected — causing the value to be invalid — when used as the radius component of a <code>radial-gradient()</code> function ({{bug(1376019)}}). Firefox's new parallel CSS engine (also known as <a href="https://wiki.mozilla.org/Quantum">Quantum CSS</a> or <a href="https://wiki.mozilla.org/Quantum/Stylo">Stylo</a>, released in Firefox 57) fixed these bugs.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
A couple of CSS pages with outdated info about Firefox pre-Quantum, I've removed the sections.