### PR TITLE
Update link to disabled attr in living standard

### DIFF
--- a/files/en-us/web/html/attributes/disabled/index.html
+++ b/files/en-us/web/html/attributes/disabled/index.html
@@ -117,7 +117,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', 'forms.html#attr-input-disabled', 'disabled attribute')}}</td>
+   <td>{{SpecName('HTML WHATWG', 'form-control-infrastructure.html#attr-fe-disabled', 'disabled attribute')}}</td>
    <td>{{Spec2('HTML WHATWG')}}</td>
    <td></td>
   </tr>


### PR DESCRIPTION
The current link (https://html.spec.whatwg.org/multipage/forms.html#attr-input-disabled) does not point to an anchor that exists on the page. The term 'disabled' does not appear within `forms.html` at all.

I think the correct destination should be https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled.

I think this has been incorrect since the multipage splitting was changed in https://github.com/whatwg/html/pull/2552 when `forms.html` was split up and `form-control-infrastructure.html` was introduced.