### PR TITLE
Adds missing InterventionReportBody property pages

### DIFF
--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.columnNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface represents the line in the source file in which the intervention occurred.</p>
+<p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -13,6 +13,11 @@ browser-compat: api.InterventionReportBody.columnNumber
 
 <p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} and {{domxref("InterventionReportBody.lineNumber")}} as it enables the location of the column in that file and line where the feature is used.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">let columnNumber = InterventionReportBody.columnNumber;</pre>
@@ -32,7 +37,9 @@ browser-compat: api.InterventionReportBody.columnNumber
 let observer = new ReportingObserver(function(reports, observer) {
   let firstReport = reports[0];
   console.log(firstReport.type); // intervention
-  console.log(firstReport.body.columnNumber);
+  console.log(firstReport.body.sourceFile); // the source file
+  console.log(firstReport.body.lineNumber); // the line in that file
+  console.log(firstReport.body.columnNumber); // the column in that file.
 }, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -32,6 +32,7 @@ browser-compat: api.InterventionReportBody.columnNumber
 let observer = new ReportingObserver(function(reports, observer) {
   let firstReport = reports[0];
   console.log(firstReport.type); // intervention
+  console.log(firstReport.body.sourceFile);
   console.log(firstReport.body.columnNumber);
 }, options);</pre>
 

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -1,0 +1,44 @@
+---
+title: InterventionReportBody.columnNumber
+slug: Web/API/InterventionReportBody/columnNumber
+tags:
+  - API
+  - Property
+  - Reference
+  - columnNumber
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.columnNumber
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface represents the line in the source file in which the intervention occurred.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let columnNumber = InterventionReportBody.columnNumber;</pre>
+
+<h3>Value</h3>
+<p>An integer, or <code>null</code> if the column is not known.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print the value of <code>columnNumber</code> to the console.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.type); // intervention
+  console.log(firstReport.body.columnNumber);
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/interventionreportbody/id/index.html
+++ b/files/en-us/web/api/interventionreportbody/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.id
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface is defined by the implementation and represents the intervention that generated the report. This can be used to group reports.</p>
+<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a string identifying the intervention that generated the report. This can be used to group reports.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/id/index.html
+++ b/files/en-us/web/api/interventionreportbody/id/index.html
@@ -1,0 +1,44 @@
+---
+title: InterventionReportBody.id
+slug: Web/API/InterventionReportBody/id
+tags:
+  - API
+  - Property
+  - Reference
+  - id
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.id
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface is defined by the implementation and represents the intervention that generated the report. This can be used to group reports.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let id = InterventionReportBody.id;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString","string")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print the value of <code>id</code> to the console.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.type); // intervention
+  console.log(firstReport.body.id);
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -16,6 +16,8 @@ browser-compat: api.InterventionReportBody
 
 <p>An intervention report is generated when usage of a feature in a web document has been blocked by the browser for reasons such as security, performance, or user annoyance. So for example, a script was been stopped because it was significantly slowing down the browser, or the browser's autoplay policy blocked audio from playing without a user gesture to trigger it.</p>
 
+<p>A deprecation report is generated when a deprecated feature (for example a deprecated API method) is used on a document being observed by a {{domxref("ReportingObserver")}}. In addition to the support of this API, receiving useful intervention warnings relies on browser vendors adding these warnings for the relevant features.</p>
+
 <h2 id="Constructor">Constructor</h2>
 
 <p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface has no constructor of its own.</p>

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -18,7 +18,7 @@ browser-compat: api.InterventionReportBody
 
 <h2 id="Constructor">Constructor</h2>
 
-<p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface has no constructor of its own.</p>
+<p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface has no constructor.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -18,7 +18,7 @@ browser-compat: api.InterventionReportBody
 
 <h2 id="Constructor">Constructor</h2>
 
-<p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface as no constructor of its own.</p>
+<p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface has no constructor of its own.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -10,28 +10,45 @@ tags:
   - Reporting API
 browser-compat: api.InterventionReportBody
 ---
-<div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
+<div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>InterventionReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of an intervention report (the return value of its {{domxref("Report.body")}} property).</p>
+<p class="summary">The <code>InterventionReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of an intervention report.</p>
 
-<p class="summary">An intervention report is generated when usage of a feature in a web document has been blocked by the browser for reasons such as security, performance, or user annoyance. So for example, a script was been stopped because it was significantly slowing down the browser, or the browser's autoplay policy blocked audio from playing without a user gesture to trigger it.</p>
+<p>An intervention report is generated when usage of a feature in a web document has been blocked by the browser for reasons such as security, performance, or user annoyance. So for example, a script was been stopped because it was significantly slowing down the browser, or the browser's autoplay policy blocked audio from playing without a user gesture to trigger it.</p>
+
+<h2 id="Constructor">Constructor</h2>
+
+<p>An instance of <code>InterventionReportBody</code> is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is <code>intervention</code>. The interface as no constructor of its own.</p>
 
 <h2 id="Properties">Properties</h2>
 
+<p>This interface also inherits properties from {{domxref("ReportBody")}}.</p>
+
 <dl>
- <dt><code>id</code></dt>
- <dd>A string representing the intervention that generated the report. This can be used to group reports by deprecated feature.</dd>
- <dt><code>message</code></dt>
- <dd>A string containing a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</dd>
- <dt><code>sourceFile</code></dt>
- <dd>A string containing the path to the source file where the intervention occurred, if known, or <code>null</code> otherwise.</dd>
- <dt><code>lineNumber</code></dt>
- <dd>A number representing the line in the source file in which the intervention occurred, if known, or <code>null</code> otherwise.</dd>
- <dt><code>columnNumber</code></dt>
- <dd>A number representing the column in the source file in which the intervention occurred, if known, or <code>null</code> otherwise.</dd>
+ <dt>{{domxref("InterventionReportBody.id")}}{{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("DOMString","string")}} representing the intervention that generated the report. This can be used to group reports.</dd>
+ <dt>{{domxref("InterventionReportBody.message")}}{{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("DOMString","string")}} containing a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</dd>
+ <dt>{{domxref("InterventionReportBody.sourceFile")}}{{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("DOMString","string")}} containing the path to the source file where the intervention occurred, if known, or <code>null</code> otherwise.</dd>
+ <dt>{{domxref("InterventionReportBody.lineNumber")}}{{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("DOMString","string")}} representing the line in the source file in which the intervention occurred, if known, or <code>null</code> otherwise.</dd>
+ <dt>{{domxref("InterventionReportBody.columnNumber")}}{{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("DOMString","string")}} representing the column in the source file in which the intervention occurred, if known, or <code>null</code> otherwise.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p>This interface also inherits methods from {{domxref("ReportBody")}}.</p>
+
+<dl>
+  <dt>{{domxref("InterventionReportBody.toJSON()")}}</dt>
+  <dd>A <em>serializer</em> which returns a JSON representation of the <code>InterventionReportBody</code> object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print details of each property of the first report to the console.</p>
 
 <pre class="brush: js">let options = {
   types: ['intervention'],
@@ -60,4 +77,5 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a></li>
+ <li><a href="https://developers.google.com/web/updates/2018/09/reportingapi">The Reporting API</a></li>
 </ul>

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.html
@@ -1,0 +1,44 @@
+---
+title: InterventionReportBody.lineNumber
+slug: Web/API/InterventionReportBody/lineNumber
+tags:
+  - API
+  - Property
+  - Reference
+  - lineNumber
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.lineNumber
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface represents the line in the source file in which the intervention occurred.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let lineNumber = InterventionReportBody.lineNumber;</pre>
+
+<h3>Value</h3>
+<p>An integer, or <code>null</code> if the line is not known.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print the value of <code>lineNumber</code> to the console.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.type); // intervention
+  console.log(firstReport.body.lineNumber);
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.html
@@ -13,6 +13,11 @@ browser-compat: api.InterventionReportBody.lineNumber
 
 <p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} as it enables the location of the line in that file where the feature is used.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">let lineNumber = InterventionReportBody.lineNumber;</pre>
@@ -32,7 +37,8 @@ browser-compat: api.InterventionReportBody.lineNumber
 let observer = new ReportingObserver(function(reports, observer) {
   let firstReport = reports[0];
   console.log(firstReport.type); // intervention
-  console.log(firstReport.body.lineNumber);
+  console.log(firstReport.body.sourceFile); // the source file
+  console.log(firstReport.body.lineNumber); // the line in that file
 }, options);</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.lineNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface represents the line in the source file in which the intervention occurred.</p>
+<p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/message/index.html
+++ b/files/en-us/web/api/interventionreportbody/message/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.message
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface contains a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
+<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/message/index.html
+++ b/files/en-us/web/api/interventionreportbody/message/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.message
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
+<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a human-readable description of the intervention, including information such as how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/message/index.html
+++ b/files/en-us/web/api/interventionreportbody/message/index.html
@@ -1,0 +1,44 @@
+---
+title: InterventionReportBody.message
+slug: Web/API/InterventionReportBody/message
+tags:
+  - API
+  - Property
+  - Reference
+  - message
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.message
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface contains a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let message = InterventionReportBody.message;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString","string")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print the value of <code>message</code> to the console.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.type); // intervention
+  console.log(firstReport.body.message);
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.sourceFile
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface contains the path to the source file where the intervention occurred.</p>
+<p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.html
@@ -1,0 +1,44 @@
+---
+title: InterventionReportBody.sourceFile
+slug: Web/API/InterventionReportBody/sourceFile
+tags:
+  - API
+  - Property
+  - Reference
+  - sourceFile
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.sourceFile
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface contains the path to the source file where the intervention occurred.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let sourceFile = InterventionReportBody.sourceFile;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString","string")}}, or <code>null</code> if the path is not known.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then print the value of <code>sourceFile</code> to the console.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.type); // intervention
+  console.log(firstReport.body.sourceFile);
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.html
@@ -13,6 +13,11 @@ browser-compat: api.InterventionReportBody.sourceFile
 
 <p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.</p>
 
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>This property can be used with {{domxref("InterventionReportBody.lineNumber")}} and {{domxref("InterventionReportBody.columnNumber")}} to locate the column and line in the file where the feature is used.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">let sourceFile = InterventionReportBody.sourceFile;</pre>

--- a/files/en-us/web/api/interventionreportbody/tojson/index.html
+++ b/files/en-us/web/api/interventionreportbody/tojson/index.html
@@ -1,0 +1,50 @@
+---
+title: InterventionReportBody.toJSON()
+slug: Web/API/InterventionReportBody/toJSON
+tags:
+  - API
+  - Method
+  - Reference
+  - toJSON
+  - InterventionReportBody
+browser-compat: api.InterventionReportBody.toJSON
+---
+<div>{{APIRef("Reporting API")}}</div>
+
+<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("InterventionReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>InterventionReportBody</code> object.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">InterventionReportBody.toJSON();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A JSON object that is the serialization of the {{domxref("InterventionReportBody")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example we create a new {{domxref("ReportingObserver")}} to observe intervention reports, then return a JSON representation of the first entry.</p>
+
+<pre class="brush: js">let options = {
+  types: ['intervention'],
+  buffered: true
+}
+
+let observer = new ReportingObserver(function(reports, observer) {
+  let firstReport = reports[0];
+  console.log(firstReport.toJSON());
+}, options);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+


### PR DESCRIPTION
Updates the main page for InterventionReportBody and adds subpages.

BCD and spec data are part of this PR https://github.com/mdn/browser-compat-data/pull/10925

Reviewer: @jpmedley 