### PR TITLE
Remove comments about interactive examples from CSS documentation

### DIFF
--- a/files/en-us/web/css/animation-timing-function/index.html
+++ b/files/en-us/web/css/animation-timing-function/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.animation-timing-function
 
 <div>{{EmbedInteractiveExample("pages/css/animation-timing-function.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.</p>
 

--- a/files/en-us/web/css/background-attachment/index.html
+++ b/files/en-us/web/css/background-attachment/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.background-attachment
 
 <div>{{EmbedInteractiveExample("pages/css/background-attachment.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/background-clip/index.html
+++ b/files/en-us/web/css/background-clip/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.background-clip
 
 <div>{{EmbedInteractiveExample("pages/css/background-clip.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>If the element has no {{cssxref("background-image")}} or {{cssxref("background-color")}}, this property will only have a visual effect when the border has transparent regions or partially opaque regions (due to {{cssxref("border-style")}} or {{cssxref("border-image")}}); otherwise, the border masks the difference.</p>
 

--- a/files/en-us/web/css/background-image/index.html
+++ b/files/en-us/web/css/background-image/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.background-image
 
 <div>{{EmbedInteractiveExample("pages/css/background-image.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The background images are drawn on stacking context layers on top of each other. The first layer specified is drawn as if it is closest to the user.</p>
 

--- a/files/en-us/web/css/background/index.html
+++ b/files/en-us/web/css/background/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.background
 
 <div>{{EmbedInteractiveExample("pages/css/background.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 

--- a/files/en-us/web/css/block-size/index.html
+++ b/files/en-us/web/css/block-size/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.block-size
 
 <div>{{EmbedInteractiveExample("pages/css/block-size.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/border-radius/index.html
+++ b/files/en-us/web/css/border-radius/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.border-radius
 
 <div>{{EmbedInteractiveExample("pages/css/border-radius.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The radius applies to the whole {{cssxref("background")}}, even if the element has no border; the exact position of the clipping is defined by the {{cssxref("background-clip")}} property.</p>
 

--- a/files/en-us/web/css/bottom/index.html
+++ b/files/en-us/web/css/bottom/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.bottom
 
 <div>{{EmbedInteractiveExample("pages/css/bottom.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The effect of <code>bottom</code> depends on how the element is positioned (i.e., the value of the {{cssxref("position")}} property):</p>
 

--- a/files/en-us/web/css/box-shadow/index.html
+++ b/files/en-us/web/css/box-shadow/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.box-shadow
 
 <div>{{EmbedInteractiveExample("pages/css/box-shadow.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The <code>box-shadow</code> property enables you to cast a drop shadow from the frame of almost any element. If a {{cssxref("border-radius")}} is specified on the element with a box shadow, the box shadow takes on the same rounded corners. The z-ordering of multiple box shadows is the same as multiple <a href="/en-US/docs/Web/CSS/text-shadow">text shadows</a> (the first specified shadow is on top).</p>
 

--- a/files/en-us/web/css/box-sizing/index.html
+++ b/files/en-us/web/css/box-sizing/index.html
@@ -23,7 +23,6 @@ browser-compat: css.properties.box-sizing
 
 <div>{{EmbedInteractiveExample("pages/css/box-sizing.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>By default in the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">CSS box model</a>, the <code>width</code> and <code>height</code> you assign to an element is applied only to the element's content box. If the element has any border or padding, this is then added to the <code>width</code> and <code>height</code> to arrive at the size of the box that's rendered on the screen. This means that when you set <code>width</code> and <code>height</code>, you have to adjust the value you give to allow for any border or padding that may be added. For example, if you have four boxes with <code>width: 25%;</code>, if any has left or right padding or a left or right border, they will not by default fit on one line within the constraints of the parent container.</p>
 

--- a/files/en-us/web/css/calc()/index.html
+++ b/files/en-us/web/css/calc()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.calc
 
 <div>{{EmbedInteractiveExample("pages/css/function-calc.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/color/index.html
+++ b/files/en-us/web/css/color/index.html
@@ -23,7 +23,6 @@ browser-compat: css.properties.color
 
 <div>{{EmbedInteractiveExample("pages/css/color.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>For an overview of using color in HTML, see <a href="/en-US/docs/Web/HTML/Applying_color">Applying color to HTML elements using CSS</a>.</p>
 

--- a/files/en-us/web/css/column-gap/index.html
+++ b/files/en-us/web/css/column-gap/index.html
@@ -17,7 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/column-gap.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>Initially a part of <a href="/en-US/docs/Web/CSS/CSS_Columns">Multi-column Layout</a>, the definition of <code>column-gap</code> has been broadened to include multiple layout methods. Now specified in <a href="/en-US/docs/Web/CSS/CSS_Box_Alignment">Box Alignment</a>, it may be used in Multi-column, Flexible Box, and Grid layouts.</p>
 

--- a/files/en-us/web/css/cursor/index.html
+++ b/files/en-us/web/css/cursor/index.html
@@ -20,7 +20,6 @@ browser-compat: css.properties.cursor
 
 <div>{{EmbedInteractiveExample("pages/css/cursor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/blur()/index.html
+++ b/files/en-us/web/css/filter-function/blur()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-blur.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/brightness()/index.html
+++ b/files/en-us/web/css/filter-function/brightness()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-brightness.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/contrast()/index.html
+++ b/files/en-us/web/css/filter-function/contrast()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-contrast.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/drop-shadow()/index.html
+++ b/files/en-us/web/css/filter-function/drop-shadow()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-drop-shadow.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>A drop shadow is effectively a blurred, offset version of the input image's alpha mask, drawn in a specific color and composited below the image.</p>
 

--- a/files/en-us/web/css/filter-function/hue-rotate()/index.html
+++ b/files/en-us/web/css/filter-function/hue-rotate()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-hue-rotate.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/invert()/index.html
+++ b/files/en-us/web/css/filter-function/invert()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-invert.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter-function/opacity()/index.html
+++ b/files/en-us/web/css/filter-function/opacity()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-opacity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div class="note">
 <p><strong>Note:</strong> This function is similar to the more established {{Cssxref("opacity")}} property. The difference is that with filters, some browsers provide hardware acceleration for better performance.</p>

--- a/files/en-us/web/css/filter-function/sepia()/index.html
+++ b/files/en-us/web/css/filter-function/sepia()/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/function-sepia.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/filter/index.html
+++ b/files/en-us/web/css/filter/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.filter
 
 <div>{{EmbedInteractiveExample("pages/css/filter.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/fit-content()/index.html
+++ b/files/en-us/web/css/fit-content()/index.html
@@ -16,7 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/function-fit-content.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The function can be used as a track size in <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid</a> properties, where the maximum size is defined by <code><a href="/en-US/docs/Web/CSS/grid-template-columns#max-content">max-content</a></code> and the minimum size by <code><a href="/en-US/docs/Web/CSS/grid-template-columns#auto">auto</a></code>, which is calculated similar to <code>auto</code> (i.e., <code><a href="/en-US/docs/Web/CSS/minmax">minmax(auto, max-content)</a></code>), except that the track size is clamped at <var>argument</var> if it is greater than the <code>auto</code> minimum.</p>
 

--- a/files/en-us/web/css/flex-shrink/index.html
+++ b/files/en-us/web/css/flex-shrink/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.flex-shrink
 
 <div>{{EmbedInteractiveExample("pages/css/flex-shrink.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.flex
 
 <div>{{EmbedInteractiveExample("pages/css/flex.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 

--- a/files/en-us/web/css/font-optical-sizing/index.html
+++ b/files/en-us/web/css/font-optical-sizing/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.font-optical-sizing
 
 <div>{{EmbedInteractiveExample("pages/css/font-optical-sizing.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/font-variant-ligatures/index.html
+++ b/files/en-us/web/css/font-variant-ligatures/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.font-variant-ligatures
 
 <div>{{EmbedInteractiveExample("pages/css/font-variant-ligatures.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/font-variation-settings/index.html
+++ b/files/en-us/web/css/font-variation-settings/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.font-variation-settings
 
 <div>{{EmbedInteractiveExample("pages/css/font-variation-settings.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/font-weight/index.html
+++ b/files/en-us/web/css/font-weight/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.font-weight
 
 <div>{{EmbedInteractiveExample("pages/css/font-weight.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.font
 
 <div>{{EmbedInteractiveExample("pages/css/font.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>As with any shorthand property, any individual value that is not specified is set to its corresponding initial value (possibly overriding values previously set using non-shorthand properties). Though not directly settable by <code>font</code>, the longhands {{cssxref("font-size-adjust")}} and {{cssxref("font-kerning")}} are also reset to their initial values.</p>
 

--- a/files/en-us/web/css/gap/index.html
+++ b/files/en-us/web/css/gap/index.html
@@ -17,7 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/gap.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/gradient/conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/conic-gradient()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.image.gradient.conic-gradient
 
 <div>{{EmbedInteractiveExample("pages/css/function-conic-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/gradient/index.html
+++ b/files/en-us/web/css/gradient/index.html
@@ -17,7 +17,6 @@ browser-compat: css.types.image.gradient
 
 <div>{{EmbedInteractiveExample("pages/css/type-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>A CSS gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element to which it applies.</p>
 

--- a/files/en-us/web/css/gradient/linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/linear-gradient()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.image.gradient.linear-gradient
 
 <div>{{EmbedInteractiveExample("pages/css/function-linear-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/gradient/radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/radial-gradient()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.image.gradient.radial-gradient
 
 <div>{{EmbedInteractiveExample("pages/css/function-radial-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
@@ -17,10 +17,6 @@ browser-compat: css.types.image.gradient.conic-gradient
 
 <p>The <strong><code>repeating-conic-gradient()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> creates an image consisting of a repeating gradient (rather than a {{cssxref('gradient/conic-gradient()','single gradient')}}) with color transitions rotated around a center point (rather than {{cssxref('gradient/repeating-radial-gradient()','radiating from the center')}}).</p>
 
-<div class="hidden">
-<p>\{{EmbedInteractiveExample("pages/css/function-repeating-conic-gradient.html")}}</p>
-The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: css language-css" id="css">/* Starburst: a blue on blue starburst: the gradient

--- a/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.image.gradient.repeating-linear-gradient
 
 <div>{{EmbedInteractiveExample("pages/css/function-repeating-linear-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The length of the gradient that repeats is the distance between the first and last color stop. If the first color does not have a color-stop-length, the color-stop-length defaults to 0. With each repetition, the positions of the color stops are shifted by a multiple of the length of the basic linear gradient. Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition. This can be altered with repeating the first color again as the last color.</p>
 

--- a/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
@@ -19,7 +19,6 @@ browser-compat: css.types.image.gradient.repeating-radial-gradient
 
 <div>{{EmbedInteractiveExample("pages/css/function-repeating-radial-gradient.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>With each repetition, the positions of the color stops are shifted by a multiple of the dimensions of the basic radial gradient (the distance between the last color stop and the first). Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition, which can be mitigated by repeating the first color as the last color.</p>
 

--- a/files/en-us/web/css/grid-row/index.html
+++ b/files/en-us/web/css/grid-row/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.grid-row
 
 <div>{{EmbedInteractiveExample("pages/css/grid-row.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>If two &lt;grid-line&gt; values are specified, the <code>grid-row-start</code> longhand is set to the value before the slash, and the <code>grid-row-end</code> longhand is set to the value after the slash.</p>
 

--- a/files/en-us/web/css/height/index.html
+++ b/files/en-us/web/css/height/index.html
@@ -19,7 +19,6 @@ browser-compat: css.properties.height
 
 <div>{{EmbedInteractiveExample("pages/css/height.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The {{cssxref("min-height")}} and {{cssxref("max-height")}} properties override <code>height</code>.</p>
 

--- a/files/en-us/web/css/hyphens/index.html
+++ b/files/en-us/web/css/hyphens/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.hyphens
 
 <div>{{EmbedInteractiveExample("pages/css/hyphens.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>Hyphenation rules are language-specific. In HTML, the language is determined by the <code><a href="/en-US/docs/Web/HTML/Global_attributes/lang">lang</a></code> attribute, and browsers will hyphenate only if this attribute is present and the appropriate hyphenation dictionary is available. In XML, the <code><a href="/en-US/docs/Web/SVG/Attribute/xml:lang">xml:lang</a></code> attribute must be used.</p>
 

--- a/files/en-us/web/css/inline-size/index.html
+++ b/files/en-us/web/css/inline-size/index.html
@@ -17,7 +17,6 @@ browser-compat: css.properties.inline-size
 
 <div>{{EmbedInteractiveExample("pages/css/inline-size.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/justify-items/index.html
+++ b/files/en-us/web/css/justify-items/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/justify-items.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The effect of this property is dependent of the layout mode we are in:</p>
 

--- a/files/en-us/web/css/left/index.html
+++ b/files/en-us/web/css/left/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.left
 
 <div>{{EmbedInteractiveExample("pages/css/left.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/letter-spacing/index.html
+++ b/files/en-us/web/css/letter-spacing/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.letter-spacing
 
 <div>{{EmbedInteractiveExample("pages/css/letter-spacing.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/line-height/index.html
+++ b/files/en-us/web/css/line-height/index.html
@@ -20,7 +20,6 @@ browser-compat: css.properties.line-height
 
 <div>{{EmbedInteractiveExample("pages/css/line-height.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/list-style-image/index.html
+++ b/files/en-us/web/css/list-style-image/index.html
@@ -17,7 +17,6 @@ browser-compat: css.properties.list-style-image
 
 <div>{{EmbedInteractiveExample("pages/css/list-style-image.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div class="note">
 <p><strong>Note:</strong> This property is applied to list items, i.e. elements with <code>{{cssxref("display")}}: list-item;</code> <a href="https://www.w3.org/TR/html5/rendering.html#lists">by default</a> this includes {{HTMLElement("li")}} elements. Because this property is inherited, it can be set on the parent element (normally {{HTMLElement("ol")}} or {{HTMLElement("ul")}}) to let it apply to all list items.</p>

--- a/files/en-us/web/css/margin-left/index.html
+++ b/files/en-us/web/css/margin-left/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.margin-left
 
 <div>{{EmbedInteractiveExample("pages/css/margin-left.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The vertical margins of two adjacent boxes may fuse. This is called <a href="/en-US/docs/CSS/margin_collapsing"><em>margin collapsing</em></a>.</p>
 

--- a/files/en-us/web/css/margin-right/index.html
+++ b/files/en-us/web/css/margin-right/index.html
@@ -14,7 +14,6 @@ browser-compat: css.properties.margin-right
 
 <div>{{EmbedInteractiveExample("pages/css/margin-right.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The vertical margins of two adjacent boxes may fuse. This is called <a href="/en-US/docs/CSS/margin_collapsing"><em>margin collapsing</em></a>.</p>
 

--- a/files/en-us/web/css/margin-top/index.html
+++ b/files/en-us/web/css/margin-top/index.html
@@ -14,7 +14,6 @@ browser-compat: css.properties.margin-top
 
 <div>{{EmbedInteractiveExample("pages/css/margin-top.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>This property has no effect on <em>non-<a href="/en-US/docs/Web/CSS/Replaced_element">replaced</a></em> inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.</p>
 

--- a/files/en-us/web/css/max-block-size/index.html
+++ b/files/en-us/web/css/max-block-size/index.html
@@ -29,7 +29,6 @@ browser-compat: css.properties.max-block-size
 
 <div>{{EmbedInteractiveExample("pages/css/max-block-size.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/max-height/index.html
+++ b/files/en-us/web/css/max-height/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.max-height
 
 <div>{{EmbedInteractiveExample("pages/css/max-height.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p><code>max-height</code> overrides {{cssxref("height")}}, but {{cssxref("min-height")}} overrides <code>max-height</code>.</p>
 

--- a/files/en-us/web/css/max-width/index.html
+++ b/files/en-us/web/css/max-width/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.max-width
 
 <div>{{EmbedInteractiveExample("pages/css/max-width.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p><code>max-width</code> overrides {{cssxref("width")}}, but {{cssxref("min-width")}} overrides <code>max-width</code>.</p>
 

--- a/files/en-us/web/css/min-height/index.html
+++ b/files/en-us/web/css/min-height/index.html
@@ -20,7 +20,6 @@ browser-compat: css.properties.min-height
 
 <div>{{EmbedInteractiveExample("pages/css/min-height.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The element's height is set to the value of <code>min-height</code> whenever <code>min-height</code> is larger than {{cssxref("max-height")}} or {{cssxref("height")}}.</p>
 

--- a/files/en-us/web/css/min-width/index.html
+++ b/files/en-us/web/css/min-width/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.min-width
 
 <div>{{EmbedInteractiveExample("pages/css/min-width.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The element's width is set to the value of <code>min-width</code> whenever <code>min-width</code> is larger than {{Cssxref("max-width")}} or {{Cssxref("width")}}.</p>
 

--- a/files/en-us/web/css/minmax()/index.html
+++ b/files/en-us/web/css/minmax()/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.grid-template-columns.minmax
 
 <div>{{EmbedInteractiveExample("pages/css/function-minmax.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/opacity/index.html
+++ b/files/en-us/web/css/opacity/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/opacity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/outline-color/index.html
+++ b/files/en-us/web/css/outline-color/index.html
@@ -22,7 +22,6 @@ browser-compat: css.properties.outline-color
 
 <div>{{EmbedInteractiveExample("pages/css/outline-color.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/outline-offset/index.html
+++ b/files/en-us/web/css/outline-offset/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.outline-offset
 
 <div>{{EmbedInteractiveExample("pages/css/outline-offset.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/outline-width/index.html
+++ b/files/en-us/web/css/outline-width/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.outline-width
 
 <div>{{EmbedInteractiveExample("pages/css/outline-width.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>It is often more convenient to use the shorthand property {{cssxref("outline")}} when defining the appearance of an outline.</p>
 

--- a/files/en-us/web/css/outline/index.html
+++ b/files/en-us/web/css/outline/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.outline
 
 <div>{{EmbedInteractiveExample("pages/css/outline.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 

--- a/files/en-us/web/css/overflow-x/index.html
+++ b/files/en-us/web/css/overflow-x/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.overflow-x
 
 <div>{{EmbedInteractiveExample("pages/css/overflow-x.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/overflow-y/index.html
+++ b/files/en-us/web/css/overflow-y/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.overflow-y
 
 <div>{{EmbedInteractiveExample("pages/css/overflow-y.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/padding-bottom/index.html
+++ b/files/en-us/web/css/padding-bottom/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.padding-bottom
 
 <div>{{EmbedInteractiveExample("pages/css/padding-bottom.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>An element's padding area is the space between its content and its border.</p>
 

--- a/files/en-us/web/css/padding-inline-end/index.html
+++ b/files/en-us/web/css/padding-inline-end/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.padding-inline-end
 
 <div>{{EmbedInteractiveExample("pages/css/padding-inline-end.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/padding-inline-start/index.html
+++ b/files/en-us/web/css/padding-inline-start/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.padding-inline-start
 
 <div>{{EmbedInteractiveExample("pages/css/padding-inline-start.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/padding-left/index.html
+++ b/files/en-us/web/css/padding-left/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.padding-left
 
 <div>{{EmbedInteractiveExample("pages/css/padding-left.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>An element's padding area is the space between its content and its border.</p>
 

--- a/files/en-us/web/css/padding-right/index.html
+++ b/files/en-us/web/css/padding-right/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.padding-right
 
 <div>{{EmbedInteractiveExample("pages/css/padding-right.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>An element's padding area is the space between its content and its border.</p>
 

--- a/files/en-us/web/css/padding-top/index.html
+++ b/files/en-us/web/css/padding-top/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.padding-top
 
 <div>{{EmbedInteractiveExample("pages/css/padding-top.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>An element's padding area is the space between its content and its border.</p>
 

--- a/files/en-us/web/css/padding/index.html
+++ b/files/en-us/web/css/padding/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.padding
 
 <div>{{EmbedInteractiveExample("pages/css/padding.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>An element's padding area is the space between its content and its border.</p>
 

--- a/files/en-us/web/css/place-content/index.html
+++ b/files/en-us/web/css/place-content/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.place-content
 
 <div>{{EmbedInteractiveExample("pages/css/place-content.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 

--- a/files/en-us/web/css/pointer-events/index.html
+++ b/files/en-us/web/css/pointer-events/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.pointer-events
 
 <div>{{EmbedInteractiveExample("pages/css/pointer-events.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/position/index.html
+++ b/files/en-us/web/css/position/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.position
 
 <div>{{EmbedInteractiveExample("pages/css/position.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/scroll-behavior/index.html
+++ b/files/en-us/web/css/scroll-behavior/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.scroll-behavior
 
 <div>{{EmbedInteractiveExample("pages/css/scroll-behavior.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>Note that any other scrolls, such as those performed by the user, are not affected by this property. When this property is specified on the root element, it applies to the viewport instead. This property specified on the <code>body</code> element will <em>not</em> propagate to the viewport.</p>
 

--- a/files/en-us/web/css/scroll-padding-block-end/index.html
+++ b/files/en-us/web/css/scroll-padding-block-end/index.html
@@ -17,7 +17,6 @@ browser-compat: css.properties.scroll-padding-block-end
 
 <div>{{EmbedInteractiveExample("pages/css/scroll-padding-block-end.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/shape-image-threshold/index.html
+++ b/files/en-us/web/css/shape-image-threshold/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.shape-image-threshold
 
 <div>{{EmbedInteractiveExample("pages/css/shape-image-threshold.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>Any pixels whose alpha component's value is greater than the threshold are considered to be part of the shape for the purposes of determining its boundaries. For example, a value of <code>0.5</code> means that the shape will enclose all the pixels that are more than 50% opaque.</p>
 

--- a/files/en-us/web/css/text-decoration-color/index.html
+++ b/files/en-us/web/css/text-decoration-color/index.html
@@ -24,7 +24,6 @@ browser-compat: css.properties.text-decoration-color
 
 <div>{{EmbedInteractiveExample("pages/css/text-decoration-color.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>CSS does not provide a direct mechanism for specifying a unique color for each line type. This effect can nevertheless be achieved by nesting elements, applying a different line type to each element (with the {{cssxref("text-decoration-line")}} property), and specifying the line color (with <code>text-decoration-color</code>) on a per-element basis.</p>
 

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -14,7 +14,6 @@ browser-compat: css.properties.text-overflow
 
 <div>{{EmbedInteractiveExample("pages/css/text-overflow.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The <code>text-overflow</code> property doesn't force an overflow to occur. To make text overflow its container you have to set other CSS properties: {{cssxref("overflow")}} and {{cssxref("white-space")}}. For example:</p>
 

--- a/files/en-us/web/css/text-shadow/index.html
+++ b/files/en-us/web/css/text-shadow/index.html
@@ -21,7 +21,6 @@ browser-compat: css.properties.text-shadow
 
 <div>{{EmbedInteractiveExample("pages/css/text-shadow.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/text-transform/index.html
+++ b/files/en-us/web/css/text-transform/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.text-transform
 
 <div>{{EmbedInteractiveExample("pages/css/text-transform.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The <code>text-transform</code> property takes into account language-specific case mapping rules such as the following:</p>
 

--- a/files/en-us/web/css/transform-function/translatez()/index.html
+++ b/files/en-us/web/css/transform-function/translatez()/index.html
@@ -18,10 +18,6 @@ browser-compat: css.types.transform-function
 
 <div>{{EmbedInteractiveExample("pages/css/function-translateZ.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to
-  contribute to the interactive examples project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a
-  pull request.</div>
 
 <p>This transformation is defined by a {{cssxref("&lt;length&gt;")}} which specifies how far inward or outward the
   element or elements move.</p>

--- a/files/en-us/web/css/var()/index.html
+++ b/files/en-us/web/css/var()/index.html
@@ -20,7 +20,6 @@ browser-compat: css.properties.custom-property.var
 
 <div>{{EmbedInteractiveExample("pages/css/var.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The <code>var()</code> function cannot be used in property names, selectors or anything else besides property values. (Doing so usually produces invalid syntax, or else a value whose meaning has no connection to the variable.)</p>
 

--- a/files/en-us/web/css/vertical-align/index.html
+++ b/files/en-us/web/css/vertical-align/index.html
@@ -14,7 +14,6 @@ browser-compat: css.properties.vertical-align
 
 <div>{{EmbedInteractiveExample("pages/css/vertical-align.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The vertical-align property can be used in two contexts:</p>
 

--- a/files/en-us/web/css/white-space/index.html
+++ b/files/en-us/web/css/white-space/index.html
@@ -16,7 +16,6 @@ browser-compat: css.properties.white-space
 
 <div>{{EmbedInteractiveExample("pages/css/white-space.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The property specifies two things:</p>
 

--- a/files/en-us/web/css/width/index.html
+++ b/files/en-us/web/css/width/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.width
 
 <div>{{EmbedInteractiveExample("pages/css/width.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>The {{cssxref("min-width")}} and {{cssxref("max-width")}} properties override <code>width</code>.</p>
 

--- a/files/en-us/web/css/word-spacing/index.html
+++ b/files/en-us/web/css/word-spacing/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.word-spacing
 
 <div>{{EmbedInteractiveExample("pages/css/word-spacing.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/5865.

This PR removes from the CSS docs all elements of the form:

```html
<div class="hidden">The source for this interactive example is stored in a GitHub repository.
If you'd like to contribute to the interactive examples project, please clone
<a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
and send us a pull request.</div>
```

I've also removed the comment from https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/repeating-conic-gradient(), where the hidden `div` also included the `{{EmbedInteractiveExample}}` macro call itself, because the example for this feature hasn't been written yet. There is an open PR to add this example: https://github.com/mdn/interactive-examples/pull/1396.