### PR TITLE
Fix Glitch demo for “Using AudioWorklet” doc

### DIFF
--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
@@ -201,7 +201,7 @@ const firstByteOfFirstChannel = firstInputFirstChannel[0]; // (or inputList[0][0
 <ol>
  <li>Load and install the audio processor module</li>
  <li>Create an {{domxref("AudioWorkletNode")}}, specifying the audio processor module to use by its name</li>
- <li>Connect inputs to the <code>AudioWorkletNode</code> and its outputs to appropriate destinations (either other nodes or to the {{domxref("AudioContext")}} object's {{domxref("AudioContext.destination", "destination")}} property.</li>
+ <li>Connect inputs to the <code>AudioWorkletNode</code> and its outputs to appropriate destinations (either other nodes or to the {{domxref("AudioContext")}} object's {{domxref("BaseAudioContext/destination", "destination")}} property.</li>
 </ol>
 
 <p>To use an audio worklet processor, you can use code similar to the following:</p>
@@ -303,7 +303,7 @@ async function createMyAudioProcessor() {
 
 <h3 id="Accessing_parameters_from_the_main_thread_script">Accessing parameters from the main thread script</h3>
 
-<p>Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's {{domxref("AudioParamMap.get", "get()")}} method:</p>
+<p>Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's <code>get()</code> method:</p>
 
 <pre class="brush: js">let gainParam = myAudioWorkletNode.parameters.get("gain");
 </pre>

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
@@ -38,14 +38,14 @@ tags:
 
 <p>Throughout the remainder of this article, we'll look at these steps in more detail, with examples (including working examples you can try out on your own).</p>
 
-<p>The example code found on this page is derived from <a href="https://glitch.com/~audioworkletnode-sample">this working example</a> which is available on <a href="https://glitch.me/">Glitch</a>. The example creates an oscillator node and adds white noise to it using an {{domxref("AudioWorkletNode")}} before playing the resulting sound out. Slider controls are available to allow controlling the gain of both the oscillator and the audio worklet's output.</p>
+<p>The example code found on this page is derived from <a href="https://glitch.com/~audioworkletnode-demo">this working example</a> which is available on <a href="https://glitch.me/">Glitch</a>. The example creates an oscillator node and adds white noise to it using an {{domxref("AudioWorkletNode")}} before playing the resulting sound out. Slider controls are available to allow controlling the gain of both the oscillator and the audio worklet's output.</p>
 
 
-<p><a href="https://glitch.com/~audioworkletnode-sample"><strong>Glitch Project Page</strong></a></p>
+<p><a href="https://glitch.com/~audioworkletnode-demo"><strong>Glitch Project Page</strong></a></p>
 
-<p><a href="https://glitch.com/edit/#!/audioworkletnode-sample"><strong>See the Code</strong></a></p>
+<p><a href="https://glitch.com/edit/#!/audioworkletnode-demo"><strong>See the Code</strong></a></p>
 
-<p><a href="https://audioworkletnode-sample.glitch.me/"><strong>Try it Live</strong></a></p>
+<p><a href="https://audioworkletnode-demo.glitch.me/"><strong>Try it Live</strong></a></p>
 
 <h2 id="Creating_an_audio_worklet_processor">Creating an audio worklet processor</h2>
 


### PR DESCRIPTION
This replaces links to https://glitch.com/~audioworkletnode-sample, which has a bug, with links to https://glitch.com/~audioworkletnode-demo, which is the same sample/demo but with the bug fixed. Fixes https://github.com/mdn/content/issues/6426.