### PR TITLE
Improve spec message for PerformanceNavigation.*

### DIFF
--- a/files/en-us/web/api/performance/navigation/index.html
+++ b/files/en-us/web/api/performance/navigation/index.html
@@ -15,19 +15,19 @@ browser-compat: api.Performance.navigation
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>.</p>
-</div>
-
 <p>The legacy
   <code><strong>Performance</strong></code><strong><code>.navigation</code></strong>
   read-only property returns a {{domxref("PerformanceNavigation")}} object representing
-  the type of navigation that occurs in the given browsing context, such as the number of
+  the type of navigation that occurs in the given browsing context, such as the number of
   redirections needed to fetch the resource.</p>
 
 <p>This property is not available in workers.</p>
+
+<div class="warning">
+  <p>This property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">
+     Navigation Timing Level 2 specification</a>. Please use the
+     {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -36,7 +36,8 @@ browser-compat: api.Performance.navigation
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performance/timing/index.html
+++ b/files/en-us/web/api/performance/timing/index.html
@@ -14,19 +14,19 @@ browser-compat: api.Performance.timing
 ---
 <p>{{APIRef("Navigation Timing")}}{{deprecated_header}}</p>
 
-<div class="warning">
-  <p>This property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface instead.</p>
-</div>
-
 <p>The legacy
   <code><strong>Performance</strong></code><strong><code>.timing</code></strong> read-only
   property returns a {{domxref("PerformanceTiming")}} object containing latency-related
   performance information.</p>
 
 <p>This property is not available in workers.</p>
+
+<div class="warning">
+  <p>This property is deprecated in the <a
+      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
+      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+    interface instead.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -35,7 +35,8 @@ browser-compat: api.Performance.timing
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/index.html
+++ b/files/en-us/web/api/performancenavigation/index.html
@@ -17,12 +17,13 @@ browser-compat: api.PerformanceNavigation
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
+<p>The legacy <strong><code>PerformanceNavigation</code></strong> interface represents information about how the navigation to the current document was done.</p>
+
 <div class="notecard warning">
   <h4>Warning</h4>
-  <p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
+  <p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
+     Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
-
-<p>The legacy <strong><code>PerformanceNavigation</code></strong> interface represents information about how the navigation to the current document was done.</p>
 
 <p>An object of this type can be obtained by calling the {{domxref("Performance.navigation")}} read-only attribute.</p>
 
@@ -59,7 +60,8 @@ browser-compat: api.PerformanceNavigation
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.html
@@ -15,16 +15,16 @@ browser-compat: api.PerformanceNavigation.redirectCount
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
+<p>The legacy
+  <code><strong>PerformanceNavigation</strong></code><strong><code>.redirectCount</code></strong>
+  read-only property returns an <code>unsigned short</code> representing the number of
+  REDIRECTs done before reaching the page.</p>
+
 <div class="notecard warning">
   <h4>Warning</h4>
   <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
     Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
-
-<p>The legacy
-  <code><strong>PerformanceNavigation</strong></code><strong><code>.redirectCount</code></strong>
-  read-only property returns an <code>unsigned short</code> representing the number of
-  REDIRECTs done before reaching the page.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -33,7 +33,8 @@ browser-compat: api.PerformanceNavigation.redirectCount
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/performancenavigation/type/index.html
+++ b/files/en-us/web/api/performancenavigation/type/index.html
@@ -14,16 +14,18 @@ browser-compat: api.PerformanceNavigation.type
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
+<p>The legacy
+  <code><strong>PerformanceNavigation.type</code></strong>
+  read-only property returns an <code>unsigned short</code> containing a constant
+  describing how the navigation to this page was done.</p>
+
 <div class="notecard warning">
   <h4>Warning</h4>
   <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
     Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
-<p>The legacy
-  <code><strong>PerformanceNavigation</strong></code><strong><code>.type</code></strong>
-  read-only property returns an <code>unsigned short</code> containing a constant
-  describing how the navigation to this page was done. Possible values are:</p>
+<p>Possible values are:</p>
 
 <table class="standard-table">
   <thead>
@@ -66,7 +68,8 @@ browser-compat: api.PerformanceNavigation.type
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer on track to become a standard, as the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing specification</a> has marked it as deprecated.
+  Use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `PerformanceNavigation.*` here, as well as the 2 properties on `Performance` giving access to the deprecated objects.

I removed the {{Specifications}} macros and replaced it with a text. Reorganized the top so that we don't start with n banners one after the other.