### PR TITLE
Improve spec messages of ref pages of the deprecated WebVR API

### DIFF
--- a/files/en-us/web/api/navigator/activevrdisplays/index.html
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.html
@@ -21,6 +21,10 @@ browser-compat: api.Navigator.activeVRDisplays
   {{domxref("VRDisplay")}} object that is currently presenting
   ({{domxref("VRDisplay.ispresenting")}} is <code>true</code>).</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre
@@ -42,7 +46,8 @@ browser-compat: api.Navigator.activeVRDisplays
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.cancelAnimationFrame
 
 <p>The <code><strong>cancelAnimationFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface is a special implementation of {{domxref("Window.cancelAnimationFrame")}} that unregisters callbacks registered with {{domxref("VRDisplay.requestAnimationFrame()")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">vrDisplayInstance.cancelAnimationFrame(<em>handle</em>);
@@ -99,7 +103,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.capabilities
 
 <p>The <strong><code>capabilities</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRDisplayCapabilities")}} object that indicates the various capabilities of the <code>VRDisplay</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myCapabilities = vrDisplayInstance.capabilities;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRDisplay.capabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthfar/index.html
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.depthFar
 
 <p>The <code><strong>depthFar</strong></code> property of the {{domxref("VRDisplay")}} interface gets and sets the z-depth defining the far plane of the <a href="https://en.wikipedia.org/wiki/Viewing_frustum">eye view frustum</a>, i.e. the furthest viewable boundary of the scene.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>Generally you should leave the value as is, but you might want to reduce it if you are trying to improve performance on slower computers.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -42,7 +46,8 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthnear/index.html
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.depthNear
 
 <p>The <code><strong>depthNear</strong></code> property of the {{domxref("VRDisplay")}} interface gets and sets the z-depth defining the near plane of the <a href="https://en.wikipedia.org/wiki/Viewing_frustum">eye view frustum</a>, i.e. the nearest viewable boundary of the scene.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>Generally you should leave the value as is, but you might want to increase it if you are trying to improve performance on slower computers, and/or your UI makes sense with the near boundary made further away.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -42,7 +46,8 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.displayId
 
 <p>The <strong><code>displayId</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns an identifier for this particular <code>VRDisplay</code>, which is also used as an association point in the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a> (see {{domxref("Gamepad.displayId")}}).</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myDisplayID = vrDisplayInstance.displayId;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRDisplay.displayId
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.displayName
 
 <p>The <strong><code>displayName</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns a human-readable name to identify the <code>VRDisplay</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This will generally be something like "Oculus VR HMD (HMD)" or "Oculus VR HMD (Sensor)".</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VRDisplay.displayName
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.exitPresent
 
 <p>The <code><strong>exitPresent()</strong></code> method of the {{domxref("VRDisplay")}} interface stops the <code>VRDisplay</code> presenting a scene.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">vrDisplayInstance.exitPresent().then(function() {
@@ -83,7 +87,8 @@ browser-compat: api.VRDisplay.exitPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.getEyeParameters
 
 <p>The <code><strong>getEyeParameters()</strong></code> method of the {{domxref("VRDisplay")}} interface returns the {{domxref("VREyeParameters")}} object containing the eye parameters for the specified eye.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myEyeParameters = vrDisplayInstance.getEyeParameters(<em>whichEye</em>);
@@ -39,7 +43,8 @@ browser-compat: api.VRDisplay.getEyeParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.getFrameData
 
 <p>The <code><strong>getFrameData()</strong></code> method of the {{domxref("VRDisplay")}} interface accepts a {{domxref("VRFrameData")}} object and populates it with the information required to render the current frame.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This includes the {{domxref("VRPose")}} and view and projection matrices for the current frame.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -103,7 +107,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplay.getImmediatePose
 
 <p>The <code><strong>getImmediatePose()</strong></code> method of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRPose")}} object defining the current pose of the <code>VRDisplay</code>, with no prediction applied.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myImmediatePose = vrDisplayInstance.getImmediatePose();
@@ -31,9 +35,10 @@ browser-compat: api.VRDisplay.getImmediatePose
 
 <p>A {{domxref("VRPose")}} object.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<pre>TBD.</pre>
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.getLayers
 
 <p>The <code><strong>getLayers()</strong></code> method of the {{domxref("VRDisplay")}} interface returns the layers currently being presented by the <code>VRDisplay</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myLayers = vrDisplayInstance.getLayers();
@@ -36,7 +40,8 @@ browser-compat: api.VRDisplay.getLayers
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/getpose/index.html
+++ b/files/en-us/web/api/vrdisplay/getpose/index.html
@@ -18,7 +18,10 @@ browser-compat: api.VRDisplay.getPose
 
 <p>The <code><strong>getPose()</strong></code> method of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRPose")}} object defining the future predicted pose of the <code>VRDisplay</code> as it will be when the current frame is actually presented.</p>
 
-<p>This method is deprecated — instead, you should use {{domxref("VRDisplay.getFrameData()")}}, which also provides a {{domxref("VRPose")}} object.</p>
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+  <p>It was evendeprecated there — instead, you should use {{domxref("VRDisplay.getFrameData()")}}, which also provides a {{domxref("VRPose")}} object.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -59,7 +62,8 @@ browser-compat: api.VRDisplay.getPose
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
+++ b/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplay.hardwareUnitId
 
 <p>The <strong><code>hardwareUnitId</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns the distinct hardware ID for the overall hardware unit that this <code>VRDevice</code> is a part of. All devices that are part of the same physical piece of hardware will have the same <code>hardwareUnitId</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var hardwareID = VRDevice.hardwareUnitId;</pre>
@@ -51,6 +55,11 @@ function reportDevices(devices) {
     list.appendChild(listItem);
   }
 }</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplay
 
 <p>The <strong><code>VRDisplay</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents any VR device supported by this API. It includes generic information such as device IDs and descriptions, as well as methods for starting to present a VR scene, retrieving eye parameters and display capabilities, and other important functionality.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>An array of all connected VR Devices can be returned by invoking the {{domxref("Navigator.getVRDisplays()")}} method.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -91,7 +95,8 @@ browser-compat: api.VRDisplay
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#interface-vrdisplay">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplay.isConnected
 
 <p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var isItConnected = vrDisplayInstance.isConnected;
@@ -50,7 +54,8 @@ browser-compat: api.VRDisplay.isConnected
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.isPresenting
 
 <p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var isItPresenting = vrDisplayInstance.isPresenting;
@@ -51,7 +55,8 @@ browser-compat: api.VRDisplay.isPresenting
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.requestAnimationFrame
 
 <p>The <code><strong>requestAnimationFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface is a special implementation of {{domxref("Window.requestAnimationFrame")}} containing a callback function that will be called every time a new frame of the <code>VRDisplay</code> presentation is rendered:</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <ul>
  <li>When the <code>VRDisplay</code> is not presenting a scene, this is functionally equivalent to {{domxref("Window.requestAnimationFrame")}}.</li>
  <li>When the <code>VRDisplay</code> is presenting, the callback is called at its native refresh rate.</li>
@@ -105,7 +109,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.requestPresent
 
 <p>The <code><strong>requestPresent()</strong></code> method of the {{domxref("VRDisplay")}} interface starts the <code>VRDisplay</code> presenting a scene.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">vrDisplayInstance.requestPresent(<em>layers</em>).then(function() {
@@ -93,7 +97,8 @@ browser-compat: api.VRDisplay.requestPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/resetpose/index.html
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplay.resetPose
 
 <p>The <code><strong>resetPose()</strong></code> method of the {{domxref("VRDisplay")}} interface resets the pose for the <code>VRDisplay</code>, treating its current {{domxref("VRPose.position")}} and {{domxref("VRPose.orientation")}} as the "origin/zero" values.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>After <code>resetPost()</code> has been called, future poses returned from {{domxref("VRDisplay.getPose()")}}/{{domxref("VRDisplay.getImmediatePose()")}} will describe positions relative to the <code>VRDisplay</code>'s position when <code>resetPose()</code> was last called and will treat the display’s yaw when <code>resetPose()</code> was last called as the forward orientation.</p>
 
 <p>The VRDisplay's reported roll and pitch do not change when <code>resetPose()</code> is called as they are relative to gravity. Calling <code>resetPose()</code> may change the {{domxref("VRStageParameters.sittingToStandingTransform")}} matrix.</p>
@@ -47,7 +51,8 @@ btn.addEventListener('click', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.stageParameters
 
 <p>The <code><strong>stageParameters</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRStageParameters")}} object containing room-scale parameters, if the <code>VRDisplay</code> is capable of supporting room-scale experiences.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myStageParameters = vrDisplayInstance.stageParameters;
@@ -32,7 +36,8 @@ browser-compat: api.VRDisplay.stageParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.html
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplay.submitFrame
 
 <p>The <code><strong>submitFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface captures the current state of the {{domxref("VRLayerInit")}} currently being presented and displays it on the <code>VRDisplay</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The frame should subsequently be rendered using the {{domxref("VRPose")}} and matrices provided by the last call to {{domxref("getFrameData()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -99,7 +103,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This method was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 
 <p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This is useful for identifying "magic window" devices that are capable of 6DoF tracking but for which {{domxref("VRDisplay.requestPresent()")}} is not meaningful. If <code>canPresent</code> is <code>false</code>, calls to {{domxref("VRDisplay.requestPresent()")}} will fail, and {{domxref("VRDisplay.getEyeParameters()")}} will return <code>null</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -15,6 +15,10 @@ browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The <strong><code>hasExternalDisplay</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display is separate from the device's primary display.</p>
 
 <div class="note">
@@ -35,7 +39,8 @@ browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRDisplayCapabilities.hasOrientation
 
 <p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display can track and return orientation information.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var hasItGotOrientation = vrDisplayCapabilitiesInstance.hasOrientation;</pre>
@@ -32,7 +36,8 @@ browser-compat: api.VRDisplayCapabilities.hasOrientation
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplayCapabilities.hasPosition
 
 <p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns <code>true</code> if the VR display can track and return position information.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var hasItGotPosition = vrDisplayCapabilitiesInstance.hasPosition;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRDisplayCapabilities.hasPosition
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRDisplayCapabilities
 
 <p>The <strong><code>VRDisplayCapabilities</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> describes the capabilities of a {{domxref("VRDisplay")}} — its features can be used to perform VR device capability tests, for example can it return position information.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This interface is accessible through the {{domxref("VRDisplay.capabilities")}} property.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -56,7 +60,8 @@ browser-compat: api.VRDisplayCapabilities
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplayCapabilities.maxLayers
 
 <p>The <strong><code>maxLayers</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("Display.requestPresent()")}} can accept.)</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var maximumLayers = vrDisplayCapabilitiesInstance.maxLayers;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRDisplayCapabilities.maxLayers
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplayEvent.display
 
 <p>The <strong><code>display</code></strong> read-only property of the {{domxref("VRDisplayEvent")}} interface returns the {{domxref("VRDisplay")}} associated with this event.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myDisplay = vrDisplayEventInstance.display;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRDisplayEvent.display
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRDisplayEvent
 
 <p>The <strong><code>VRDisplayEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the event object of WebVR-related events (see the<a href="/en-US/docs/Web/API/WebVR_API#window"> list of WebVR window extensions</a>).</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
@@ -43,7 +47,8 @@ browser-compat: api.VRDisplayEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRDisplayEvent.reason
 
 <p>The <strong><code>reason</code></strong> read-only property of the {{domxref("VRDisplayEvent")}} interface returns a human-readable reason why the event was fired.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myReason = vrDisplayEventInstance.reason;</pre>
@@ -38,7 +42,8 @@ browser-compat: api.VRDisplayEvent.reason
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -14,7 +14,11 @@ browser-compat: api.VRDisplayEvent.VRDisplayEvent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The {{domxref("VRDisplayEvent")}} constructor creates a <code>VRDisplayEvent</code> object instance.</p>
+<p>The {{domxref("VRDisplayEvent()")}} constructor creates a <code>VRDisplayEvent</code> object instance.</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -45,7 +49,8 @@ browser-compat: api.VRDisplayEvent.VRDisplayEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: VRDisplayEvent.VRDisplayEvent()
+title: VRDisplayEvent()
 slug: Web/API/VRDisplayEvent/VRDisplayEvent
 tags:
   - API
@@ -14,7 +14,7 @@ browser-compat: api.VRDisplayEvent.VRDisplayEvent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The {{domxref("VRDisplayEvent()")}} constructor creates a <code>VRDisplayEvent</code> object instance.</p>
+<p>The <strong><code>VRDisplayEvent()</code></strong> constructor creates a {{domxref("VRDisplayEvent")}} object instance.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VREyeParameters.fieldOfView
 
 <p>The <strong><code>fieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface returns a {{domxref("VRFieldOfView")}} object <dfn>describing t</dfn>he current field of view for the eye, which can vary as the user adjusts their interpupillary distance (IPD).</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myFOV = eyeParametersInstance.fieldOfView;</pre>
@@ -32,7 +36,8 @@ browser-compat: api.VREyeParameters.fieldOfView
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VREyeParameters
 
 <p>The <strong><code>VREyeParameters</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents all the information required to correctly render a scene for a given eye, including field of view information.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This interface is accessible through the {{domxref("VRDisplay.getEyeParameters()")}} method.</p>
 
 <div class="warning">
@@ -62,7 +66,8 @@ browser-compat: api.VREyeParameters
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VREyeParameters.maximumFieldOfView
 
 <p>The <strong><code>maximumFieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the maximum supported field of view for the current eye.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var maxFOV = myEyeParameters.maximumFieldOfView;</pre>
@@ -26,9 +30,10 @@ browser-compat: api.VREyeParameters.maximumFieldOfView
 
 <p>A {{domxref("VRFieldOfView")}} object.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<p>TBD</p>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VREyeParameters.minimumFieldOfView
 
 <p>The <strong><code>minimumFieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the minimum supported field of view for the current eye.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var minFOV = myEyeParameters.minimumFieldOfView;</pre>
@@ -26,9 +30,10 @@ browser-compat: api.VREyeParameters.minimumFieldOfView
 
 <p>A {{domxref("VRFieldOfView")}} object.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<p>TBD</p>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VREyeParameters.offset
 
 <p>The <strong><code>offset</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface <dfn>r</dfn><dfn>epresents the o</dfn>ffset from the center point between the user's eyes to the center of the eye, measured in meters.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This value should represent half the user’s interpupillary distance (IPD), but may also represent the distance from the center point of the headset to the center point of the lens for the given eye.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -37,7 +41,8 @@ browser-compat: api.VREyeParameters.offset
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VREyeParameters.recommendedFieldOfView
 
 <p>The <strong><code>recommendedFieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended field of view for the current eye — ideally based on user calibration.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var recFOV = myEyeParameters.recommendedFieldOfView;</pre>
@@ -45,6 +49,11 @@ browser-compat: api.VREyeParameters.recommendedFieldOfView
   ...
 
 }</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VREyeParameters.renderHeight
 
 <p>The <strong><code>renderHeight</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended render target height of each eye viewport, in pixels.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This is already in device pixel units, so there's no need to multiply by <a href="/en-US/docs/Web/API/Window/devicePixelRatio">Window.devicePixelRatio</a> before setting to <a href="/en-US/docs/Web/API/HTMLCanvasElement/height">HTMLCanvasElement.height.</a></p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VREyeParameters.renderHeight
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VREyeParameters.renderRect
 
 <p>The <code><strong>renderRect</strong></code> read-only property of the {{domxref("VREyeParameters")}} interface <dfn>specifies</dfn> the viewport of a canvas into which visuals for the current eye should be rendered.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myRenderRect = MyEyeParameters.renderRect;</pre>
@@ -26,9 +30,10 @@ browser-compat: api.VREyeParameters.renderRect
 
 <p>A {{domxref("DOMRect")}} object.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<p>TBD</p>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VREyeParameters.renderWidth
 
 <p>The <strong><code>renderWidth</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended render target width of each eye viewport, in pixels.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This is already in device pixel units, so there's no need to multiply by <a href="/en-US/docs/Web/API/Window/devicePixelRatio">Window.devicePixelRatio</a> before setting to <a href="/en-US/docs/Web/API/HTMLCanvasElement/width">HTMLCanvasElement.width.</a></p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VREyeParameters.renderWidth
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFieldOfView.downDegrees
 
 <p>The <strong><code>downDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees downwards that the field of view extends in.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myDownDegrees = VRFieldOfView.downDegrees;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRFieldOfView.downDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRFieldOfView
 
 <p>The <strong><code>VRFieldOfView</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a field of view defined by 4 different degree values describing the view from a center point.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Properties">Properties</h2>
 
 <dl>
@@ -80,7 +84,8 @@ function reportFieldOfView() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFieldOfView.leftDegrees
 
 <p>The <strong><code>leftDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the left that the field of view extends in.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myLeftDegrees = VRFieldOfView.leftDegrees;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRFieldOfView.leftDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFieldOfView.rightDegrees
 
 <p>The <strong><code>rightDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the right that the field of view extends in.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myRightDegrees = VRFieldOfView.rightDegrees;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRFieldOfView.rightDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFieldOfView.upDegrees
 
 <p>The <strong><code>upDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees upwards that the field of view extends in.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myUpDegrees = VRFieldOfView.upDegrees;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRFieldOfView.upDegrees
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRFieldOfView.VRFieldOfView
 
 <p>The <strong><code>VRFieldOfView()</code></strong> constructor creates a new {{domxref("VRFieldOFView")}} object.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <p>There are two forms of this constructor, which take their information in slightly different ways. The first one accepts four separate arguments — the {{domxref("VRFieldOfView.upDegrees")}}, {{domxref("VRFieldOfView.rightDegrees")}}, {{domxref("VRFieldOfView.downDegrees")}}, and {{domxref("VRFieldOfView.leftDegrees")}} values you want the field of view to have</p>
@@ -74,6 +78,11 @@ var myFOV = new VRFieldOfView(init);</pre>
 <div class="note">
 <p><strong>Note</strong>: When testing, setting a weird/tiny field of view can really mess up your view. It is a good idea to grab the current field of view first (using {{domxref("VREyeParameters.fieldOfView")}}) before making any drastic changes, so you can reset it afterwards if needed.</p>
 </div>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -1,5 +1,5 @@
 ---
-title: VRFieldOfView.VRFieldOfView()
+title: VRFieldOfView()
 slug: Web/API/VRFieldOfView/VRFieldOfView
 tags:
   - API
@@ -12,8 +12,6 @@ tags:
   - WebVR
 browser-compat: api.VRFieldOfView.VRFieldOfView
 ---
-<p>{{deprecated_header}}</p>
-
 <p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>VRFieldOfView()</code></strong> constructor creates a new {{domxref("VRFieldOFView")}} object.</p>

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRFrameData
 
 <p>The <strong><code>VRFrameData</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents all the information needed to render a single frame of a VR scene; constructed by {{domxref("VRDisplay.getFrameData()")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
@@ -46,7 +50,8 @@ browser-compat: api.VRFrameData
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 
 <p>The <strong><code>leftProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix4fv")}} function.</p>
 
 <div class="warning">
@@ -37,7 +41,8 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.leftViewMatrix
 
 <p>The <strong><code>leftViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix4fv")}} function.</p>
 
 <div class="warning">
@@ -37,7 +41,8 @@ browser-compat: api.VRFrameData.leftViewMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.pose
 
 <p>The <strong><code>pose</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns the {{domxref("VRPose")}} of the {{domxref("VRDisplay")}} at the current {{domxref("VRFrameData.timestamp")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myPose = vrFrameDataInstance.pose;</pre>
@@ -31,7 +35,8 @@ browser-compat: api.VRFrameData.pose
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 
 <p>The <strong><code>rightProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix4fv")}} function.</p>
 
 <div class="warning">
@@ -37,7 +41,8 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.rightViewMatrix
 
 <p>The <strong><code>rightViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix4fv")}} function.</p>
 
 <div class="warning">
@@ -37,7 +41,8 @@ browser-compat: api.VRFrameData.rightViewMatrix
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/timestamp/index.html
+++ b/files/en-us/web/api/vrframedata/timestamp/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRFrameData.timestamp
 
 <p>The <strong><code>timestamp</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a constantly increasing timestamp value representing the time a frame update occurred.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>Timestamps are useful for determining if position state data has been updated from the hardware. Since values are monotonically increasing, they can be compared to determine the ordering of updates — newer values will always be greater than or equal to older values.</p>
 
 <p>The timestamp starts at 0 the first time {{domxref("VRDisplay.getFrameData()")}} is invoked for a given {{domxref("VRDisplay")}}.</p>
@@ -65,7 +69,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -1,5 +1,5 @@
 ---
-title: VRFrameData.VRFrameData()
+title: VRFrameData()
 slug: Web/API/VRFrameData/VRFrameData
 tags:
   - API
@@ -14,7 +14,7 @@ browser-compat: api.VRFrameData.VRFrameData
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The {{domxref("VRFrameData")}} constructor creates a <code>VRFrameData</code> object instance.</p>
+<p>The <strong><code>VRFrameData()</code></strong> constructor creates a {{domxref("VRFrameData")}} object instance.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRFrameData.VRFrameData
 
 <p>The {{domxref("VRFrameData")}} constructor creates a <code>VRFrameData</code> object instance.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myFrameData = new VRFrameData();</pre>
@@ -30,7 +34,8 @@ browser-compat: api.VRFrameData.VRFrameData
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This constructor was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRLayerInit
 
 <p>The <strong><code>VRLayerInit</code></strong> interface (dictionary) of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a content layer (an {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}) that you want to present in a VR display.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>You can retrieve <code>VRLayerInit</code> objects using {{domxref("VRDisplay.getLayers()")}}, and present them using the {{domxref("VRDisplay.requestPresent()")}} method.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -72,7 +76,8 @@ if(navigator.getVRDisplays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -15,10 +15,10 @@ browser-compat: api.VRLayerInit
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>VRLayerInit</code></strong> interface (dictionary) of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a content layer (an {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}) that you want to present in a VR display.</p>
+<p>The <strong><code>VRLayerInit</code></strong> dictionary of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a content layer (an {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}) that you want to present in a VR display.</p>
 
 <div class="notepad note">
-  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+  <p><strong>Note:</strong> This dictionary was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
 <p>You can retrieve <code>VRLayerInit</code> objects using {{domxref("VRDisplay.getLayers()")}}, and present them using the {{domxref("VRDisplay.requestPresent()")}} method.</p>
@@ -76,7 +76,7 @@ if(navigator.getVRDisplays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>This dictionary was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRLayerInit.leftBounds
 
 <p>The <code><strong>leftBounds</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the left texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myVRLayerInit = { };
@@ -41,7 +45,8 @@ myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRLayerInit.rightBounds
 
 <p>The <code><strong>rightBounds</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the right texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myVRLayerInit = { };
@@ -41,7 +45,8 @@ myVRLayerInit.rightBounds = [0.5, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRLayerInit.source
 
 <p>The <code><strong>source</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myVRLayerInit = { };
@@ -32,7 +36,8 @@ myVRLayerInit.source = myCanvas;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.angularAcceleration
 
 <p>The <strong><code>angularAcceleration</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the angular acceleration vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>In other words, the current acceleration of the sensor's rotation around the <code>x</code>, <code>y</code>, and <code>z</code> axes.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -54,7 +58,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.angularVelocity
 
 <p>The <strong><code>angularVelocity</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the angular velocity vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in radians per second.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>In other words, the current velocity at which the sensor is rotating around the <code>x</code>, <code>y</code>, and <code>z</code> axes.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -54,7 +58,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/hasorientation/index.html
+++ b/files/en-us/web/api/vrpose/hasorientation/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRPose.hasOrientation
 
 <p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("VRPose")}} interface returns a boolean indicating whether the {{domxref("VRPose.orientation")}} property is valid (i.e. if the hardware is currently registering a valid orientation). If it is <code>false</code>, the orientation property will return <code>null</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myHasOrientation = VRPositionState.hasOrientation;</pre>
@@ -26,9 +30,10 @@ browser-compat: api.VRPose.hasOrientation
 
 <p>A {{domxref("Boolean")}}.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<pre>TBD.</pre>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/hasposition/index.html
+++ b/files/en-us/web/api/vrpose/hasposition/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRPose.hasPosition
 
 <p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("VRPose")}} interface returns a boolean indicating whether the {{domxref("VRPose.position")}} property is valid (i.e. if the hardware is currently registering a valid position). If it is <code>false</code>, the <code>position</code> property will return <code>null</code>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var myHasPosition = VRPositionState.hasPosition;</pre>
@@ -26,9 +30,10 @@ browser-compat: api.VRPose.hasPosition
 
 <p>A {{domxref("Boolean")}}.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<pre>TBD.</pre>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRPose
 
 <p>The <strong><code>VRPose</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the state of a VR sensor at a given timestamp (which includes orientation, position, velocity, and acceleration information.)</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This interface is accessible through the {{domxref("VRDisplay.getPose()")}} and {{domxref("VRDisplay.getFrameData()")}} methods. {{domxref("VRDisplay.getPose()")}} is deprecated.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -48,7 +52,8 @@ browser-compat: api.VRPose
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.linearAcceleration
 
 <p>The <strong><code>linearAcceleration</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the linear acceleration vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>In other words, the current acceleration of the sensor, along the <code>x</code>, <code>y</code>, and <code>z</code> axes.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -54,7 +58,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.linearVelocity
 
 <p>The <strong><code>linearVelocity</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the linear velocity vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>In other words, the current velocity at which the sensor is moving along the <code>x</code>, <code>y</code>, and <code>z</code> axes.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -54,7 +58,8 @@ function drawVRScene() {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.orientation
 
 <p>The <strong><code>orientation</code></strong> read-only property of the {{domxref("VRPose")}} interface returns the orientation of the sensor at the current {{domxref("VRPose.timestamp")}}, as a quarternion value.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The value is a {{domxref("Float32Array")}}, made up of the following values:</p>
 
 <ul>
@@ -46,7 +50,8 @@ browser-compat: api.VRPose.orientation
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRPose.position
 
 <p>The <strong><code>position</code></strong> read-only property of the {{domxref("VRPose")}} interface returns the position of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}} as a 3D vector.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The coordinate system is as follows:</p>
 
 <ul>
@@ -49,7 +53,8 @@ browser-compat: api.VRPose.position
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrpose/timestamp/index.html
+++ b/files/en-us/web/api/vrpose/timestamp/index.html
@@ -18,6 +18,10 @@ browser-compat: api.VRPose.timestamp
 
 <p>The <strong><code>timestamp</code></strong> read-only property of the {{domxref("VRPose")}} interface returns the current time stamp of the system — a monotonically increasing value representing the time since the current app was started.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This property is useful for determining if position data has been updated, and what order updates have occurred in.</p>
 
 <div class="warning">
@@ -32,9 +36,10 @@ browser-compat: api.VRPose.timestamp
 
 <p>A {{domxref("DOMHighResTimeStamp")}} representing the timestamp, in seconds.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<pre>TBD.</pre>
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -16,6 +16,10 @@ browser-compat: api.VRStageParameters
 
 <p>The <strong><code>VRStageParameters</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the values describing the stage area for devices that support room-scale experiences.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>This interface is accessible through the {{domxref("VRDisplay.stageParameters")}} property.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -51,7 +55,8 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRStageParameters.sittingToStandingTransform
 
 <p>The <strong><code>sittingToStandingTransform</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface contains a matrix that transforms the sitting-space view matrices of {{domxref("VRFrameData")}} to standing-space.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>Basically, this can be passed into your WebGL code to transform the rendered view from a sitting to standing view.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VRStageParameters.sittingToStandingTransform
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRStageParameters.sizeX
 
 <p>The <strong><code>sizeX</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface <dfn>returns the w</dfn>idth of the play-area bounds in meters.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The bounds are defined as an axis-aligned rectangle on the floor, for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle. The center of the rectangle is at (0,0,0) in standing-space coordinates.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VRStageParameters.sizeX
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -17,6 +17,10 @@ browser-compat: api.VRStageParameters.sizeY
 
 <p>The <strong><code>sizeY</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface <dfn>returns the depth</dfn> of the play-area bounds in meters.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The bounds are defined as an axis-aligned rectangle on the floor, for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle. The center of the rectangle is at (0,0,0) in standing-space coordinates.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -33,7 +37,8 @@ browser-compat: api.VRStageParameters.sizeY
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/index.html
@@ -144,25 +144,9 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("GamepadExtensions")}}</td>
-   <td>{{Spec2("GamepadExtensions")}}</td>
-   <td>Defines the <a href="/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions">Experimental Gamepad extensions</a>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebVR 1.1")}}</td>
-   <td>{{Spec2("WebVR 1.1")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>This API was specified in the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
@@ -17,8 +17,8 @@ tags:
 
 <p class="summary">The WebVR API is a fantastic addition to the web developer's toolkit, allowing WebGL scenes to be presented in virtual reality displays such as the Oculus Rift and HTC Vive. But how do you get started with developing VR apps for the Web? This article will guide you through the basics.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The WebVR API's most stable version — 1.1 — has recently been implemented in Firefox 55 (Windows in release version, and Mac OS X on Nightly only) and is also available in Chrome when used with Google Daydream hardware. There is also a later evolution of the spec — 2.0 — but this is at an early stage right now. You can find information on the latest state of the specs at <a href="https://w3c.github.io/webvr/">WebVR Spec Version List</a>.</p>
+<div class="notepad note">
+  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
 <h2 id="Getting_started">Getting started</h2>

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
@@ -13,13 +13,9 @@ tags:
 ---
 <div>{{APIRef("WebVR API")}}{{deprecated_header}}</div>
 
-<div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
+<div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 
 <p class="summary">The WebVR API is a fantastic addition to the web developer's toolkit, allowing WebGL scenes to be presented in virtual reality displays such as the Oculus Rift and HTC Vive. But how do you get started with developing VR apps for the Web? This article will guide you through the basics.</p>
-
-<div class="notepad note">
-  <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
-</div>
 
 <h2 id="Getting_started">Getting started</h2>
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
@@ -15,9 +15,7 @@ tags:
 
 <p class="summary">Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a>, and specifically the <a href="/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions">Gamepad Extensions API</a> that adds API features for accessing <a href="/en-US/docs/Web/API/GamepadPose">controller pose</a>, <a href="/en-US/docs/Web/API/GamepadHapticActuator">haptic actuators</a>, and more. This article explains the basics.</p>
 
-<div class="notepad note">
-  <p><strong>Note:</strong> This API was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
-</div>
+<div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 
 <h2 id="The_WebVR_API">The WebVR API</h2>
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
@@ -15,6 +15,10 @@ tags:
 
 <p class="summary">Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a>, and specifically the <a href="/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions">Gamepad Extensions API</a> that adds API features for accessing <a href="/en-US/docs/Web/API/GamepadPose">controller pose</a>, <a href="/en-US/docs/Web/API/GamepadHapticActuator">haptic actuators</a>, and more. This article explains the basics.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This API was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <h2 id="The_WebVR_API">The WebVR API</h2>
 
 <p>The <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is a nascent, but very interesting new feature of the web platform that allows developers to create web-based virtual reality experiences. It does this by providing access to VR headsets connected to your computer as {{domxref("VRDisplay")}} objects, which can be manipulated to start and stop presentation to the display, queried for movement data (e.g. orientation and position) that can be used to update the display on each frame of the animation loop, and more.</p>

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.html
@@ -21,7 +21,12 @@ browser-compat: api.Window.onvrdisplayactivate
   {{domxref("Window")}} interface represents an event handler that will run when a display
   is able to be presented to (when the {{event("vrdisplayactivate")}} event fires), for
   example if an HMD has been moved to bring it out of standby, or woken up by being put
-  on.</p>
+  on.
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -40,7 +45,9 @@ browser-compat: api.Window.onvrdisplayactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.html
@@ -45,7 +45,7 @@ browser-compat: api.Window.onvrdisplayactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplayblur/index.html
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.html
@@ -50,7 +50,7 @@ browser-compat: api.Window.onvrdisplayblur
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplayblur/index.html
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.html
@@ -21,13 +21,19 @@ browser-compat: api.Window.onvrdisplayblur
   interface represents an event handler that will run when presentation to a display has
   been paused for some reason by the browser, OS, or VR hardware (when the
   {{event("vrdisplayblur")}} event fires) — for example, while the user is interacting
-  with a system menu or browser, to prevent tracking or loss of experience.</p>
+  with a system menu or browser, to prevent tracking or loss of experience.
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>While a {{domxref("VRDisplay")}} is blurred it does not lose it’s presenting status
   ({{domxref("VRDisplay.isPresenting")}} continues to report <code>true</code>) but
   {{domxref("VRDisplay.getFrameData()")}} returns <code>false</code> without updating the
   provided {{domxref("VRFrameData")}} and {{domxref("VRDisplay.getPose()")}} returns a
-  {{domxref("VRPose")}} with <code>null</code> members.</p>
+  {{domxref("VRPose")}} with <code>null</code> members.
+</p>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -44,7 +50,9 @@ browser-compat: api.Window.onvrdisplayblur
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.html
@@ -19,7 +19,12 @@ browser-compat: api.Window.onvrdisplayconnect
 <p>The <code><strong>onvrdisplayconnect</strong></code> property of the
   {{domxref("Window")}} interface represents an event handler that will run when a
   compatible VR display has been connected to the computer (when the
-  {{event("vrdisplayconnect")}} event fires).</p>
+  {{event("vrdisplayconnect")}} event fires).
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -37,7 +42,9 @@ browser-compat: api.Window.onvrdisplayconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.html
@@ -42,7 +42,7 @@ browser-compat: api.Window.onvrdisplayconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
@@ -42,7 +42,7 @@ browser-compat: api.Window.onvrdisplaydeactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
@@ -23,6 +23,10 @@ browser-compat: api.Window.onvrdisplaydeactivate
   for example if an HMD has gone into standby or sleep mode due to a period of inactivity.
 </p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -38,7 +42,9 @@ browser-compat: api.Window.onvrdisplaydeactivate
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
@@ -40,7 +40,7 @@ browser-compat: api.Window.onvrdisplaydisconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
@@ -21,6 +21,10 @@ browser-compat: api.Window.onvrdisplaydisconnect
   disconnected from the computer (when the {{event("vrdisplaydisconnect")}} event fires).
 </p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -36,7 +40,9 @@ browser-compat: api.Window.onvrdisplaydisconnect
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.html
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.html
@@ -42,7 +42,7 @@ browser-compat: api.Window.onvrdisplayfocus
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.html
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.html
@@ -20,7 +20,12 @@ browser-compat: api.Window.onvrdisplayfocus
 <p>The <strong><code>onvrdisplayfocus</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when
   presentation to a display has resumed after being blurred (when the
-  {{event("vrdisplayfocus")}} event fires).</p>
+  {{event("vrdisplayfocus")}} event fires).
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -37,7 +42,9 @@ browser-compat: api.Window.onvrdisplayfocus
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
@@ -36,7 +36,7 @@ browser-compat: api.Window.onvrdisplaypointerrestricted
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
@@ -14,8 +14,12 @@ browser-compat: api.Window.onvrdisplaypointerrestricted
 
 <p>The <strong><code>onvrdisplaypointerrestricted</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the VR
-  display's pointer input is restricted to consumption via a <a
-    href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
+  display's pointer input is restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -32,7 +36,8 @@ browser-compat: api.Window.onvrdisplaypointerrestricted
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
@@ -14,8 +14,12 @@ browser-compat: api.Window.onvrdisplaypointerunrestricted
 
 <p>The <strong><code>onvrdisplaypointerunrestricted</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the VR
-  display's pointer input is no longer restricted to consumption via a <a
-    href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
+  display's pointer input is no longer restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -32,7 +36,8 @@ browser-compat: api.Window.onvrdisplaypointerunrestricted
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
@@ -36,7 +36,7 @@ browser-compat: api.Window.onvrdisplaypointerunrestricted
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
@@ -20,7 +20,12 @@ browser-compat: api.Window.onvrdisplaypresentchange
 <p>The <strong><code>onvrdisplaypresentchange</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the
   presenting state of a VR display changes — i.e. goes from presenting to not presenting,
-  or vice versa (when the {{event("vrdisplaypresentchange")}} event fires).</p>
+  or vice versa (when the {{event("vrdisplaypresentchange")}} event fires).
+</p>
+
+<div class="notepad note">
+  <p><strong>Note:</strong> This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
 
 <p>The event object is of type {{domxref("VRDisplayEvent")}}.</p>
 
@@ -44,7 +49,8 @@ browser-compat: api.Window.onvrdisplaypresentchange
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
@@ -49,7 +49,7 @@ browser-compat: api.Window.onvrdisplaypresentchange
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event handler was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Window.vrdisplayactivate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplayactivate_event
 
 <p>The <strong><code>vrdisplayactivate</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a VR display is able to be presented to, for example if an HMD has been moved to bring it out of standby, or woken up by being put on.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -52,7 +56,8 @@ browser-compat: api.Window.vrdisplayactivate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplayblur_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayblur_event/index.html
@@ -14,6 +14,10 @@ browser-compat: api.Window.vrdisplayblur_event
 
 <p>The <strong><code>vrdisplayblur</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when presentation to a VR display has been paused for some reason by the browser, OS, or VR hardware — for example, while the user is interacting with a system menu or browser, to prevent tracking or loss of experience.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -53,7 +57,8 @@ browser-compat: api.Window.vrdisplayblur_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplayblur_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayblur_event/index.html
@@ -57,7 +57,7 @@ browser-compat: api.Window.vrdisplayblur_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Window.vrdisplayconnect_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplayconnect_event
 
 <p>The <strong><code>vrdisplayconnect</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a compatible VR display is connected to the computer.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -52,7 +56,8 @@ browser-compat: api.Window.vrdisplayconnect_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
@@ -58,7 +58,7 @@ browser-compat: api.Window.vrdisplaydeactivate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplaydeactivate_event
 
 <p>The <strong><code>vrdisplaydeactivate</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a VR display can no longer be presented to, for example if an HMD has gone into standby or sleep mode due to a period of inactivity.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -54,7 +58,8 @@ browser-compat: api.Window.vrdisplaydeactivate_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
@@ -38,6 +38,10 @@ browser-compat: api.Window.vrdisplaydisconnect_event
 
 <p>You can use the <code>vrdisplaydisconnect</code> event in an <code><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener</a></code> method:</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <pre class="brush: js">window.addEventListener('vrdisplaydisconnect', function() {
   info.textContent = 'Display disconnected.';
   reportDisplays();
@@ -52,7 +56,8 @@ browser-compat: api.Window.vrdisplaydisconnect_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Window.vrdisplaydisconnect_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayfocus_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayfocus_event/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Window.vrdisplayfocus_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplayfocus_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayfocus_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplayfocus_event
 
 <p>The <strong><code>vrdisplayfocus</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when presentation to a VR display has resumed after being blurred.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -52,7 +56,8 @@ browser-compat: api.Window.vrdisplayfocus_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
@@ -54,7 +54,7 @@ browser-compat: api.Window.vrdisplaypointerrestricted_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplaypointerrestricted_event
 
 <p>The <strong><code>vrdisplaypointerrestricted</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the VR display's pointer input is restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -50,7 +54,8 @@ browser-compat: api.Window.vrdisplaypointerrestricted_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
@@ -54,7 +54,7 @@ browser-compat: api.Window.vrdisplaypointerunrestricted_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplaypointerunrestricted_event
 
 <p>The <strong><code>vrdisplaypointerunrestricted</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the VR display's pointer input is no longer restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -50,7 +54,8 @@ browser-compat: api.Window.vrdisplaypointerunrestricted_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
@@ -13,6 +13,10 @@ browser-compat: api.Window.vrdisplaypresentchange_event
 
 <p>The <strong><code>vrdisplaypresentchange</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the presenting state of a VR display changes — i.e. goes from presenting to not presenting, or vice versa.</p>
 
+<div class="notepad note">
+  <p><strong>Note:</strong> This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
+</div>
+
 <table class="properties">
  <tbody>
   <tr>
@@ -60,7 +64,8 @@ browser-compat: api.Window.vrdisplaypresentchange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
@@ -64,7 +64,7 @@ browser-compat: api.Window.vrdisplaypresentchange_event
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a>. It is no longer on track to becoming a standard.</p>
+<p>This event was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
 <p>Until all browsers have implemented the new <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>


### PR DESCRIPTION
This is last PR and will close #6108 \o/

Following the test in #6181, this improve the spec messages (and top notes) of all WebVR API reference pages!