### PR TITLE
Add references to Markdown guide

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -79,6 +79,10 @@ const greeting = "I'm a good example";
 ```
 </pre>
 
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/3512">https://github.com/mdn/content/issues/3512</a>.</p>
+
 <h2>Notes, warnings, and callouts</h2>
 
 <p>Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts.</p>
@@ -224,6 +228,10 @@ const greeting = "I'm a good example";
   <p>Like that.</p>
 </div>
 
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/3483">https://github.com/mdn/content/issues/3483</a>.</p>
+
 <h2>Definition lists</h2>
 
 <p>To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}). In this form:</p>
@@ -316,6 +324,10 @@ On MDN, this would produce the following HTML:
 
 <p>The rationale for the syntax described here is that it works well enough with tools that expect CommonMark (for example, Prettier or GitHub previews) while being reasonably easy to write and to parse.</p>
 
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/4367">https://github.com/mdn/content/issues/4367</a>.</p>
+
 <h2>Tables</h2>
 
 <p>In GFM (but not CommonMark) there is a syntax for tables: <a href="https://github.github.com/gfm/#tables-extension-">https://github.github.com/gfm/#tables-extension-</a>. We will make use of this but the GFM syntax only supports a subset of the features available in HTML.</p>
@@ -356,6 +368,10 @@ cell 1    | cell 2    | cell 3
 cell 4    | cell 5    | cell 6
 </pre>
 
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/4325">https://github.com/mdn/content/issues/4325</a>.</p>
+
 <h2>Heading IDs</h2>
 
 <h2>Live samples</h2>
@@ -371,6 +387,10 @@ cell 4    | cell 5    | cell 6
   <li>For ordinal expressions like 1<sup>st</sup>, prefer words like "first".</li>
   <li>For footnotes, don’t mark up the footnote references with, e.g., <code>&lt;sup&gt;[1]&lt;/sup&gt;</code>; it’s unnecessary.</li>
 </ul>
+
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/4578">https://github.com/mdn/content/issues/4578</a>.</p>
 
 <h2>KumaScript</h2>
 


### PR DESCRIPTION
I really like the way the meta-docs for BCD refer to the place decisions were made, so this PR does the same for Markdown choices. I'm open to suggestions for better wording choices than "discussion reference" and "this issue was resolved" but I think it'll do in the absence of anything better.