### PR TITLE
FF90: Minor tweaks to JavaScript class private features

### DIFF
--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -38,7 +38,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
-  <li><a href="/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields">Private class fields and methods</a> are now supported by default ({{bug(1708235)}} and {{bug(1708236)}}).</li>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields">Private class static and instance fields and methods</a> are now supported by default ({{bug(1708235)}} and {{bug(1708236)}}).</li>
   <li>Custom date/time formats specified as options to the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat"><code>Intl.DateTimeFormat()</code> constructor</a> can now include <code>dayPeriod</code> — a value indicating that the approximate time of day (e.g. "in the morning", "at night", etc.) should be included as a <code>narrow</code>, <code>short</code>, or <code>long</code> string ({{bug(1645115)}}).</li>
  </ul>
 

--- a/files/en-us/web/javascript/reference/classes/index.html
+++ b/files/en-us/web/javascript/reference/classes/index.html
@@ -258,7 +258,7 @@ Rectangle.prototype.prototypeWidth = 25;
 
 <p>Private fields cannot be created later through assigning to them, the way that normal properties can.</p>
 
-<p>For more information, see {{jsxref("Classes/Private_class_fields", "private class fields", "", "true")}}.</p>
+<p>For more information, see {{jsxref("Classes/Private_class_fields", "private class features", "", "true")}}.</p>
 
 <h2 id="Sub_classing_with_extends">Sub classing with <code>extends</code></h2>
 
@@ -418,7 +418,7 @@ class Bar extends calculatorMixin(randomizerMixin(Foo)) { }</pre>
  <li>{{jsxref("Statements/class", "class declaration", "", "true")}}</li>
  <li>{{jsxref("Operators/class", "class expression", "", "true")}}</li>
  <li>{{jsxref("Classes/Public_class_fields", "Public class fields", "", "true")}}</li>
- <li>{{jsxref("Classes/Private_class_fields", "Private class fields", "", "true")}}</li>
+ <li>{{jsxref("Classes/Private_class_fields", "Private class features", "", "true")}}</li>
  <li>{{jsxref("Operators/super", "super")}}</li>
  <li><a href="https://hacks.mozilla.org/2015/07/es6-in-depth-classes/">Blog post: "ES6 In Depth: Classes"</a></li>
  <li><a href="https://github.com/tc39/proposal-class-fields">Fields and public/private class properties proposal (stage 3)</a></li>


### PR DESCRIPTION
Trivial docs follow up for #5386

I just reviewed the updated private class features docs for FF90. These already did pretty much everything I thought needed doing. All this does is:
1. Release note - referred to private class fields and method. Strictly accurate, but worth mentioning static methods here.
2. Fixed up a couple of link titles to "Private class fields" which has now been named private class features. 

I don't think anything else "needs" to be done. 