### PR TITLE
Use <a><code>||</code></a>, not <code><a>||</a></code>

### DIFF
--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -64,7 +64,7 @@ console.log(valC); // 42</pre>
 
 <p>Earlier, when one wanted to assign a default value to a variable, a common pattern was
   to use the logical OR operator
-  (<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR">||</a></code>):
+  (<a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR"><code>||</code></a>):
 </p>
 
 <pre class="brush: js">let foo;


### PR DESCRIPTION
Fixes #6368

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Unsatisfactory and maybe misleading text decoration.

> Issue number (if there is an associated issue)

#6368

> Anything else that could help us review it
No.
