### PR TITLE
Move the description of downloading screenshots

### DIFF
--- a/files/en-us/tools/responsive_design_mode/index.html
+++ b/files/en-us/tools/responsive_design_mode/index.html
@@ -47,7 +47,16 @@ tags:
    <li>You can also change the device's screen size by grabbing the bottom-right corner of the viewport and dragging it to the size you want.</li>
   </ul>
  </li>
- <li><em>Orientation (portrait or landscape)</em> - This setting persists between sessions
+ <li><em>Orientation (portrait or landscape)</em> - This setting persists between sessions</li>
+ <li><em>DPR (pixel ratio)</em> - Beginning with Firefox 68, the DPR is no longer editable; create a custom device in order to change the DPR</li>
+ <li><em>Throttling</em> - A drop-down list where you can select the connection throttling to apply, for example 2G, 3G, or LTE</li>
+ <li><em>Enable/Disable touch simulation</em> - Toggles whether or not Responsive Design Mode simulates touch events. While touch event simulation is enabled, mouse events are translated into <a href="/en-US/docs/Web/API/Touch_events">touch events</a>; this includes (starting in Firefox 79) translating a mouse-drag event into a touch-drag event. (Note that when touch simulation is enabled, this toolbar icon is blue; when simulation is disabled, it is black.</li>
+</ul>
+
+<p>On the right end of the screen, three buttons allow you to:</p>
+
+<ul>
+ <li><em>Camera button</em> - take a screenshot
   <ul>
    <li>
     <p>Screenshots are saved to Firefox's default download location.</p>
@@ -57,15 +66,6 @@ tags:
    </li>
   </ul>
  </li>
- <li><em>DPR (pixel ratio)</em> - Beginning with Firefox 68, the DPR is no longer editable; create a custom device in order to change the DPR</li>
- <li><em>Throttling</em> - A drop-down list where you can select the connection throttling to apply, for example 2G, 3G, or LTE</li>
- <li><em>Enable/Disable touch simulation</em> - Toggles whether or not Responsive Design Mode simulates touch events. While touch event simulation is enabled, mouse events are translated into <a href="/en-US/docs/Web/API/Touch_events">touch events</a>; this includes (starting in Firefox 79) translating a mouse-drag event into a touch-drag event. (Note that when touch simulation is enabled, this toolbar icon is blue; when simulation is disabled, it is black.</li>
-</ul>
-
-<p>On the right end of the screen, three buttons allow you to:</p>
-
-<ul>
- <li><em>Camera button</em> - take a screenshot</li>
  <li><em>Settings button</em> - Opens the RDM settings menu</li>
  <li><em>Close button</em> - closes RDM mode and returns to regular browsing</li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The description of handling screenshots should be under the Camera's description, but currently it is under the Orientation's.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
