### PR TITLE
Added example for `DOMException` constructor.

### DIFF
--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -36,7 +36,7 @@ var domException = new DOMException(message, name);</pre>
   <dd>A newly created {{domxref("DOMException")}} object.</dd>
 </dl>
 
-<h2 id="Example">Examples</h2>
+<h2 id="Examples">Examples</h2>
 
 <p>In this example, pressing the button causes a custom <code>DOMException</code> to be thrown, which is then caught and the custom error message shown in an alert.</p>
 

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -38,7 +38,25 @@ var domException = new DOMException(message, name);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>TBD</p>
+<pre class="brush: html">
+&lt;button&gt;Trigger DOM Exception&lt;/button&gt;
+</pre>
+
+<pre class="brush: js">
+const button = document.querySelector('button');
+
+button.onclick = function() {
+    try {
+        throw new DOMException("Custom DOM Exception");
+    } catch(error) {
+        alert(`Error: ${error.message}`);
+    }
+}
+</pre>
+
+<p>{{ EmbedLiveSample('Example', '100%', 60, "", "", "hide-codepen-jsfiddle") }}</p>
+
+<p>In this example, pressing the button causes a custom <code>DOMException</code> to be thrown, which is then caught and the custom error message shown in an alert.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -62,7 +62,7 @@ button.onclick = function() {
 
 <h3>Result</h3>
 
-<p>{{ EmbedLiveSample('Example', '100%', 60) }}</p>
+<p>{{ EmbedLiveSample('Examples', '100%', 60) }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -36,11 +36,17 @@ var domException = new DOMException(message, name);</pre>
   <dd>A newly created {{domxref("DOMException")}} object.</dd>
 </dl>
 
-<h2 id="Example">Example</h2>
+<h2 id="Example">Examples</h2>
+
+<p>In this example, pressing the button causes a custom <code>DOMException</code> to be thrown, which is then caught and the custom error message shown in an alert.</p>
+
+<h3>HTML</h3>
 
 <pre class="brush: html">
 &lt;button&gt;Trigger DOM Exception&lt;/button&gt;
 </pre>
+
+<h3>JavaScript</h3>
 
 <pre class="brush: js">
 const button = document.querySelector('button');
@@ -54,9 +60,9 @@ button.onclick = function() {
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Example', '100%', 60, "", "", "hide-codepen-jsfiddle") }}</p>
+<h3>Result</h3>
 
-<p>In this example, pressing the button causes a custom <code>DOMException</code> to be thrown, which is then caught and the custom error message shown in an alert.</p>
+<p>{{ EmbedLiveSample('Example', '100%', 60) }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`DOMException` constructor's example said "TBD".

MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/DOMException/DOMException#Example


> Issue number (if there is an associated issue)

Fixes #6279
