### PR TITLE
Document bluetooth write value functions

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -27,6 +27,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic
     getDescriptors(optional BluetoothDescriptorUUID <dfn>descriptor</dfn>);
   Promise&lt;DataView&gt; readValue();
   Promise&lt;void&gt; writeValue(BufferSource <dfn>value</dfn>);
+  Promise&lt;void&gt; writeValueWithResponse(BufferSource <dfn>value</dfn>);
   Promise&lt;void&gt; startNotifications();
   Promise&lt;void&gt; stopNotifications();
 };
@@ -56,6 +57,8 @@ BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.readValue()")}}</dt>
  <dd>Returns a {{JSxRef("Promise")}} that resolves to an {{JSxRef("ArrayBuffer")}} holding a duplicate of the <code>value</code> property if it is available and supported. Otherwise it throws an error.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValue()")}}</dt>
+ <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
+ <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}}</dt>
  <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.startNotifications()")}}</dt>
  <dd>Returns a {{JSxRef("Promise")}} when <code>navigator.bluetooth</code> is added to the active notification context.</dd>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -57,12 +57,12 @@ BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
  <dd>Returns a {{JSxRef("Promise")}} that resolves to an {{JSxRef("Array")}} of all {{DOMxRef("BluetoothRemoteGATTDescriptor")}} objects for a given descriptor UUID.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.readValue()")}}</dt>
  <dd>Returns a {{JSxRef("Promise")}} that resolves to an {{JSxRef("ArrayBuffer")}} holding a duplicate of the <code>value</code> property if it is available and supported. Otherwise it throws an error.</dd>
- <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValue()")}}</dt>
- <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
- <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}}</dt>
- <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
- <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}}</dt>
- <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
+ <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValue()", "BluetoothRemoteGATTCharacteristic.writeValue(<var>value</var>)")}}</dt>
+ <dd>Sets the <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"optional"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</dd>
+ <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()", "BluetoothRemoteGATTCharacteristic.writeValueWithResponse(<var>value</var>)")}}</dt>
+ <dd>Sets the <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"required"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</dd>
+ <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()", "BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse(<var>value</var>)")}}</dt>
+ <dd>Sets the <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"never"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.startNotifications()")}}</dt>
  <dd>Returns a {{JSxRef("Promise")}} when <code>navigator.bluetooth</code> is added to the active notification context.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.stopNotifications()")}}</dt>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -28,6 +28,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic
   Promise&lt;DataView&gt; readValue();
   Promise&lt;void&gt; writeValue(BufferSource <dfn>value</dfn>);
   Promise&lt;void&gt; writeValueWithResponse(BufferSource <dfn>value</dfn>);
+  Promise&lt;void&gt; writeValueWithoutResponse(BufferSource <dfn>value</dfn>);
   Promise&lt;void&gt; startNotifications();
   Promise&lt;void&gt; stopNotifications();
 };
@@ -59,6 +60,8 @@ BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValue()")}}</dt>
  <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}}</dt>
+ <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
+ <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}}</dt>
  <dd>Sets the value property to the bytes contained in an {{JSxRef("ArrayBuffer")}} and returns a {{JSxRef("Promise")}}.</dd>
  <dt>{{DOMxRef("BluetoothRemoteGATTCharacteristic.startNotifications()")}}</dt>
  <dd>Returns a {{JSxRef("Promise")}} when <code>navigator.bluetooth</code> is added to the active notification context.</dd>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
@@ -16,9 +16,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 
 <p>Use {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}} and {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}} instead.</p>
 
-<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValue()</code></strong> method
-  sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and
-  returns a {{jsxref("Promise")}}.</p>
+<p>The<strong><code>BluetoothRemoteGATTCharacteristic.writeValue()</code></strong> method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object’s <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"optional"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 ---
 <p>{{Deprecated_header}}</p>
 
-<p>Use <code>writeValueWithResponse()</code> and <code>writeValueWithoutResponse()</code> instead.</p>
+<p>Use {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}} and {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}} instead.</p>
 
 <p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValue()</code></strong> method
   sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.html
@@ -1,0 +1,43 @@
+---
+title: BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()
+slug: Web/API/BluetoothRemoteGATTCharacteristic/writeValueWithoutResponse
+tags:
+- API
+- Bluetooth
+- BluetoothRemoteGATTCharacteristic
+- Experimental
+- Property
+- Reference
+- Web Bluetooth API
+- writeValueWithoutResponse
+browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse
+---
+<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()</code></strong> method
+  sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and
+  returns a {{jsxref("Promise")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre
+  class="brush: js">BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse(value).then(function() { ... })</pre>
+
+<h3 id="Returns">Returns</h3>
+
+<p>A {{jsxref("Promise")}}.</p>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt>value</dt>
+  <dd>An {{jsxref("ArrayBuffer")}}. </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.html
@@ -12,9 +12,7 @@ tags:
 - writeValueWithoutResponse
 browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse
 ---
-<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()</code></strong> method
-  sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and
-  returns a {{jsxref("Promise")}}.</p>
+<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()</code></strong> method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object’s <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"never"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.html
@@ -12,9 +12,7 @@ tags:
 - writeValueWithResponse
 browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithResponse
 ---
-<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithResponse()</code></strong> method
-  sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and
-  returns a {{jsxref("Promise")}}.</p>
+<p>The<strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithResponse()</code></strong> method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object’s <code>value</code> property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls <a href="https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue"><code>WriteCharacteristicValue</code>(<var>this</var>=<code>this</code>, <var>value=value</var>, <var>response</var>=<code>"required"</code>)</a>, and returns the resulting {{JSxRef("Promise")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.html
@@ -1,0 +1,43 @@
+---
+title: BluetoothRemoteGATTCharacteristic.writeValueWithResponse()
+slug: Web/API/BluetoothRemoteGATTCharacteristic/writeValueWithResponse
+tags:
+- API
+- Bluetooth
+- BluetoothRemoteGATTCharacteristic
+- Experimental
+- Property
+- Reference
+- Web Bluetooth API
+- writeValueWithResponse
+browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithResponse
+---
+<p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValueWithResponse()</code></strong> method
+  sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and
+  returns a {{jsxref("Promise")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre
+  class="brush: js">BluetoothRemoteGATTCharacteristic.writeValueWithResponse(value).then(function() { ... })</pre>
+
+<h3 id="Returns">Returns</h3>
+
+<p>A {{jsxref("Promise")}}.</p>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt>value</dt>
+  <dd>An {{jsxref("ArrayBuffer")}}. </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<div>{{APIRef("Web Bluetooth")}}</div>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The BluetoothGattRemoteCharacteristic page was missing the non-deprecated methods for writing values.


> Issue number (if there is an associated issue)

 #3426


> Anything else that could help us review it
