### PR TITLE
Rename Point -> WebKitPoint

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8294,6 +8294,7 @@
 /en-US/docs/Web/API/PeriodicSyncManager/unregister()	/en-US/docs/Web/API/PeriodicSyncManager/unregister
 /en-US/docs/Web/API/PermissionStatus/status	/en-US/docs/Web/API/PermissionStatus/state
 /en-US/docs/Web/API/PictureInPictureWindow/PictureInPictureWindow:_resize_event	/en-US/docs/Web/API/PictureInPictureWindow/resize_event
+/en-US/docs/Web/API/Point	/en-US/docs/Web/API/WebKitPoint
 /en-US/docs/Web/API/Position	/en-US/docs/Web/API/GeolocationPosition
 /en-US/docs/Web/API/Position.coords	/en-US/docs/Web/API/GeolocationPosition/coords
 /en-US/docs/Web/API/Position.timestamp	/en-US/docs/Web/API/GeolocationPosition/timestamp
@@ -8796,7 +8797,6 @@
 /en-US/docs/Web/API/WebGL_API/Using_shaders_to_apply_color_in_WebGL	/en-US/docs/Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
 /en-US/docs/Web/API/WebGL_API/Using_textures_in_WebGL	/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
 /en-US/docs/Web/API/WebKitCSSMatrix	/en-US/docs/Web/API/DOMMatrix
-/en-US/docs/Web/API/WebKitPoint	/en-US/docs/Web/API/Point
 /en-US/docs/Web/API/WebRTC_API/Architecture	/en-US/docs/Web/API/WebRTC_API/Protocols
 /en-US/docs/Web/API/WebRTC_API/Architecture/Connectivity	/en-US/docs/Web/API/WebRTC_API/Connectivity
 /en-US/docs/Web/API/WebRTC_API/Architecture/Protocols	/en-US/docs/Web/API/WebRTC_API/Protocols
@@ -8840,8 +8840,8 @@
 /en-US/docs/Web/API/WheelEvent.deltaX	/en-US/docs/Web/API/WheelEvent/deltaX
 /en-US/docs/Web/API/WheelEvent.deltaY	/en-US/docs/Web/API/WheelEvent/deltaY
 /en-US/docs/Web/API/WheelEvent.deltaZ	/en-US/docs/Web/API/WheelEvent/deltaZ
-/en-US/docs/Web/API/Window.convertPointFromNodeToPage	/en-US/docs/Web/API/Window/convertPointFromNodeToPage
-/en-US/docs/Web/API/Window.convertPointFromPageToNode	/en-US/docs/Web/API/Window/convertPointFromPageToNode
+/en-US/docs/Web/API/Window.convertPointFromNodeToPage	/en-US/docs/Web/API/Window/webkitConvertPointFromNodeToPage
+/en-US/docs/Web/API/Window.convertPointFromPageToNode	/en-US/docs/Web/API/Window/webkitConvertPointFromPageToNode
 /en-US/docs/Web/API/Window.devicePixelRatio	/en-US/docs/Web/API/Window/devicePixelRatio
 /en-US/docs/Web/API/Window.dispatchEvent	/en-US/docs/Web/API/EventTarget/dispatchEvent
 /en-US/docs/Web/API/Window.localStorage	/en-US/docs/Web/API/Window/localStorage
@@ -8859,6 +8859,8 @@
 /en-US/docs/Web/API/Window/caches	/en-US/docs/Web/API/WindowOrWorkerGlobalScope/caches
 /en-US/docs/Web/API/Window/clearInterval	/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval
 /en-US/docs/Web/API/Window/clearTimeout	/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout
+/en-US/docs/Web/API/Window/convertPointFromNodeToPage	/en-US/docs/Web/API/Window/webkitConvertPointFromNodeToPage
+/en-US/docs/Web/API/Window/convertPointFromPageToNode	/en-US/docs/Web/API/Window/webkitConvertPointFromPageToNode
 /en-US/docs/Web/API/Window/fetch	/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 /en-US/docs/Web/API/Window/indexedDB	/en-US/docs/Web/API/WindowOrWorkerGlobalScope/indexedDB
 /en-US/docs/Web/API/Window/mozRequestAnimationFrame	/en-US/docs/Web/API/window/requestAnimationFrame

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -70067,18 +70067,6 @@
       "Sheppy"
     ]
   },
-  "Web/API/Point": {
-    "modified": "2020-10-15T21:32:53.457Z",
-    "contributors": [
-      "teoli",
-      "fscholz",
-      "Sheppy",
-      "libbymc",
-      "Sebastianz",
-      "kscarfone",
-      "cvrebert"
-    ]
-  },
   "Web/API/PointerEvent": {
     "modified": "2020-10-15T21:39:50.207Z",
     "contributors": [
@@ -87526,6 +87514,18 @@
       "chrisdavidmills"
     ]
   },
+  "Web/API/WebKitPoint": {
+    "modified": "2020-10-15T21:32:53.457Z",
+    "contributors": [
+      "teoli",
+      "fscholz",
+      "Sheppy",
+      "libbymc",
+      "Sebastianz",
+      "kscarfone",
+      "cvrebert"
+    ]
+  },
   "Web/API/WebRTC_API": {
     "modified": "2020-12-14T11:30:04.164Z",
     "contributors": [
@@ -89652,26 +89652,6 @@
       "Dria",
       "Callek",
       "JesseW"
-    ]
-  },
-  "Web/API/Window/convertPointFromNodeToPage": {
-    "modified": "2020-10-15T21:32:54.816Z",
-    "contributors": [
-      "fscholz",
-      "Sheppy",
-      "Sebastianz",
-      "teoli",
-      "cvrebert"
-    ]
-  },
-  "Web/API/Window/convertPointFromPageToNode": {
-    "modified": "2020-10-15T21:32:54.759Z",
-    "contributors": [
-      "fscholz",
-      "Sheppy",
-      "Sebastianz",
-      "kscarfone",
-      "cvrebert"
     ]
   },
   "Web/API/Window/copy_event": {
@@ -92560,6 +92540,26 @@
       "chrisdavidmills",
       "abbycar",
       "slimsag"
+    ]
+  },
+  "Web/API/Window/webkitConvertPointFromNodeToPage": {
+    "modified": "2020-10-15T21:32:54.816Z",
+    "contributors": [
+      "fscholz",
+      "Sheppy",
+      "Sebastianz",
+      "teoli",
+      "cvrebert"
+    ]
+  },
+  "Web/API/Window/webkitConvertPointFromPageToNode": {
+    "modified": "2020-10-15T21:32:54.759Z",
+    "contributors": [
+      "fscholz",
+      "Sheppy",
+      "Sebastianz",
+      "kscarfone",
+      "cvrebert"
     ]
   },
   "Web/API/Window/window": {

--- a/files/en-us/web/api/webkitpoint/index.html
+++ b/files/en-us/web/api/webkitpoint/index.html
@@ -1,6 +1,6 @@
 ---
 title: Point
-slug: Web/API/Point
+slug: Web/API/WebKitPoint
 tags:
   - API
   - CSS Transforms
@@ -39,7 +39,7 @@ browser-compat: api.Point
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{domxref("Window.convertPointFromNodeToPage()")}}</li>
- <li>{{domxref("Window.convertPointFromPageToNode()")}}</li>
+ <li>{{domxref("Window.webkitConvertPointFromNodeToPage()")}}</li>
+ <li>{{domxref("Window.webkitConvertPointFromPageToNode()")}}</li>
  <li><a href="https://msdn.microsoft.com/en-us/library/ie/dn760730(v=vs.85).aspx"><code>WebKitPoint</code> documentation at the IE Dev Center</a></li>
 </ul>

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.html
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.html
@@ -1,16 +1,16 @@
 ---
 title: Window.convertPointFromNodeToPage()
-slug: Web/API/Window/convertPointFromNodeToPage
+slug: Web/API/Window/webkitConvertPointFromNodeToPage
 tags:
-- API
-- HTML DOM
-- Method
-- Non-standard
-- Point
-- Reference
-- Safari
-- WebKit
-- Window
+  - API
+  - HTML DOM
+  - Method
+  - Non-standard
+  - Point
+  - Reference
+  - Safari
+  - WebKit
+  - Window
 browser-compat: api.Window.convertPointFromNodeToPage
 ---
 <div>{{APIRef}}</div>

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.html
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.html
@@ -1,16 +1,16 @@
 ---
 title: Window.convertPointFromPageToNode
-slug: Web/API/Window/convertPointFromPageToNode
+slug: Web/API/Window/webkitConvertPointFromPageToNode
 tags:
-- API
-- Method
-- Non-standard
-- Point
-- Reference
-- Safari
-- WebKit
-- Window
-- convertPointFromPageToNode
+  - API
+  - Method
+  - Non-standard
+  - Point
+  - Reference
+  - Safari
+  - WebKit
+  - Window
+  - convertPointFromPageToNode
 browser-compat: api.Window.convertPointFromPageToNode
 ---
 <div>{{APIRef}}</div>


### PR DESCRIPTION
To go along with the BCD update in https://github.com/mdn/browser-compat-data/pull/11361, this PR renames the `Point` API to `WebKitPoint`, along with the related conversion methods in the `Window` API, since all of these methods have a prefix.
