### PR TITLE
Fix a typo: "stabiliy" -> "stability"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
@@ -286,7 +286,7 @@ const result = mapped.map(v => in[v.i]);
 
 <p>It's important to note that students that have the same grade (for example, Alex and Devlin), will remain in the same order as before calling the sort. This is what a stable sorting algorithm guarantees.</p>
 
-<p>Before version 10 (or EcmaScript 2019), sort stabiliy was not guaranteed, meaning that you could end up with the following:</p>
+<p>Before version 10 (or EcmaScript 2019), sort stability was not guaranteed, meaning that you could end up with the following:</p>
 
 <pre class="brush: js">[
   { name: "Eagle",  grade: 13 },


### PR DESCRIPTION
Edit spelling of 'stability'

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Stability was spelled incorrectly


> Issue number (if there is an associated issue)
N/A


> Anything else that could help us review it
N/A