### PR TITLE
fix: update rotation matrices to rotate in the proper direction

### DIFF
--- a/files/en-us/web/css/transform-function/rotate()/index.html
+++ b/files/en-us/web/css/transform-function/rotate()/index.html
@@ -59,7 +59,6 @@ browser-compat: css.types.transform-function
                   <mo>)</mo>
                 </mtd>
                 <mtd>
-                  <mo>-</mo>
                   <mo>sin</mo>
                   <mo>(</mo>
                   <mi>a</mi>
@@ -68,6 +67,7 @@ browser-compat: css.types.transform-function
               </mtr>
               <mtr>
                 <mtd>
+                  <mo>-</mo>
                   <mo>sin</mo>
                   <mo>(</mo>
                   <mi>a</mi>
@@ -146,7 +146,6 @@ browser-compat: css.types.transform-function
                   <mo>)</mo>
                 </mtd>
                 <mtd>
-                  <mo>-</mo>
                   <mo>sin</mo>
                   <mo>(</mo>
                   <mi>a</mi>
@@ -158,6 +157,7 @@ browser-compat: css.types.transform-function
               </mtr>
               <mtr>
                 <mtd>
+                  <mo>-</mo>
                   <mo>sin</mo>
                   <mo>(</mo>
                   <mi>a</mi>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The rotation matrices are for rotations in the conventional direction (positive angles give counter-clockwise rotations, negative angles give clockwise rotations), but the `rotate()` CSS function description describes the opposite behavior.
I have more details/thoughts and why I could be wrong in the linked issue

> Issue number (if there is an associated issue)

Fixes #6538

> Anything else that could help us review it

1. I haven't updated the examples for homogenous coordinates, but happy to do so on this PR once I've verified they need updating too
2. The older mathml syntax doesn't render correctly on browsers aside from Safari (go figure). Happy to update the syntax in this PR as well, I just wasn't sure how people feel about keeping PRs scoped to a single change.