### PR TITLE
Changed an obsolete link in “OpenSearch description format” doc

### DIFF
--- a/files/en-us/web/opensearch/index.html
+++ b/files/en-us/web/opensearch/index.html
@@ -70,7 +70,7 @@ tags:
   <li><code>type="application/x-moz-keywordsearch"</code> specifies the URL used when a keyword search is entered in the location bar. This is supported only in Firefox.</li>
  </ul>
 
- <p>For these URL types, you can use <code>{searchTerms}</code> to substitute the search terms entered by the user in the search bar or location bar. Other supported dynamic search parameters are described in <a class="external" href="https://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 parameters</a>.</p>
+ <p>For these URL types, you can use <code>{searchTerms}</code> to substitute the search terms entered by the user in the search bar or location bar. Other supported dynamic search parameters are described in <a class="external" href="https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-11-parameters">OpenSearch 1.1 parameters</a>.</p>
 
  <p>For search suggestions, the <code>application/x-suggestions+json</code> URL template is used to fetch a suggestion list in <a href="/en-US/docs/Glossary/JSON">JSON</a> format. For details on how to implement search suggestion support on a server, see <a href="/en-US/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins">Supporting search suggestions in search plugins</a>.</p>
  </dd>


### PR DESCRIPTION
Replaced http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3 by https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-11-parameters.
This is actually a redirection done by www.opensearch.org. History can be founded in https://web.archive.org/web/20200919105201/http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
