### PR TITLE
Fix content implying JS numeric literals can be signed

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.html
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.html
@@ -87,7 +87,7 @@ tags:
  <li>With the keyword {{jsxref("Statements/const", "const")}} or {{jsxref("Statements/let", "let")}}. For example, <code>let y = 13</code>. This syntax can be used to declare a block-scope local variable. (See <a href="#variable_scope">Variable scope</a> below.)</li>
 </ul>
 
-<p>You can declare variables to unpack values from <a href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals">Object Literals</a> using the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment">Destructuring Assignment</a> syntax. For example, <code>let { bar } = foo</code>. This will create a variable named <code>bar</code> and assign to it the value corresponding to the key of the same name from our object <code>foo</code>.  </p>
+<p>You can declare variables to unpack values from <a href="#object_literals">Object Literals</a> using the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment">Destructuring Assignment</a> syntax. For example, <code>let { bar } = foo</code>. This will create a variable named <code>bar</code> and assign to it the value corresponding to the key of the same name from our object <code>foo</code>.  </p>
 
 <p>You can also assign a value to a variable For example, <code>x = 42</code>. This form creates an <strong><a href="/en-US/docs/Web/JavaScript/Reference/Statements/var#description">undeclared global</a></strong> variable. It also generates a strict JavaScript warning. Undeclared global variables can often lead to unexpected behavior. Thus, it is discouraged to use undeclared global variables.</p>
 
@@ -443,7 +443,7 @@ y = 42 + ' is the answer' // "42 is the answer"
 
 <h3 id="Numeric_literals">Numeric literals</h3>
 
-<p>{{jsxref("Number")}} and {{jsxref("BigInt")}} types can be written in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2).</p>
+<p>Integer and {{jsxref("BigInt")}} literals can be written in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2).</p>
 
 <ul>
  <li>A <em>decimal</em> numeric literal is a sequence of digits without a leading <code>0</code> (zero).</li>
@@ -456,10 +456,10 @@ y = 42 + ' is the answer' // "42 is the answer"
 
 <p>Some examples of numeric literals are:</p>
 
-<pre class="eval">0, 117, -345, 123456789123456789n             (decimal, base 10)
-015, 0001, -0o77, 0o777777777777n             (octal, base 8)
-0x1123, 0x00111, -0xF1A7, 0x123456789ABCDEFn  (hexadecimal, "hex" or base 16)
-0b11, 0b0011, -0b11, 0b11101001010101010101n  (binary, base 2)
+<pre class="eval">0, 117, 123456789123456789n             (decimal, base 10)
+015, 0001, 0o777777777777n              (octal, base 8)
+0x1123, 0x00111, 0x123456789ABCDEFn     (hexadecimal, "hex" or base 16)
+0b11, 0b0011, 0b11101001010101010101n   (binary, base 2)
 </pre>
 
 <p>For more information, see <a href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals">Numeric literals in the Lexical grammar reference</a>.</p>
@@ -469,7 +469,7 @@ y = 42 + ' is the answer' // "42 is the answer"
 <p>A floating-point literal can have the following parts:</p>
 
 <ul>
- <li>A decimal integer which can be signed (preceded by "<code>+</code>" or "<code>-</code>"),</li>
+ <li>An unsigned decimal integer,</li>
  <li>A decimal point ("<code>.</code>"),</li>
  <li>A fraction (another decimal number),</li>
  <li>An exponent.</li>
@@ -479,14 +479,14 @@ y = 42 + ' is the answer' // "42 is the answer"
 
 <p>More succinctly, the syntax is:</p>
 
-<pre class="eval">[(+|-)][digits].[digits][(E|e)[(+|-)]digits]
+<pre class="eval">[digits].[digits][(E|e)[(+|-)]digits]
 </pre>
 
 <p>For example:</p>
 
 <pre class="eval">3.1415926
--.123456789
--3.1E+12
+.123456789
+3.1E+12
 .1e-23
 </pre>
 


### PR DESCRIPTION
According to JavaScript's lexical grammar at
<https://262.ecma-international.org/12.0/#sec-literals-numeric-literals>,
numeric literals are unsigned.  This commit removes examples and
content which incorrectly imply that numeric literals can be preceeded
by a sign.

It also fixes an unrelated minor pre-existing "flaw" signalled by the
MDN preview tool on the same page.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
This fix is needed because the content is technically incorrect.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
