### PR TITLE
Modify spec message of  HTMLMenuItemElememt

### DIFF
--- a/files/en-us/web/api/htmlmenuitemelement/index.html
+++ b/files/en-us/web/api/htmlmenuitemelement/index.html
@@ -10,13 +10,11 @@ tags:
   - Reference
 browser-compat: api.HTMLMenuItemElement
 ---
-<p>{{APIRef("HTML DOM")}}{{Draft}}{{Deprecated_Header}}</p>
+<p>{{APIRef("HTML DOM")}}{{Deprecated_Header}}</p>
 
 <p class="summary">The <strong><code>HTMLMenuItemElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menuitem")}} elements.</p>
 
 <p>{{InheritanceDiagram(600,120)}}</p>
-
-<div>{{InterfaceOverview("HTML DOM")}}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlmenuitemelement/index.html
+++ b/files/en-us/web/api/htmlmenuitemelement/index.html
@@ -20,7 +20,7 @@ browser-compat: api.HTMLMenuItemElement
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with  `HTMLMenuItemElement`:
- I adapted the spec message
- I removed the {{InterfaceOverview}} macro that is broken (do not add any overview, just empty sections) and breaks the Hx structure of the page (we need to remove this macro from MDN Web Docs).