### PR TITLE
Fix spec msg for MediaController-related properties

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/controller/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.html
@@ -7,9 +7,10 @@ tags:
   - HTMLMediaElement
   - Property
   - Web
+  - Deprecated
 browser-compat: api.HTMLMediaElement.controller
 ---
-<div>{{APIRef("HTML DOM")}}</div>
+<div>{{APIRef("HTML DOM")}}{{deprecated_header}}</div>
 
 <p>The <strong><code>HTMLMediaElement.controller</code></strong> property represents the media controller assigned to the element.</p>
 
@@ -19,7 +20,7 @@ browser-compat: api.HTMLMediaElement.controller
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("MediaController")}} object or <code>null</code> if no media controller is assigned to the element. The default is <code>null</code>.</p>
+<p>A <code>MediaController</code> object or <code>null</code> if no media controller is assigned to the element. The default is <code>null</code>.</p>
 
 <h2 id="Example">Example</h2>
 
@@ -28,7 +29,7 @@ browser-compat: api.HTMLMediaElement.controller
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>In 2016, the whole Media Controller feature was <a href="https://github.com/w3c/html/issues/246">removed from the HTML specification</a>. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -60,8 +60,6 @@ browser-compat: api.HTMLMediaElement
  <dd>Returns a {{domxref("MediaError")}} object for the most recent error, or <code>null</code> if there has not been an error.</dd>
  <dt>{{domxref("HTMLMediaElement.loop")}}</dt>
  <dd>A {{jsxref('Boolean')}} that reflects the {{htmlattrxref("loop", "video")}} HTML attribute, which indicates whether the media element should start over when it reaches the end.</dd>
- <dt>{{domxref("HTMLMediaElement.mediaGroup")}}</dt>
- <dd>A {{domxref("DOMString")}} that reflects the {{ htmlattrxref("mediagroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common {{domxref('MediaController')}}.</dd>
  <dt>{{domxref("HTMLMediaElement.mediaKeys")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("MediaKeys")}} object or <code>null</code>. MediaKeys is a set of keys that an associated HTMLMediaElement can use for decryption of media data during playback.</dd>
  <dt>{{domxref("HTMLMediaElement.muted")}}</dt>
@@ -107,11 +105,13 @@ browser-compat: api.HTMLMediaElement
  <dd>Sets the {{domxref('EventHandler')}} called when playback is blocked while waiting for an encryption key.</dd>
 </dl>
 
-<h2 id="Obsolete_attributes">Obsolete attributes</h2>
+<h2 id="Obsolete_attributes">Obsolete properties</h2>
 
-<p>These attributes are obsolete and should not be used, even if a browser still supports them.</p>
+<p>These properties are obsolete and should not be used, even if a browser still supports them.</p>
 
 <dl>
+<dt>{{domxref("HTMLMediaElement.mediaGroup")}} {{deprecated_inline}}</dt>
+ <dd>A {{domxref("DOMString")}} that reflects the {{ htmlattrxref("mediagroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common {{domxref('MediaController')}}.</dd>
  <dt>{{domxref("HTMLMediaElement.mozAudioCaptured")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>Returns a {{jsxref('Boolean')}}. Related to audio stream capture.</dd>
  <dt>{{domxref("HTMLMediaElement.mozChannels")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}</dt>

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
@@ -7,9 +7,10 @@ tags:
   - HTMLMediaElement
   - Property
   - Web
+  - Deprecated
 browser-compat: api.HTMLMediaElement.mediaGroup
 ---
-<div>{{APIRef("HTML DOM")}}</div>
+<div>{{APIRef("HTML DOM")}}{{deprecated_header}}</div>
 
 <p>The <strong><code>HTMLMediaElement.mediaGroup</code></strong> property reflects the {{htmlattrxref("mediaGroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common <code>controller</code>.</p>
 
@@ -28,7 +29,7 @@ browser-compat: api.HTMLMediaElement.mediaGroup
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>In 2016, the whole Media Controller feature was <a href="https://github.com/w3c/html/issues/246">removed from the HTML specification</a>. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `HTMLMediaElement.controller` and `HTMLMediaElement.mediaGroup`.

If Safari wasn't still supporting it, I would have deleted them.

- I removed the {{Specifications}} macro and replaced it with a text. 
- I added the deprecated banner at the top
- Removed the red link to `MediaController` never documented (and we won't document it at this point)
