### PR TITLE
Use better bcd keys for <transform-function> CSS functions

### DIFF
--- a/files/en-us/web/css/transform-function/matrix()/index.html
+++ b/files/en-us/web/css/transform-function/matrix()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.matrix
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/matrix3d()/index.html
+++ b/files/en-us/web/css/transform-function/matrix3d()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.matrix3d
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/perspective()/index.html
+++ b/files/en-us/web/css/transform-function/perspective()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.perspective
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/rotate()/index.html
+++ b/files/en-us/web/css/transform-function/rotate()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.rotate
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/rotate3d()/index.html
+++ b/files/en-us/web/css/transform-function/rotate3d()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.rotate3d
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/rotatex()/index.html
+++ b/files/en-us/web/css/transform-function/rotatex()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.rotateX
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/rotatey()/index.html
+++ b/files/en-us/web/css/transform-function/rotatey()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.rotateY
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/rotatez()/index.html
+++ b/files/en-us/web/css/transform-function/rotatez()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.rotateZ
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/scale()/index.html
+++ b/files/en-us/web/css/transform-function/scale()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.scale
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/scale3d()/index.html
+++ b/files/en-us/web/css/transform-function/scale3d()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.scale3d
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/scalex()/index.html
+++ b/files/en-us/web/css/transform-function/scalex()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.scaleX
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/scaley()/index.html
+++ b/files/en-us/web/css/transform-function/scaley()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.scaleY
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/scalez()/index.html
+++ b/files/en-us/web/css/transform-function/scalez()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.scaleZ
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/skew()/index.html
+++ b/files/en-us/web/css/transform-function/skew()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.skew
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/skewx()/index.html
+++ b/files/en-us/web/css/transform-function/skewx()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.skewX
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/skewy()/index.html
+++ b/files/en-us/web/css/transform-function/skewy()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.skewY
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/translate()/index.html
+++ b/files/en-us/web/css/transform-function/translate()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.translate
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/translate3d()/index.html
+++ b/files/en-us/web/css/transform-function/translate3d()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.translate3d
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/translatex()/index.html
+++ b/files/en-us/web/css/transform-function/translatex()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.translateX
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/translatey()/index.html
+++ b/files/en-us/web/css/transform-function/translatey()/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.translateY
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/transform-function/translatez()/index.html
+++ b/files/en-us/web/css/transform-function/translatez()/index.html
@@ -8,7 +8,7 @@ tags:
   - CSS Transforms
   - Function
   - Reference
-browser-compat: css.types.transform-function
+browser-compat: css.types.transform-function.translateZ
 ---
 <div>{{CSSRef}}</div>
 


### PR DESCRIPTION
This makes use of the new bcd keys introduced in mdn/browser-compat-data#11304.

This has to land after the bcd landed.