### PR TITLE
Source spec from macros in web/manifest

### DIFF
--- a/files/en-us/web/manifest/index.html
+++ b/files/en-us/web/manifest/index.html
@@ -8,6 +8,7 @@ tags:
   - Progressive web apps
   - Reference
   - Web
+browser-compat: html.manifest
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -92,24 +93,11 @@ It is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed t
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{SpecName("Manifest")}}</td>
-			<td>{{Spec2("Manifest")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/manifest/protocol_handlers/index.html
+++ b/files/en-us/web/manifest/protocol_handlers/index.html
@@ -5,8 +5,9 @@ tags:
   - protocol_handlers
   - Manifest
   - Web
+  - Non-standard
 ---
-<div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
+<div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{Non-standard_Header}}</div>
 
 <table class="properties">
  <tbody>
@@ -67,33 +68,8 @@ tags:
 </table>
 
 <h2 id="Specifications">Specifications</h2>
-<!-- Currently living here https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/URLProtocolHandler/explainer.md -->
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#protocol_handlers', 'protocol_handlers')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/URLProtocolHandler/explainer.md">URL Protocol Handlers Explainer on Microsoft Edge GitHub repo</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+
+<p>This feature is not part of any specification. It has been proposed to be added to the <a href="https://w3c.github.io/manifest/">Manifest</a> specification <a href="https://github.com/w3c/manifest/issues/846">[1]</a> <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/URLProtocolHandler/explainer.md">[2]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of #1146.

This converts the web/manifest  to the `{{Specifications}}` macro.

Note that `protocol_handlers` is only a proposal.