### PR TITLE
Swap overflow-x and overflow-y

### DIFF
--- a/files/en-us/web/css/overflow/index.html
+++ b/files/en-us/web/css/overflow/index.html
@@ -70,9 +70,9 @@ overflow: unset;
  <dt><code>-moz-scrollbars-none</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
  <dd>Use <code>overflow: hidden</code> instead.</dd>
  <dt><code>-moz-scrollbars-horizontal</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
- <dd>Use <code>{{Cssxref("overflow-x")}}: scroll</code> and <code>{{Cssxref("overflow-y")}}: hidden</code>, or <code>overflow: hidden scroll</code> instead.</dd>
+ <dd>Use <code>{{Cssxref("overflow-x")}}: scroll</code> and <code>{{Cssxref("overflow-y")}}: hidden</code>, or <code>overflow: scroll hidden</code> instead.</dd>
  <dt><code>-moz-scrollbars-vertical</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
- <dd>Use <code>{{Cssxref("overflow-x")}}: hidden</code> and <code>{{Cssxref("overflow-y")}}: scroll</code>, or <code>overflow: scroll hidden</code> instead.</dd>
+ <dd>Use <code>{{Cssxref("overflow-x")}}: hidden</code> and <code>{{Cssxref("overflow-y")}}: scroll</code>, or <code>overflow: hidden scroll</code> instead.</dd>
  <dt><code>-moz-hidden-unscrollable</code> {{deprecated_inline}}</dt>
  <dd>Use <code>overflow: clip</code> instead.</dd>
 </dl>


### PR DESCRIPTION
The first keyword passed to `overflow` should be for `overflow-x` and the second for `overflow-y`, not the other way around.