### PR TITLE
Fix spec msg of PushSubscription.subscriptionId

### DIFF
--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.html
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.html
@@ -16,9 +16,13 @@ browser-compat: api.PushSubscription.subscriptionId
 ---
 <div>{{APIRef("Push API")}}{{Deprecated_header}}</div>
 
-<p>The <code><strong>endpoint</strong></code> read-only property of the
-  {{domxref("PushSubscription")}} interface returns a {{domxref("DOMString")}} containing
+<p>The <code><strong>subscriptionId</strong></code> read-only property of the
+  {{domxref("PushSubscription")}} interface returns a {{domxref("DOMString")}} containing
   the subscription ID associated with the push subscription.</p>
+
+<div class="notecard warning">
+  Instead of this feature, use the {{domxref("PushSubscription.endPoint")}} property on the same interface.
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -27,7 +31,7 @@ browser-compat: api.PushSubscription.subscriptionId
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was removed from the <a href="https://w3c.github.io/push-api/#pushsubscription-interface">Push API</a> specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `PushSubscription.subscriptionId`.

- I removed the {{Specifications}} macro and replaced it with a text. 
- I added info at the top about the modern way of doing it.
- I removed a couple gremlins.
