### PR TITLE
Fix spec messages for  execCommand and queryCommand"

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -13,19 +13,23 @@ browser-compat: api.Document.execCommand
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
-<p><span class="seoSummary">When an HTML document has been switched to
+<p>When an HTML document has been switched to
     <code><a href="/en-US/docs/Web/API/Document/designMode">designMode</a></code>, its
     <code>document</code> object exposes an <strong><code>execCommand</code></strong>
     method to run commands that manipulate the current editable region, such as <a
       href="/en-US/docs/Web/HTML/Element/input">form inputs</a> or
     <code><a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable">contentEditable</a></code>
-    elements.</span></p>
+    elements.</p>
 
 <p>Most commands affect the document's <a
     href="/en-US/docs/Web/API/Selection">selection</a> (bold, italics, etc.), while others
   insert new elements (adding a link), or affect an entire line (indenting). When using
   <code>contentEditable</code>, <code>execCommand()</code> affects the currently active
   editable element.</p>
+
+<div class="Notecard note">
+  <p><strong>Note:</strong> This method is obsolete and should not be used. In particular, to interact with the clipboard, consider using the <a href="/en-US/docs/Web/API/Clipboard_API">Clipboard API</a> instead.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -41,7 +45,7 @@ browser-compat: api.Document.execCommand
   <p><strong>Note</strong>: <code><var>document</var>.execCommand()</code> only returns
     <code>true</code> if it is invoked as part of a user interaction. You can't use it to
     verify browser support before calling a command. From Firefox 82, nested
-    <code>document.execCommand()</code> calls will always return <code>false</code>. </p>
+    <code>document.execCommand()</code> calls will always return <code>false</code>.</p>
 </div>
 
 <h3 id="Parameters">Parameters</h3>
@@ -217,8 +221,7 @@ browser-compat: api.Document.execCommand
     deprecated in favor of <code>styleWithCSS</code>.</dd>
   <dt><code>styleWithCSS</code></dt>
   <dd>Replaces the <code>useCSS</code> command. <code>true</code> modifies/generates
-    <code>style</code> attributes in markup, false generates presentational elements.<br>
-     </dd>
+    <code>style</code> attributes in markup, false generates presentational elements.<br></dd>
 </dl>
 
 <h2 id="Example">Example</h2>
@@ -228,7 +231,7 @@ browser-compat: api.Document.execCommand
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandenabled/index.html
+++ b/files/en-us/web/api/document/querycommandenabled/index.html
@@ -52,7 +52,7 @@ if(flg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandstate/index.html
+++ b/files/en-us/web/api/document/querycommandstate/index.html
@@ -57,7 +57,7 @@ browser-compat: api.Document.queryCommandState
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/querycommandsupported/index.html
+++ b/files/en-us/web/api/document/querycommandsupported/index.html
@@ -50,7 +50,7 @@ if(flg) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #6108.

We are dealing with features that are no more on the standard track (deprecated), with bcd tables. The idea is to remove the `{{Specifications}}`, that implies missing data in this case, without putting back an outdated table like before

Dealing with `Document.execCommand` here, as well as the 3 `Document.queryCommand*` methods

I removed the {{Specifications}} macros and replaced it with a text. For execCommand, hinted at the top to look at the Clipboard API for some cases.