### PR TITLE
Source spec table from macros in web/web_components

### DIFF
--- a/files/en-us/web/web_components/html_imports/index.html
+++ b/files/en-us/web/web_components/html_imports/index.html
@@ -7,17 +7,17 @@ tags:
 <p>{{DefaultAPISidebar("Web Components")}}</p>
 
 <div class="blockIndicator obsolete">
-<p><strong>Obsolete since Google Chrome 73</strong><br>
+<p><strong>Obsolete since Google Chrome 73</strong><br>
  This feature is obsolete. Although it may still work in some browsers, its use is discouraged since it could be removed at any time. Try to avoid using it.</p>
 </div>
 
 <div class="notecard warning">
-<p>Firefox will not ship <em>HTML Imports</em> in its current form. See this <a href="https://hacks.mozilla.org/2015/06/the-state-of-web-components/">status update</a> for more information. Until there is a consensus on the standard or alternative mechanisms are worked out, you can use a polyfill such as Google's <code><a href="https://github.com/webcomponents/webcomponentsjs">webcomponents.js</a></code>.</p>
+<p>Firefox will not ship <em>HTML Imports</em> in its current form. See this <a href="https://hacks.mozilla.org/2015/06/the-state-of-web-components/">status update</a> for more information. Until there is a consensus on the standard or alternative mechanisms are worked out, you can use a polyfill such as Google's <code><a href="https://github.com/webcomponents/webcomponentsjs">webcomponents.js</a></code>.</p>
 </div>
 
-<p><em>HTML Imports</em> is intended to be the packaging mechanism for <a href="/en-US/docs/Web/Web_Components">web components</a>, but you can also use HTML Imports by itself.</p>
+<p><em>HTML Imports</em> is intended to be the packaging mechanism for <a href="/en-US/docs/Web/Web_Components">web components</a>, but you can also use HTML Imports by itself.</p>
 
-<p>You import an HTML file by using a <a href="/en-US/docs/Web/HTML/Element/link"><code>&lt;link&gt;</code></a> tag in an HTML document like this: </p>
+<p>You import an HTML file by using a <a href="/en-US/docs/Web/HTML/Element/link"><code>&lt;link&gt;</code></a> tag in an HTML document like this:</p>
 
 <pre>&lt;link rel="import" href="myfile.html"&gt;</pre>
 
@@ -25,21 +25,5 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spec-table standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML Imports")}}</td>
-   <td>{{Spec2("HTML Imports")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("html.elements.link.rel.import")}}</p>

--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -159,40 +159,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG","scripting.html#the-template-element","&lt;template&gt; element")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>The definition of {{HTMLElement("template")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG","custom-elements.html#custom-elements","custom elements")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>The definition of <a href="/en-US/docs/Web/Web_Components/Using_custom_elements">HTML Custom Elements</a>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM WHATWG","#shadow-trees","shadow trees")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td>The definition of <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">Shadow DOM</a>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML Imports", "", "")}}</td>
-   <td>{{Spec2("HTML Imports")}}</td>
-   <td>Initial <a href="/en-US/docs/Web/Web_Components/HTML_Imports">HTML Imports</a> definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Shadow DOM", "", "")}}</td>
-   <td>{{Spec2("Shadow DOM")}}</td>
-   <td>Initial <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">Shadow DOM</a> definition.</td>
-  </tr>
- </tbody>
-</table>
+<h3>The <code>template</code> and custom elements</h3>
+
+{{Specifications("html.elements.template")}}
+
+<h3>The shadow DOM</h3>
+
+{{Specifications("api.ShadowRoot")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -159,7 +159,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<h3>The <code>template</code> and custom elements</h3>
+<h3>The <code>template</code> element and custom elements</h3>
 
 {{Specifications("html.elements.template")}}
 


### PR DESCRIPTION
This is part of #1146.

This converts the web/web_components pages  to the `{{Specifications}}` macro.
