### PR TITLE
Source spec info from macros for HTML attributes

### DIFF
--- a/files/en-us/web/html/attributes/accept/index.html
+++ b/files/en-us/web/html/attributes/accept/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{HTMLSidebar}}</p>
 
-<p class="summary"><span class="seoSummary">The <strong><code>accept</code></strong> attribute takes as its value a comma-separated list of one or more file types, or {{anch("Unique file type specifiers", "unique file type specifiers")}}, describing which file types to allow. </span>The accept property is an attribute of the {{HTMLElement("input/file", "file")}} {{htmlelement("input")}} type. It was supported on the {{htmlelement("form")}} element, but was removed in favor of {{HTMLElement("input/file", "file")}} in HTML5.</p>
+<p class="summary">The <strong><code>accept</code></strong> attribute takes as its value a comma-separated list of one or more file types, or {{anch("Unique file type specifiers", "unique file type specifiers")}}, describing which file types to allow. The accept property is an attribute of the {{HTMLElement("input/file", "file")}} {{htmlelement("input")}} type. It was supported on the {{htmlelement("form")}} element, but was removed in favor of {{HTMLElement("input/file", "file")}} in HTML5.</p>
 
 <p>Because a given file type may be identified in more than one manner, it's useful to provide a thorough set of type specifiers when you need files of specific type, or use the wild card to denote a type of any format is acceptable.</p>
 
@@ -137,28 +137,17 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#attr-input-accept', 'accept attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'sec-forms.html#attr-input-accept', 'accept attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("html.elements.input.accept")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attribute.accept")}}</p>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.accept")}}</p>
+
+<h3>For the <code>form</code> element</h3>
+
+<p>{{Compat("html.elements.form.accept")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/autocomplete/index.html
+++ b/files/en-us/web/html/attributes/autocomplete/index.html
@@ -236,18 +236,7 @@ TN99 8ZZ</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', "#attr-fe-autocomplete", "autocomplete")}}</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications("html.global_attributes.autocomplete")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/html/attributes/capture/index.html
+++ b/files/en-us/web/html/attributes/capture/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{HTMLSidebar}}{{draft}}</p>
 
-<p><span class="seoSummary"><span class="summary">The <strong><code>capture</code></strong> attribute specifies that, optionally, a new file should be captured, and which device should be used to capture that new media of a type defined by the <code><a href="accept">accept</a></code> attribute. </span>Values include <code>user</code> and <code>environment</code>. </span>The capture attribute is supported on the {{HTMLElement("input/file", "file")}} input type.</p>
+<p>The <strong><code>capture</code></strong> attribute specifies that, optionally, a new file should be captured, and which device should be used to capture that new media of a type defined by the <code><a href="accept">accept</a></code> attribute. Values include <code>user</code> and <code>environment</code>. The capture attribute is supported on the {{HTMLElement("input/file", "file")}} input type.</p>
 
 <p>The <code>capture</code> attribute takes as it's value a string that specifies which camera to use for capture of image or video data, if the <a href="accept">accept</a> attribute indicates that the input should be of one of those types.</p>
 
@@ -63,24 +63,11 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML Media Capture', '#the-capture-attribute','capture attribute')}}</td>
-			<td>{{Spec2('HTML Media Capture')}}</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications("html.elements.input.capture")}}}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attribute.capture")}}</p>
+<p>{{Compat("html.elements.input.capture")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/crossorigin/index.html
+++ b/files/en-us/web/html/attributes/crossorigin/index.html
@@ -10,9 +10,9 @@ tags:
   - Reference
   - Security
 ---
-<p>{{HTMLSidebar}}{{draft}}</p>
+<p>{{HTMLSidebar}}</p>
 
-<p class="seoSummary">The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>, defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.</p>
+<p>The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>, defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.</p>
 
 <p>The <code>crossorigin</code> content attribute on media elements is a CORS settings attribute.</p>
 
@@ -44,7 +44,7 @@ tags:
 <p>An invalid keyword and an empty string will be handled as the <code>anonymous</code> keyword.</p>
 
 <div class="notecard note">
-<p>Prior to Firefox 83 the <code>crossorigin</code> attribute was not supported for <code>rel="icon"</code> there is also <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1121645">an open issue for Chrome</a>.</p>
+<p>Prior to Firefox 83 the <code>crossorigin</code> attribute was not supported for <code>rel="icon"</code> there is also <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1121645">an open issue for Chrome</a>.</p>
 </div>
 
 <h3 id="Example_crossorigin_with_the_script_element">Example: crossorigin with the script element</h3>
@@ -61,41 +61,43 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', 'infrastructure.html#cors-settings-attributes', 'CORS settings attributes')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', 'embedded-content.html#attr-img-crossorigin', 'crossorigin')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+<h3>For the <code>script</code> element</h3>
+
+{{Specifications("html.elements.script.crossorigin")}}
+
+<h3>For the </code>video</code> and <code>audio</code> elements</h3>
+
+{{Specifications("html.elements.video.crossorigin")}}
+
+<h3>For the </code>link</code> element</h3>
+
+{{Specifications("html.elements.link.crossorigin")}}
+
+<h3>For the </code>img</code> element</h3>
+
+{{Specifications("html.elements.img.crossorigin")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="script_crossorigin">script crossorigin</h3>
+<h3>For the <code>script</code> element</h3>
 
 <p>{{Compat("html.elements.script.crossorigin")}}</p>
 
-<h3 id="video_crossorigin">video crossorigin</h3>
+<h3>For the </code>video</code> element</h3>
 
 <p>{{Compat("html.elements.video.crossorigin")}}</p>
 
-<h3 id="link_crossorigin">link crossorigin</h3>
+<h3>For the </code>audio</code> element</h3>
+
+<p>{{Compat("html.elements.audio.crossorigin")}}</p>
+
+<h3>For the </code>link</code> element</h3>
 
 <p>{{Compat("html.elements.link.crossorigin")}}</p>
+
+<h3>For the </code>img</code> element</h3>
+
+<p>{{Compat("html.elements.img.crossorigin")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/disabled/index.html
+++ b/files/en-us/web/html/attributes/disabled/index.html
@@ -10,9 +10,9 @@ tags:
 ---
 <p>{{HTMLSidebar}}</p>
 
-<p><span class="seoSummary">The Boolean <code><strong>disabled</strong></code> attribute, when present, makes the element not mutable, focusable, or even submitted with the form. The user can neither edit nor focus on the control, nor its form control descendants.</span> If the <code>disabled</code> attribute is specified on a form control, the element and its form control descendants do not participate in constraint validation. Often browsers grey out such controls and it won't receive any browsing events, like mouse clicks or focus-related ones.</p>
+<p>The Boolean <code><strong>disabled</strong></code> attribute, when present, makes the element not mutable, focusable, or even submitted with the form. The user can neither edit nor focus on the control, nor its form control descendants. If the <code>disabled</code> attribute is specified on a form control, the element and its form control descendants do not participate in constraint validation. Often browsers grey out such controls and it won't receive any browsing events, like mouse clicks or focus-related ones.</p>
 
-<p>The <code>disabled</code> attribute is supported by {{ HTMLElement("button") }}, {{ HTMLElement("command") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }} and {{ HTMLElement("input")}}.</p>
+<p>The <code>disabled</code> attribute is supported by {{ HTMLElement("button") }}, {{ HTMLElement("command") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }} and {{ HTMLElement("input")}}.</p>
 
 <p>This Boolean disabled attribute indicates that the user cannot interact with the control or its descendant controls. If this attribute is not specified, the control inherits its setting from the containing element, for example <code>fieldset</code>; if there is no containing element with the <code>disabled</code> attribute set, and the control itself does not have the attribute, then the control is enabled. If declared on an {{ HTMLElement("optgroup") }}, the select is still interactive (unless otherwise disabled), but none of the items in the option group are selectable.</p>
 
@@ -48,7 +48,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>When form controls are disabled, many browsers will display them in a lighter, greyed-out color by default. Here are examples of a disabled checkbox, radio button, {{ HTMLElement("option") }} and {{ HTMLElement("optgroup") }}, as well as some form controls that are disabled via the disabled attribute set on the ancestor <code>{{ HTMLElement("fieldset")}}</code>  element. The {{ HTMLElement("option") }}s are disabled, but the {{ HTMLElement("select") }} itself is not. We could have disable the entire {{ HTMLElement("select") }} by adding the attribute to that element rather than its descendants.</p>
+<p>When form controls are disabled, many browsers will display them in a lighter, greyed-out color by default. Here are examples of a disabled checkbox, radio button, {{ HTMLElement("option") }} and {{ HTMLElement("optgroup") }}, as well as some form controls that are disabled via the disabled attribute set on the ancestor <code>{{ HTMLElement("fieldset")}}</code> element. The {{ HTMLElement("option") }}s are disabled, but the {{ HTMLElement("select") }} itself is not. We could have disable the entire {{ HTMLElement("select") }} by adding the attribute to that element rather than its descendants.</p>
 
 <div>
 <pre class="brush: html">&lt;fieldset&gt;
@@ -74,19 +74,19 @@ tags:
 &lt;p&gt;
  &lt;label&gt;Select an option:
   &lt;select&gt;
-    &lt;optgroup label="Group 1"&gt;
-      &lt;option&gt;Option 1.1&lt;/option&gt;
-    &lt;/optgroup&gt;
-    &lt;optgroup label="Group 2"&gt;
-      &lt;option&gt;Option 2.1&lt;/option&gt;
-      &lt;option disabled&gt;Option 2.2&lt;/option&gt;
-      &lt;option&gt;Option 2.3&lt;/option&gt;
-    &lt;/optgroup&gt;
-    &lt;optgroup label="Group 3" disabled&gt;
-      &lt;option&gt;Disabled 3.1&lt;/option&gt;
-      &lt;option&gt;Disabled 3.2&lt;/option&gt;
-      &lt;option&gt;Disabled 3.3&lt;/option&gt;
-    &lt;/optgroup&gt;
+    &lt;optgroup label="Group 1"&gt;
+      &lt;option&gt;Option 1.1&lt;/option&gt;
+    &lt;/optgroup&gt;
+    &lt;optgroup label="Group 2"&gt;
+      &lt;option&gt;Option 2.1&lt;/option&gt;
+      &lt;option disabled&gt;Option 2.2&lt;/option&gt;
+      &lt;option&gt;Option 2.3&lt;/option&gt;
+    &lt;/optgroup&gt;
+    &lt;optgroup label="Group 3" disabled&gt;
+      &lt;option&gt;Disabled 3.1&lt;/option&gt;
+      &lt;option&gt;Disabled 3.2&lt;/option&gt;
+      &lt;option&gt;Disabled 3.3&lt;/option&gt;
+    &lt;/optgroup&gt;
   &lt;/select&gt;
  &lt;/label&gt;
 &lt;/p&gt;
@@ -107,36 +107,47 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#attr-input-disabled', 'disabled attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#attr-input-disabled', 'disabled attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'sec-forms.html#the-disabled-attribute', 'disabled attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>button</code>, <code>input</code>, <code>select</code>, <code>textarea</code> and <code>fieldset</code> elements</h3>
+
+{{Specifications("html.elements.button.disabled")}}
+
+<h3>For the <code>option</code> element</h3>
+
+{{Specifications("html.elements.option.disabled")}}
+
+<h3>For the <code>optgroup</code> element</h3>
+
+{{Specifications("html.elements.options.disabled")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.disabled")}}</p>
+<h3>For the <code>button</code> element</h3>
+
+<p>{{Compat("html.elements.button.disabled")}}</p>
+
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.disabled")}}</p>
+
+<h3>For the <code>select</code> element</h3>
+
+<p>{{Compat("html.elements.select.disabled")}}</p>
+
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Compat("html.elements.textarea.disabled")}}</p>
+
+<h3>For the <code>fieldset</code> element</h3>
+
+<p>{{Compat("html.elements.fieldset.disabled")}}</p>
+
+<h3>For the <code>option</code> element</h3>
+
+<p>{{Compat("html.elements.option.disabled")}}</p>
+
+<h3>For the <code>button</code> element</h3>
+
+<p>{{Compat("html.elements.optgroup.disabled")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/elementtiming/index.html
+++ b/files/en-us/web/html/attributes/elementtiming/index.html
@@ -36,22 +36,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Element Timing API', 'forms.html#attr-label-for', 'for as used with label')}}</td>
-   <td>{{Spec2('Element Timing API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Compat("html.elements.attribute.elementtiming")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/html/attributes/for/index.html
+++ b/files/en-us/web/html/attributes/for/index.html
@@ -31,44 +31,20 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#attr-label-for', 'for as used with label')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-    <td>{{SpecName('HTML WHATWG', 'form-elements.html#attr-output-for', 'for as used with output')}}</td>
-    <td>{{Spec2('HTML WHATWG')}}</td>
-    <td></td>
-   </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'sec-forms.html#element-attrdef-label-for', 'for as used with label')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-    <td>{{SpecName('HTML5 W3C', 'sec-forms.html#element-attrdef-output-for', 'for as used with output')}}</td>
-    <td>{{Spec2('HTML5 W3C')}}</td>
-    <td></td>
-   </tr>
- </tbody>
-</table>
+<h3>For the <code>label</code></h3>
+
+<p>{{Specifications("html.elements.label.for")}}</p>
+
+<h3>For the <code>output</code></h3>
+
+<p>{{Specifications("html.elements.output.for")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3>Support with label</h3>
+<h3>For the <code>label</code></h3>
 
 <p>{{Compat("html.elements.label.for")}}</p>
 
-<h3>Support with output</h3>
+<h3>For the <code>output</code></h3>
 
 <p>{{Compat("html.elements.output.for")}}</p>

--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -129,7 +129,7 @@ tags:
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Attributes/capture">capture</a></code></td>
    <td>{{ HTMLElement("input") }}</td>
-   <td>From the {{SpecName('HTML Media Capture', '#the-capture-attribute','media capture')}}spec, specifies a new file can be captured.</td>
+   <td>From the <a href="https://w3c.github.io/html-media-capture/#the-capture-attribute">HTML Media Capture</a> specification, defines how a new file can be captured.</td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Element/keygen#attr-challenge">challenge</a></code></td>

--- a/files/en-us/web/html/attributes/max/index.html
+++ b/files/en-us/web/html/attributes/max/index.html
@@ -104,51 +104,31 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#the-min-and-max-attributes', 'max attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'input.html#the-min-and-max-attributes', 'max attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#the-progress-element', 'progress element')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#the-progress-element', 'progress element')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#the-meter-element', 'meter element')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#the-meter-element', 'meter element')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.input.max")}}</p>
+
+<h3>For the <code>meter</code> element</h3>
+
+<p>{{Specifications("html.elements.meter.max")}}</p>
+
+<h3>For the <code>progress</code> element</h3>
+
+<p>{{Specifications("html.elements.progress.max")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.max")}}</p>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.max")}}</p>
+
+<h3>For the <code>meter</code> element</h3>
+
+<p>{{Compat("html.elements.meter.max")}}</p>
+
+<h3>For the <code>progress</code> element</h3>
+
+<p>{{Compat("html.elements.progress.max")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/maxlength/index.html
+++ b/files/en-us/web/html/attributes/maxlength/index.html
@@ -11,9 +11,9 @@ tags:
   - maxlength
   - textarea
 ---
-<p>{{HTMLSidebar}}{{draft}}</p>
+<p>{{HTMLSidebar}}</p>
 
-<p><span class="seoSummary">The <strong><code>maxlength</code></strong> attribute defines the maximum number of characters (as UTF-16 code units) the user can enter into an {{htmlelement('input')}} or {{htmlelement('textarea')}}. This must be an integer value 0 or higher.</span> If no maxlength is specified, or an invalid value is specified, the input or textarea has no maximum length.</p>
+<p>The <strong><code>maxlength</code></strong> attribute defines the maximum number of characters (as UTF-16 code units) the user can enter into an {{htmlelement('input')}} or {{htmlelement('textarea')}}. This must be an integer value 0 or higher. If no maxlength is specified, or an invalid value is specified, the input or textarea has no maximum length.</p>
 
 <p>Any <code>maxlength</code> value must be greater than or equal to the value of <code><a href="/en-US/docs/Web/HTML/Attributes/minlength">minlength</a></code>, if present and valid. The input will fail constraint validation if the length of the text value of the field is greater than maxlength UTF-16 code units long. Constraint validation is only applied when the value is changed by the user.</p>
 
@@ -30,28 +30,23 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#attr-input-maxlength', 'maxlength attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'input.html#attr-maxlength-accept', 'maxlength attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.element.input.maxlength")}}</p>
+
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Specifications("html.elements.element.textarea.maxlength")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attribute.maxlength")}}</p>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.element.input.maxlength")}}</p>
+
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Compat("html.elements.element.textarea.maxlength")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/min/index.html
+++ b/files/en-us/web/html/attributes/min/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{HTMLSidebar}}</p>
 
-<p><span class="seoSummary">The <strong><code>min</code></strong> attribute defines the minimum value that is acceptable and valid for the input containing the attribute. If the <code><a href="/en-US/docs/Web/HTML/Element/input#attr-value">value</a></code> of the element is less than this, the element fails <a href="/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation">constraint validation</a>. This value must be less than or equal to the value of the <code>max</code> attribute. If a value is specified for <code>min</code> that isn't a valid number, the input has no minimum value.</span></p>
+<p>The <strong><code>min</code></strong> attribute defines the minimum value that is acceptable and valid for the input containing the attribute. If the <code><a href="/en-US/docs/Web/HTML/Element/input#attr-value">value</a></code> of the element is less than this, the element fails <a href="/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation">constraint validation</a>. This value must be less than or equal to the value of the <code>max</code> attribute. If a value is specified for <code>min</code> that isn't a valid number, the input has no minimum value.</p>
 
 <p>Valid for the numeric input types, including the {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}}, {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}}, {{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number", "number")}} and {{HTMLElement("input/range", "range")}} types, and the {{htmlelement('meter')}} element, the <code>min</code> attribute is a number that specifies the most negative value a form control to be considered valid.</p>
 
@@ -117,31 +117,23 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#the-min-and-max-attributes', 'min attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'input.html#the-min-and-max-attributes', 'min attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.input.min")}}</p>
+
+<h3>For the <code>meter</code> element</h3>
+
+<p>{{Specifications("html.elements.meter.min")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.min")}}</p>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.min")}}</p>
+
+<h3>For the <code>meter</code> element</h3>
+
+<p>{{Compat("html.elements.meter.min")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/minlength/index.html
+++ b/files/en-us/web/html/attributes/minlength/index.html
@@ -41,21 +41,21 @@ input:invalid:focus {
 
 <h3>For the <code>input</code> element</h3>
 
-<p>{{Specifications("html.elements.element.input.minlength")}}</p>
+<p>{{Specifications("html.elements.input.minlength")}}</p>
 
 <h3>For the <code>textarea</code> element</h3>
 
-<p>{{Specifications("html.elements.element.textarea.minlength")}}</p>
+<p>{{Specifications("html.elements.textarea.minlength")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <h3>For the <code>input</code> element</h3>
 
-<p>{{Compat("html.elements.element.input.minlength")}}</p>
+<p>{{Compat("html.elements.input.minlength")}}</p>
 
 <h3>For the <code>textarea</code> element</h3>
 
-<p>{{Compat("html.elements.element.textarea.minlength")}}</p>
+<p>{{Compat("html.elements.textarea.minlength")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/minlength/index.html
+++ b/files/en-us/web/html/attributes/minlength/index.html
@@ -39,28 +39,23 @@ input:invalid:focus {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#attr-input-minlength', 'minlength attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'input.html#attr-minlength-accept', 'minlength attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.element.input.minlength")}}</p>
+
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Specifications("html.elements.element.textarea.minlength")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attribute.minlength")}}</p>
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.element.input.minlength")}}</p>
+
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Compat("html.elements.element.textarea.minlength")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/multiple/index.html
+++ b/files/en-us/web/html/attributes/multiple/index.html
@@ -17,7 +17,7 @@ tags:
 
 <pre class="brush: html">&lt;input type="email" <strong>multiple</strong> name="emails" id="emails"&gt;</pre>
 
-<p>If and only if the <code>multiple</code> attribute is specified, the value can be a list of properly-formed comma-separated e-mail addresses. Any trailing and leading whitespace is removed from each address in the list.</p>
+<p>If and only if the <code>multiple</code> attribute is specified, the value can be a list of properly-formed comma-separated e-mail addresses. Any trailing and leading whitespace is removed from each address in the list.</p>
 
 <p>When <code>multiple</code> is set on the {{HTMLElement("input/file", "file")}} input type, the user can select one or more files. The user can choose multiple files from the file picker in any way that their chosen platform allows (e.g. by holding down <kbd>Shift</kbd> or <kbd>Control</kbd>, and then clicking).</p>
 
@@ -66,7 +66,7 @@ tags:
 <pre class="brush: css">input:invalid {border: red solid 3px;}</pre>
 </div>
 
-<p>If and only if the <code>multiple</code> attribute is specified, the value can be a list of properly-formed comma-separated e-mail addresses. Any trailing and leading whitespace is removed from each address in the list. If the <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code> attribute is present, at least one email address is required.</p>
+<p>If and only if the <code>multiple</code> attribute is specified, the value can be a list of properly-formed comma-separated e-mail addresses. Any trailing and leading whitespace is removed from each address in the list. If the <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code> attribute is present, at least one email address is required.</p>
 
 <p>Some browsers support the appearance of the <code><a href="/en-US/docs/Web/HTML/Attributes/list">list</a></code> of options from the associated {{htmlelement('datalist')}} for subsequent email addresses when <code>multiple</code> is present. Others do not.</p>
 
@@ -96,7 +96,7 @@ tags:
 
 <p>Note the difference in appearance between the example with <code>multiple</code> set and the other <code>file</code> input without.</p>
 
-<p>When the form is submitted,had we used <code><a href="/en-US/docs/Web/HTML/Element/form">method="get"</a></code> each selected file's name would have been added to URL parameters as<code>?uploads=img1.jpg&amp;uploads=img2.svg</code>. However, since we are sumbitting <a href="/en-US/docs/Web/API/XMLHttpRequest/multipart">multipart</a> form data, we much use post. See the {{htmlelement('form')}} element  and <a href="/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_method_attribute">sending form data</a> for more information.</p>
+<p>When the form is submitted,had we used <code><a href="/en-US/docs/Web/HTML/Element/form">method="get"</a></code> each selected file's name would have been added to URL parameters as<code>?uploads=img1.jpg&amp;uploads=img2.svg</code>. However, since we are sumbitting <a href="/en-US/docs/Web/API/XMLHttpRequest/multipart">multipart</a> form data, we much use post. See the {{htmlelement('form')}} element and <a href="/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_method_attribute">sending form data</a> for more information.</p>
 
 <h3 id="select">select</h3>
 
@@ -153,27 +153,23 @@ select[multiple]:active {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#attr-input-multiple', 'multiple attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'input.html#attr-input-multiple', 'multiple attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the the <code>select</code> element</h3>
+
+{{Specifications("html.elements.select.multiple")}}
+
+<h3>For the the <code>input</code> element</h3>
+
+{{Specifications("html.elements.input.multiple")}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<h3>For the the <code>select</code> element</h3>
+
+{{Compat("html.elements.select.multiple")}}
+
+<h3>For the the <code>input</code> element</h3>
+
+{{Compat("html.elements.input.multiple")}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/pattern/index.html
+++ b/files/en-us/web/html/attributes/pattern/index.html
@@ -120,36 +120,11 @@ input:valid+span:after {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('HTML WHATWG', 'forms.html#attr-input-pattern', 'pattern') }}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', 'forms.html#attr-input-pattern', 'pattern') }}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5 W3C', 'forms.html#attr-input-pattern', 'pattern') }}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications("html.elements.input.pattern")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.pattern")}}</p>
+<p>{{Compat("html.elements.input.pattern")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/readonly/index.html
+++ b/files/en-us/web/html/attributes/readonly/index.html
@@ -8,13 +8,13 @@ tags:
   - Forms
   - required
 ---
-<p>{{HTMLSidebar}}{{draft}}</p>
+<p>{{HTMLSidebar}}</p>
 
-<p><span class="seoSummary">The Boolean <code><strong>readonly</strong></code> attribute, when present, makes the element not mutable, meaning the user can not edit the control.</span> If the <code>readonly</code> attribute is specified on an input element, because the user can not edit the input, the element does not participate in constraint validation.</p>
+<p>The Boolean <code><strong>readonly</strong></code> attribute, when present, makes the element not mutable, meaning the user can not edit the control. If the <code>readonly</code> attribute is specified on an input element, because the user can not edit the input, the element does not participate in constraint validation.</p>
 
-<p>The <code>readonly</code> attribute is supported by  <code>{{HTMLElement("input/text","text")}}</code>, <code>{{HTMLElement("input/search","search")}}</code>, <code>{{HTMLElement("input/url","url")}}</code>, <code>{{HTMLElement("input/tel","tel")}}</code>, <code>{{HTMLElement("input/email","email")}}</code>, <code>{{HTMLElement("input/password","password")}}</code>, <code>{{HTMLElement("input/date","date")}}</code>, <code>{{HTMLElement("input/month","month")}}</code>, <code>{{HTMLElement("input/week","week")}}</code>, <code>{{HTMLElement("input/time","time")}}</code>, <code>{{HTMLElement("input/datetime-local","datetime-local")}}</code>, and <code>{{HTMLElement("input/number","number")}}</code><code>{{HTMLElement("input")}}</code> types and the <code>{{HTMLElement("textarea")}}</code> form control elements. If present on any of these input types and elements, the <code>{{cssxref(':read-only')}}</code> pseudo class will match. If the attribute is not included, the <code>{{cssxref(':read-write')}}</code> pseudo class will match.</p>
+<p>The <code>readonly</code> attribute is supported by <code>{{HTMLElement("input/text","text")}}</code>, <code>{{HTMLElement("input/search","search")}}</code>, <code>{{HTMLElement("input/url","url")}}</code>, <code>{{HTMLElement("input/tel","tel")}}</code>, <code>{{HTMLElement("input/email","email")}}</code>, <code>{{HTMLElement("input/password","password")}}</code>, <code>{{HTMLElement("input/date","date")}}</code>, <code>{{HTMLElement("input/month","month")}}</code>, <code>{{HTMLElement("input/week","week")}}</code>, <code>{{HTMLElement("input/time","time")}}</code>, <code>{{HTMLElement("input/datetime-local","datetime-local")}}</code>, and <code>{{HTMLElement("input/number","number")}}</code><code>{{HTMLElement("input")}}</code> types and the <code>{{HTMLElement("textarea")}}</code> form control elements. If present on any of these input types and elements, the <code>{{cssxref(':read-only')}}</code> pseudo class will match. If the attribute is not included, the <code>{{cssxref(':read-write')}}</code> pseudo class will match.</p>
 
-<p>The attribute is not supported or relevant to <code>{{HTMLElement("select")}}</code> or input types that are already not mutable, such as {{HTMLElement("input/checkbox","checkbox")}} and {{HTMLElement("input/radio","radio")}} or cannot, by definition, start with a value, such as the {{HTMLElement("input/file","file")}}  input type. {{HTMLElement("input/range","range")}} and {{HTMLElement("input/color","color")}}, as both have default values. It is also not supported on {{HTMLElement("input/hidden","hidden")}} as it can not be expected that a user to fill out a form that is hidden. Nor is it supported on any of the button types, including <code>image</code>.</p>
+<p>The attribute is not supported or relevant to <code>{{HTMLElement("select")}}</code> or input types that are already not mutable, such as {{HTMLElement("input/checkbox","checkbox")}} and {{HTMLElement("input/radio","radio")}} or cannot, by definition, start with a value, such as the {{HTMLElement("input/file","file")}} input type. {{HTMLElement("input/range","range")}} and {{HTMLElement("input/color","color")}}, as both have default values. It is also not supported on {{HTMLElement("input/hidden","hidden")}} as it can not be expected that a user to fill out a form that is hidden. Nor is it supported on any of the button types, including <code>image</code>.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Only text controls can be made read-only, since for other controls (such as checkboxes and buttons) there is no useful distinction between being read-only and being disabled, so the <code>readonly</code> attribute does not apply.</p>
@@ -47,23 +47,23 @@ tags:
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;div class="group"&gt;
-  &lt;input type="textbox" value="Some value" readonly="readonly"/&gt;
-  &lt;label&gt;Textbox&lt;/label&gt;
+  &lt;input type="textbox" value="Some value" readonly="readonly"/&gt;
+  &lt;label&gt;Textbox&lt;/label&gt;
 &lt;/div&gt;
 &lt;div class="group"&gt;
-  &lt;input type="date" value="2020-01-01" readonly="readonly"/&gt;
-  &lt;label&gt;Date&lt;/label&gt;
+  &lt;input type="date" value="2020-01-01" readonly="readonly"/&gt;
+  &lt;label&gt;Date&lt;/label&gt;
 &lt;/div&gt;
 &lt;div class="group"&gt;
-  &lt;input type="email" value="Some value" readonly="readonly"/&gt;
-  &lt;label&gt;Email&lt;/label&gt;
+  &lt;input type="email" value="Some value" readonly="readonly"/&gt;
+  &lt;label&gt;Email&lt;/label&gt;
 &lt;/div&gt;
 &lt;div class="group"&gt;
-  &lt;input type="password" value="Some value" readonly="readonly"/&gt;
-  &lt;label&gt;Password&lt;/label&gt;
+  &lt;input type="password" value="Some value" readonly="readonly"/&gt;
+  &lt;label&gt;Password&lt;/label&gt;
 &lt;/div&gt;
 &lt;div class="group"&gt;
-  &lt;textarea readonly="readonly"&gt;Some value&lt;/textarea&gt;
+  &lt;textarea readonly="readonly"&gt;Some value&lt;/textarea&gt;
   &lt;label&gt;Message&lt;/label&gt;
 &lt;/div&gt;
 </pre>
@@ -105,36 +105,23 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#attr-input-readonly', 'readonly attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#attr-input-readonly', 'readonly attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'sec-forms.html#the-readonly-attribute', 'readonly attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Specifications("html.elements.textarea.readonly")}}</p>
+
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.input.readonly")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.readonly")}}</p>
+<h3>For the <code>textarea</code> element</h3>
+
+<p>{{Compat("html.elements.textarea.readonly")}}</p>
+
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.readonly")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -337,79 +337,36 @@ tags:
 <dl>
 	<dt>apple-touch-icon-precomposed</dt>
 	<dd>
-	<pre class="brush: html"> &lt;!-- third-generation iPad with high-resolution Retina display: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/img/favicon144.e7e21ca263ca.png"&gt;
-  &lt;!-- iPhone with high-resolution Retina display: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="114x114" href="/static/img/favicon114.d526f38b09c5.png"&gt;
-  &lt;!-- first- and second-generation iPad: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/img/favicon72.cc65d1d762a0.png"&gt;
-  &lt;!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" href="/static/img/favicon57.de33179910ae.png"&gt;
-  &lt;!-- basic favicon --&gt;
-  &lt;link rel="icon" href="/static/img/favicon32.7f3da72dcea1.png"&gt;</pre>
+	<pre class="brush: html"> &lt;!-- third-generation iPad with high-resolution Retina display: --&gt;
+  &lt;link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/img/favicon144.e7e21ca263ca.png"&gt;
+  &lt;!-- iPhone with high-resolution Retina display: --&gt;
+  &lt;link rel="apple-touch-icon-precomposed" sizes="114x114" href="/static/img/favicon114.d526f38b09c5.png"&gt;
+  &lt;!-- first- and second-generation iPad: --&gt;
+  &lt;link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/img/favicon72.cc65d1d762a0.png"&gt;
+  &lt;!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --&gt;
+  &lt;link rel="apple-touch-icon-precomposed" href="/static/img/favicon57.de33179910ae.png"&gt;
+  &lt;!-- basic favicon --&gt;
+  &lt;link rel="icon" href="/static/img/favicon32.7f3da72dcea1.png"&gt;</pre>
 	</dd>
 </dl>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("html.elements.attributes.rel")}}</p>
-
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('HTML WHATWG', 'links.html#linkTypes', 'rel attribute')}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>Added <code>opener</code>. Made <code>noopener</code> default for <code>target="_blank"</code>.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5 W3C', 'links.html#linkTypes', 'rel attribute')}}</td>
-			<td>{{Spec2('HTML5 W3C')}}</td>
-			<td>Added <code>tag</code>, <code>search</code>, <code>prefetch</code>, <code>noreferrer</code>, <code>nofollow</code>, <code>icon</code>, and <code>author</code>.<br>
-			Renamed <code>copyright</code> to <code>license</code>.<br>
-			Removed <code>start</code>, <code>chapter</code>, <code>section</code>, <code>subsection</code>, and <code>appendix</code></td>
-		</tr>
-		<tr>
-			<td>{{SpecName("Preload", "#x2.link-type-preload", "preload")}}</td>
-			<td>{{Spec2("Preload")}}</td>
-			<td>Added <code>preload</code>.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("Resource Hints", "#dfn-preconnect", "preconnect")}}</td>
-			<td>{{Spec2("Resource Hints")}}</td>
-			<td>Added <code>dns-prefetch</code>, <code>preconnect</code>, and <code>prerender</code> values.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("HTML4.01", "types.html#type-links", "link types")}}</td>
-			<td>{{Spec2("HTML4.01")}}</td>
-			<td>Added <code>alternate</code>, <code>stylesheet</code>, <code>start</code>, <code>chapter</code>, <code>section</code>, <code>subsection</code>, <code>appendix</code>, and <code>bookmark</code>.<br>
-			Renamed <code>previous</code> to <code>prev</code>.<br>
-			Removed <code>top</code>, and <code>search</code>.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName("HTML3.2", "#link", "&lt;link&gt;")}}</td>
-			<td>
-			<p>{{Spec2("HTML3.2")}}<span class="spec-Obsolete"> (Obsolete)</span></p>
-			</td>
-			<td>Added <code>top</code>, <code>contents</code>, <code>index</code>, <code>glossary</code>, <code>copyright</code>, <code>next</code>, <code>previous</code>, <code>help</code>, and <code>search</code>.</td>
-		</tr>
-		<tr>
-			<td>{{RFC(1866, "HTML 2.0")}}</td>
-			<td>{{Spec2("HTML2.0")}}<span class="spec-Obsolete">(Obsolete)</span></td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<h3>For the <code>a</code> and <code>area</code> elements</h3>
 
-<h2 id="Browser_compatibility_2">Browser compatibility</h2>
+{{Specifications("html.elements.a.rel")}}
+
+<h3>For the <code>link</code> elements</h3>
+
+{{Specifications("html.elements.link.rel")}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<h3>For <code>a</code> and <code>area</code> elements</h3>
+
+{{Compat("html.elements.a.rel")}}
+
+<h3>For <code>link</code> elements</h3>
 
 <p>{{Compat("html.elements.link.rel")}}</p>
 

--- a/files/en-us/web/html/attributes/required/index.html
+++ b/files/en-us/web/html/attributes/required/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{HTMLSidebar}}</p>
 
-<p><span class="seoSummary">The Boolean <code><strong>required</strong></code> attribute</span> which, if present, indicates that the user must specify a value for the input before the owning form can be submitted. The <code>required</code> attribute is supported by <code>{{HTMLElement("input/text","text")}}</code>, <code>{{HTMLElement("input/search","search")}}</code>, <code>{{HTMLElement("input/url","url")}}</code>, <code>{{HTMLElement("input/tel","tel")}}</code>, <code>{{HTMLElement("input/email","email")}}</code>, <code>{{HTMLElement("input/password","password")}}</code>, <code>{{HTMLElement("input/date","date")}}</code>, <code>{{HTMLElement("input/month","month")}}</code>, <code>{{HTMLElement("input/week","week")}}</code>, <code>{{HTMLElement("input/time","time")}}</code>, <code>{{HTMLElement("input/datetime-local","datetime-local")}}</code>, <code>{{HTMLElement("input/number","number")}}</code>, <code>{{HTMLElement("input/checkbox","checkbox")}}</code>, <code>{{HTMLElement("input/radio","radio")}}</code>, <code>{{HTMLElement("input/file","file")}}</code>, {{HTMLElement("input")}} types along with the {{HTMLElement("select")}} and {{HTMLElement("textarea")}} form control elements. If present on any of these input types and elements, the {{cssxref(':required')}} pseudo class will match. If the attribute is not included, the {{cssxref(':optional')}} pseudo class will match.</p>
+<p>The Boolean <code><strong>required</strong></code> attribute which, if present, indicates that the user must specify a value for the input before the owning form can be submitted. The <code>required</code> attribute is supported by <code>{{HTMLElement("input/text","text")}}</code>, <code>{{HTMLElement("input/search","search")}}</code>, <code>{{HTMLElement("input/url","url")}}</code>, <code>{{HTMLElement("input/tel","tel")}}</code>, <code>{{HTMLElement("input/email","email")}}</code>, <code>{{HTMLElement("input/password","password")}}</code>, <code>{{HTMLElement("input/date","date")}}</code>, <code>{{HTMLElement("input/month","month")}}</code>, <code>{{HTMLElement("input/week","week")}}</code>, <code>{{HTMLElement("input/time","time")}}</code>, <code>{{HTMLElement("input/datetime-local","datetime-local")}}</code>, <code>{{HTMLElement("input/number","number")}}</code>, <code>{{HTMLElement("input/checkbox","checkbox")}}</code>, <code>{{HTMLElement("input/radio","radio")}}</code>, <code>{{HTMLElement("input/file","file")}}</code>, {{HTMLElement("input")}} types along with the {{HTMLElement("select")}} and {{HTMLElement("textarea")}} form control elements. If present on any of these input types and elements, the {{cssxref(':required')}} pseudo class will match. If the attribute is not included, the {{cssxref(':optional')}} pseudo class will match.</p>
 
 <p>The attribute is not supported or relevant to {{HTMLElement("input/range","range")}} and {{HTMLElement("input/color","color")}}, as both have default values. It is also not supported on {{HTMLElement("input/hidden","hidden")}} as it can not be expected that a user to fill out a form that is hidden. Nor is it supported on any of the button types, including <code>image</code>.</p>
 
@@ -63,42 +63,36 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#attr-input-required', 'required attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'forms.html#attr-input-required', 'required attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'sec-forms.html#the-required-attribute', 'required attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>select</code> element</h3>
+
+{{Specifications("html.elements.select.required")}}
+
+<h3>For the <code>input</code> element</h3>
+
+{{Specifications("html.elements.input.required")}}
+
+<h3>For the <code>textarea</code> element</h3>
+
+{{Specifications("html.elements.textarea.required")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attributes.required")}}</p>
+<h3>For the <code>select</code> element</h3>
 
-<h2 id="See_also">See also</h2>
+{{Compat("html.elements.select.required")}}
+
+<h3>For the <code>input</code> element</h3>
+
+{{Compat("html.elements.input.required")}}
+
+<h3>For the <code>textarea</code> element</h3>
+
+{{Compat("html.elements.textarea.required")}}
 
 <ul>
  <li>{{cssxref('validityState.valueMissing')}}</li>
  <li>{{cssxref(':required')}} and {{cssxref(':optional')}}</li>
  <li>{{htmlelement('input')}}</li>
  <li>{{htmlelement('select')}}</li>
+ <li>{{htmlelement('textarea')}}</li>
 </ul>

--- a/files/en-us/web/html/attributes/size/index.html
+++ b/files/en-us/web/html/attributes/size/index.html
@@ -41,28 +41,23 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#attr-input-size', 'size attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', 'input.html#attr-size-accept', 'size attribute')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-  </tr>
- </tbody>
-</table>
+<h3>For the <code>select</code> element</h3>
+
+<p>{{Specifications("html.elements.select.size")}}</p>
+
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Specifications("html.elements.input.size")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.attribute.size")}}</p>
+<h3>For the <code>select</code> element</h3>
+
+<p>{{Compat("html.elements.select.size")}}</p>
+
+<h3>For the <code>input</code> element</h3>
+
+<p>{{Compat("html.elements.input.size")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/attributes/step/index.html
+++ b/files/en-us/web/html/attributes/step/index.html
@@ -9,7 +9,7 @@ tags:
   - Reference
   - step
 ---
-<p>{{HTMLSidebar}}{{draft}}</p>
+<p>{{HTMLSidebar}}</p>
 
 <p><span class="seoSummary">The <strong><code>step</code></strong> attribute is a number that specifies the granularity that the value must adhere to or the keyword <code>any</code>. It is valid for the numeric input types, including the {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}}, {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}}, {{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number", "number")}} and {{HTMLElement("input/range", "range")}} types.</span></p>
 
@@ -99,27 +99,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'input.html#the-step-attribute', 'step attribute')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', 'input.html#the-step-attribute', 'step attribute')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("html.elements.input.step")}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<h3>For the <code>select</code> element</h3>
+
+{{Compat("html.elements.input.step")}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/global_attributes/index.html
+++ b/files/en-us/web/html/global_attributes/index.html
@@ -133,18 +133,7 @@ browser-compat: html.global_attributes
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "dom.html#global-attributes", "Global attributes")}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/html/viewport_meta_tag/index.html
+++ b/files/en-us/web/html/viewport_meta_tag/index.html
@@ -75,22 +75,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Device', '#viewport-meta', '&lt;meta name="viewport"&gt;')}}</td>
-   <td>{{Spec2('CSS3 Device')}}</td>
-   <td>Non-normatively describes the Viewport META element</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("html.elements.meta.name")}}
 
 <p>There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by thousands of web sites. It would be good to have a true standard for web pages to control viewport properties. As the standardization process proceeds, we at Mozilla will work to keep up to date with any changes.</p>
 


### PR DESCRIPTION
This is part of #1146.

I sourced specification for HTML attributes using {{Specification}}

A few notes:
- I'm not sure having HTML/attributes/ pages (and SVG/attributes) is a good thing. I'm not judging this here, I merely addapt them.
- BCD for input attribute is next to non-existent. I'm not fixing this here.
- I used several macros for the cases where the attributes are on several elements. 
- Missing spec_url where bcd was present are fixed in mdn/browser-compat-data#11240
- If no bcd, I keep the error message: it will be fixed when we add bcd info.

After this PR, there are 0 {{SpecName}}/{{Spec2}} macros left in web/html. 

I plan to use the same techniques for the SVG attributes (>200 tables!)