### PR TITLE
WASM errors aren't specced to have a message

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/index.html
@@ -26,7 +26,7 @@ browser-compat: javascript.builtins.WebAssembly.CompileError
 
 <dl>
  <dt>{{jsxref("Error.prototype.message", "WebAssembly.CompileError.prototype.message")}}</dt>
- <dd>Error message. Although ECMA-262 specifies that {{jsxref("URIError")}} should provide its own <code>message</code> property, in <a href="/en-US/docs/Mozilla/Projects/SpiderMonkey">SpiderMonkey</a>, it inherits {{jsxref("Error.prototype.message")}}.</dd>
+ <dd>Error message. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.name", "WebAssembly.CompileError.prototype.name")}}</dt>
  <dd>Error name. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.fileName", "WebAssembly.CompileError.prototype.fileName")}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/index.html
@@ -25,7 +25,7 @@ browser-compat: javascript.builtins.WebAssembly.LinkError
 
 <dl>
  <dt>{{jsxref("Error.prototype.message", "WebAssembly.LinkError.prototype.message")}}</dt>
- <dd>Error message. Although ECMA-262 specifies that {{jsxref("URIError")}} should provide its own <code>message</code> property, in <a href="/en-US/docs/Mozilla/Projects/SpiderMonkey">SpiderMonkey</a>, it inherits {{jsxref("Error.prototype.message")}}.</dd>
+ <dd>Error message. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.name", "WebAssembly.LinkError.prototype.name")}}</dt>
  <dd>Error name. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.fileName", "WebAssembly.LinkError.prototype.fileName")}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
@@ -25,7 +25,7 @@ browser-compat: javascript.builtins.WebAssembly.RuntimeError
 
 <dl>
  <dt>{{jsxref("Error.prototype.message", "WebAssembly.RuntimeError.prototype.message")}}</dt>
- <dd>Error message. Although ECMA-262 specifies that {{jsxref("URIError")}} should provide its own <code>message</code> property, in <a href="/en-US/docs/Mozilla/Projects/SpiderMonkey">SpiderMonkey</a>, it inherits {{jsxref("Error.prototype.message")}}.</dd>
+ <dd>Error message. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.name", "WebAssembly.RuntimeError.prototype.name")}}</dt>
  <dd>Error name. Inherited from {{jsxref("Error")}}.</dd>
  <dt>{{jsxref("Error.prototype.fileName", "WebAssembly.RuntimeError.prototype.fileName")}}</dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

All the WebAssembly errors incorrectly mention URIError instead of their own name, unlike other Error pages in MDN.

> Issue number (if there is an associated issue)



> Anything else that could help us review it

WebAssembly's errors also have a [simpler spec](https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror) that ECMAScript errors. As a result, I just removed the text about spec complance rather than fixing it.
