### PR TITLE
Capitalize url and make it a link to its glossary entry

### DIFF
--- a/files/en-us/glossary/preflight_request/index.html
+++ b/files/en-us/glossary/preflight_request/index.html
@@ -30,7 +30,7 @@ Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
 Access-Control-Max-Age: 86400
 </pre>
 
-<p>The preflight response can be optionally cached for the requests created in the same url using {{HTTPHeader("Access-Control-Max-Age")}} header like in the above example.</p>
+<p>The preflight response can be optionally cached for the requests created in the same {{Glossary("URL")}} using {{HTTPHeader("Access-Control-Max-Age")}} header like in the above example.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Fixes #6496 