### PR TITLE
Generator function documentation typos fixed

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.html
@@ -28,8 +28,8 @@ browser-compat: javascript.builtins.Generator
 const gen = generator(); // "Generator { }"
 
 console.log(gen.next().value); // 1
-console.log(generator().next().value); // 1
-console.log(generator().next().value); // 1</pre>
+console.log(generator().next().value); // 2
+console.log(generator().next().value); // 3</pre>
 
 <h2 id="Instance_methods">Instance methods</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The comments documenting the expected response for an example generator function call were wrong. This can cause confusion amongst people unfamiliar with the function due to its inaccuracy.


> Issue number (if there is an associated issue)
None


> Anything else that could help us review it
It's just a quick typo fix
