### PR TITLE
Fix spec msg of Navigator.registerContentHandler

### DIFF
--- a/files/en-us/web/api/navigator/registercontenthandler/index.html
+++ b/files/en-us/web/api/navigator/registercontenthandler/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Navigator.registerContentHandler
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature was removed from the HTML specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `Navigator.registerContentHandler`.

- I removed the {{Specifications}} macro and replaced it with a text. 
