### PR TITLE
Fix typo in "contain" doc

### DIFF
--- a/files/en-us/web/css/contain/index.html
+++ b/files/en-us/web/css/contain/index.html
@@ -176,7 +176,7 @@ article {
   contain: content;
 }</pre>
 
-<p>This also means that the first image no longer floats down to the second article, and instead stays inside it's containing element's bounds:</p>
+<p>This also means that the first image no longer floats down to the second article, and instead stays inside its containing element's bounds:</p>
 
 <p>{{EmbedGHLiveSample("css-examples/contain/contain-fix.html", '100%', 500)}}</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Small typo: it should say "its", not "it's". That's it :)