### PR TITLE
Adds a link to W3C counter-styles examples

### DIFF
--- a/files/en-us/web/css/@counter-style/index.html
+++ b/files/en-us/web/css/@counter-style/index.html
@@ -128,6 +128,10 @@ ul {
 
 <p>See more examples on the <a href="https://mdn.github.io/css-examples/counter-style-demo/">demo page</a>.</p>
 
+<h3>Ready-made counter styles</h3>
+
+<p>Find a collection of over 100 <code>counter-style</code> code snippets in the <a href="https://www.w3.org/TR/predefined-counter-styles/">Ready-made Counter Styles</a> document. This document provides counter styles that meet the needs of languages and cultures around the world.</p>
+
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}
@@ -135,12 +139,6 @@ ul {
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
-<h3 id="Quantum_CSS_notes">Quantum CSS notes</h3>
-
-<ul>
- <li>Gecko allowed <code>none</code> as a value of the <code>system</code> and <code>fallback</code> descriptors of <code>@counter-style</code>, which as per spec should result in an invalid at-rule. Firefox's new parallel CSS engine (also known as <a class="external external-icon" href="https://wiki.mozilla.org/Quantum">Quantum CSS</a> or <a class="external external-icon" href="https://wiki.mozilla.org/Quantum/Stylo">Stylo</a>, released in Firefox 57) fixed this ({{bug(1377414)}}).</li>
-</ul>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/@counter-style/index.html
+++ b/files/en-us/web/css/@counter-style/index.html
@@ -132,6 +132,8 @@ ul {
 
 <p>Find a collection of over 100 <code>counter-style</code> code snippets in the <a href="https://www.w3.org/TR/predefined-counter-styles/">Ready-made Counter Styles</a> document. This document provides counter styles that meet the needs of languages and cultures around the world.</p>
 
+<p>The <a href="https://r12a.github.io/app-counters/">Counter styles converter</a> pulls from this list to test and create copy and paste code for counter styles.</p>
+
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}


### PR DESCRIPTION
Fixes #6447 by adding this excellent list of counter-styles.

Also removed outdated Quantum notes.
