### PR TITLE
Fix flaw in “The box model” doc

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.html
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.html
@@ -338,7 +338,7 @@ tags:
    <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors/Combinators">Combinators</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">The box model</a></li>
+ <li>The box model [this article]</li>
  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders">Backgrounds and borders</a></li>
  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a></li>
  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content">Overflowing content</a></li>


### PR DESCRIPTION
https://github.com/mdn/content/pull/6278 caused the “The·box·model” article to end up with a navigational hyperlink to itself.

This change corrects the flaw by changing the hyperlink to **The box model [this article]** as plain text.