### PR TITLE
Source spec section from macros in CSS (phase 2)

### DIFF
--- a/files/en-us/web/css/@media/shape/index.html
+++ b/files/en-us/web/css/@media/shape/index.html
@@ -64,20 +64,7 @@ browser-compat: css.at-rules.media.shape
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Round Display', '#shape-media-feature', 'shape')}}</td>
-   <td>{{Spec2('CSS Round Display')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/@media/update-frequency/index.html
+++ b/files/en-us/web/css/@media/update-frequency/index.html
@@ -11,17 +11,17 @@ browser-compat: css.at-rules.media.update
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>update</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features">media feature</a> can be used to test how frequently (if at all) the output device is able to modify the appearance of content.</p>
+<p>The <strong><code>update</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features">media feature</a> can be used to test how frequently (if at all) the output device is able to modify the appearance of content.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>update</code> feature is specified as a single keyword value chosen from the list below.</p>
+<p>The <code>update</code> feature is specified as a single keyword value chosen from the list below.</p>
 
 <dl>
  <dt><code>none</code></dt>
  <dd>Once it has been rendered, the layout can no longer be updated. Example: documents printed on paper.</dd>
  <dt><code>slow</code></dt>
- <dd>The layout may change dynamically according to the usual rules of CSS, but the output device is not able to render or display changes quickly enough for them to be perceived as a smooth animation. Examples: e-book readers or severely underpowered devices.</dd>
+ <dd>The layout may change dynamically according to the usual rules of CSS, but the output device is not able to render or display changes quickly enough for them to be perceived as a smooth animation. Examples: e-book readers or severely underpowered devices.</dd>
  <dt><code>fast</code></dt>
  <dd>The layout may change dynamically according to the usual rules of CSS, and the output device is not unusually constrained in speed, so regularly-updating things like <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS Animations</a> can be used. Example: computer screens.</dd>
 </dl>
@@ -36,19 +36,19 @@ browser-compat: css.at-rules.media.update
 <h3 id="CSS">CSS</h3>
 
 <pre class="brush: css">@keyframes jiggle {
-  from {
-    transform: translateY(0);
+  from {
+    transform: translateY(0);
   }
 
-  to {
-    transform: translateY(25px);
+  to {
+    transform: translateY(25px);
   }
 }
 
 @media (update: fast) {
-  p {
-    animation: 1s jiggle linear alternate infinite;
-  }
+  p {
+    animation: 1s jiggle linear alternate infinite;
+  }
 }</pre>
 
 <h3 id="Result">Result</h3>
@@ -57,22 +57,7 @@ browser-compat: css.at-rules.media.update
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Media Queries', '#update', 'update')}}</td>
-   <td>{{Spec2('CSS4 Media Queries')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -81,6 +66,6 @@ browser-compat: css.at-rules.media.update
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries">Using Media Queries</a></li>
+ <li><a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries">Using Media Queries</a></li>
  <li><a href="/en-US/docs/Web/CSS/@media">@media</a></li>
 </ul>

--- a/files/en-us/web/css/_colon_current/index.html
+++ b/files/en-us/web/css/_colon_current/index.html
@@ -5,7 +5,7 @@ browser-compat: css.selectors.current
 ---
 <p>{{CSSRef}}</p>
 
-<p>The <strong><code>:current</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector is a time-dimensional pseudo-class that represents the element, or an ancestor of the element, that is currently being displayed. For example in a video with captions which are being displayed by <a href="/en-US/docs/Web/API/WebVTT_API">WebVTT</a>.</p>
+<p>The <strong><code>:current</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector is a time-dimensional pseudo-class that represents the element, or an ancestor of the element, that is currently being displayed. For example in a video with captions which are being displayed by <a href="/en-US/docs/Web/API/WebVTT_API">WebVTT</a>.</p>
 
 <pre class="brush: css">:current(p, span) {
   background-color: yellow;
@@ -20,18 +20,18 @@ browser-compat: css.selectors.current
 <h3 id="CSS">CSS</h3>
 
 <pre class="brush: css">:current(p, span) {
-  background-color: yellow;
+  background-color: yellow;
 }</pre>
 
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;video controls preload="metadata"&gt;
   &lt;source src="video.mp4" type="video/mp4" /&gt;
-  &lt;source src="video.webm" type="video/webm" /&gt;
-  &lt;track label="English" kind="subtitles" srclang="en" src="subtitles.vtt" default&gt;
+  &lt;source src="video.webm" type="video/webm" /&gt;
+  &lt;track label="English" kind="subtitles" srclang="en" src="subtitles.vtt" default&gt;
 &lt;/video&gt;</pre>
 
-<h3 id="WebVTT">WebVTT </h3>
+<h3 id="WebVTT">WebVTT</h3>
 
 <pre>WEBVTT FILE
 
@@ -50,22 +50,7 @@ This is the third caption
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Selectors", "#the-current-pseudo", ":current")}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_local-link/index.html
+++ b/files/en-us/web/css/_colon_local-link/index.html
@@ -5,7 +5,7 @@ browser-compat: css.selectors.local-link
 ---
 <p>{{ CSSRef }}</p>
 
-<p>The <strong><code>:local-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents a link to the same document. Therefore an element that is the source anchor of a hyperlink whose target’s absolute URL matches the element’s own document URL.</p>
+<p>The <strong><code>:local-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents a link to the same document. Therefore an element that is the source anchor of a hyperlink whose target’s absolute URL matches the element's own document URL.</p>
 
 <pre>/* Selects any &lt;a&gt; that links to the current document */
 a:local-link {
@@ -38,22 +38,7 @@ a:local-link {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS4 Selectors', '#the-local-link-pseudo', ':local-link') }}</td>
-			<td>{{ Spec2('CSS4 Selectors') }}</td>
-			<td>Initial definition</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_nth-col/index.html
+++ b/files/en-us/web/css/_colon_nth-col/index.html
@@ -5,7 +5,7 @@ browser-compat: css.selectors.nth-col
 ---
 <p>{{CSSRef}}{{SeeCompatTable}}</p>
 
-<p>The <strong><code>:nth-col()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is designed for tables and grids. It accepts the An+B notation such as used with the {{Cssxref(":nth-child")}} selector, using this to target every nth column. The values odd and even are also valid. </p>
+<p>The <strong><code>:nth-col()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is designed for tables and grids. It accepts the An+B notation such as used with the {{Cssxref(":nth-child")}} selector, using this to target every nth column. The values odd and even are also valid.</p>
 
 <pre class="brush: css">/* Selects every odd column in a table */
 :nth-col(odd) {
@@ -14,7 +14,7 @@ browser-compat: css.selectors.nth-col
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>nth-col</code> pseudo-class is specified with a single argument, which represents the pattern for matching elements.</p>
+<p>The <code>nth-col</code> pseudo-class is specified with a single argument, which represents the pattern for matching elements.</p>
 
 <p>See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.</p>
 
@@ -31,16 +31,16 @@ browser-compat: css.selectors.nth-col
 <pre class="brush: html">&lt;table&gt;
   &lt;tr&gt;
     &lt;td&gt;one&lt;/td&gt;
-    &lt;td&gt;two&lt;/td&gt;
-    &lt;td&gt;three&lt;/td&gt;
-    &lt;td&gt;four&lt;/td&gt;
-  &lt;/tr&gt;
+    &lt;td&gt;two&lt;/td&gt;
+    &lt;td&gt;three&lt;/td&gt;
+    &lt;td&gt;four&lt;/td&gt;
+  &lt;/tr&gt;
   &lt;tr&gt;
   &lt;td&gt;one&lt;/td&gt;
-    &lt;td&gt;two&lt;/td&gt;
-    &lt;td&gt;three&lt;/td&gt;
-    &lt;td&gt;four&lt;/td&gt;
-  &lt;/tr&gt;
+    &lt;td&gt;two&lt;/td&gt;
+    &lt;td&gt;three&lt;/td&gt;
+    &lt;td&gt;four&lt;/td&gt;
+  &lt;/tr&gt;
 &lt;/table&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
@@ -62,22 +62,7 @@ browser-compat: css.selectors.nth-col
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Selectors', '#the-nth-col-pseudo', ':nth-col')}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_nth-last-col/index.html
+++ b/files/en-us/web/css/_colon_nth-last-col/index.html
@@ -5,7 +5,7 @@ browser-compat: css.selectors.nth-last-col
 ---
 <p>{{CSSRef}}{{SeeCompatTable}}</p>
 
-<p>The <strong><code>:nth-last-col()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is designed for tables and grids. It accepts the An+B notation such as used with the {{Cssxref(":nth-child")}} selector, using this to target every nth column before it, therefore counting back from the end of the set of columns. The values odd and even are also valid. </p>
+<p>The <strong><code>:nth-last-col()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> is designed for tables and grids. It accepts the An+B notation such as used with the {{Cssxref(":nth-child")}} selector, using this to target every nth column before it, therefore counting back from the end of the set of columns. The values odd and even are also valid.</p>
 
 <pre class="brush: css">/* Selects every odd column in a table */
 :nth-last-col(odd) {
@@ -14,7 +14,7 @@ browser-compat: css.selectors.nth-last-col
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>nth-last-col</code> pseudo-class is specified with a single argument, which represents the pattern for matching elements.</p>
+<p>The <code>nth-last-col</code> pseudo-class is specified with a single argument, which represents the pattern for matching elements.</p>
 
 <p>See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.</p>
 
@@ -31,16 +31,16 @@ browser-compat: css.selectors.nth-last-col
 <pre class="brush: html">&lt;table&gt;
   &lt;tr&gt;
     &lt;td&gt;one&lt;/td&gt;
-    &lt;td&gt;two&lt;/td&gt;
-    &lt;td&gt;three&lt;/td&gt;
-    &lt;td&gt;four&lt;/td&gt;
-  &lt;/tr&gt;
+    &lt;td&gt;two&lt;/td&gt;
+    &lt;td&gt;three&lt;/td&gt;
+    &lt;td&gt;four&lt;/td&gt;
+  &lt;/tr&gt;
   &lt;tr&gt;
   &lt;td&gt;one&lt;/td&gt;
-    &lt;td&gt;two&lt;/td&gt;
-    &lt;td&gt;three&lt;/td&gt;
-    &lt;td&gt;four&lt;/td&gt;
-  &lt;/tr&gt;
+    &lt;td&gt;two&lt;/td&gt;
+    &lt;td&gt;three&lt;/td&gt;
+    &lt;td&gt;four&lt;/td&gt;
+  &lt;/tr&gt;
 &lt;/table&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
@@ -62,22 +62,7 @@ browser-compat: css.selectors.nth-last-col
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Selectors', '#the-nth-last-col-pseudo', ':nth-last-col')}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_paused/index.html
+++ b/files/en-us/web/css/_colon_paused/index.html
@@ -33,7 +33,7 @@ browser-compat: css.selectors.paused
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_paused/index.html
+++ b/files/en-us/web/css/_colon_paused/index.html
@@ -10,7 +10,7 @@ browser-compat: css.selectors.paused
 ---
 <p>{{CSSRef}}{{SeeCompatTable}}</p>
 
-<p>The <strong><code>:paused</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being “played” or “paused”, when that element is “paused”. </p>
+<p>The <strong><code>:paused</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "paused".</p>
 
 <p>A resource is paused either due to being in an non-activated state, or due to the user explicitly paused it.</p>
 
@@ -27,28 +27,13 @@ browser-compat: css.selectors.paused
 <h3 id="CSS">CSS</h3>
 
 <pre class="brush: css">:paused {
-  border: 5px solid orange;
+  border: 5px solid orange;
 }
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Selectors", "#selectordef-paused", ":paused")}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_picture-in-picture/index.html
+++ b/files/en-us/web/css/_colon_picture-in-picture/index.html
@@ -52,22 +52,7 @@ browser-compat: css.selectors.picture-in-picture
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Picture-in-Picture', '#:picture-in-picture-pseudo-class', ':picture-in-picture')}}</td>
-   <td>{{Spec2('Picture-in-Picture')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_playing/index.html
+++ b/files/en-us/web/css/_colon_playing/index.html
@@ -27,28 +27,13 @@ browser-compat: css.selectors.playing
 <h3 id="CSS">CSS</h3>
 
 <pre class="brush: css">:playing {
-  border: 5px solid green;
+  border: 5px solid green;
 }
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Selectors", "#selectordef-playing", ":playing")}}</td>
-   <td>{{Spec2('CSS4 Selectors')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_colon_state/index.html
+++ b/files/en-us/web/css/_colon_state/index.html
@@ -42,22 +42,7 @@ browser-compat: css.selectors.state
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Custom State", "#selectordef-state", 'The <code>:state()</code> selector')}}</td>
-   <td>{{Spec2("CSS Custom State")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/_doublecolon_cue-region/index.html
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.html
@@ -69,20 +69,7 @@ browser-compat: css.selectors.cue-region
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebVTT", "#the-cue-region-pseudo-element", "the <code>::cue-region</code> pseudo-element")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -53,22 +53,7 @@ width: abs(20% - 100px);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Values", "#sign-funcs", "abs()")}}</td>
-   <td>{{Spec2("CSS4 Values")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/align-content/index.html
+++ b/files/en-us/web/css/align-content/index.html
@@ -7,6 +7,7 @@ tags:
   - CSS Property
   - Reference
   - recipe:css-property
+browser-compat: css.properties.align-content
 ---
 <p>The <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>align-content</code></strong> property sets the distribution of space between and around content items along a <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">flexbox</a>'s cross-axis or a <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">grid</a>'s block axis.</p>
 
@@ -14,7 +15,7 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/align-content.html")}}</div>
 
-<p>This property has no effect on single line flex containers (i.e. ones with <code>flex-wrap: nowrap</code>).</p>
+<p>This property has no effect on single line flex containers (i.e. ones with <code>flex-wrap: nowrap</code>).</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -77,7 +78,7 @@ align-content: unset;
  <dd>The items are packed in their default position as if no <code>align-content</code> value was set.</dd>
  <dt><code>baseline</code>, <code>first baseline</code>, <code>last baseline</code></dt>
  <dd>
-   <p>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box’s first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.</p>
+   <p>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box's first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.</p>
    <img alt='the baseline is the line upon which most letters "sit" and below which descenders extend.' src="410px-typography_line_terms.svg.png">
    <p>The fallback alignment for <code>first baseline</code> is <code>start</code>, the one for <code>last baseline</code> is <code>end</code>.</p>
  </dd>
@@ -248,39 +249,11 @@ display.addEventListener('change', function (evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-align-content", "align-content")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Adds the [ first | last ]? baseline, start, end, left, right, unsafe | safe values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Flexbox", "#align-content-property", "align-content")}}</td>
-   <td>{{Spec2("CSS3 Flexbox")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
-
-<div>{{cssinfo}}</div>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.align-content.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.align-content.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/align-items/index.html
+++ b/files/en-us/web/css/align-items/index.html
@@ -7,6 +7,7 @@ tags:
   - CSS Property
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.align-items
 ---
 <p>The <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>align-items</code></strong> property sets the {{cssxref("align-self")}} value on all direct children as a group. In Flexbox, it controls the alignment of items on the {{glossary("Cross Axis")}}. In Grid Layout, it controls the alignment of items on the Block Axis within their {{glossary("Grid Areas", "grid area")}}.</p>
 
@@ -232,37 +233,11 @@ display.addEventListener('change', function (evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-align-items", "align-items")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Update to latest syntax definitions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Flexbox', '#propdef-align-items', 'align-items')}}</td>
-   <td>{{Spec2('CSS3 Flexbox')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.align-items.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.align-items.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/align-self/index.html
+++ b/files/en-us/web/css/align-self/index.html
@@ -8,10 +8,11 @@ tags:
   - CSS Property
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.align-self
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>align-self</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property overrides a grid or flex item's {{cssxref("align-items")}} value. In Grid, it aligns the item inside the {{glossary("Grid Areas", "grid area")}}. In Flexbox, it aligns the item on the {{glossary("cross axis")}}.</p>
+<p>The <strong><code>align-self</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property overrides a grid or flex item's {{cssxref("align-items")}} value. In Grid, it aligns the item inside the {{glossary("Grid Areas", "grid area")}}. In Flexbox, it aligns the item on the {{glossary("cross axis")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/align-self.html")}}</div>
 
@@ -77,7 +78,7 @@ align-self: unset;</pre>
  <dt><code>baseline<br>
  first baseline</code><br>
  <code>last baseline</code></dt>
- <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box’s first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
+ <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box's first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
  The fallback alignment for <code>first baseline</code> is <code>start</code>, the one for <code>last baseline</code> is <code>end</code>.</dd>
  <dt><code>stretch</code></dt>
  <dd>If the combined size of the items along the cross axis is less than the size of the alignment container and the item is <code>auto</code>-sized, its size is increased equally (not proportionally), while still respecting the constraints imposed by {{cssxref("max-height")}}/{{cssxref("max-width")}} (or equivalent functionality), so that the combined size of all <code>auto</code>-sized items exactly fills the alignment container along the cross axis.</dd>
@@ -131,37 +132,11 @@ div:nth-child(3) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-align-self", "align-self")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Update to latest syntax definitions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Flexbox", "#propdef-align-self", "align-self")}}</td>
-   <td>{{Spec2("CSS3 Flexbox")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.align-self.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.align-self.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 
@@ -170,5 +145,5 @@ div:nth-child(3) {
  <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
  <li>CSS Grid Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in CSS Grid layouts</a></em></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Box_Alignment">CSS Box Alignment</a></li>
- <li>The {{cssxref("align-items")}} property</li>
+ <li>The {{cssxref("align-items")}} property</li>
 </ul>

--- a/files/en-us/web/css/break-after/index.html
+++ b/files/en-us/web/css/break-after/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.break-after
 ---
 <div>{{CSSRef}}</div>
 
@@ -161,7 +162,7 @@ break-after: unset;
 
 <p>In the following example we have a container that contains an <code>&lt;h1&gt;</code> spanning all columns (achieved using <code>column-span: all</code>) and a series of <code>&lt;h2&gt;</code>s and paragraphs laid out in multiple columns using <code>column-width: 200px</code>.</p>
 
-<p>By default, the subheadings and paragraphs were laid out rather messily because the headings were not in a uniform place. However, we used <code>break-after: column</code> on the <code>&lt;p&gt;</code> elements to force a column break after each one, meaning that you end up with an <code>&lt;h2&gt;</code> neatly at the top of each column.</p>
+<p>By default, the subheadings and paragraphs were laid out rather messily because the headings were not in a uniform place. However, we used <code>break-after: column</code> on the <code>&lt;p&gt;</code> elements to force a column break after each one, meaning that you end up with an <code>&lt;h2&gt;</code> neatly at the top of each column.</p>
 
 <h4 id="HTML">HTML</h4>
 
@@ -219,42 +220,11 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fragmentation', '#break-between', 'break-after')}}</td>
-   <td>{{Spec2('CSS3 Fragmentation')}}</td>
-   <td>Adds the <code>recto</code> and <code>verso</code> keywords. Changes the media type of this property from <code>paged</code> to {{xref_cssvisual}}. Defines the breaking algorithm with different kinds of breaks.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Regions', '#region-flow-break', 'break-after')}}</td>
-   <td>{{Spec2('CSS3 Regions')}}</td>
-   <td>Extends the property to handle region breaks. Adds the <code>avoid-region</code> and <code>region</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#break-before-break-after-break-inside', 'break-after')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition. Extends the CSS 2.1 {{cssxref("page-break-after")}} property to handle both page and column breaks.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_multi-column_layout">Support in multi-column layout</h3>
-
-<p>{{Compat("css.properties.break-after.multicol_context")}}</p>
-
-<h3 id="Support_in_paged_media">Support in paged media</h3>
-
-<p>{{Compat("css.properties.break-after.paged_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/break-before/index.html
+++ b/files/en-us/web/css/break-before/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.break-before
 ---
 <div>{{CSSRef}}</div>
 
@@ -67,9 +68,9 @@ break-before: unset;
  <dd>Allows, but does not force, any break (page, column, or region) to be inserted right before the principal box.</dd>
  <dt><code>avoid</code></dt>
  <dd>Avoids any break (page, column, or region) from being inserted right before the principal box.</dd>
- <dt><code>always</code> {{experimental_inline}}</dt>
- <dd>Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.</dd>
- <dt><code>all</code> {{experimental_inline}}</dt>
+ <dt><code>always</code> {{experimental_inline}}</dt>
+ <dd>Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.</dd>
+ <dt><code>all</code> {{experimental_inline}}</dt>
  <dd>Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.</dd>
 </dl>
 
@@ -110,7 +111,7 @@ break-before: unset;
 
 <h2 id="Page_break_aliases">Page break aliases</h2>
 
-<p>For compatibility reasons, the legacy {{cssxref("page-break-before")}} property should be treated by browsers as an alias of <code>break-before</code>. This ensures that sites using <code>page-break-before</code> continue to work as designed. A subset of values should be aliased as follows:</p>
+<p>For compatibility reasons, the legacy {{cssxref("page-break-before")}} property should be treated by browsers as an alias of <code>break-before</code>. This ensures that sites using <code>page-break-before</code> continue to work as designed. A subset of values should be aliased as follows:</p>
 
 <table class="standard-table">
  <thead>
@@ -161,7 +162,7 @@ break-before: unset;
 
 <p>In the following example we have a container that contains an <code>&lt;h1&gt;</code> spanning all columns (achieved using <code>column-span: all</code>) and a series of <code>&lt;h2&gt;</code>s and paragraphs laid out in multiple columns using <code>column-width: 200px</code>.</p>
 
-<p>By default, the subheadings and paragraphs were laid out rather messily because the headings were not in a uniform place. However, we used <code>break-before: column</code> on the <code>&lt;h2&gt;</code> elements to force a column break before each one, meaning that you end up with an <code>&lt;h2&gt;</code> neatly at the top of each column.</p>
+<p>By default, the subheadings and paragraphs were laid out rather messily because the headings were not in a uniform place. However, we used <code>break-before: column</code> on the <code>&lt;h2&gt;</code> elements to force a column break before each one, meaning that you end up with an <code>&lt;h2&gt;</code> neatly at the top of each column.</p>
 
 <h4 id="HTML">HTML</h4>
 
@@ -219,42 +220,11 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fragmentation', '#break-between', 'break-before')}}</td>
-   <td>{{Spec2('CSS3 Fragmentation')}}</td>
-   <td>Adds the <code>recto</code> and <code>verso</code> keywords. Changes the media type of this property from <code>paged</code> to {{xref_cssvisual}}. Defines the breaking algorithm with different kinds of breaks.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Regions', '#region-flow-break', 'break-before')}}</td>
-   <td>{{Spec2('CSS3 Regions')}}</td>
-   <td>Extends the property to handle region breaks. Adds the <code>avoid-region</code> and <code>region</code> keywords.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#break-before-break-after-break-inside', 'break-before')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition. Extends the CSS 2.1 {{cssxref("page-break-before")}} property to handle both page and column breaks.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_multi-column_layout">Support in multi-column layout</h3>
-
-<p>{{Compat("css.properties.break-before.multicol_context")}}</p>
-
-<h3 id="Support_in_paged_media">Support in paged media</h3>
-
-<p>{{Compat("css.properties.break-before.paged_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/break-inside/index.html
+++ b/files/en-us/web/css/break-inside/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.break-inside
 ---
 <div>{{CSSRef}}</div>
 
@@ -167,36 +168,11 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Fragmentation', '#break-within', 'break-inside')}}</td>
-   <td>{{Spec2('CSS3 Fragmentation')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Regions', '#region-flow-break', 'break-inside')}}</td>
-   <td>{{Spec2('CSS3 Regions')}}</td>
-   <td>Extends the property to handle region breaks.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#break-before-break-after-break-inside', 'break-inside')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("css.properties.break-inside", 4)}}</p>
+<p>{{Compat)}}</p>
 
 <h3 id="Notes_on_compatibility">Notes on compatibility</h3>
 

--- a/files/en-us/web/css/break-inside/index.html
+++ b/files/en-us/web/css/break-inside/index.html
@@ -172,7 +172,7 @@ article {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat)}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Notes_on_compatibility">Notes on compatibility</h3>
 

--- a/files/en-us/web/css/calc()/index.html
+++ b/files/en-us/web/css/calc()/index.html
@@ -71,7 +71,7 @@ width: calc(100% - 80px);</pre>
 
 <h2 id="Usage_with_integers">Usage with integers</h2>
 
-<p>When <strong><code>calc()</code></strong> is used where an {{cssxref("&lt;integer&gt;")}} is expected, the value will be rounded to the nearest integer. For example:</p>
+<p>When <strong><code>calc()</code></strong> is used where an {{cssxref("&lt;integer&gt;")}} is expected, the value will be rounded to the nearest integer. For example:</p>
 
 <pre class="brush: css">.modal {
   z-index: calc(3 / 2);
@@ -79,7 +79,7 @@ width: calc(100% - 80px);</pre>
 
 <p>This will give <code>.modal</code> a final <code>z-index</code> value of 2.</p>
 
-<p><strong>Note:</strong> The Chrome browser currently won’t accept some values returned by <strong><code>calc()</code></strong> when an integer is expected. This includes any division, even if it results in an integer. ie. <code>z-index: calc(4 / 2);</code> will not be accepted.</p>
+<p><strong>Note:</strong> The Chrome browser currently won't accept some values returned by <strong><code>calc()</code></strong> when an integer is expected. This includes any division, even if it results in an integer. ie. <code>z-index: calc(4 / 2);</code> will not be accepted.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -150,22 +150,7 @@ width: calc(100% - 80px);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Values', '#calc-notation', 'calc()')}}</td>
-   <td>{{Spec2('CSS3 Values')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/caption-side/index.html
+++ b/files/en-us/web/css/caption-side/index.html
@@ -111,27 +111,7 @@ td {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS Logical Properties', '#caption-side', 'caption-side') }}</td>
-   <td>{{ Spec2('CSS Logical Properties') }}</td>
-   <td>Defines the <code>top</code> and <code>bottom</code> values as relative to the <code>writing-mode</code> value.</td>
-  </tr>
-  <tr>
-   <td>{{ SpecName('CSS2.1', 'tables.html#caption-position', 'caption-side') }}</td>
-   <td>{{ Spec2('CSS2.1') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/caret-color/index.html
+++ b/files/en-us/web/css/caret-color/index.html
@@ -98,22 +98,7 @@ p.custom {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 UI", "#propdef-caret-color", "caret-color")}}</td>
-   <td>{{Spec2("CSS3 UI")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/clamp()/index.html
+++ b/files/en-us/web/css/clamp()/index.html
@@ -21,7 +21,7 @@ browser-compat: css.types.clamp
 
 <div>{{EmbedInteractiveExample("pages/css/function-clamp.html")}}</div>
 
-<p>Note that using <code>clamp()</code> for font sizes, as in these examples, allows you to set a font-size that grows with the size of the viewport, but doesn't go below a minimum font-size or above a maximum font-size. It has the same effect as the code in <a href="https://css-tricks.com/snippets/css/fluid-typography/">Fluid Typography</a> but in one line, and without the use of media queries.</p>
+<p>Note that using <code>clamp()</code> for font sizes, as in these examples, allows you to set a font-size that grows with the size of the viewport, but doesn't go below a minimum font-size or above a maximum font-size. It has the same effect as the code in <a href="https://css-tricks.com/snippets/css/fluid-typography/">Fluid Typography</a> but in one line, and without the use of media queries.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -94,22 +94,7 @@ p {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Values", "#funcdef-clamp", "clamp()")}}</td>
-   <td>{{Spec2('CSS4 Values')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/clear/index.html
+++ b/files/en-us/web/css/clear/index.html
@@ -22,7 +22,7 @@ browser-compat: css.properties.clear
 <p>The floats that are relevant to be cleared are the earlier floats within the same <a href="/en-US/docs/Web/Guide/CSS/Block_formatting_context">block formatting context</a>.</p>
 
 <div class="note">
-<p>If an element contains only floated elements, its height collapses to nothing. If you want it to always be able to resize, so that it contains floating elements inside it, you need to self-clear its children. This is called <strong>clearfix</strong>, and one way to do it is to add <code>clear</code> to a replaced {{cssxref("::after")}} <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> on it.</p>
+<p>If an element contains only floated elements, its height collapses to nothing. If you want it to always be able to resize, so that it contains floating elements inside it, you need to self-clear its children. This is called <strong>clearfix</strong>, and one way to do it is to add <code>clear</code> to a replaced {{cssxref("::after")}} <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> on it.</p>
 
 <pre class="brush: css">#container::after {
   content: "";
@@ -199,32 +199,7 @@ p {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Logical Properties', '#float-clear', 'float and clear')}}</td>
-   <td>{{Spec2('CSS Logical Properties')}}</td>
-   <td>Adds the values <code>inline-start</code> and <code>inline-end</code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visuren.html#flow-control', 'clear')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>No significant changes, though details are clarified.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#clear', 'clear')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/clip-path/index.html
+++ b/files/en-us/web/css/clip-path/index.html
@@ -572,32 +572,7 @@ clipPathSelect.addEventListener("change", function (evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#the-clip-path", 'clip-path')}}</td>
-   <td>{{Spec2('CSS Masks')}}</td>
-   <td>Extends its application to HTML elements. The <code>clip-path</code> property replaces the deprecated {{cssxref("clip")}} property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('SVG1.1', 'masking.html#ClipPathProperty', 'clip-path')}}</td>
-   <td>{{Spec2('SVG1.1')}}</td>
-   <td>Initial definition (applies to SVG elements only).</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Shapes 2", "#supported-basic-shapes", 'path')}}</td>
-   <td>{{Spec2('CSS Shapes 2')}}</td>
-   <td>Defines <code>path()</code>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/clip/index.html
+++ b/files/en-us/web/css/clip/index.html
@@ -41,7 +41,7 @@ clip: unset;</pre>
   <p>The <code>&lt;top&gt;</code>, <code>&lt;right&gt;</code>, <code>&lt;bottom&gt;</code>, and <code>&lt;left&gt;</code> values may be either a {{cssxref("&lt;length&gt;")}} or <code>auto</code>. If any side's value is <code>auto</code>, the element is clipped to that side's <em>inside border edge</em>.</p>
  </dd>
  <dt><code>auto</code></dt>
- <dd>The element does not clip (default). This is different from <code>rect(auto, auto, auto, auto)</code>, which clips to the element’s inside border edges.</dd>
+ <dd>The element does not clip (default). This is different from <code>rect(auto, auto, auto, auto)</code>, which clips to the element's inside border edges.</dd>
 </dl>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -102,27 +102,7 @@ clip: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Masks', '#clip-property', 'clip')}}</td>
-   <td>{{Spec2('CSS Masks')}}</td>
-   <td>Deprecates <code>clip</code> property, suggests {{cssxref("clip-path")}} as replacement.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visufx.html#clipping', 'clip')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color-adjust/index.html
+++ b/files/en-us/web/css/color-adjust/index.html
@@ -73,16 +73,16 @@ color-adjust: unset;</pre>
 <h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">.my-box {
-  background-color: black;
-  background-image: linear-gradient(rgba(0, 0, 180, 0.5), rgba(70, 140, 220, 0.5));
-  color: #900;
-  width: 15rem;
-  height: 6rem;
-  text-align: center;
-  font: 24px "Helvetica", sans-serif;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background-color: black;
+  background-image: linear-gradient(rgba(0, 0, 180, 0.5), rgba(70, 140, 220, 0.5));
+  color: #900;
+  width: 15rem;
+  height: 6rem;
+  text-align: center;
+  font: 24px "Helvetica", sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color-adjust: exact;
 }
 </pre>
@@ -90,7 +90,7 @@ color-adjust: unset;</pre>
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;div class="my-box"&gt;
-  &lt;p&gt;Need more contrast!&lt;/p&gt;
+  &lt;p&gt;Need more contrast!&lt;/p&gt;
 &lt;/div&gt;</pre>
 
 <h4 id="Result">Result</h4>
@@ -99,22 +99,7 @@ color-adjust: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS Color Adjust', '#propdef-color-adjust', 'color-adjust')}}</td>
-			<td>{{Spec2('CSS Color Adjust')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color-scheme/index.html
+++ b/files/en-us/web/css/color-scheme/index.html
@@ -68,22 +68,7 @@ color-scheme: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('CSS Color Adjust', '#color-scheme-prop', 'color-scheme')}}</td>
-			<td>{{Spec2('CSS Color Adjust')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color/index.html
+++ b/files/en-us/web/css/color/index.html
@@ -118,40 +118,7 @@ p { color: hsla(0, 100%, 50%, 0.5); }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Colors', '#the-color-property', 'color')}}</td>
-   <td>{{Spec2('CSS4 Colors')}}</td>
-   <td>Adds commaless syntaxes for the <code>rgb()</code>, <code>rgba()</code>, <code>hsl()</code>, and <code>hsla()</code> functions. Allows alpha values in <code>rgb()</code> and <code>hsl()</code>, turning <code>rgba()</code> and <code>hsla()</code> into (deprecated) aliases for them.<br>
-    Adds color keyword <code>rebeccapurple</code>.<br>
-    Adds 4- and 8-digit hex color values, where the last digit(s) represents the alpha value.<br>
-    Adds <code>hwb()</code>, <code>device-cmyk()</code>, and <code>color()</code> functions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Colors', '#color', 'color')}}</td>
-   <td>{{Spec2('CSS3 Colors')}}</td>
-   <td>Deprecates system-colors. Adds SVG colors. Adds the <code>rgba()</code>, <code>hsl()</code>, and <code>hsla()</code> functions.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'colors.html#colors', 'color')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Adds the <code>orange</code> color and the system colors.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#color', 'color')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/color()/index.html
+++ b/files/en-us/web/css/color_value/color()/index.html
@@ -33,24 +33,11 @@ color(display-p3 1 0.5 0 / .5);
     <p><code>[ &lt;number-percentage&gt;+ | &lt;string&gt; ]</code> is either one or more {{cssxref("number")}} or {{cssxref("percentage")}} values providing the parameter values that the colorspace takes, or a {{cssxref("string")}} giving the name of a color defined by the colorspace.</p>
     <p><code> / &lt;alpha-value&gt;</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</p>
   </dd>
- </dl>
+</dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS4 Colors', '#funcdef-color')}}</td>
-    <td>{{Spec2('CSS4 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/color-contrast()/index.html
+++ b/files/en-us/web/css/color_value/color-contrast()/index.html
@@ -30,22 +30,9 @@ color-contrast(#008080 vs olive, var(--myColor), #d2691e)
   </dd>
 </dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS5 Colors', '#colorcontrast')}}</td>
-    <td>{{Spec2('CSS5 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/color-mix()/index.html
+++ b/files/en-us/web/css/color_value/color-mix()/index.html
@@ -29,20 +29,19 @@ color-mix(in srgb, #34c9eb 20%, white);
     <p><code>[ &lt;color&gt;</code> is any valid {{cssxref("color_value","color")}}.</p>
     <p><code>&lt;percentage&gt;</code> is the percentage of that color to mix.</p>
   </dd>
- </dl>
+</dl>
 
- <h2 id="Examples">Examples</h2>
+<h2 id="Examples">Examples</h2>
 
-
-  <h3>HTML</h3>
+<h3>HTML</h3>
  <pre class="brush: html">&lt;ul>
   &lt;li>10% #34c9eb&lt;/li>
   &lt;li>40% #34c9eb&lt;/li>
   &lt;li>70% #34c9eb&lt;/li>
 &lt;/ul></pre>
 
-  <h3 id="CSS">CSS</h3>
-  <div class="hidden">
+<h3 id="CSS">CSS</h3>
+<div class="hidden">
   <pre class="brush: css">ul {
     display: flex;
     list-style-type: none;
@@ -56,8 +55,9 @@ color-mix(in srgb, #34c9eb 20%, white);
     padding: 10px;
   }
   </pre>
-  </div>
-  <pre class="brush: css">li:nth-child(1) {
+</div>
+
+<pre class="brush: css">li:nth-child(1) {
   background-color: color-mix(in srgb, #34c9eb 10%, white);
 }
 
@@ -69,26 +69,13 @@ li:nth-child(3) {
   background-color: color-mix(in srgb, #34c9eb 70%, white);
 }</pre>
 
-  <h4 id="result">Result</h4>
-  <p>In a supporting browser the three items become more blue as a higher percentage of <code>#34c9eb</code> is mixed in.</p>
-  <p>{{EmbedLiveSample('Examples','100%', 200)}}</p>
+<h4 id="result">Result</h4>
+<p>In a supporting browser the three items become more blue as a higher percentage of <code>#34c9eb</code> is mixed in.</p>
+<p>{{EmbedLiveSample('Examples','100%', 200)}}</p>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS5 Colors', '#color-mix')}}</td>
-    <td>{{Spec2('CSS5 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/device-cmyk()/index.html
+++ b/files/en-us/web/css/color_value/device-cmyk()/index.html
@@ -32,24 +32,11 @@ device-cmyk(0 81% 81% 30% / .5, rgb(178 34 34));
     <p><code> / &lt;alpha-value&gt;</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</p>
     <p><code>&lt;color&gt;</code> is an optional fallback {{cssxref("&lt;color&gt;")}} to use if the user agent does not know how to translate the CMYK color to RGB.</p>
   </dd>
- </dl>
+</dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS4 Colors', '#device-cmyk')}}</td>
-    <td>{{Spec2('CSS4 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/hwb()/index.html
+++ b/files/en-us/web/css/color_value/hwb()/index.html
@@ -32,24 +32,11 @@ hwb(194, 0%, 0%, .5); /* with comma-separated values */
     <p><code>B</code> (blackness) specifies the amount of black to mix in, also from 0% (no blackness) to 100% (full blackness).</p>
     <p><code>A</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</p>
   </dd>
- </dl>
+</dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS4 Colors', '#the-hwb-notation')}}</td>
-    <td>{{Spec2('CSS4 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/lab()/index.html
+++ b/files/en-us/web/css/color_value/lab()/index.html
@@ -32,24 +32,11 @@ lab(52.2345% 40.1645 59.9971 / .5);
     <p>The third argument <code>b</code> is the distance along the <code>b</code> axis in the Lab colorspace.</p>
     <p><code>A</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</p>
   </dd>
- </dl>
+</dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS4 Colors', '#lab-colors')}}</td>
-    <td>{{Spec2('CSS4 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specificatiions</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/color_value/lch()/index.html
+++ b/files/en-us/web/css/color_value/lch()/index.html
@@ -34,7 +34,7 @@ lch(52.2345% 72.2 56.2 / .5);
   </dd>
 </dl>
 
-<h2 id="Specifications">Specificatiions</h2>
+<h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}
 

--- a/files/en-us/web/css/color_value/lch()/index.html
+++ b/files/en-us/web/css/color_value/lch()/index.html
@@ -9,7 +9,7 @@ tags:
   - Web
   - color
   - lch
-browser-compat: css.types.color.lab
+browser-compat: css.types.color.lch
 ---
 <div>{{CSSRef}}</div>
 
@@ -32,24 +32,11 @@ lch(52.2345% 72.2 56.2 / .5);
     <p>The third argument <code>H</code> is the hue angle. <code>0deg</code> points along the positive "a" axis (toward purplish red), <code>90deg</code> points along the positive "b" axis (toward mustard yellow), <code>180deg</code> points along the negative "a" axis (toward greenish cyan), and <code>270deg</code> points along the negative "b" axis (toward sky blue).</p>
     <p><code>A</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</p>
   </dd>
- </dl>
+</dl>
 
- <table class="standard-table">
-  <thead>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-  </thead>
-  <tbody>
-   <tr>
-    <td>{{SpecName('CSS4 Colors', '#lab-colors')}}</td>
-    <td>{{Spec2('CSS4 Colors')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
-</table>
+<h2 id="Specifications">Specificatiions</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-count/index.html
+++ b/files/en-us/web/css/column-count/index.html
@@ -74,22 +74,7 @@ column-count: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#cc', 'column-count')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-fill/index.html
+++ b/files/en-us/web/css/column-fill/index.html
@@ -37,9 +37,9 @@ column-fill: unset;
  <dt><code>auto</code></dt>
  <dd>Columns are filled sequentially. Content takes up only the room it needs, possibly resulting in some columns remaining empty.</dd>
  <dt><code>balance</code></dt>
- <dd>Content is equally divided between columns. In fragmented contexts, such as <a href="/en-US/docs/Web/CSS/Paged_Media">paged media</a>, only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.</dd>
+ <dd>Content is equally divided between columns. In fragmented contexts, such as <a href="/en-US/docs/Web/CSS/Paged_Media">paged media</a>, only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.</dd>
  <dt><code>balance-all</code></dt>
- <dd>Content is equally divided between columns. In fragmented contexts, such as <a href="/en-US/docs/Web/CSS/Paged_Media">paged media</a>, all fragments are balanced.</dd>
+ <dd>Content is equally divided between columns. In fragmented contexts, such as <a href="/en-US/docs/Web/CSS/Paged_Media">paged media</a>, all fragments are balanced.</dd>
 </dl>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -87,22 +87,7 @@ p.fill-balance {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#cf', 'column-fill')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-gap/index.html
+++ b/files/en-us/web/css/column-gap/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - column-gap
   - 'recipe:css-property'
+browser-compat: css.properties.column-gap
 ---
 <div>{{CSSRef}}</div>
 
@@ -147,46 +148,11 @@ column-gap: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#column-row-gap", "column-gap")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Applies to grid and flexbox</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Grid", "#gutters", "column-gap")}}</td>
-   <td>{{Spec2("CSS3 Grid")}}</td>
-   <td>Specifies how this property affects grid layouts</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Multicol", "#column-gap", "column-gap")}}</td>
-   <td>{{Spec2("CSS3 Multicol")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.column-gap.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.column-gap.grid_context")}}</p>
-
-<h3 id="Support_in_Multi-column_layout">Support in Multi-column layout</h3>
-
-<p>{{Compat("css.properties.column-gap.multicol_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/column-rule-color/index.html
+++ b/files/en-us/web/css/column-rule-color/index.html
@@ -77,22 +77,7 @@ column-rule-color: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#crc', 'column-rule-color')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-rule-style/index.html
+++ b/files/en-us/web/css/column-rule-style/index.html
@@ -77,22 +77,7 @@ column-rule-style: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{ SpecName('CSS3 Multicol', '#crs', 'column-rule-style') }}</td>
-			<td>{{ Spec2('CSS3 Multicol') }}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-rule-width/index.html
+++ b/files/en-us/web/css/column-rule-width/index.html
@@ -76,22 +76,7 @@ column-rule-width: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Multicol', '#crw', 'column-rule-width') }}</td>
-   <td>{{ Spec2('CSS3 Multicol') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-rule/index.html
+++ b/files/en-us/web/css/column-rule/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.column-rule
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>column-rule</code></strong> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width, style, and color of the line drawn between columns in a multi-column layout.</p>
+<p>The <strong><code>column-rule</code></strong> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width, style, and color of the line drawn between columns in a multi-column layout.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/column-rule.html")}}</div>
 
@@ -100,22 +100,7 @@ p.abc { column-rule: thick inset blue; }
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#column-rule', 'column-rule')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-span/index.html
+++ b/files/en-us/web/css/column-span/index.html
@@ -87,22 +87,7 @@ h2 {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#column-span', 'column-span')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column-width/index.html
+++ b/files/en-us/web/css/column-width/index.html
@@ -76,27 +76,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh 
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Sizing', '#column-sizing', 'column-width')}}</td>
-   <td>{{Spec2('CSS3 Sizing')}}</td>
-   <td>Adds intrinsic sizes via the keywords <code>min-content</code>, <code>max-content</code>, and <code>fit-content</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#cw', 'column-width')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/column_combinator/index.html
+++ b/files/en-us/web/css/column_combinator/index.html
@@ -67,22 +67,7 @@ col.selected || td {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("CSS4 Selectors", "#the-column-combinator", "column combinator")}}</td>
-			<td>{{Spec2("CSS4 Selectors")}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/columns/index.html
+++ b/files/en-us/web/css/columns/index.html
@@ -88,22 +88,7 @@ columns: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Multicol', '#columns', 'columns')}}</td>
-   <td>{{Spec2('CSS3 Multicol')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/contain-intrinsic-size/index.html
+++ b/files/en-us/web/css/contain-intrinsic-size/index.html
@@ -25,22 +25,7 @@ contain-intrinsic-size: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Sizing', '#propdef-contain-intrinsic-size')}}</td>
-   <td>{{Spec2('CSS4 Sizing')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/contain/index.html
+++ b/files/en-us/web/css/contain/index.html
@@ -182,22 +182,7 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Containment 2', '#contain-property', 'contain')}}</td>
-   <td>{{Spec2('CSS Containment 2')}}</td>
-   <td>Added <code>style</code> keyword</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/content-visibility/index.html
+++ b/files/en-us/web/css/content-visibility/index.html
@@ -95,22 +95,7 @@ section {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS Containment 2', '#content-visibility')}}</td>
-   <td>{{Spec2('CSS Containment 2')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/content/index.html
+++ b/files/en-us/web/css/content/index.html
@@ -262,27 +262,7 @@ li {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Content", "#content-property", "content")}}</td>
-   <td>{{Spec2("CSS3 Content")}}</td>
-   <td>Adds support for alt-text</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "generate.html#content", "content")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/counter()/index.html
+++ b/files/en-us/web/css/counter()/index.html
@@ -33,9 +33,9 @@ counter(countername, upper-roman)</pre>
 
 <dl>
  <dt>{{cssxref("&lt;custom-ident&gt;")}}</dt>
- <dd>A name identifying the counter, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and  {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be <code>none</code>, <code>unset</code>, <code>initial</code>, or <code>inherit</code>.</dd>
+ <dd>A name identifying the counter, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be <code>none</code>, <code>unset</code>, <code>initial</code>, or <code>inherit</code>.</dd>
  <dt><code>&lt;counter-style&gt;</code></dt>
- <dd>A {{cssxref("&lt;list-style-type&gt;")}} name, {{cssxref("&lt;@counter-style&gt;")}} name or {{cssxref("symbols()")}} function, where a counter style name is a <code>numeric</code>, <code>alphabetic</code>, or <code>symbolic</code> simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other <a href="/en-US/docs/Web/CSS/CSS_Counter_Styles">predefined counter style</a>. If omitted, the counter-style defaults to <code>decimal</code>.</dd>
+ <dd>A {{cssxref("&lt;list-style-type&gt;")}} name, {{cssxref("&lt;@counter-style&gt;")}} name or {{cssxref("symbols()")}} function, where a counter style name is a <code>numeric</code>, <code>alphabetic</code>, or <code>symbolic</code> simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other <a href="/en-US/docs/Web/CSS/CSS_Counter_Styles">predefined counter style</a>. If omitted, the counter-style defaults to <code>decimal</code>.</dd>
 </dl>
 
 <h3 id="Formal_syntax">Formal syntax</h3>
@@ -63,7 +63,7 @@ li {
   counter-increment: listCounter;
 }
 li::after {
-  content: "[" counter(listCounter) "] == ["
+  content: "[" counter(listCounter) "] == ["
                counter(listCounter, upper-roman) "]";
 }</pre>
 
@@ -90,7 +90,7 @@ li {
   counter-increment: count;
 }
 li::after {
-  content: "[" counter(count, <dfn>decimal-leading-zero</dfn>) "] == ["
+  content: "[" counter(count, <dfn>decimal-leading-zero</dfn>) "] == ["
                counter(count, lower-alpha) "]";
 }</pre>
 
@@ -100,27 +100,7 @@ li::after {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Lists", "#counter-functions", "CSS Counters")}}</td>
-   <td>{{Spec2("CSS3 Lists")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "generate.html#counter-styles", "CSS Counters")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/counter-increment/index.html
+++ b/files/en-us/web/css/counter-increment/index.html
@@ -80,27 +80,7 @@ counter-increment: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Lists", "#propdef-counter-increment", "counter-increment")}}</td>
-   <td>{{Spec2("CSS3 Lists")}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "generate.html#propdef-counter-increment", "counter-increment")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/counter-reset/index.html
+++ b/files/en-us/web/css/counter-reset/index.html
@@ -78,27 +78,7 @@ counter-reset: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Lists', '#counter-reset', 'counter-reset')}}</td>
-   <td>{{Spec2('CSS3 Lists')}}</td>
-   <td>No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'generate.html#propdef-counter-reset', 'counter-reset')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/counter-set/index.html
+++ b/files/en-us/web/css/counter-set/index.html
@@ -51,7 +51,7 @@ counter-set: unset;
  <dt>{{cssxref("custom-ident", "&lt;custom-ident&gt;")}}</dt>
  <dd>The name of the counter to set.</dd>
  <dt>{{cssxref("&lt;integer&gt;")}}</dt>
- <dd>The value to set the counter to on each occurrence of the element. Defaults to <code>0</code> if not specified. If there isn't currently a counter of the given name on the element, the element will create a new counter of the given name with a starting value of 0 (though it may then immediately set or increment that value to something different).</dd>
+ <dd>The value to set the counter to on each occurrence of the element. Defaults to <code>0</code> if not specified. If there isn't currently a counter of the given name on the element, the element will create a new counter of the given name with a starting value of 0 (though it may then immediately set or increment that value to something different).</dd>
  <dt><code>none</code></dt>
  <dd>No counter set is to be performed. This can be used to override a <code>counter-set</code> defined in a less specific rule.</dd>
 </dl>
@@ -77,22 +77,7 @@ counter-set: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Lists', '#propdef-counter-set', 'counter-set')}}</td>
-   <td>{{Spec2('CSS3 Lists')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/counters()/index.html
+++ b/files/en-us/web/css/counters()/index.html
@@ -33,7 +33,7 @@ counters(countername, '.', upper-roman)</pre>
 
 <dl>
  <dt>{{cssxref("&lt;custom-ident&gt;")}}</dt>
- <dd>A name identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and  {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be <code>none</code>, <code>unset</code>, <code>initial</code>, or <code>inherit</code>.</dd>
+ <dd>A name identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be <code>none</code>, <code>unset</code>, <code>initial</code>, or <code>inherit</code>.</dd>
  <dt><code>&lt;counter-style&gt;</code></dt>
  <dd>A counter style name or <code><a href="/en-US/docs/Web/CSS/symbols">symbols()</a></code> function, where a counter style name is a numeric, alphabetic, or symbolic simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other <a href="/en-US/docs/Web/CSS/CSS_Counter_Styles">predefined counter style</a>. If omitted, the counter-style defaults to decimal</dd>
  <dt>{{cssxref("&lt;string&gt;")}}</dt>
@@ -86,7 +86,7 @@ li::marker {
    content:  counters(listCounter, '.', upper-roman) ') ';
 }
 li::before {
-  content:  counters(listCounter, ".") " == " counters(listCounter, ".", lower-roman) ;
+  content:  counters(listCounter, ".") " == " counters(listCounter, ".", lower-roman) ;
 }</pre>
 
 <h4 id="Result">Result</h4>
@@ -133,7 +133,7 @@ li::marker {
    content: counters(count, '.', upper-alpha) ') ';
 }
 li::before {
-  content: counters(count, ".", <dfn>decimal-leading-zero</dfn>) " == " counters(count, ".", lower-alpha);
+  content: counters(count, ".", <dfn>decimal-leading-zero</dfn>) " == " counters(count, ".", lower-alpha);
 }</pre>
 
 <h4 id="Result_2">Result</h4>
@@ -142,27 +142,7 @@ li::before {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Lists", "#counter-functions", "CSS Counters")}}</td>
-   <td>{{Spec2("CSS3 Lists")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "generate.html#counter-styles", "CSS Counters")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/cross-fade()/index.html
+++ b/files/en-us/web/css/cross-fade()/index.html
@@ -13,7 +13,7 @@ browser-compat: css.types.image.cross-fade
 ---
 <p>{{CSSRef}}</p>
 
-<p>The <strong><code>cross-fade()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> can be used to blend two or more images at a defined transparency. It can be used for many simple image manipulations, such as tinting an image with a solid color or highlighting a particular area of the page by combining an image with a radial gradient.</p>
+<p>The <strong><code>cross-fade()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> can be used to blend two or more images at a defined transparency. It can be used for many simple image manipulations, such as tinting an image with a solid color or highlighting a particular area of the page by combining an image with a radial gradient.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -21,7 +21,7 @@ browser-compat: css.types.image.cross-fade
 
 <h3 id="Specification_syntax">Specification syntax</h3>
 
-<p>The <code>cross-fade()</code> function takes a list of images with a percentage defining how much of each image is retained in terms of opacity when it is blended with the other images. The percent value must be coded without quotes, must contain the “%” symbol, and its value must be between 0% and 100%.</p>
+<p>The <code>cross-fade()</code> function takes a list of images with a percentage defining how much of each image is retained in terms of opacity when it is blended with the other images. The percent value must be coded without quotes, must contain the <code>'%'</code> symbol, and its value must be between 0% and 100%.</p>
 
 <p>The function can be used in CSS anywhere an ordinary image reference can be used.</p>
 
@@ -117,22 +117,7 @@ cross-fade(url(white.png), url(black.png), 100%); /* fully white */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Images', '#cross-fade-function', 'cross-fade()')}}</td>
-   <td>{{Spec2('CSS4 Images')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/cursor/index.html
+++ b/files/en-us/web/css/cursor/index.html
@@ -289,27 +289,7 @@ cursor: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Basic UI', '#cursor', 'cursor')}}</td>
-   <td>{{Spec2('CSS3 Basic UI')}}</td>
-   <td>Addition of several keywords and the positioning syntax for <code>url()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'ui.html#cursor-props', 'cursor')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/display/index.html
+++ b/files/en-us/web/css/display/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - display
   - recipe:css-property
+browser-compat: css.properties.display
 ---
 <div>{{CSSRef}}</div>
 
@@ -63,7 +64,7 @@ display: unset;
 
 <dl>
  <dt>{{CSSxRef("&lt;display-outside&gt;")}}</dt>
- <dd>These keywords specify the element’s outer display type, which is essentially its role in flow layout.</dd>
+ <dd>These keywords specify the element's outer display type, which is essentially its role in flow layout.</dd>
 </dl>
 
 <p>{{page("/en-US/docs/Web/CSS/display-outside", "Syntax")}}</p>
@@ -72,7 +73,7 @@ display: unset;
 
 <dl>
  <dt>{{CSSxRef("&lt;display-inside&gt;")}}</dt>
- <dd>These keywords specify the element’s inner display type, which defines the type of formatting context that its contents are laid out in (assuming it is a non-replaced element).</dd>
+ <dd>These keywords specify the element's inner display type, which defines the type of formatting context that its contents are laid out in (assuming it is a non-replaced element).</dd>
 </dl>
 
 <p>{{page("/en-US/docs/Web/CSS/display-inside", "Syntax")}}</p>
@@ -317,51 +318,11 @@ updateDisplay();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Display', '#the-display-properties', 'display')}}</td>
-   <td>{{Spec2('CSS3 Display')}}</td>
-   <td>Added <code>run-in</code>, <code>flow</code>, <code>flow-root</code>, <code>contents</code>, and multi-keyword values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Ruby', '#ruby-display', 'display')}}</td>
-   <td>{{Spec2('CSS3 Ruby')}}</td>
-   <td>Added <code>ruby</code>, <code>ruby-base</code>, <code>ruby-text</code>, <code>ruby-base-container</code>, and <code>ruby-text-container</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Grid', '#grid-containers', 'display')}}</td>
-   <td>{{Spec2('CSS3 Grid')}}</td>
-   <td>Added the grid box model values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Flexbox', '#flex-containers', 'display')}}</td>
-   <td>{{Spec2('CSS3 Flexbox')}}</td>
-   <td>Added the flexible box model values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS2.1', 'visuren.html#display-prop', 'display')}}</td>
-   <td>{{Spec2('CSS2.1')}}</td>
-   <td>Added the table model values and <code>inline-block<em>.</em></code></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS1', '#display', 'display')}}</td>
-   <td>{{Spec2('CSS1')}}</td>
-   <td>Initial definition. Basic values: <code>none</code>, <code>block</code>, <code>inline</code>, and <code>list-item</code>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("css.properties.display", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/gap/index.html
+++ b/files/en-us/web/css/gap/index.html
@@ -10,13 +10,13 @@ tags:
   - Reference
   - gap
   - 'recipe:css-property'
+browser-compat: css.properties.gap
 ---
 <div>{{CSSRef}}</div>
 
 <p>The <strong><code>gap</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the gaps ({{glossary("gutters")}}) between rows and columns. It is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> for {{CSSxRef("row-gap")}} and {{CSSxRef("column-gap")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/gap.html")}}</div>
-
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -51,7 +51,7 @@ gap: revert;
 gap: unset;
 </pre>
 
-<p>This property is specified as a value for <code>&lt;'row-gap'&gt;</code> followed optionally by a value for <code>&lt;'column-gap'&gt;</code>. If <code>&lt;'column-gap'&gt;</code> is omitted, it’s set to the same value as <code>&lt;'row-gap'&gt;</code>.</p>
+<p>This property is specified as a value for <code>&lt;'row-gap'&gt;</code> followed optionally by a value for <code>&lt;'column-gap'&gt;</code>. If <code>&lt;'column-gap'&gt;</code> is omitted, it's set to the same value as <code>&lt;'row-gap'&gt;</code>.</p>
 
 <p><code>&lt;'row-gap'&gt;</code> and <code>&lt;'column-gap'&gt;</code> are each specified as a <code>&lt;length&gt;</code> or a <code>&lt;percentage&gt;</code>.</p>
 
@@ -171,36 +171,11 @@ gap: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-gap", "gap")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.gap.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.gap.grid_context")}}</p>
-
-<h3 id="Support_in_Multi-column_layout">Support in Multi-column layout</h3>
-
-<p>{{Compat("css.properties.gap.multicol_context")}}</p>
+<p>{{Compat)}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/gap/index.html
+++ b/files/en-us/web/css/gap/index.html
@@ -175,7 +175,7 @@ gap: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/image-resolution/index.html
+++ b/files/en-us/web/css/image-resolution/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Reference
   - image-resolution
+browser-compat: css.properties.image-resolution
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
@@ -37,7 +38,7 @@ image-resolution: unset;</pre>
  <dt><code>from-image</code></dt>
  <dd>Uses the intrinsic resolution as specified by the image format. If the image does not specify its own resolution, the explicitly specified resolution is used (if given), else it defaults to <code>1dppx</code> (1 image pixel per CSS px unit).</dd>
  <dt><code>snap</code></dt>
- <dd>If the <code>snap</code> keyword is provided, the computed resolution is the specified resolution rounded to the nearest value that would map one image pixel to an integer number of device pixels. If the resolution is taken from the image, then the used intrinsic resolution is the image’s native resolution similarly adjusted.</dd>
+ <dd>If the <code>snap</code> keyword is provided, the computed resolution is the specified resolution rounded to the nearest value that would map one image pixel to an integer number of device pixels. If the resolution is taken from the image, then the used intrinsic resolution is the image's native resolution similarly adjusted.</dd>
 </dl>
 
 <div class="notecard note">
@@ -76,29 +77,16 @@ image-resolution: unset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Images", "#the-image-resolution", "image-resolution")}}</td>
-   <td>{{Spec2("CSS4 Images")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The <code>image-resolution</code> property is currently unsupported by browsers. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1086473">Chromium bug: 1086473</a>.</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
  <li>Other image-related CSS properties: {{cssxref("object-fit")}}, {{cssxref("object-position")}}, {{cssxref("image-orientation")}}, {{cssxref("image-rendering")}}.</li>
+ <li><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1086473">Chromium bug: 1086473</a>.</li>
+
 </ul>

--- a/files/en-us/web/css/justify-content/index.html
+++ b/files/en-us/web/css/justify-content/index.html
@@ -7,6 +7,7 @@ tags:
   - CSS Property
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.justify-content
 ---
 <div>{{CSSRef}}</div>
 
@@ -172,37 +173,11 @@ justifyContent.addEventListener("change", function (evt) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS3 Box Alignment', '#propdef-justify-content', 'justify-content')}}</td>
-   <td>{{Spec2('CSS3 Box Alignment')}}</td>
-   <td>Adds the [ first | last ]? baseline, self-start, self-end, start, end, left, right, unsafe | safe values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Flexbox', '#propdef-justify-content', 'justify-content')}}</td>
-   <td>{{Spec2('CSS3 Flexbox')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.justify-content.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.justify-content.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/justify-items/index.html
+++ b/files/en-us/web/css/justify-items/index.html
@@ -7,6 +7,7 @@ tags:
   - CSS Property
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.justify-items
 ---
 <div>{{CSSRef}}</div>
 
@@ -103,13 +104,13 @@ justify-items: unset;
  <dt><code>center</code></dt>
  <dd>The items are packed flush to each other toward the center of the of the alignment container.</dd>
  <dt><code>left</code></dt>
- <dd>The items are packed flush to each other toward the left edge of the alignment container. If the property’s axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
+ <dd>The items are packed flush to each other toward the left edge of the alignment container. If the property's axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
  <dt><code>right</code></dt>
- <dd>The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property’s axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
+ <dd>The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property's axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
  <dt><code>baseline<br>
  first baseline</code><br>
  <code>last baseline</code></dt>
- <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box’s first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
+ <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box's first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
  The fallback alignment for <code>first baseline</code> is <code>start</code>, the one for <code>last baseline</code> is <code>end</code>.</dd>
  <dt><code>stretch</code></dt>
  <dd>If the combined size of the items is less than the size of the alignment container, any <code>auto</code>-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by {{CSSxRef("max-height")}}/{{CSSxRef("max-width")}} (or equivalent functionality), so that the combined size exactly fills the alignment container.</dd>
@@ -140,10 +141,10 @@ justify-items: unset;
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;article class="container" tabindex="0"&gt;
-  &lt;span&gt;First child&lt;/span&gt;
-  &lt;span&gt;Second child&lt;/span&gt;
-  &lt;span&gt;Third child&lt;/span&gt;
-  &lt;span&gt;Fourth child&lt;/span&gt;
+  &lt;span&gt;First child&lt;/span&gt;
+  &lt;span&gt;Second child&lt;/span&gt;
+  &lt;span&gt;Third child&lt;/span&gt;
+  &lt;span&gt;Fourth child&lt;/span&gt;
 &lt;/article&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
@@ -189,32 +190,11 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-justify-items", "justify-items")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.justify-items.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.justify-items.grid_context")}}</p>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/justify-self/index.html
+++ b/files/en-us/web/css/justify-self/index.html
@@ -7,6 +7,7 @@ tags:
   - CSS Property
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.justify-self
 ---
 <div>{{CSSRef}}</div>
 
@@ -101,13 +102,13 @@ justify-self: unset;
  <dt><code>center</code></dt>
  <dd>The items are packed flush to each other toward the center of the of the alignment container.</dd>
  <dt><code>left</code></dt>
- <dd>The items are packed flush to each other toward the left edge of the alignment container. If the property’s axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
+ <dd>The items are packed flush to each other toward the left edge of the alignment container. If the property's axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
  <dt><code>right</code></dt>
- <dd>The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property’s axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
+ <dd>The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property's axis is not parallel with the inline axis, this value behaves like <code>start</code>.</dd>
  <dt><code>baseline<br>
  first baseline</code><br>
  <code>last baseline</code></dt>
- <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box’s first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
+ <dd>Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box's first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.<br>
  The fallback alignment for <code>first baseline</code> is <code>start</code>, the one for <code>last baseline</code> is <code>end</code>.</dd>
  <dt><code>stretch</code></dt>
  <dd>If the combined size of the items is less than the size of the alignment container, any <code>auto</code>-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by {{CSSxRef("max-height")}}/{{CSSxRef("max-width")}} (or equivalent functionality), so that the combined size exactly fills the alignment container.</dd>
@@ -136,10 +137,10 @@ justify-self: unset;
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;article class="container"&gt;
-  &lt;span&gt;First child&lt;/span&gt;
-  &lt;span&gt;Second child&lt;/span&gt;
-  &lt;span&gt;Third child&lt;/span&gt;
-  &lt;span&gt;Fourth child&lt;/span&gt;
+  &lt;span&gt;First child&lt;/span&gt;
+  &lt;span&gt;Second child&lt;/span&gt;
+  &lt;span&gt;Third child&lt;/span&gt;
+  &lt;span&gt;Fourth child&lt;/span&gt;
 &lt;/article&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
@@ -193,28 +194,13 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-justify-self", "justify-self")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specificatiions}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
 
-<p>{{Compat("css.properties.justify-self.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/justify-self/index.html
+++ b/files/en-us/web/css/justify-self/index.html
@@ -198,8 +198,6 @@ article {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/justify-self/index.html
+++ b/files/en-us/web/css/justify-self/index.html
@@ -194,7 +194,7 @@ article {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specificatiions}}
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/mask-border-mode/index.html
+++ b/files/en-us/web/css/mask-border-mode/index.html
@@ -57,22 +57,7 @@ mask-border-mode: alpha;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS Masks", "#propdef-mask-border-mode", "mask-border-mode")}}</td>
-   <td>{{Spec2("CSS Masks")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/opacity/index.html
+++ b/files/en-us/web/css/opacity/index.html
@@ -7,6 +7,7 @@ tags:
   - Opacity
   - Reference
   - recipe:css-property
+browser-compat: css.properties.opacity
 ---
 <div>{{CSSRef}}</div>
 
@@ -142,31 +143,11 @@ img.opacity:hover {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSS4 Colors', '#transparency', 'opacity')}}</td>
-   <td>{{Spec2('CSS4 Colors')}}</td>
-   <td>Defines percentage opacity values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('CSS3 Colors', '#opacity', 'opacity')}}</td>
-   <td>{{Spec2('CSS3 Colors')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("css.properties.opacity", 2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/row-gap/index.html
+++ b/files/en-us/web/css/row-gap/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - 'recipe:css-property'
   - row-gap
+browser-compat: css.properties.row-gap
 ---
 <div>{{CSSRef}}</div>
 
@@ -119,32 +120,11 @@ row-gap: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS3 Box Alignment", "#propdef-row-gap", "row-gap")}}</td>
-   <td>{{Spec2("CSS3 Box Alignment")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.row-gap.flex_context")}}</p>
-
-<h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
-
-<p>{{Compat("css.properties.row-gap.grid_context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/touch-action/index.html
+++ b/files/en-us/web/css/touch-action/index.html
@@ -7,6 +7,7 @@ tags:
   - Pointer Events
   - Reference
   - 'recipe:css-property'
+browser-compat: css.properties.touch-action
 ---
 <p>{{CSSRef}}</p>
 
@@ -97,10 +98,10 @@ touch-action: unset;
 <h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">#map {
-  height: 150vh;
-  width: 70vw;
-  background: linear-gradient(blue, green);
-  touch-action: none;
+  height: 150vh;
+  width: 70vw;
+  background: linear-gradient(blue, green);
+  touch-action: none;
 }
 </pre>
 
@@ -110,41 +111,11 @@ touch-action: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Compat', '#touch-action', 'touch-action')}}</td>
-   <td>{{Spec2('Compat')}}</td>
-   <td>Added <code>pinch-zoom</code> property value.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 3', '#the-touch-action-css-property', 'touch-action')}}</td>
-   <td>{{Spec2('Pointer Events 3')}}</td>
-   <td>Added <code>pan-left</code>, <code>pan-right</code>, <code>pan-up</code>, <code>pan-down</code> property values.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events 2', '#the-touch-action-css-property', 'touch-action')}}</td>
-   <td>{{Spec2('Pointer Events 2')}}</td>
-   <td>Latest recommendation.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Pointer Events', '#the-touch-action-css-property', 'touch-action')}}</td>
-   <td>{{Spec2('Pointer Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{compat("css.properties.touch-action")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
This is part of #1146.

I forgot the properties starting with 'c' in the first phase. I also deal with cases were the bcd wasn't in front-runner or had several compat table (most of the time erroneously).

A few notes:

- Recent CSS color functions, `lch()`, `lab()`, `hwb()` and `color()`, temporarily lose their spec table. PR mdn/browser-compat-data#10898 landed last week but is not yet in the npm package. It will come back once mdn/content start using this week's package of bcd. On the way, I fixed one `browser-compat:` clause in front-runner that was incorrect.
- A few CSS proposals, not yet implemented, lose their table (until there will be a bcd entry); like always, I leave it that way, it will get fixed automatically when they get a bcd entry: `:nth-col`, `:nth-last-col`, `image-resolution`, `:state`, `:local-link`, `:picture-in-picture`, `:playing`, `:current`, `:paused`, `::cue-region`, `@media/shape`, `@media/update`, `mask-border-mode`, `color-contrast()`, `device-cmyk()`.
- A few properties, supported in several display modes, had a non-complete bcd. I opened PR mdn/browser-compat-data#11354 to fix it.