### PR TITLE
[DO NOT MERGE] Rename feature policy in APIs (1 of 4).

### DIFF
--- a/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.html
+++ b/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.html
@@ -17,7 +17,7 @@ browser-compat: api.AbsoluteOrientationSensor.AbsoluteOrientationSensor
 
 <p><span class="seoSummary">The <strong><code>AbsoluteOrientationSensor</code></strong> constructor creates a new {{domxref("AbsoluteOrientationSensor")}} object which describes the device's physical orientation in relation to the Earth's reference coordinate system.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/absoluteorientationsensor/index.html
+++ b/files/en-us/web/api/absoluteorientationsensor/index.html
@@ -20,7 +20,7 @@ browser-compat: api.AbsoluteOrientationSensor
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code>, <code>'gyroscope'</code>, and <code>'magnetometer'</code> device sensors through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/accelerometer/accelerometer/index.html
+++ b/files/en-us/web/api/accelerometer/accelerometer/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Accelerometer.Accelerometer
 
 <p><span class="seoSummary">The <strong><code>Accelerometer</code></strong> constructor creates a new {{domxref("Accelerometer")}} object which returns the acceleration of the device along all three axes at the time it is read.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/accelerometer/index.html
+++ b/files/en-us/web/api/accelerometer/index.html
@@ -19,7 +19,7 @@ browser-compat: api.Accelerometer
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code>, device sensor through the <a href="/en-US/docs/Web/API/Permissions"><code>Permissions</code></a> API.</p>
 
-<p>If a feature policy blocks the use of a feature, it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks the use of a feature, it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/accelerometer/x/index.html
+++ b/files/en-us/web/api/accelerometer/x/index.html
@@ -18,7 +18,7 @@ browser-compat: api.Accelerometer.x
 
 <p><span class="seoSummary">The <strong><code>x</code></strong> read-only property of the {{domxref("Accelerometer")}} interface returns a double precision integer containing the acceleration of the device along the its x axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/accelerometer/y/index.html
+++ b/files/en-us/web/api/accelerometer/y/index.html
@@ -18,7 +18,7 @@ browser-compat: api.Accelerometer.y
 
 <p><span class="seoSummary">The <strong><code>y</code></strong> read-only property of the {{domxref("Accelerometer")}} interface returns a double precision integer containing the acceleration of the device along the its y axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/accelerometer/z/index.html
+++ b/files/en-us/web/api/accelerometer/z/index.html
@@ -18,7 +18,7 @@ browser-compat: api.Accelerometer.z
 
 <p><span class="seoSummary">The <strong><code>z</code></strong> read-only property of the {{domxref("Accelerometer")}} interface returns a double precision integer containing the acceleration of the device along the its z axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.html
+++ b/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AmbientLightSensor.AmbientLightSensor
 
 <p><span class="seoSummary">The <strong><code>AmbientLightSensor()</code></strong> constructor creates a new {{domxref("AmbientLightSensor")}} object, which returns the current light level or illuminance of the ambient light around the hosting device.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ambientlightsensor/illuminance/index.html
+++ b/files/en-us/web/api/ambientlightsensor/illuminance/index.html
@@ -17,7 +17,7 @@ browser-compat: api.AmbientLightSensor.illuminance
 
 <p><span class="seoSummary">The <strong><code>illuminance</code></strong> property of the {{domxref("AmbientLightSensor")}} interface returns the current light level in <a href="https://en.wikipedia.org/wiki/Lux">lux</a> of the ambient light level around the hosting device.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ambientlightsensor/index.html
+++ b/files/en-us/web/api/ambientlightsensor/index.html
@@ -19,7 +19,7 @@ browser-compat: api.AmbientLightSensor
 
 <p>To use this sensor, the user must grant permission to the <code>'ambient-light-sensor'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/credentialscontainer/get/index.html
+++ b/files/en-us/web/api/credentialscontainer/get/index.html
@@ -98,8 +98,8 @@ browser-compat: api.CredentialsContainer.get
   <h2 id="See_also">See also</h2>
 
   <ul>
-    <li>{{HTTPHeader("Feature-Policy")}} directive
-      {{HTTPHeader("Feature-Policy/publickey-credentials-get","publickey-credentials-get")}}
+    <li>{{HTTPHeader("Permissions-Policy")}} directive
+      {{HTTPHeader("Permissions-Policy/publickey-credentials-get","publickey-credentials-get")}}
     </li>
   </ul>
 </div>

--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -96,8 +96,8 @@ browser-compat: api.Document.domain
   several cases:</p>
 
 <ul>
-  <li>The {{httpheader('Feature-Policy/document-domain','document-domain')}}
-    {{HTTPHeader("Feature-Policy")}} is disabled.</li>
+  <li>The {{httpheader('Permissions-Policy/document-domain','document-domain')}}
+    {{HTTPHeader("Permissions-Policy")}} is disabled.</li>
   <li>The document is inside a sandboxed {{htmlelement("iframe")}}.</li>
   <li>The document has no {{glossary("browsing context")}}.</li>
   <li>The document's <a

--- a/files/en-us/web/api/document/featurepolicy/index.html
+++ b/files/en-us/web/api/document/featurepolicy/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Document.featurePolicy
 ---
 <p>{{APIRef("Feature Policy")}}</p>
 
-<p>The <strong><code>featurePolicy</code></strong> read-only property of the {{domxref("Document")}} interface returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for inspecting the feature policies applied to a specific document.</p>
+<p>The <strong><code>featurePolicy</code></strong> read-only property of the {{domxref("Document")}} interface returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for inspecting the permissions policies applied to a specific document.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -19,7 +19,7 @@ browser-compat: api.Document.featurePolicy
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("FeaturePolicy")}} object that can be used to inspect the Feature Policy settings applied to the document.</p>
+<p>A {{domxref("FeaturePolicy")}} object that can be used to inspect the Permissions Policy settings applied to the document.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -82,7 +82,7 @@ browser-compat: api.Document
  <dt>{{DOMxRef("Document.pointerLockElement")}} {{ReadOnlyInline}}</dt>
  <dd>Returns the element set as the target for mouse events while the pointer is locked. <code>null</code> if lock is pending, pointer is unlocked, or if the target is in another document.</dd>
  <dt>{{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
- <dd>Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.</dd>
+ <dd>Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the permissions policies applied to a specific document.</dd>
  <dt>{{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}</dt>
  <dd>Returns all the {{HTMLElement("script")}} elements on the document.</dd>
  <dt>{{DOMxRef("Document.scrollingElement")}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.html
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.html
@@ -20,7 +20,7 @@ browser-compat: api.Document.pictureInPictureEnabled
     {{domxref("Document")}} interface indicates whether or not picture-in-picture mode is
     available.</span> Picture-in-Picture mode is available by default unless specified
   otherwise by a <a
-    href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/picture-in-picture">Feature-Policy</a>.
+    href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy/picture-in-picture">Permissions-Policy</a>.
 </p>
 
 <p>Although this property is read-only, it will not throw if it is modified (even in

--- a/files/en-us/web/api/element/requestfullscreen/index.html
+++ b/files/en-us/web/api/element/requestfullscreen/index.html
@@ -79,7 +79,7 @@ browser-compat: api.Element.requestFullscreen
         current active document.</li>
       <li>The element is not contained by a document.</li>
       <li>The element is not permitted to use the <code>"fullscreen"</code> feature,
-        either because of Feature Policy configuration or other access control features.
+        either because of Permissions Policy configuration or other access control features.
       </li>
       <li>The element and its document are the same node.</li>
     </ul>
@@ -102,7 +102,7 @@ browser-compat: api.Element.requestFullscreen
     attribute applied to it.</li>
 </ul>
 
-<p>Additionally, of course, the Feature Policy <code>"fullscreen"</code> permission must
+<p>Additionally, of course, the Permissions Policy <code>"fullscreen"</code> permission must
   be granted.</p>
 
 <h3 id="Detecting_full-screen_activation">Detecting full-screen activation</h3>

--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
@@ -7,6 +7,7 @@ tags:
 - Feature Policy
 - Feature-Policy
 - FeaturePolicy
+- Permissions-Policy
 - Reference
 browser-compat: api.FeaturePolicy.allowedFeatures
 ---
@@ -14,10 +15,14 @@ browser-compat: api.FeaturePolicy.allowedFeatures
 
 <p><span class="seoSummary">The <strong><code>allowedFeatures()</code></strong> method of
     the {{DOMxRef("FeaturePolicy")}} interface returns a list of directive names of all
-    features allowed by the feature policy.enables introspection of individual directives
-    of the Feature Policy it is run on. As such, <code>allowedFeatures()</code> method
+    features allowed by the permissions policy.enables introspection of individual directives
+    of the Permissions Policy it is run on. As such, <code>allowedFeatures()</code> method
     returns a subset of directives returned by {{DOMxRef("FeaturePolicy.features",
     "features()")}}.</span></p>
+
+<div class="note">
+  <p>The <code>Permissions-Policy</code> header was previously named <code>Feature-Policy</code>. This API as well as some linked-to articles and demos still use the older name.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,8 +35,8 @@ browser-compat: api.FeaturePolicy.allowedFeatures
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An array of strings representing the Feature Policy directive names that are allowed by
-  the Feature Policy this method is called on.</p>
+<p>An array of strings representing the Permissions Policy directive names that are allowed by
+  the Permissions Policy this method is called on.</p>
 
 <h2 id="Example">Example</h2>
 
@@ -42,7 +47,7 @@ browser-compat: api.FeaturePolicy.allowedFeatures
 <pre class="brush: js">// First, get the Feature Policy object
 const featurePolicy = document.featurePolicy
 
-// Then query feature for specific
+// Then query feature for a specific Permissions Policy
 const allowed = featurePolicy.allowedFeatures()
 
 for (const directive of allowed){

--- a/files/en-us/web/api/featurepolicy/allowsfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/allowsfeature/index.html
@@ -1,15 +1,27 @@
 ---
 title: FeaturePolicy.allowsFeature()
 slug: Web/API/FeaturePolicy/allowsFeature
+tags:
+- API
+- Directive
+- Feature Policy
+- Feature-Policy
+- FeaturePolicy
+- Permissions-Policy
+- Reference
 browser-compat: api.FeaturePolicy.allowsFeature
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
 
 <p><span class="seoSummary">The <strong><code>allowsFeature()</code></strong> method of
 		the {{DOMxRef("FeaturePolicy")}} interface enables introspection of individual
-		directives of the Feature Policy it is run on. It returns a {{JSxRef("Boolean")}}
+		directives of the Permissions Policy it is run on. It returns a {{JSxRef("Boolean")}}
 		that is <code>true</code> if and only if the specified feature is allowed in the
 		specified context (or the default context if no context is specified).</span></p>
+
+<div class="note">
+  <p>The <code>Permissions-Policy</code> header was previously named <code>Feature-Policy</code>. This API as well as some linked-to articles and demos still use the older name.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -39,13 +51,13 @@ browser-compat: api.FeaturePolicy.allowsFeature
 <h2 id="Example">Example</h2>
 
 <p>The following example queries whether or not the document is allowed to use camera API
-	by the Feature Policy. Please note that Camera API might be restricted by the
+	by the Permissions Policy. Please note that Camera API might be restricted by the
 	Permissions API, if the user did not grant the corresponding permission yet.</p>
 
 <pre class="brush: js">// First, get the Feature Policy object
 const featurePolicy = document.featurePolicy
 
-// Then query feature for specific
+// Then query feature for a specific Permissions Policy
 const allowed = featurePolicy.allowsFeature("camera")
 
 if (allowed){

--- a/files/en-us/web/api/featurepolicy/features/index.html
+++ b/files/en-us/web/api/featurepolicy/features/index.html
@@ -1,6 +1,14 @@
 ---
 title: FeaturePolicy.features()
 slug: Web/API/FeaturePolicy/features
+tags:
+- API
+- Directive
+- Feature Policy
+- Feature-Policy
+- FeaturePolicy
+- Permissions-Policy
+- Reference
 browser-compat: api.FeaturePolicy.features
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
@@ -8,8 +16,12 @@ browser-compat: api.FeaturePolicy.features
 <p><span class="seoSummary">The <strong><code>features()</code></strong> method of the
         {{DOMxRef("FeaturePolicy")}} interface returns a list of names of all features
         supported by the User Agent. Feature whose name appears on the list might not be
-        allowed by the Feature Policy of the current execution context and/or might not be
+        allowed by the Permissions Policy of the current execution context and/or might not be
         accessible because of user's permissions.</span></p>
+
+<div class="note">
+  <p>The <code>Permissions-Policy</code> header was previously named <code>Feature-Policy</code>. This API as well as some linked-to articles and demos still use the older name.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -22,7 +34,7 @@ browser-compat: api.FeaturePolicy.features
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A list of strings that represent names of all Feature Policy directives supported by
+<p>A list of strings that represent names of all Permissions Policy directives supported by
     the User Agent.</p>
 
 <h2 id="Example">Example</h2>
@@ -32,7 +44,7 @@ browser-compat: api.FeaturePolicy.features
 <pre class="brush: js">// Get the Feature Policy object
 const featurePolicy = document.featurePolicy
 
-// Retrieve the list of all supported Feature Policy directives
+// Retrieve the list of all supported Permissions Policy directives
 const supportedDirectives = featurePolicy.features()
 
 // Print out each directive into the console

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
@@ -3,16 +3,23 @@ title: FeaturePolicy.getAllowlistForFeature()
 slug: Web/API/FeaturePolicy/getAllowlistForFeature
 tags:
 - API
+- Directive
 - Feature Policy
 - Feature-Policy
+- FeaturePolicy
+- Permissions-Policy
 - Reference
 browser-compat: api.FeaturePolicy.getAllowlistForFeature
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
 
 <p><span class="seoSummary">The <strong><code>getAllowlistForFeature()</code></strong>
-    method of the {{DOMxRef("FeaturePolicy")}} allows query of the allow list for a
-    specific feature for the current Feature Policy.</span></p>
+    method of the {{DOMxRef("FeaturePolicy")}} interface allows query of the allow list for a
+    specific feature for the current Permissions Policy.</span></p>
+
+<div class="note">
+  <p>The <code>Permissions-Policy</code> header was previously named <code>Feature-Policy</code>. This API as well as some linked-to articles and demos still use the older name.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -27,19 +34,19 @@ browser-compat: api.FeaturePolicy.getAllowlistForFeature
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An <a href="Web/HTTP/Feature_Policy/Using_Feature_Policy">Allow list</a> for the
+<p>An <a href="Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Allow list</a> for the
   specified feature.</p>
 
 <h2 id="Errors">Errors</h2>
 
-<p>The function will raise a warning if the specified Feature Policy directive name is not
+<p>The function will raise a warning if the specified Permissions Policy directive name is not
   known. However, it will also return empty array, indicating that no origin is allowed to
   use the feature.</p>
 
 <h2 id="Example">Example</h2>
 
 <p>The following example prints all the origins that are allowed to use Camera API by the
-  Feature Policy. Please note that Camera API might be restricted by the Permissions API,
+  Permissions Policy. Please note that Camera API might be restricted by the Permissions API,
   if the user did not grant the corresponding permission yet.</p>
 
 <pre class="brush: js">// First, get the Feature Policy object

--- a/files/en-us/web/api/featurepolicy/index.html
+++ b/files/en-us/web/api/featurepolicy/index.html
@@ -2,21 +2,22 @@
 title: FeaturePolicy
 slug: Web/API/FeaturePolicy
 tags:
-  - API
-  - Feature Policy
-  - Feature-Policy
-  - FeaturePolicy
-  - Interface
-  - Permissions
-  - Privileges
-  - Reference
-  - access
-  - delegation
+- API
+- Directive
+- Feature Policy
+- Feature-Policy
+- FeaturePolicy
+- Permissions-Policy
+- Reference
 browser-compat: api.FeaturePolicy
 ---
 <p>{{APIRef("Feature Policy")}}</p>
 
-<p>The <code>FeaturePolicy</code> interface of the <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy API</a> represents the set of policies applied to the current execution context.</p>
+<p>The <code>FeaturePolicy</code> interface of the <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy API</a> represents the set of permissions policies applied to the current execution context.</p>
+
+<div class="note">
+  <p>The <code>Permissions-Policy</code> header was previously named <code>Feature-Policy</code>. This API as well as some linked-to articles and demos still use the older name.</p>
+</div>
 
 <h2 id="FeaturePolicy_Methods">FeaturePolicy Methods</h2>
 
@@ -24,9 +25,9 @@ browser-compat: api.FeaturePolicy
  <dt>{{DOMxRef("FeaturePolicy.allowsFeature")}}</dt>
  <dd>Returns a Boolean that indicates whether or not a particular feature is enabled in the specified context.</dd>
  <dt>{{DOMxRef("FeaturePolicy.features")}}</dt>
- <dd>Returns a list of names of all features supported by the User Agent. Feature whose name appears on the list might not be allowed by the Feature Policy of the current execution context and/or might not be accessible because of user's permissions.</dd>
+ <dd>Returns a list of names of all features supported by the User Agent. Feature whose name appears on the list might not be allowed by the Permissions Policy of the current execution context and/or might not be accessible because of user's permissions.</dd>
  <dt>{{DOMxRef("FeaturePolicy.allowedFeatures")}}</dt>
- <dd>Returns a list of names of all features supported by the User Agent and allowed by the Feature Policy. Note that features appearing on this list might still be behind a user permission.</dd>
+ <dd>Returns a list of names of all features supported by the User Agent and allowed by the Permissions Policy. Note that features appearing on this list might still be behind a user permission.</dd>
  <dt>{{DOMxRef("FeaturePolicy.getAllowlistForFeature")}}</dt>
  <dd>Returns the Allow list for the specified feature.</dd>
 </dl>
@@ -42,6 +43,6 @@ browser-compat: api.FeaturePolicy
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{HTTPHeader("Feature-Policy")}}</li>
+ <li>{{HTTPHeader("Permissions-Policy")}}</li>
  <li><a href="/en-US/docs/Web/Privacy">Privacy, permissions, and information security</a></li>
 </ul>

--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -115,9 +115,9 @@ tags:
 
 <h2 id="Controlling_access">Controlling access</h2>
 
-<p>The availability of full-screen mode can be controlled using <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a>. The full-screen mode feature is identified by the string <code>"fullscreen"</code>, with a default allow-list value of <code>"self"</code>, meaning that full-screen mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.</p>
+<p>The availability of full-screen mode can be controlled using <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a>. The full-screen mode feature is identified by the string <code>"fullscreen"</code>, with a default allow-list value of <code>"self"</code>, meaning that full-screen mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.</p>
 
-<p>See <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> to learn more about using Feature Policy to control access to an API.</p>
+<p>See <a href="/en-US/docs/Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Using Permissions Policy</a> to learn more about using Permissions Policy to control access to an API.</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -36,7 +36,7 @@ browser-compat: api.GravitySensor.GravitySensor
         used, the latter for frequencies less than a second. The actual reading frequency
         depends on device hardware and consequently may be less than requested. The default
         frequency is the one defined by the underlying platform.</li>
-      <li><code>referenceFrame</code>: The local coordinate system representing 
+      <li><code>referenceFrame</code>: The local coordinate system representing
         the reference frame. It can be either  <code>'device'</code> or
         <code>'screen'</code>. The default is <code>'device'</code>.</li>
     </ul>
@@ -47,9 +47,9 @@ browser-compat: api.GravitySensor.GravitySensor
 
 <dl>
   <dt>SecurityError</dt>
-  <dd>Use of this feature was blocked by a feature policy. If a feature policy blocks use of a feature,
+  <dd>Use of this feature was blocked by a permissions policy. If a permissions policy blocks use of a feature,
     it is because your code is inconsistent with the policies set on your server.
-    This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</dd>
+    This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/gyroscope/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/gyroscope/index.html
@@ -18,9 +18,9 @@ browser-compat: api.Gyroscope.Gyroscope
     creates a new {{domxref("Gyroscope")}} object which provides on each reading the
     angular velocity of the device along all three axes.</span></p>
 
-<p>If a feature policy blocks use of a feature, it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature, it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/index.html
@@ -19,7 +19,7 @@ browser-compat: api.Gyroscope
 
 <p>To use this sensor, the user must grant permission to the <code>'gyroscope'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/gyroscope/x/index.html
+++ b/files/en-us/web/api/gyroscope/x/index.html
@@ -19,9 +19,9 @@ browser-compat: api.Gyroscope.x
     {{domxref("Gyroscope")}} interface returns a double precision integer containing the
     angular velocity of the device along the its x axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/gyroscope/y/index.html
+++ b/files/en-us/web/api/gyroscope/y/index.html
@@ -19,9 +19,9 @@ browser-compat: api.Gyroscope.y
     {{domxref("Gyroscope")}} interface returns a double precision integer containing the
     angular velocity of the device along the its y axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/gyroscope/z/index.html
+++ b/files/en-us/web/api/gyroscope/z/index.html
@@ -19,9 +19,9 @@ browser-compat: api.Gyroscope.z
     {{domxref("Gyroscope")}} interface returns a double precision integer containing the
     angular velocity of the device along the its z axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmliframeelement/featurepolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/featurepolicy/index.html
@@ -15,7 +15,7 @@ browser-compat: api.HTMLIFrameElement.featurePolicy
 <p><span class="seoSummary">The <strong><code>featurePolicy</code></strong> read-only
     property of the {{DOMxRef("HTMLIFrameElement")}} interface returns the
     {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting
-    the feature policies applied to a specific frame.</span></p>
+    the permissions policies applied to a specific frame.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -26,7 +26,7 @@ browser-compat: api.HTMLIFrameElement.featurePolicy
 
 <p>A <a href="/en-US/docs/Web/API/FeaturePolicy"
     title="Note: This interface is called Policy in Firefox."><code>FeaturePolicy</code></a> object
-  that can be used to inspect the Feature Policy settings applied to the frame.</p>
+  that can be used to inspect the Permissions Policy settings applied to the frame.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmliframeelement/index.html
+++ b/files/en-us/web/api/htmliframeelement/index.html
@@ -46,7 +46,7 @@ browser-compat: api.HTMLIFrameElement
  <dt>{{domxref("HTMLIFrameElement.name")}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "iframe")}} HTML attribute, containing a name by which to refer to the frame.</dd>
  <dt>{{domxref("HTMLIFrameElement.featurePolicy")}} {{readonlyinline}}{{experimental_inline}}</dt>
- <dd>Returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.</dd>
+ <dd>Returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for introspecting the permissions policies applied to a specific document.</dd>
  <dt>{{domxref("HTMLIFrameElement.referrerPolicy")}} {{experimental_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "iframe")}} HTML attribute indicating which referrer to use when fetching the linked resource.</dd>
  <dt>{{domxref("HTMLIFrameElement.sandbox")}}</dt>

--- a/files/en-us/web/api/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/index.html
@@ -20,7 +20,7 @@ browser-compat: api.LinearAccelerationSensor
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
@@ -20,9 +20,9 @@ browser-compat: api.LinearAccelerationSensor.LinearAccelerationSensor
     provides on each reading the acceleration applied to the device along all three axes,
     but without the contribution of gravity.</span></p>
 
-<p>If a feature policy blocks use of a feature, it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature, it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/index.html
@@ -18,7 +18,7 @@ browser-compat: api.Magnetometer
 
 <p>To use this sensor, the user must grant permission to the <code>'magnetometer'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature, it's because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature, it's because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/magnetometer/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/magnetometer/index.html
@@ -18,9 +18,9 @@ browser-compat: api.Magnetometer.Magnetometer
     creates a new {{domxref("Magnetometer")}} object which returns information about the
     magnetic field as detected by a device’s primary magnetometer sensor.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/magnetometer/x/index.html
+++ b/files/en-us/web/api/magnetometer/x/index.html
@@ -18,9 +18,9 @@ browser-compat: api.Magnetometer.x
 <p><span class="seoSummary">The <strong><code>x</code></strong> read-only property of the
     {{domxref("Magnetometer")}} interface returns a double precision integer containing
     the magnetic field around the device's x axis. </span></p>
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/magnetometer/y/index.html
+++ b/files/en-us/web/api/magnetometer/y/index.html
@@ -18,9 +18,9 @@ browser-compat: api.Magnetometer.y
 <p><span class="seoSummary">The <strong><code>y</code></strong> read-only property of the
     {{domxref("Magnetometer")}} interface returns a double precision integer containing
     the magnetic field around the device's y axis. </span></p>
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/magnetometer/z/index.html
+++ b/files/en-us/web/api/magnetometer/z/index.html
@@ -19,9 +19,9 @@ browser-compat: api.Magnetometer.z
     {{domxref("Magnetometer")}} interface returns a double-precision integer containing
     the magnetic field around the device's z axis. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.html
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.html
@@ -204,8 +204,8 @@ browser-compat: api.MediaDevices.getUserMedia
     browsing instance is not permitted access to the device, the user has denied access
     for the current session, or the user has denied all access to user media devices
     globally. On browsers that support managing media permissions with <a
-      href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a>, this error is
-    returned if Feature Policy is not configured to allow access to the input source(s).
+      href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a>, this error is
+    returned if Permissions Policy is not configured to allow access to the input source(s).
     <div class="note">Older versions of the specification used <code>SecurityError</code>
       for this instead; <code>SecurityError</code> has taken on a new meaning.</div>
   </dd>
@@ -255,7 +255,7 @@ browser-compat: api.MediaDevices.getUserMedia
   inputs. Only a window's top-level document context for a valid origin can even request
   permission to use <code>getUserMedia()</code>, unless the top-level context expressly
   grants permission for a given {{HTMLElement("iframe")}} to do so using <a
-    href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a>. Otherwise, the user
+    href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a>. Otherwise, the user
   will never even be asked for permission to use the input devices.</p>
 
 <p>For additional details on these requirements and rules, how they are reflected in the
@@ -294,22 +294,22 @@ browser-compat: api.MediaDevices.getUserMedia
 <div class="notecard note">
   <p><strong>Note:</strong> The security model for <code>getUserMedia()</code> is still
     somewhat in flux. The originally-designed security mechanism is in the process of
-    being replaced with Feature Policy, so various browsers have different levels of
+    being replaced with Permissions Policy, so various browsers have different levels of
     security support, using different mechanisms. You should test your code carefully on a
     variety of devices and browsers to be sure it is as broadly compatible as possible</p>
 </div>
 
-<h4 id="Feature_Policy">Feature Policy</h4>
+<h4 id="Permissions_Policy">Permissions Policy</h4>
 
-<p>The <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> security
+<p>The <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a> security
   management feature of {{Glossary("HTTP")}} is in the process of being introduced into
   browsers, with support available to some extent in many browsers (though not always
   enabled by default, as in Firefox). <code>getUserMedia()</code> is one method which will
-  require the use of Feature Policy, and your code needs to be prepared to deal with this.
+  require the use of Permissions Policy, and your code needs to be prepared to deal with this.
   For example, you may need to use the {{htmlattrxref("allow", "iframe")}} attribute on
   any {{HTMLElement("iframe")}} that uses <code>getUserMedia()</code>, and pages that use
   <code>getUserMedia()</code> will eventually need to supply the
-  {{HTTPHeader("Feature-Policy")}} header.</p>
+  {{HTTPHeader("Permissions-Policy")}} header.</p>
 
 <p>The two permissions that apply to <code>getUserMedia()</code> are <code>camera</code>
   and <code>microphone</code>.</p>
@@ -318,12 +318,12 @@ browser-compat: api.MediaDevices.getUserMedia
   and any embedded {{HTMLElement("iframe")}} elements that are loaded from the same
   origin:</p>
 
-<pre>Feature-Policy: camera 'self'</pre>
+<pre>Permissions-Policy: camera 'self'</pre>
 
 <p>This will request access to the microphone for the current origin and the specific
   origin https://developer.mozilla.org:</p>
 
-<pre>Feature-Policy: microphone 'self' https://developer.mozilla.org</pre>
+<pre>Permissions-Policy: microphone 'self' https://developer.mozilla.org</pre>
 
 <p>If you're using <code>getUserMedia()</code> within an <code>&lt;iframe&gt;</code>, you
   can request permission just for that frame, which is clearly more secure than requesting
@@ -334,7 +334,7 @@ browser-compat: api.MediaDevices.getUserMedia
 &lt;/iframe&gt;</pre>
 
 <p>Read our guide, <a
-    href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature
+    href="/en-US/docs/Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Using Feature
     Policy</a>, to learn more about how it works.</p>
 
 <h4 id="Encryption_based_security">Encryption based security</h4>

--- a/files/en-us/web/api/mediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/audio/index.html
@@ -53,7 +53,7 @@ browser-compat: api.MediaStreamConstraints.audio
 
 <h2 id="Example">Examples</h2>
 
-<p>For browsers with <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a>
+<p>For browsers with <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a>
   enabled, the samples below need the <code>microphone</code> feature enabled. See
   {{SectionOnPage("/en-US/docs/Web/API/MediaDevices/getUserMedia", "Security")}} for
   details and examples on how to configure this.</p>

--- a/files/en-us/web/api/navigator/getbattery/index.html
+++ b/files/en-us/web/api/navigator/getbattery/index.html
@@ -22,8 +22,8 @@ browser-compat: api.Navigator.getBattery
 
 <div class="notecard note">
   <p><strong>Note:</strong> In some browsers access to this feature is controlled by
-    {{HTTPHeader("Feature-Policy")}} directive
-    {{HTTPHeader("Feature-Policy/battery","battery")}}.</p>
+    {{HTTPHeader("Permissions-Policy")}} directive
+    {{HTTPHeader("Permissions-Policy/battery","battery")}}.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -54,8 +54,8 @@ browser-compat: api.Navigator.getBattery
   <dd><strong>Note:</strong> No User Agent currently throws this exception, but the
     specification describes the following behaviors:<br>
     This document is not allowed to use this feature. For example, it might not be
-    explicitly allowed or restricted via {{HTTPHeader("Feature-Policy")}}
-    {{HTTPHeader("Feature-Policy/battery", "battery")}} feature.</dd>
+    explicitly allowed or restricted via {{HTTPHeader("Permissions-Policy")}}
+    {{HTTPHeader("Permissions-Policy/battery", "battery")}} feature.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>
@@ -89,6 +89,6 @@ navigator.getBattery().then(function(battery) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Battery_Status_API">Battery Status API</a></li>
-  <li><code>Feature-Policy</code> {{HTTPHeader("Feature-Policy/battery", "battery")}}
+  <li><code>Permissions-Policy</code> {{HTTPHeader("Permissions-Policy/battery", "battery")}}
     feature</li>
 </ul>

--- a/files/en-us/web/api/orientationsensor/index.html
+++ b/files/en-us/web/api/orientationsensor/index.html
@@ -17,7 +17,7 @@ browser-compat: api.OrientationSensor
 
 <p><span class="seoSummary">The <strong><code>OrientationSensor</code></strong> interface of the <a href="/en-US/docs/Web/API/Sensor_APIs">Sensor APIs</a> is the base class for orientation sensors. This interface cannot be used directly. Instead it provides properties and methods accessed by interfaces that inherit from it. </span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Interfaces_based_on_OrientationSensor">Interfaces based on OrientationSensor</h2>
 

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.html
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.html
@@ -33,9 +33,9 @@ browser-compat: api.OrientationSensor.populateMatrix
   <li>Z = Vz * sin(θ/2)</li>
 </ul>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
   with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+  a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/payment_request_api/index.html
+++ b/files/en-us/web/api/payment_request_api/index.html
@@ -130,5 +130,5 @@ tags:
  <li><a href="https://webkit.org/blog/8182/introducing-the-payment-request-api-for-apple-pay/">Introducing the Payment Request API for Apple Pay</a></li>
  <li><a href="https://developers.google.com/pay/api/web/guides/paymentrequest/tutorial">Google Pay API PaymentRequest Tutorial</a></li>
  <li><a href="https://github.com/w3c/payment-request-info/wiki/FAQ">W3C Payment Request API FAQ</a></li>
- <li>Feature Policy directive {{httpheader("Feature-Policy/payment", "payment")}}</li>
+ <li>Permissions Policy directive {{httpheader("Permissions-Policy/payment", "payment")}}</li>
 </ul>

--- a/files/en-us/web/api/picture-in-picture_api/index.html
+++ b/files/en-us/web/api/picture-in-picture_api/index.html
@@ -60,7 +60,7 @@ tags:
 
 <dl>
  <dt>{{DOMxRef("Document.pictureInPictureEnabled")}}</dt>
- <dd>The <code>pictureInPictureEnabled</code> property tells you whether or not it is possible to engage picture-in-picture mode. This is <code>false</code> if picture-in-picture mode is not available for any reason (e.g. the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/picture-in-picture"><code>"picture-in-picture"</code> feature</a> has been disallowed, or picture-in-picture mode is not supported).</dd>
+ <dd>The <code>pictureInPictureEnabled</code> property tells you whether or not it is possible to engage picture-in-picture mode. This is <code>false</code> if picture-in-picture mode is not available for any reason (e.g. the <a href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy/picture-in-picture"><code>"picture-in-picture"</code> feature</a> has been disallowed, or picture-in-picture mode is not supported).</dd>
 </dl>
 
 <h3 id="Properties_on_the_Document_or_ShadowRoot_interfaces">Properties on the Document or ShadowRoot interfaces</h3>
@@ -89,9 +89,9 @@ tags:
 
 <h2 id="Controlling_access">Controlling access</h2>
 
-<p>The availability of picture-in-picture mode can be controlled using <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a>. The full-screen mode feature is identified by the string <code>"picture-in-picture"</code>, with a default allow-list value of <code>"self"</code>, meaning that picture-in-picture mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.</p>
+<p>The availability of picture-in-picture mode can be controlled using <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a>. The full-screen mode feature is identified by the string <code>"picture-in-picture"</code>, with a default allow-list value of <code>"self"</code>, meaning that picture-in-picture mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.</p>
 
-<p>See <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> to learn more about using Feature Policy to control access to an API.</p>
+<p>See <a href="/en-US/docs/Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Using Permissions Policy</a> to learn more about using Permissions Policy to control access to an API.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/index.html
@@ -20,7 +20,7 @@ browser-compat: api.RelativeOrientationSensor
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code>, and <code>'gyroscope'</code> device sensors through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
@@ -19,9 +19,9 @@ browser-compat: api.RelativeOrientationSensor.RelativeOrientationSensor
 		constructor creates a new {{domxref("RelativeOrientationSensor")}} object which
 		describes the device's physical orientation.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent
 	with the policies set on your server. This is not something that would ever be shown
-	to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+	to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/reporting_api/index.html
+++ b/files/en-us/web/api/reporting_api/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The Reporting API provides a generic reporting mechanism for web applications to use to make reports available based on various platform features (for example <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a>, <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy">Feature-Policy</a>, or feature deprecation reports) in a consistent manner.</p>
+<p class="summary">The Reporting API provides a generic reporting mechanism for web applications to use to make reports available based on various platform features (for example <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a>, <a href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy">Permissions-Policy</a>, or feature deprecation reports) in a consistent manner.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 
@@ -19,7 +19,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> violations.</li>
- <li><a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy">Feature-Policy</a> violations.</li>
+ <li><a href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy">Permissions-Policy</a> violations.</li>
  <li>Deprecated feature usage (when you are using something that will stop working soon in browsers).</li>
  <li>Occurrence of crashes.</li>
  <li>Occurrence of user-agent interventions (when the browser blocks something your code is trying to do because it is deemed a security risk for example, or just plain annoying, like auto-playing audio).</li>
@@ -158,5 +158,5 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <ul>
  <li><a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a></li>
- <li><code><a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy">Feature-Policy</a></code></li>
+ <li><code><a href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy">Permissions-Policy</a></code></li>
 </ul>

--- a/files/en-us/web/api/screen_capture_api/index.html
+++ b/files/en-us/web/api/screen_capture_api/index.html
@@ -87,15 +87,15 @@ tags:
  <dd>An enumerated string type which is used to identify the kind of display surface to capture. This type is used for the <code>displaySurface</code> property in the constraints and settings objects, and has the possible values <code>application</code>, <code>browser</code>, <code>monitor</code>, and <code>window</code>.</dd>
 </dl>
 
-<h2 id="Feature_Policy_validation">Feature Policy validation</h2>
+<h2 id="Permissions_Policy_validation">Permissions Policy validation</h2>
 
-<p>{{Glossary("User agent", "User agents")}} that support Feature Policy (either using HTTP's {{HTTPHeader("Feature-Policy")}} header or the {{HTMLElement("iframe")}} attribute {{htmlattrxref("allow", "iframe")}}) can specify a desire to use the Screen Capture API using the policy control directive <code>display-capture</code>:</p>
+<p>{{Glossary("User agent", "User agents")}} that support Permissions Policy (either using HTTP's {{HTTPHeader("permissions policy")}} header or the {{HTMLElement("iframe")}} attribute {{htmlattrxref("allow", "iframe")}}) can specify a desire to use the Screen Capture API using the policy control directive <code>display-capture</code>:</p>
 
 <pre class="brush: html">&lt;iframe allow="display-capture" src="/some-other-document.html"&gt;</pre>
 
 <p>The default allow list is <code>self</code>, which lets the any content within the document use Screen Capture.</p>
 
-<p>See <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> for a more in-depth explanation of how Feature Policy is used.</p>
+<p>See <a href="/en-US/docs/Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Using permissions policy</a> for a more in-depth explanation of how permissions policy is used.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.html
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.html
@@ -318,11 +318,11 @@ Click the Start Capture button to begin.&lt;/p&gt;
 
 <h2 id="Security_2">Security</h2>
 
-<p>In order to function when <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> is enabled, you will need the <code>display-capture</code> permission. This can be done using the {{HTTPHeader("Feature-Policy")}} {{Glossary("HTTP")}} header or—if you're using the Screen Capture API in an {{HTMLElement("iframe")}}, the <code>&lt;iframe&gt;</code> element's {{htmlattrxref("allow", "iframe")}} attribute.</p>
+<p>In order to function when <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a> is enabled, you will need the <code>display-capture</code> permission. This can be done using the {{HTTPHeader("Permissions-Policy")}} {{Glossary("HTTP")}} header or—if you're using the Screen Capture API in an {{HTMLElement("iframe")}}, the <code>&lt;iframe&gt;</code> element's {{htmlattrxref("allow", "iframe")}} attribute.</p>
 
 <p>For example, this line in the HTTP headers will enable Screen Capture API for the document and any embedded {{HTMLElement("iframe")}} elements that are loaded from the same origin:</p>
 
-<pre>Feature-Policy: display-capture 'self'</pre>
+<pre>Permissions-Policy: display-capture 'self'</pre>
 
 <p>If you're performing screen capture within an <code>&lt;iframe&gt;</code>, you can request permission just for that frame, which is clearly more secure than requesting a more general permission:</p>
 

--- a/files/en-us/web/api/screen_wake_lock_api/index.html
+++ b/files/en-us/web/api/screen_wake_lock_api/index.html
@@ -111,9 +111,9 @@ try {
  <li>Only active documents can acquire screen wake locks and previously acquired locks are automatically released when document becomes inactive. Therefore make sure to re-acquire screen wake lock if necessary when document becomes active (listen for <a href="/en-US/docs/Web/API/Document/visibilitychange_event">visibilitychange</a> event).</li>
 </ul>
 
-<h2 id="Feature_Policy_integration">Feature Policy integration</h2>
+<h2 id="Permissions_Policy_integration">Permissions Policy integration</h2>
 
-<p>Access to Screen Wake Lock API is controlled by <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> directive {{HTTPHeader("Feature-Policy/screen-wake-lock","screen-wake-lock")}}. Refer to <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> for reference how to use it.</p>
+<p>Access to Screen Wake Lock API is controlled by <a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a> directive {{HTTPHeader("Permissions-Policy/screen-wake-lock","screen-wake-lock")}}. Refer to <a href="/en-US/docs/Web/HTTP/Permissions_Policy/Using_Permissions_Policy">Using Permissions Policy</a> for reference how to use it.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -143,6 +143,6 @@ try {
 <ul>
  <li><a href="https://web.dev/wakelock/">An introductory article on the Screen Wake Lock API</a></li>
  <li><a href="https://wake-lock-demo.glitch.me/">A Screen Wake Lock API demo on glitch</a></li>
- <li><a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> directive {{HTTPHeader("Feature-Policy/screen-wake-lock","screen-wake-lock")}}</li>
+ <li><a href="/en-US/docs/Web/HTTP/Permissions_Policy">Permissions Policy</a> directive {{HTTPHeader("Permissions-Policy/screen-wake-lock","screen-wake-lock")}}</li>
 </ul>
 </div>

--- a/files/en-us/web/api/sensor/index.html
+++ b/files/en-us/web/api/sensor/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Sensor
 
 <p><span class="seoSummary">The <strong><code>Sensor</code></strong> interface of the <a href="/en-US/docs/Web/API/Sensor_APIs">Sensor APIs</a> is the base class for all the other sensor interfaces. This interface cannot be used directly. Instead it provides properties, event handlers, and methods accessed by interfaces that inherit from it.</span></p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 
 <h2 id="Interfaces_based_on_Sensor">Interfaces based on Sensor</h2>
 

--- a/files/en-us/web/api/sensor_apis/index.html
+++ b/files/en-us/web/api/sensor_apis/index.html
@@ -55,7 +55,7 @@ if (window.AmbientLightSensor) {
 <p>The code example below illustrates these principles. The {{jsxref('statements/try...catch', 'try...catch')}} block catches errors thrown during sensor instantiation. It implements a handler for {{domxref('Sensor.onerror')}} to catch errors thrown during use. The only time anything is shown to the user is when <a href="/en-US/docs/Web/API/Permissions_API">permissions</a> need to be requested and when the sensor type isn't supported by the device.</p>
 
 <div class="note">
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+<p>If a permissions policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Permissions-Policy')}} for implementation instructions.</p>
 </div>
 
 <pre class="brush: js">let accelerometer = null;
@@ -74,8 +74,8 @@ try {
 } catch (error) {
     // Handle construction errors.
     if (error.name === 'SecurityError') {
-        // See the note above about feature policy.
-        console.log('Sensor construction was blocked by a feature policy.');
+        // See the note above about permissions policy.
+        console.log('Sensor construction was blocked by a permissions policy.');
     } else if (error.name === 'ReferenceError') {
         console.log('Sensor is not supported by the User Agent.');
     } else {
@@ -83,7 +83,7 @@ try {
     }
 }</pre>
 
-<h3 id="permissions_and_feature_policy">Permissions and Feature Policy</h3>
+<h3 id="permissions_and_permissions_policy">Permissions and Permissions Policy</h3>
 
 <p>Sensor readings may not be taken unless the user grants permission to a specific sensor type. Do this using the {{domxref('Permissions')}} API. A brief example, shown below, requests permission before attempting to use the sensor.</p>
 
@@ -105,14 +105,14 @@ sensor.onerror = event =&gt; {
     console.log("No permissions to use AbsoluteOrientationSensor.");
 };</pre>
 
-<p>The following table describes for each sensor type, the name required for the Permissions API, the {{HTMLElement('iframe')}} element's <code>allow</code> attribute and the {{httpheader('Feature-Policy')}} directive.</p>
+<p>The following table describes for each sensor type, the name required for the Permissions API, the {{HTMLElement('iframe')}} element's <code>allow</code> attribute and the {{httpheader('Permissions-Policy')}} directive.</p>
 
 <table class="standard-table">
  <caption>Sensor permissions</caption>
  <thead>
   <tr>
    <th scope="col">Sensor</th>
-   <th scope="col">Permission/Feature Policy Name</th>
+   <th scope="col">Permission/Permissions Policy Name</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/web/api/serial/getports/index.html
+++ b/files/en-us/web/api/serial/getports/index.html
@@ -25,7 +25,7 @@ browser-compat: api.Serial.getPorts
 
 <dl>
   <dt>{{domxref("DOMException")}} <code>"SecurityError"</code></dt>
-  <dd>The returned <code>Promise</code> rejects with this error if a <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> restricts use of this API or a permission to use it has not granted via a user gesture.</dd>
+  <dd>The returned <code>Promise</code> rejects with this error if a <a href="/en-US/docs/Web/HTTP/Peature_Policy">permissions policy</a> restricts use of this API or a permission to use it has not granted via a user gesture.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/serial/requestport/index.html
+++ b/files/en-us/web/api/serial/requestport/index.html
@@ -42,7 +42,7 @@ browser-compat: api.Serial.requestPort
 
 <dl>
   <dt>{{domxref("DOMException")}} <code>"SecurityError"</code></dt>
-  <dd>The returned <code>Promise</code> rejects with this error if a <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> restricts use of this API or a permission to use it has not granted via a user gesture.</dd>
+  <dd>The returned <code>Promise</code> rejects with this error if a <a href="/en-US/docs/Web/HTTP/permissions_policy">permissions policy</a> restricts use of this API or a permission to use it has not granted via a user gesture.</dd>
   <dt>{{domxref("DOMException")}} <code>"AbortError"</code></dt>
   <dd>The returned <code>Promise</code> rejects with this if the user does not select a port when prompted.</dd>
 </dl>

--- a/files/en-us/web/api/webxr_device_api/index.html
+++ b/files/en-us/web/api/webxr_device_api/index.html
@@ -164,7 +164,7 @@ tags:
  <dt><a href="/en-US/docs/Web/API/WebXR_Device_API/Performance">WebXR performance guide</a></dt>
  <dd>Recommendations and tips to help you optimize the performance of your WebXR application.</dd>
  <dt><a href="/en-US/docs/Web/API/WebXR_Device_API/Permissions_and_security">Permissions and security for WebXR</a></dt>
- <dd>The WebXR Device API has several areas of security to contend with, from establishing feature-policy to ensuring the user intends to use the mixed reality presentation before activating it.</dd>
+ <dd>The WebXR Device API has several areas of security to contend with, from establishing permissions-policy to ensuring the user intends to use the mixed reality presentation before activating it.</dd>
 </dl>
 
 <h3 id="Including_other_media">Including other media</h3>

--- a/files/en-us/web/api/webxr_device_api/permissions_and_security/index.html
+++ b/files/en-us/web/api/webxr_device_api/permissions_and_security/index.html
@@ -4,7 +4,7 @@ slug: Web/API/WebXR_Device_API/Permissions_and_security
 ---
 <p>{{DefaultAPISidebar("WebXR Device API")}}{{Draft}}</p>
 
-<p>The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> has several areas of security to contend with, from establishing feature-policy to ensuring the user intends to use the mixed reality presentation before activating it. Among other things, you need to confirm access to device features such as the microphone and/or camera, get permission to use immersive VR mode (if applicable), and so forth. <span class="seoSummary">The variety of hardware and software involved in XR brings multiple APIs and technologies into play. In this guide, we'll cover how to ensure your app has the permissions it needs to provide a secure and private XR experience.</span></p>
+<p>The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> has several areas of security to contend with, from establishing permissions-policy to ensuring the user intends to use the mixed reality presentation before activating it. Among other things, you need to confirm access to device features such as the microphone and/or camera, get permission to use immersive VR mode (if applicable), and so forth. <span class="seoSummary">The variety of hardware and software involved in XR brings multiple APIs and technologies into play. In this guide, we'll cover how to ensure your app has the permissions it needs to provide a secure and private XR experience.</span></p>
 
 <h2 id="Introduction">Introduction</h2>
 
@@ -12,7 +12,7 @@ slug: Web/API/WebXR_Device_API/Permissions_and_security
 
 <h2 id="Immersive_presentation_of_VR">Immersive presentation of VR</h2>
 
-<p>First, any requests to activate the <code>immersive-vr</code> mode are rejected if the domain issuing the request does not have permission to enable an immersive session. This permission comes from the <code>xr-spatial-tracking</code> <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a>.</p>
+<p>First, any requests to activate the <code>immersive-vr</code> mode are rejected if the domain issuing the request does not have permission to enable an immersive session. This permission comes from the <code>xr-spatial-tracking</code> <a href="/en-US/docs/Web/HTTP/Permissions_Policy">permissions policy</a>.</p>
 
 <p>Once that check is passed, the request to enter <code>immersive-vr</code> mode is allowed if all of the following are true:</p>
 

--- a/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.html
+++ b/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.html
@@ -126,7 +126,7 @@ const xr = getXR("if-needed"); // Use the polyfill only if navigator.xr missing
 
 <h3 id="Permissions_and_security">Permissions and security</h3>
 
-<p>There are a number of security measures in place revolving around WebXR. First among these is that use of <code>immersive-vr</code> mode—which entirely replaces the user's view of the world—requires that the <code>xr-spatial-tracking</code>  <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a> be in place. On top of that, the document needs to be secure and currently focused. Finally, you must call {{domxref("XRSystem.requestSession", "requestSession()")}} from a user event handler, such as the handler for the {{domxref("Element.click_event", "click")}} event.</p>
+<p>There are a number of security measures in place revolving around WebXR. First among these is that use of <code>immersive-vr</code> mode—which entirely replaces the user's view of the world—requires that the <code>xr-spatial-tracking</code>  <a href="/en-US/docs/Web/HTTP/Permissions_Policy">permissions policy</a> be in place. On top of that, the document needs to be secure and currently focused. Finally, you must call {{domxref("XRSystem.requestSession", "requestSession()")}} from a user event handler, such as the handler for the {{domxref("Element.click_event", "click")}} event.</p>
 
 <p>For more specifics about securing WebXR actitvities and usage, see the article <a href="/en-US/docs/Web/API/WebXR_Device_API/Permissions_and_security">Permissions and security for WebXR</a>.</p>
 
@@ -166,7 +166,7 @@ if (immersiveOK) {
  <dd>An on-screen presentation of the XR imagery within the context of the document window.</dd>
 </dl>
 
-<p>If the session couldn't be created for some reason—such as feature policy disallowing its use or the user declining to grant permission to use the headset—the promise gets rejected. So a more complete function that starts up and returns a WebXR session could look like this:</p>
+<p>If the session couldn't be created for some reason—such as permissions policy disallowing its use or the user declining to grant permission to use the headset—the promise gets rejected. So a more complete function that starts up and returns a WebXR session could look like this:</p>
 
 <pre class="brush: js">async function createImmersiveSession(xr) {
   try {

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -161,5 +161,5 @@ browser-compat: api.XMLHttpRequest
   </ul>
  </li>
  <li><a href="https://www.html5rocks.com/en/tutorials/file/xhr2/">HTML5 Rocks — New Tricks in XMLHttpRequest2</a></li>
- <li>Feature-Policy directive {{httpheader("Feature-Policy/sync-xhr", "sync-xhr")}}</li>
+ <li>Permissions-Policy directive {{httpheader("Permissions-Policy/sync-xhr", "sync-xhr")}}</li>
 </ul>

--- a/files/en-us/web/api/xrsessioninit/index.html
+++ b/files/en-us/web/api/xrsessioninit/index.html
@@ -53,7 +53,7 @@ tags:
   <tr>
    <th scope="col">Reference space type</th>
    <th scope="col">User consent rquirement</th>
-   <th scope="col">Feature policy requirement</th>
+   <th scope="col">Permissions policy requirement</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.html
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.html
@@ -45,7 +45,7 @@ browser-compat: api.XRSystem.devicechange_event
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<p><code>devicechange</code> events are not delivered if the document which owns the <strong>{{domxref("XRSystem")}}</strong> object has been granted permission to do so through the <code><a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking">xr-spatial-tracking</a></code> feature policy.</p>
+<p><code>devicechange</code> events are not delivered if the document which owns the <strong>{{domxref("XRSystem")}}</strong> object has been granted permission to do so through the <code><a href="/en-US/docs/Web/HTTP/Headers/Permissions-Policy/xr-spatial-tracking">xr-spatial-tracking</a></code> permissions policy.</p>
 
 <p>You can use this event to, for example, monitor for the availability of a WebXR-compatible device so that you can enable a UI element which the user can use to activate immersive mode. This is shown in the {{anch("Example", "example")}} below.</p>
 

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.html
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.html
@@ -56,7 +56,7 @@ browser-compat: api.XRSystem.isSessionSupported
 <dl>
   <dt><code>SecurityError</code></dt>
   <dd>The document's origin does not have permission to use the
-    <code>xr-spatial-tracking</code> <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature
+    <code>xr-spatial-tracking</code> <a href="/en-US/docs/Web/HTTP/Permissions_Policy">permissions
       policy</a>.</dd>
 </dl>
 


### PR DESCRIPTION
**NOTE:** This is part I of a multi-part submission to rename the `Feature-Policy` header to `Permissions-Policy` as described in #1831.

The effort is enormous. To make it more manageable, I'm breaking it into multiple PRs. 