### PR TITLE
Fix spacing

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.html
@@ -55,7 +55,7 @@ tags:
 <ul>
  <li>The element is exposed to the system's accessibility infrastructure as having the <code>switch</code> role.</li>
  <li>When the <code>aria-checked</code> attribute's value changes, an accessible event is fired using the system's accessibility API if one is available and it supports the <code>switch</code> role.</li>
- <li>All elements that are descendants of an element with the <code>switch</code> role applied to it are automatically assigned role <code>presentation</code>. This prevents elements that are used to construct the switch  from being interacted with individually by assistive technologies. Text in these elements remains visible to the user agent and may be read or otherwise delivered to the user, unless it's expressly hidden using {{cssxref("display", "display: none")}} or <code>aria-hidden="true"</code>.</li>
+ <li>All elements that are descendants of an element with the <code>switch</code> role applied to it are automatically assigned role <code>presentation</code>. This prevents elements that are used to construct the switch from being interacted with individually by assistive technologies. Text in these elements remains visible to the user agent and may be read or otherwise delivered to the user, unless it's expressly hidden using {{cssxref("display", "display: none")}} or <code>aria-hidden="true"</code>.</li>
 </ul>
 
 <p>The assistive technology, if it supports the <code>switch</code> role, responds by doing the following:</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is two spaces between two words, one of them should be removed.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Switch_role