### PR TITLE
Better specify when the return type of play() got full browser upport

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/play/index.html
+++ b/files/en-us/web/api/htmlmediaelement/play/index.html
@@ -36,7 +36,7 @@ browser-compat: api.HTMLMediaElement.play
   rejected if for any reason playback cannot be started.</p>
 
 <div class="note">
-  <p><strong>Note:</strong> Older browsers may not return a value from
+  <p><strong>Note:</strong> Browsers released before 2019 may not return a value from
     <code>play()</code>.</p>
 </div>
 
@@ -136,12 +136,6 @@ function handlePlayButton() {
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}
-
-<div class="note">
-  <p><strong>Note:</strong> The WHATWG and W3C versions of the specification differ (as of
-    August, 2018) as to whether this method returns a {{jsxref("Promise")}} or nothing at
-    all, respectively.</p>
-</div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Microsoft Edge 17 in 2018 was the last browser that added the support, while others did in 2016.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

"Old browsers" is a vague word and thus easily confuses readers (e.g. https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1024)

> Issue number (if there is an associated issue)



> Anything else that could help us review it
