### PR TITLE
Fix grammatical error in :local-link (an -> a)

### DIFF
--- a/files/en-us/web/css/_colon_local-link/index.html
+++ b/files/en-us/web/css/_colon_local-link/index.html
@@ -5,7 +5,7 @@ browser-compat: css.selectors.local-link
 ---
 <p>{{ CSSRef }}</p>
 
-<p>The <strong><code>:local-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents an link to the same document. Therefore an element that is the source anchor of a hyperlink whose target’s absolute URL matches the element’s own document URL.</p>
+<p>The <strong><code>:local-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents a link to the same document. Therefore an element that is the source anchor of a hyperlink whose target’s absolute URL matches the element’s own document URL.</p>
 
 <pre>/* Selects any &lt;a&gt; that links to the current document */
 a:local-link {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In English, the correct indefinite article to come before the word "link" is "a" not "an" because "link" begins with a consonant sound.