### PR TITLE
Remove flaws in bitwise XOR operator

### DIFF
--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
@@ -17,11 +17,9 @@ browser-compat: javascript.operators.bitwise_xor
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor.html")}}</div>
 
-
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> ^ <var>b</var></code>
-</pre>
+<pre class="brush: js"><var>a</var> ^ <var>b</var></pre>
 
 <h2 id="Description">Description</h2>
 
@@ -74,7 +72,7 @@ After:              10100000000000000110000000000001</pre>
   </tbody>
 </table>
 
-<pre class="brush: js">.    9 (base 10) = 00000000000000000000000000001001 (base 2)
+<pre class="brush: js">     9 (base 10) = 00000000000000000000000000001001 (base 2)
     14 (base 10) = 00000000000000000000000000001110 (base 2)
                    --------------------------------
 14 ^ 9 (base 10) = 00000000000000000000000000000111 (base 2) = 7 (base 10)
@@ -99,13 +97,12 @@ After:              10100000000000000110000000000001</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise">Bitwise
+  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise">Bitwise
       operators in the JS guide</a></li>
   <li><a
       href="/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment">Bitwise


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

- Unnecessary period - maybe automatic double-space-to-period conversion added it?
- Lowercased fragment URL
- Removed redundant `<code>` element in `<pre>`

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

None.