### PR TITLE
Fix small typo before ChannelSplitterNode example

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -40,7 +40,7 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 
 <p>The following simple example shows how you could separate a stereo track (say, a piece
   of music), and process the left and right channel differently. To use them, you need to
-  use the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode)"}}
+  use the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode)")}}
   method, which allow you to specify the index of the channel to connect from and the
   index of the channel to connect to.</p>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -40,7 +40,7 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 
 <p>The following simple example shows how you could separate a stereo track (say, a piece
   of music), and process the left and right channel differently. To use them, you need to
-  use the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode")}}
+  use the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode)"}}
   method, which allow you to specify the index of the channel to connect from and the
   index of the channel to connect to.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The hyperlink had the ending parenthesis cut off, just moving the quote so it's fixed.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A