### PR TITLE
Drop rb & rtc from “Inline text semantics” of “HTML elements reference”

### DIFF
--- a/files/en-us/web/html/element/rb/index.html
+++ b/files/en-us/web/html/element/rb/index.html
@@ -5,7 +5,6 @@ tags:
   - Deprecated
   - Element
   - HTML
-  - HTML text-level semantics
   - Reference
   - Ruby
   - Text

--- a/files/en-us/web/html/element/rtc/index.html
+++ b/files/en-us/web/html/element/rtc/index.html
@@ -5,7 +5,6 @@ tags:
   - Deprecated
   - Element
   - HTML
-  - HTML text-level semantics
   - NeedsContent
   - Reference
   - Ruby Text


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/6299