### PR TITLE
Drop named-groups support note in regex “Groups and ranges” doc

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
@@ -137,10 +137,6 @@ do {
   console.log(`Hello ${match.groups.firstname} ${match.groups.lastname}`);
 } while((match = regexpNames.exec(personList)) !== null);</pre>
 
-<div class="notecard note">
-<p><strong>Note:</strong> Not all browsers support this feature; refer to the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">compatibility table</a>.</p>
-</div>
-
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility shows that all browsers other than IE now support named capture groups in regular expressions. So given the current state of wide support, lack of IE support doesn’t merit a special note here. Fixes https://github.com/mdn/content/issues/6284.