### PR TITLE
Fix spec msg of WEBGL_compressed_texture_atc

### DIFF
--- a/files/en-us/web/api/webgl_compressed_texture_atc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_atc/index.html
@@ -47,8 +47,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ATC_WEBGL, 512, 512
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
-
+This feature is defined in a specification that was <a href="https://www.khronos.org/registry/webgl/extensions/rejected/WEBGL_compressed_texture_atc/">rejected</a>. It is no longer on track to become a standard.</p>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/webgl_compressed_texture_atc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_atc/index.html
@@ -47,7 +47,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ATC_WEBGL, 512, 512
 
 <h2 id="Specifications">Specifications</h2>
 
-This feature is defined in a specification that was <a href="https://www.khronos.org/registry/webgl/extensions/rejected/WEBGL_compressed_texture_atc/">rejected</a>. It is no longer on track to become a standard.</p>
+<p>This feature is defined in a specification that was <a href="https://www.khronos.org/registry/webgl/extensions/rejected/WEBGL_compressed_texture_atc/">rejected</a>. It is no longer on track to become a standard.</p>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `WEBGL_compressed_texture_atc`.

- I removed the {{Specifications}} macro and replaced it with a text. 
