### PR TITLE
Clarify 'unsafe-hashes'

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.html
@@ -1,0 +1,229 @@
+---
+title: 'CSP: script-src'
+slug: Web/HTTP/Headers/Content-Security-Policy/script-src
+tags:
+  - CSP
+  - Content
+  - Content-Security-Policy
+  - Directive
+  - HTTP
+  - Reference
+  - Script
+  - Security
+  - script-src
+  - source
+browser-compat: http.headers.csp.Content-Security-Policy.script-src
+---
+<div>{{HTTPSidebar}}</div>
+
+<p>The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) <code><strong>script-src</strong></code> directive specifies valid sources for JavaScript. This includes not only URLs loaded directly into {{HTMLElement("script")}} elements, but also things like inline script event handlers (<code>onclick</code>) and <a href="/en-US/docs/Web/XSLT">XSLT stylesheets</a> which can trigger script execution.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">CSP version</th>
+   <td>1</td>
+  </tr>
+  <tr>
+   <th scope="row">Directive type</th>
+   <td>{{Glossary("Fetch directive")}}</td>
+  </tr>
+  <tr>
+   <th scope="row">{{CSP("default-src")}} fallback</th>
+   <td>Yes. If this directive is absent, the user agent will look for the <code>default-src</code> directive.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Syntax">Syntax</h2>
+
+<p>One or more sources can be allowed for the <code>script-src</code> policy:</p>
+
+<pre class="brush: html">Content-Security-Policy: script-src &lt;source&gt;;
+Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
+</pre>
+
+<h3 id="Sources">Sources</h3>
+
+<dl>
+  <dt>&lt;host-source&gt;</dt>
+  <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
+  Examples:
+  <ul>
+   <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
+   <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
+   <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
+   <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
+  </ul>
+  </dd>
+  <dt>&lt;scheme-source&gt;</dt>
+  <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
+  <ul>
+   <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
+   <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
+   <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
+   <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
+  </ul>
+  </dd>
+  <dt><code>'self'</code></dt>
+  <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
+  <dt><code>'unsafe-eval'</code></dt>
+  <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
+  <dt id="unsafe-hashes"><code>'unsafe-hashes'</code></dt>
+  <dd>
+  <p>Allows enabling specific inline <a href="/en-US/docs/Web/Guide/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</p>
+  <p>For every inline event-handler attribute in the document, you must generate a hash (base64 value) from the value of the attribute (that is, the complete code in attribute’s value), using a particular hash algorithm (e.g., <code>sha256</code>, <code>sha384</code> or <code>sha512</code>), and then add a <code>&lt;hash-algorithm&gt;-&lt;base64-value&gt;</code> source expression for that hash to the value of the <code>script-src</code> directive.</p>
+  </dd>
+  <dt><code>'unsafe-inline'</code></dt>
+  <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, and inline event handlers. The single quotes are required.</dd>
+  <dt><code>'none'</code></dt>
+  <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
+  <dt>'nonce-&lt;base64-value&gt;'</dt>
+  <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource’s policy is otherwise trivial. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
+  <div class="note">
+  <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g. as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
+  </div>
+  </dd>
+  <dt>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</dt>
+  <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
+ </dl>
+</div>
+
+<div id="strict-dynamic">
+<dl>
+ <dt>'strict-dynamic'</dt>
+ <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
+</dl>
+</div>
+
+<div id="report-sample">
+<dl>
+ <dt>'report-sample'</dt>
+ <dd>Requires a sample of the violating code to be included in the violation report.</dd>
+</dl>
+</div>
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Violation_case">Violation case</h3>
+
+<p>Given this CSP header:</p>
+
+<pre class="brush: bash">Content-Security-Policy: script-src https://example.com/</pre>
+
+<p>the following script is blocked and won't be loaded or executed:</p>
+
+<pre class="brush: html">&lt;script src="https://not-example.com/js/library.js"&gt;&lt;/script&gt;</pre>
+
+<p>Note that inline event handlers are blocked as well:</p>
+
+<pre class="brush: html">&lt;button id="btn" onclick="doSomething()"&gt;</pre>
+
+<p>You should replace them with {{domxref("EventTarget.addEventListener", "addEventListener")}} calls:</p>
+
+<pre class="brush: js">document.getElementById("btn").addEventListener('click', doSomething);</pre>
+
+<h3 id="Unsafe_inline_script">Unsafe inline script</h3>
+
+<div class="note">
+<p><strong>Note:</strong> Disallowing inline styles and inline scripts is one of the biggest security wins CSP provides. However, if you absolutely have to use it, there are a few mechanisms that will allow them.</p>
+</div>
+
+<p>To allow inline scripts and inline event handlers, <code>'unsafe-inline'</code>, a nonce-source or a hash-source that matches the inline block can be specified.</p>
+
+<pre class="brush: bash">Content-Security-Policy: script-src 'unsafe-inline';
+</pre>
+
+<p>The above Content Security Policy will allow inline {{HTMLElement("script")}} elements</p>
+
+<pre class="brush: html">&lt;script&gt;
+  var inline = 1;
+&lt;/script&gt;</pre>
+
+<p>You can use a nonce-source to only allow specific inline script blocks:</p>
+
+<pre class="brush: bash">Content-Security-Policy: script-src 'nonce-2726c7f26c'</pre>
+
+<p>You will have to set the same nonce on the {{HTMLElement("script")}} element:</p>
+
+<pre class="brush: html">&lt;script nonce="2726c7f26c"&gt;
+  var inline = 1;
+&lt;/script&gt;</pre>
+
+<p>Alternatively, you can create hashes from your inline scripts. CSP supports sha256, sha384 and sha512.</p>
+
+<pre class="brush: bash">Content-Security-Policy: script-src 'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='</pre>
+
+<p>When generating the hash, don't include the {{HTMLElement("script")}} tags and note that capitalization and whitespace matter, including leading or trailing whitespace.</p>
+
+<pre class="brush: html">&lt;script&gt;var inline = 1;&lt;/script&gt;</pre>
+
+<h3 id="Unsafe_eval_expressions">Unsafe eval expressions</h3>
+
+<p>The <code>'unsafe-eval'</code> source expression controls several script execution methods that create code from strings. If <code>'unsafe-eval'</code> isn't specified with the <code>script-src</code> directive, the following methods are blocked and won't have any effect:</p>
+
+<ul>
+ <li>{{jsxref("Global_Objects/eval", "eval()")}}</li>
+ <li>{{jsxref("Function", "Function()")}}</li>
+ <li>When passing a string literal like to methods like: <code>window.setTimeout("alert(\"Hello World!\");", 500);</code>
+  <ul>
+   <li>{{domxref("WindowOrWorkerGlobalScope.setTimeout")}}</li>
+   <li>{{domxref("WindowOrWorkerGlobalScope.setInterval")}}</li>
+   <li>{{domxref("window.setImmediate")}}</li>
+  </ul>
+ </li>
+ <li>{{domxref("window.execScript")}} {{non-standard_inline}} (IE &lt; 11 only)</li>
+</ul>
+
+<h3 id="examples-strict-dynamic">strict-dynamic</h3>
+
+<p>The <code>'strict-dynamic'</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any whitelist or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> will be ignored. For example, a policy such as <code>script-src 'strict-dynamic' 'nonce-R4nd0m' https://whitelisted.com/</code> would allow loading of a root script with <code>&lt;script nonce="R4nd0m" src="https://example.com/loader.js"&gt;</code> and propagate that trust to any script loaded by <code>loader.js</code>, but disallow loading scripts from <code>https://whitelisted.com/</code> unless accompanied by a nonce or loaded from a trusted script.</p>
+
+<pre class="brush: bash">script-src 'strict-dynamic' 'nonce-<em>someNonce</em>'</pre>
+
+<p><em>Or</em></p>
+
+<pre class="brush: bash">script-src 'strict-dynamic' 'sha256-<em>base64EncodedHash</em>'</pre>
+
+<p>It is possible to deploy <code>strict-dynamic</code> in a backwards compatible way, without requiring user-agent sniffing.<br>
+ The policy:</p>
+
+<pre class="brush: bash">script-src 'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'</pre>
+
+<p>will act like <code>'unsafe-inline' https:</code> in browsers that support CSP1, <code>https: 'nonce-abcdefg'</code> in browsers that support CSP2, and <code>'nonce-abcdefg' 'strict-dynamic'</code> in browsers that support CSP3.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{specName("CSP 3.0", "#directive-script-src", "script-src")}}</td>
+   <td>{{Spec2('CSP 3.0')}}</td>
+   <td>No changes.</td>
+  </tr>
+  <tr>
+   <td>{{specName("CSP 1.1", "#directive-script-src", "script-src")}}</td>
+   <td>{{Spec2('CSP 1.1')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{HTTPHeader("Content-Security-Policy")}}</li>
+ <li>{{HTMLElement("script")}}</li>
+ <li>{{CSP("script-src-elem")}}</li>
+ <li>{{CSP("script-src-attr")}}</li>
+</ul>


### PR DESCRIPTION
This commit adds a sentence to explain an extra action needed 
when using the 'unsafe-hashes' attribute.

The reason is this: The name 'unsafe-hashes' implies it has _something_
to do with hashes; but it does not give any clue about having to do
with "inline event handlers".  
The documentation does though, 
but the documention does not mention what should be hashed. It has
to be understood implicitly.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
