### PR TITLE
Fix typo in IIFE alert example

### DIFF
--- a/files/en-us/glossary/iife/index.html
+++ b/files/en-us/glossary/iife/index.html
@@ -100,7 +100,7 @@ for (var i = 0; i &lt; 2; i++) {
   button.innerText = "Button " + i;
   button.onclick = (function (copyOfI) {
     return function() {alert(copyOfI);};
-  }(i));
+  })(i);
   document.body.appendChild(button);
 }
 console.log(i); // 2</pre>


### PR DESCRIPTION
The invocation `(i)` for the onclick IIFE was incorrectly placed before the closing parenthesis

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The invocation `(i)` for the onclick IIFE was incorrectly placed before the closing parenthesis. This is a typo in the example which may be confusing for readers.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Compare the original example snippet and notice the typo for the syntax of an IIFE