### PR TITLE
Chore: Update reset code snippet

### DIFF
--- a/files/en-us/learn/css/building_blocks/images_media_form_elements/index.html
+++ b/files/en-us/learn/css/building_blocks/images_media_form_elements/index.html
@@ -151,7 +151,8 @@ textarea {
   font-family: inherit;
   font-size: 100%;
   box-sizing: border-box;
-  padding: 0; margin: 0;
+  padding: 0; 
+  margin: 0;
 }
 
 textarea {


### PR DESCRIPTION
Make the code snippet easy to read.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
At the [reset CSS code block](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Images_media_form_elements#putting_it_all_together_into_a_reset), the padding and margin are on the same line. It's hard to read.
<img width="989" alt="image" src="https://user-images.githubusercontent.com/13126965/123785458-e7b9f400-d91b-11eb-9957-a1af1bc4c03f.png">

