### PR TITLE
Remove remnants of non-standard Gecko-only Event methods/properties

### DIFF
--- a/files/en-us/web/api/event/defaultprevented/index.html
+++ b/files/en-us/web/api/event/defaultprevented/index.html
@@ -13,8 +13,6 @@ browser-compat: api.Event.defaultPrevented
 
 <p>The <code><strong>defaultPrevented</strong></code> read-only property of the {{domxref("Event")}} interface returns a {{jsxref("Boolean")}} indicating whether or not the call to {{ domxref("Event.preventDefault()") }} canceled the event.</p>
 
-<div class="note"><strong>Note:</strong> You should use this instead of the non-standard, deprecated <code>getPreventDefault()</code> method (see {{ bug(691151) }}).</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <em>defaultWasPrevented</em> = <em>event</em>.defaultPrevented;</pre>

--- a/files/en-us/web/api/event/index.html
+++ b/files/en-us/web/api/event/index.html
@@ -158,12 +158,6 @@ browser-compat: api.Event
 <dl>
  <dt>{{domxref("Event.initEvent()")}} {{deprecated_inline}}</dt>
  <dd>Initializes the value of an Event created. If the event has already been dispatched, this method does nothing.</dd>
- <dt>{{domxref("Event.getPreventDefault()")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Returns the value of {{domxref("Event.defaultPrevented")}}.</dd>
- <dt>{{domxref("Event.preventBubble()")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Prevents the event from bubbling. Use {{domxref("event.stopPropagation")}} instead.</dd>
- <dt>{{domxref("Event.preventCapture()")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Prevents the event from bubbling. Use {{domxref("event.stopPropagation")}} instead.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
To go along with their removal in BCD (see https://github.com/mdn/browser-compat-data/pull/11100 and https://github.com/mdn/browser-compat-data/pull/11101), this PR removes the remaining mentions of the `getPreventDefault`, `preventBubble`, and `preventCapture` properties of the Event API.  All of these have been Gecko-only and removed over two years ago.  The individual pages are already removed from the MDN web docs; all this PR is doing is removing the remaining links and mentions of them.
