### PR TITLE
Updating padding logical properties

### DIFF
--- a/files/en-us/web/css/padding-block-end/index.html
+++ b/files/en-us/web/css/padding-block-end/index.html
@@ -36,11 +36,16 @@ padding-block-end: unset;
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>padding-block-end</code> property takes the same values as the {{cssxref("padding-left")}} property.</p>
+<dl>
+  <dt>{{cssxref("&lt;length&gt;")}}</dt>
+  <dd>The size of the padding as a fixed value. Must be nonnegative.</dd>
+  <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
+  <dd>The size of the padding as a percentage, relative to the <em>inline-size</em> of the containing block. Must be nonnegative.</dd>
+</dl>
 
 <h2 id="Description">Description</h2>
 
-<p>This property corresponds to the {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
+<p>The <code>padding-block-end</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the phsyical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
 
 <p>It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.</p>
 

--- a/files/en-us/web/css/padding-block-start/index.html
+++ b/files/en-us/web/css/padding-block-start/index.html
@@ -36,11 +36,16 @@ padding-block-start: unset;
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>padding-block-start</code> property takes the same values as the {{cssxref("padding-left")}} property.</p>
+<dl>
+  <dt>{{cssxref("&lt;length&gt;")}}</dt>
+  <dd>The size of the padding as a fixed value. Must be nonnegative.</dd>
+  <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
+  <dd>The size of the padding as a percentage, relative to the <em>inline-size</em> of the containing block. Must be nonnegative.</dd>
+</dl>
 
 <h2 id="Description">Description</h2>
 
-<p>This property corresponds to the {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
+<p>The <code>padding-block-start</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the phsyical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
 
 <p>It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.</p>
 

--- a/files/en-us/web/css/padding-block/index.html
+++ b/files/en-us/web/css/padding-block/index.html
@@ -11,6 +11,17 @@ browser-compat: css.properties.padding-block
 
 <p>The <strong><code>padding-block</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> defines the logical block start and end padding of an element, which maps to physical padding properties depending on the element's writing mode, directionality, and text orientation.</p>
 
+<h2 id="Constituent_properties">Constituent properties</h2>
+
+<p>This property is a shorthand for the following CSS properties:</p>
+
+<ul>
+ <li>{{cssxref("padding-block-end")}}</li>
+ <li>{{cssxref("padding-block-start")}}</li>
+</ul>
+
+<h2 id="Syntax">Syntax</h2>
+
 <pre class="brush:css no-line-numbers">/* &lt;length&gt; values */
 padding-block: 10px 20px;  /* An absolute length */
 padding-block: 1em 2em;   /* relative to the text size */
@@ -26,16 +37,7 @@ padding-block: revert;
 padding-block: unset;
 </pre>
 
-<h2 id="Constituent_properties">Constituent properties</h2>
-
-<p>This property is a shorthand for the following CSS properties:</p>
-
-<ul>
- <li>{{cssxref("padding-block-end")}}</li>
- <li>{{cssxref("padding-block-start")}}</li>
-</ul>
-
-<h2 id="Syntax">Syntax</h2>
+<p>The <code>padding-block</code> property may be specified with one or two values. If one value is given, it is used as the value for both {{cssxref("padding-block-start")}} and {{cssxref("padding-block-end")}}. If two values are given, the first is used for {{cssxref("padding-block-start")}} and the second for {{cssxref("padding-block-end")}}.</p>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/padding-inline-end/index.html
+++ b/files/en-us/web/css/padding-inline-end/index.html
@@ -37,11 +37,16 @@ padding-inline-end: unset;
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>padding-inline-end</code> property takes the same values as the {{cssxref("padding-left")}} property.</p>
+<dl>
+  <dt>{{cssxref("&lt;length&gt;")}}</dt>
+  <dd>The size of the padding as a fixed value. Must be nonnegative.</dd>
+  <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
+  <dd>The size of the padding as a percentage, relative to the <em>inline-size</em> of the containing block. Must be nonnegative.</dd>
+</dl>
 
 <h2 id="Description">Description</h2>
 
-<p>This property corresponds to the {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
+<p>The <code>padding-inline-end</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the phsyical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
 
 <p>It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other paddings of the element.</p>
 

--- a/files/en-us/web/css/padding-inline-start/index.html
+++ b/files/en-us/web/css/padding-inline-start/index.html
@@ -37,11 +37,16 @@ padding-inline-start: unset;
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>padding-inline-start</code> property takes the same values as the {{cssxref("padding-left")}} property.</p>
+<dl>
+  <dt>{{cssxref("&lt;length&gt;")}}</dt>
+  <dd>The size of the padding as a fixed value. Must be nonnegative.</dd>
+  <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
+  <dd>The size of the padding as a percentage, relative to the <em>inline-size</em> of the containing block. Must be nonnegative.</dd>
+</dl>
 
 <h2 id="Description">Description</h2>
 
-<p>This property corresponds to the {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
+<p>The <code>padding-inline-start</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the phsyical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
 
 <p>It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.</p>
 

--- a/files/en-us/web/css/padding-inline/index.html
+++ b/files/en-us/web/css/padding-inline/index.html
@@ -10,6 +10,17 @@ browser-compat: css.properties.padding-inline
 
 <p>The <strong><code>padding-inline</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> defines the logical inline start and end padding of an element, which maps to physical padding properties depending on the element's writing mode, directionality, and text orientation.</p>
 
+<h2 id="Constituent_properties">Constituent properties</h2>
+
+<p>This property is a shorthand for the following CSS properties:</p>
+
+<ul>
+  <li><a href="/en-US/docs/Web/CSS/padding-inline-end"><code>padding-inline-end</code></a></li>
+  <li><a href="/en-US/docs/Web/CSS/padding-inline-start"><code>padding-inline-start</code></a></li>
+ </ul>
+
+<h2 id="Syntax">Syntax</h2>
+
 <pre class="brush:css no-line-numbers">/* &lt;length&gt; values */
 padding-inline: 10px 20px;  /* An absolute length */
 padding-inline: 1em 2em;   /* relative to the text size */
@@ -25,20 +36,16 @@ padding-inline: revert;
 padding-inline: unset;
 </pre>
 
-<h2 id="Constituent_properties">Constituent properties</h2>
-
-<p>This property is a shorthand for the following CSS properties:</p>
-
-<ul>
- <li><a href="/en-US/docs/Web/CSS/padding-inline-end"><code>padding-inline-end</code></a></li>
- <li><a href="/en-US/docs/Web/CSS/padding-inline-start"><code>padding-inline-start</code></a></li>
-</ul>
-
-<h2 id="Syntax">Syntax</h2>
+<p>The <code>padding-inline</code> property may be specified with one or two values. If one value is given, it is used as the value for both {{cssxref("padding-inline-start")}} and {{cssxref("padding-inline-end")}}. If two values are given, the first is used for {{cssxref("padding-inline-start")}} and the second for {{cssxref("padding-inline-end")}}.</p>
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>padding-inline</code> property takes the same values as the {{cssxref("padding-left")}} property.</p>
+<dl>
+  <dt>{{cssxref("&lt;length&gt;")}}</dt>
+  <dd>The size of the padding as a fixed value. Must be nonnegative.</dd>
+  <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
+  <dd>The size of the padding as a percentage, relative to the <em>inline-size</em> of the containing block. Must be nonnegative.</dd>
+</dl>
 
 <h2 id="Description">Description</h2>
 


### PR DESCRIPTION
Fixes #6435 and #6309 

Given we had two issues about a very similar thing I have changed these pages. They now show the values rather than referring people to another padding property, which isn't especially useful and could be misleading.

If this is ok, then I will look at the other logical properties as I expect margin at least has the same issue. I've also reordered the shorthand pages to match other CSS pages. 