### PR TITLE
Move css paint() to image/paint()

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -10101,7 +10101,8 @@
 /en-US/docs/Web/CSS/orient	/en-US/docs/Web/CSS/-moz-orient
 /en-US/docs/Web/CSS/overflow-x2	/en-US/docs/Web/CSS/overflow-x
 /en-US/docs/Web/CSS/pad	/en-US/docs/Web/CSS/@counter-style/pad
-/en-US/docs/Web/CSS/paint	/en-US/docs/Web/CSS/paint()
+/en-US/docs/Web/CSS/paint	/en-US/docs/Web/CSS/image/paint()
+/en-US/docs/Web/CSS/paint()	/en-US/docs/Web/CSS/image/paint()
 /en-US/docs/Web/CSS/path	/en-US/docs/Web/CSS/path()
 /en-US/docs/Web/CSS/prefix	/en-US/docs/Web/CSS/@counter-style/prefix
 /en-US/docs/Web/CSS/radial-gradient	/en-US/docs/Web/CSS/gradient/radial-gradient()

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -111856,6 +111856,17 @@
       "apepper"
     ]
   },
+  "Web/CSS/image/paint()": {
+    "modified": "2020-11-16T09:08:59.452Z",
+    "contributors": [
+      "chrisdavidmills",
+      "ramiy",
+      "rachelandrew",
+      "wbamberg",
+      "mfuji09",
+      "estelle"
+    ]
+  },
   "Web/CSS/ime-mode": {
     "modified": "2020-10-15T21:06:19.171Z",
     "contributors": [
@@ -114449,17 +114460,6 @@
       "F1na",
       "grendel",
       "jojomojo"
-    ]
-  },
-  "Web/CSS/paint()": {
-    "modified": "2020-11-16T09:08:59.452Z",
-    "contributors": [
-      "chrisdavidmills",
-      "ramiy",
-      "rachelandrew",
-      "wbamberg",
-      "mfuji09",
-      "estelle"
     ]
   },
   "Web/CSS/paint-order": {

--- a/files/en-us/web/css/image/paint()/index.html
+++ b/files/en-us/web/css/image/paint()/index.html
@@ -1,6 +1,6 @@
 ---
 title: paint()
-slug: Web/CSS/paint()
+slug: Web/CSS/image/paint()
 tags:
   - CSS
   - CSS Function


### PR DESCRIPTION
The css functional notation `paint()` can be used only where `<image>` can be used. So I move it under it, like we did for all functional notations linked to a single css type.