### PR TITLE
Follow-up fixes for Request/Response docs

### DIFF
--- a/files/en-us/web/api/request/arraybuffer/index.html
+++ b/files/en-us/web/api/request/arraybuffer/index.html
@@ -13,8 +13,7 @@ browser-compat: api.Request.arrayBuffer
 <div>{{APIRef("Fetch")}}</div>
 
 <p>The <strong><code>arrayBuffer()</code></strong> method of the {{domxref("Request")}} interface
-  takes a {{domxref("Request")}} stream and reads it to completion. It returns a promise
-  that resolves with an {{jsxref("ArrayBuffer")}}.</p>
+reads the request body and returns it as a promise that resolves with an {{jsxref("ArrayBuffer")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -35,12 +34,11 @@ request.arrayBuffer().then(function(buffer) {
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">
-const myArray = new ArrayBuffer(512);
-const longInt8View = new Uint8Array(myArray);
+const myArray = new Uint8Array(10);
 
 const request = new Request('/myEndpoint', {
   method: 'POST',
-  body: longInt8View
+  body: myArray
 });
 
 request.arrayBuffer().then(function(buffer) {

--- a/files/en-us/web/api/request/blob/index.html
+++ b/files/en-us/web/api/request/blob/index.html
@@ -12,9 +12,8 @@ browser-compat: api.Request.blob
 ---
 <div>{{APIRef("Fetch")}}</div>
 
-<p>The <strong><code>blob()</code></strong> method of the {{domxref("Request")}} interface takes
-  a {{domxref("Request")}} stream and reads it to completion. It returns a promise that
-  resolves with a {{domxref("Blob")}}.</p>
+<p>The <strong><code>blob()</code></strong> method of the {{domxref("Request")}} interface
+reads the request body and returns it as a promise that resolves with a {{domxref("Blob")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/request/clone/index.html
+++ b/files/en-us/web/api/request/clone/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Request.clone
 
 <p>The <strong><code>clone()</code></strong> method of the {{domxref("Request")}} interface creates a copy of the current <code>Request</code> object.</p>
 
-<p><code>clone()</code> throws a {{jsxref("TypeError")}} if the response body has already been used. In fact, the main reason <code>clone()</code> exists is to allow multiple uses of body objects (when they are one-use only.)</p>
+<p><code>clone()</code> throws a {{jsxref("TypeError")}} if the request body has already been used. In fact, the main reason <code>clone()</code> exists is to allow multiple uses of body objects (when they are one-use only.)</p>
 
 <p>If intend to modify the request, you may prefer the {{domxref("Request")}} constructor.</p>
 

--- a/files/en-us/web/api/request/formdata/index.html
+++ b/files/en-us/web/api/request/formdata/index.html
@@ -13,8 +13,7 @@ browser-compat: api.Request.formData
 <div>{{APIRef("Fetch")}}</div>
 
 <p>The <strong><code>formData()</code></strong> method of the {{domxref("Request")}} interface
-  takes a {{domxref("Request")}} stream and reads it to completion. It returns a promise
-  that resolves with a {{domxref("FormData")}} object.</p>
+reads the request body and returns it as a promise that resolves with a {{domxref("FormData")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Request
  <dt>{{domxref("Request.body")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("ReadableStream")}} of the body contents.</dd>
  <dt>{{domxref("Request.bodyUsed")}} {{readonlyInline}}</dt>
- <dd>Stores a {{domxref("Boolean")}} that declares whether the body has been used in a response yet.</dd>
+ <dd>Stores a {{domxref("Boolean")}} that declares whether the body has been used in a request yet.</dd>
  <dt>{{domxref("Request.cache")}} {{readonlyInline}}</dt>
  <dd>Contains the cache mode of the request (e.g., <code>default</code>, <code>reload</code>, <code>no-cache</code>).</dd>
  <dt>{{domxref("Request.credentials")}} {{readonlyInline}}</dt>
@@ -67,7 +67,7 @@ browser-compat: api.Request
  >{{domxref("Request.formData()")}}</dt>
  <dd>Returns a promise that resolves with a {{domxref("FormData")}} representation of the request body.</dd>
  <dt>{{domxref("Request.json()")}}</dt>
- <dd>Returns a promise that resolves with a {{jsxref("JSON")}} representation of the request body.</dd>
+ <dd>Returns a promise that resolves with a JavaScript object that is the result of parsing the request body as {{JSxRef("JSON")}}.</dd>
  <dt>{{domxref("Request.text()")}}</dt>
  <dd>Returns a promise that resolves with an {{domxref("USVString")}} (text) representation of the request body.</dd>
 </dl>

--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -63,13 +63,13 @@ browser-compat: api.Request
  <dt>{{domxref("Request.blob()")}}</dt>
  <dd>Returns a promise that resolves with a {{domxref("Blob")}} representation of the request body.</dd>
  <dt>{{domxref("Request.clone()")}}</dt>
- <dd>Creates a copy of the current <code>Request</code> object.</dd><dt
- >{{domxref("Request.formData()")}}</dt>
+ <dd>Creates a copy of the current <code>Request</code> object.</dd>
+ <dt>{{domxref("Request.formData()")}}</dt>
  <dd>Returns a promise that resolves with a {{domxref("FormData")}} representation of the request body.</dd>
  <dt>{{domxref("Request.json()")}}</dt>
- <dd>Returns a promise that resolves with a JavaScript object that is the result of parsing the request body as {{JSxRef("JSON")}}.</dd>
+ <dd>Returns a promise that resolves with the result of parsing the request body as {{JSxRef("JSON")}}.</dd>
  <dt>{{domxref("Request.text()")}}</dt>
- <dd>Returns a promise that resolves with an {{domxref("USVString")}} (text) representation of the request body.</dd>
+ <dd>Returns a promise that resolves with a text representation of the request body.</dd>
 </dl>
 
 <div class="note">

--- a/files/en-us/web/api/request/json/index.html
+++ b/files/en-us/web/api/request/json/index.html
@@ -12,9 +12,9 @@ browser-compat: api.Request.json
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
-<p>The <strong><code>json()</code></strong> method of the {{DOMxRef("Request")}} interface takes
-  a {{DOMxRef("Request")}} stream and reads it to completion. It returns a promise which
-  resolves with a JavaScript object that is the result of parsing the body text as {{JSxRef("JSON")}}.</p>
+<p>The <strong><code>json()</code></strong> method of the {{domxref("Request")}} interface
+reads the request body and returns it as a promise that resolves with a
+JavaScript object that is the result of parsing the body text as {{JSxRef("JSON")}}.</p>
 
 <p>Note that despite the method being named <code>json()</code>, the result is not JSON but is instead the result of taking JSON as input and parsing it to produce a JavaScript object.</p>
 

--- a/files/en-us/web/api/request/json/index.html
+++ b/files/en-us/web/api/request/json/index.html
@@ -13,8 +13,7 @@ browser-compat: api.Request.json
 <div>{{APIRef("Fetch API")}}</div>
 
 <p>The <strong><code>json()</code></strong> method of the {{domxref("Request")}} interface
-reads the request body and returns it as a promise that resolves with a
-JavaScript object that is the result of parsing the body text as {{JSxRef("JSON")}}.</p>
+reads the request body and returns it as a promise that resolves with the result of parsing the body text as {{JSxRef("JSON")}}.</p>
 
 <p>Note that despite the method being named <code>json()</code>, the result is not JSON but is instead the result of taking JSON as input and parsing it to produce a JavaScript object.</p>
 

--- a/files/en-us/web/api/request/text/index.html
+++ b/files/en-us/web/api/request/text/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Request.text
 <div>{{APIRef("Fetch")}}</div>
 
 <p>The <strong><code>text()</code></strong> method of the {{domxref("Request")}} interface
-reads the request body and returns it as a promise that resolves with a {{domxref("USVString")}} object (text).
+reads the request body and returns it as a promise that resolves with a {{jsxref("String")}}.
 The response is <em>always</em> decoded using UTF-8.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -28,7 +28,7 @@ The response is <em>always</em> decoded using UTF-8.</p>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A Promise that resolves with a {{domxref("USVString")}}.</p>
+<p>A Promise that resolves with a {{jsxref("String")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/request/text/index.html
+++ b/files/en-us/web/api/request/text/index.html
@@ -12,10 +12,9 @@ browser-compat: api.Request.text
 ---
 <div>{{APIRef("Fetch")}}</div>
 
-<p>The <strong><code>text()</code></strong> method of the {{domxref("Request")}} interface takes
-  a {{domxref("Request")}} stream and reads it to completion. It returns a promise that
-  resolves with a {{domxref("USVString")}} object (text). The response
-  is <em>always</em> decoded using UTF-8.</p>
+<p>The <strong><code>text()</code></strong> method of the {{domxref("Request")}} interface
+reads the request body and returns it as a promise that resolves with a {{domxref("USVString")}} object (text).
+The response is <em>always</em> decoded using UTF-8.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -41,7 +40,7 @@ const request = new Request('/myEndpoint', {
   body: text
 });
 
-request.formData().then(function(text) {
+request.text().then(function(text) {
   // do something with the text sent in the request
 });
 </pre>

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -53,21 +53,21 @@ browser-compat: api.Response
 
 <dl>
  <dt>{{domxref("Response.arrayBuffer()")}}</dt>
- <dd>Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with an {{domxref("ArrayBuffer")}}.</dd>
+ <dd>Returns a promise that resolves with an {{domxref("ArrayBuffer")}} representation of the response body.</dd>
  <dt>{{domxref("Response.blob()")}}</dt>
- <dd>Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with a {{domxref("Blob")}}.</dd>
+ <dd>Returns a promise that resolves with a {{domxref("Blob")}} representation of the response body.</dd>
  <dt>{{domxref("Response.clone()")}}</dt>
  <dd>Creates a clone of a <code>Response</code> object.</dd>
  <dt>{{domxref("Response.error()")}}</dt>
  <dd>Returns a new <code>Response</code> object associated with a network error.</dd>
  <dt>{{domxref("Response.formData()")}}</dt>
- <dd>Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with a {{domxref("FormData")}} object.</dd>
+ <dd>Returns a promise that resolves with a {{domxref("FormData")}} representation of the response body.</dd>
  <dt>{{domxref("Response.json()")}}</dt>
- <dd>Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with the result of parsing the body text as {{jsxref("JSON")}}, which is a JavaScript value of datatype object, string, etc.</dd>
+ <dd>Returns a promise that resolves with a JavaScript object that is the result of parsing the response body text as {{jsxref("JSON")}}.</dd>
  <dt>{{domxref("Response.redirect()")}}</dt>
  <dd>Creates a new response with a different URL.</dd>
  <dt>{{domxref("Response.text()")}}</dt>
- <dd>Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with a {{domxref("USVString")}} (text).</dd>
+ <dd>Returns a promise that resolves with a {{domxref("USVString")}} (text) representation of the response body.</dd>
 </dl>
 
 

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -63,11 +63,11 @@ browser-compat: api.Response
  <dt>{{domxref("Response.formData()")}}</dt>
  <dd>Returns a promise that resolves with a {{domxref("FormData")}} representation of the response body.</dd>
  <dt>{{domxref("Response.json()")}}</dt>
- <dd>Returns a promise that resolves with a JavaScript object that is the result of parsing the response body text as {{jsxref("JSON")}}.</dd>
+ <dd>Returns a promise that resolves with the result of parsing the response body text as {{jsxref("JSON")}}.</dd>
  <dt>{{domxref("Response.redirect()")}}</dt>
  <dd>Creates a new response with a different URL.</dd>
  <dt>{{domxref("Response.text()")}}</dt>
- <dd>Returns a promise that resolves with a {{domxref("USVString")}} (text) representation of the response body.</dd>
+ <dd>Returns a promise that resolves with a text representation of the response body.</dd>
 </dl>
 
 

--- a/files/en-us/web/api/response/json/index.html
+++ b/files/en-us/web/api/response/json/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Response.json
 
 <p>The <strong><code>json()</code></strong> method of the {{DOMxRef("Response")}} interface takes
   a {{DOMxRef("Response")}} stream and reads it to completion. It returns a promise which
-  resolves with a JavaScript object that is the result of parsing the body text as {{JSxRef("JSON")}}.</p>
+  resolves with the result of parsing the body text as {{JSxRef("JSON")}}.</p>
 
 <p>Note that despite the method being named <code>json()</code>, the result is not JSON but is instead the result of taking JSON as input and parsing it to produce a JavaScript object.</p>
 

--- a/files/en-us/web/api/response/text/index.html
+++ b/files/en-us/web/api/response/text/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Response.text
 
 <p>The <strong><code>text()</code></strong> method of the {{domxref("Response")}} interface takes
   a {{domxref("Response")}} stream and reads it to completion. It returns a promise that
-  resolves with a {{domxref("USVString")}} object (text). The response
+  resolves with a {{jsxref("String")}}. The response
   is <em>always</em> decoded using UTF-8.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -29,7 +29,7 @@ browser-compat: api.Response.text
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A Promise that resolves with a {{domxref("USVString")}}.</p>
+<p>A Promise that resolves with a {{jsxref("String")}}.</p>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
The Request/Response docs are imprecise as noted in the review of https://github.com/mdn/content/pull/6455
This PR addresses the comments.

cc @foolip @sideshowbarker 