### PR TITLE
NetworkInformation.downlink - remove in-text compatibility info

### DIFF
--- a/files/en-us/web/api/networkinformation/downlink/index.html
+++ b/files/en-us/web/api/networkinformation/downlink/index.html
@@ -21,11 +21,6 @@ browser-compat: api.NetworkInformation.downlink
   recent bandwidth measurement data, the attribute value is determined by the properties
   of the underlying connection technology.</p>
 
-<p>Note that Chrome-based browsers do not conform to the specification, and <a
-    href="https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/network/network_state_notifier.cc;l=460;drc=49bf35554c123bbc44a0ef52675144eba2dd7bbc?originalUrl=https:%2F%2Fcs.chromium.org%2F">arbitrarily
-    cap</a> the reported downlink at a maximum of 10 Mbps as an anti-fingerprinting
-  measure. Similar caps exist for the reported latency.</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre


### PR DESCRIPTION
This removes the Chrome compatibility note about fingerprinting in https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink

The information is being moved into BCD. See https://github.com/mdn/browser-compat-data/pull/11030