### PR TITLE
Fix spec msg of Node.isSupported

### DIFF
--- a/files/en-us/web/api/node/issupported/index.html
+++ b/files/en-us/web/api/node/issupported/index.html
@@ -54,7 +54,7 @@ browser-compat: api.Node.isSupported
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `Node.isSupported`.

I did the minimum (only IE is supporting it and it is a rather non functionning feature): I removed the {{Specifications}} macro and replaced it with a text. 
