### PR TITLE
Fix double angle brackets typo in HTMLImageElement»alt doc

### DIFF
--- a/files/en-us/web/api/htmlimageelement/alt/index.html
+++ b/files/en-us/web/api/htmlimageelement/alt/index.html
@@ -223,7 +223,7 @@ p {
 <h4 id="HTML_2">HTML</h4>
 
 <p>The HTML below creates a snippet of content from a site using the described icon. Note
-  the use of the <code>alt</code> attribute on the {{HTMLElement("&lt;img&gt;")}},
+  the use of the <code>alt</code> attribute on the {{HTMLElement("img")}},
   providing a good substitution string to use in case the image doesn't load.</p>
 
 <pre class="brush: html">&lt;div class="container"&gt;


### PR DESCRIPTION
Trivial type:
Previously, it appears as ```attribute on the <<img>>, providing```, which is clearly unintentional. From other examples in the same text, the `HTMLElement()` function takes a string without angle brackets.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Replaces double angle brackets with single.