### PR TITLE
correct typo: "if the server _can_ detect [a loop], it will send back a 500"

### DIFF
--- a/files/en-us/web/http/redirections/index.html
+++ b/files/en-us/web/http/redirections/index.html
@@ -268,7 +268,7 @@ rewrite ^/images/(.*)$ https://images.example.com/$1 permanent;
 
 <p>Redirection loops happen when additional redirections follow the one that has already been followed. In other words, there is a loop that will never be finished and no page will ever be found.</p>
 
-<p>Most of the time this is a server problem, and if the server cannot detect it, it will send back a {{HTTPStatus("500")}} <code>Internal Server Error</code>. If you encounter such an error soon after modifying a server configuration, this is likely a redirection loop.</p>
+<p>Most of the time this is a server problem, and if the server can detect it, it will send back a {{HTTPStatus("500")}} <code>Internal Server Error</code>. If you encounter such an error soon after modifying a server configuration, this is likely a redirection loop.</p>
 
 <p>Sometimes, the server won't detect it: a redirection loop can spread over several servers which each don't have the full picture. In this case, browsers will detect it and display an error message. Firefox displays:</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
If a web server _can_ detect a loop, it'll send the 500 error; it can't send the server error if it _cannot_ detect the loop.

> Issue number (if there is an associated issue)
n/a

> Anything else that could help us review it
n/a