### PR TITLE
subtlecrypto: Random key/IV for 2nd AES-CTR encryption example

### DIFF
--- a/files/en-us/web/api/subtlecrypto/encrypt/index.html
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.html
@@ -189,8 +189,8 @@ function encryptMessage(key) {
 }
 </pre>
 
-<pre class="brush: js">let iv = new Uint8Array(16);
-let key = new Uint8Array(16);
+<pre class="brush: js">let iv = window.crypto.getRandomValues(new Uint8Array(16));
+let key = window.crypto.getRandomValues(new Uint8Array(16));
 let data = new Uint8Array(12345);
 //crypto functions are wrapped in promises so we have to use await and make sure the function that
 //contains this code is an async function


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The second example for AES-CTR encryption initializes a key and IV as Uint8Array without writing random values to it, leaving it
zero-valued. The null-value key and IV are directly used for encryption, causing the encryption operation to be insecure/ineffective.


> Anything else that could help us review it

I suggest to fill key and IV with cryptographically secure random values. This avoids that developers may copy the snippet from MDN, leaving IV or key as a null-value. Especially given that there is no explanation for the second example, the risk is very high that developers are unaware of the problems of a non-random/repeatedly used IV or key and directly apply such a snippet.