### PR TITLE
Fix bcd keys for <filter-function> and its CSS functions

### DIFF
--- a/files/en-us/web/css/filter-function/blur()/index.html
+++ b/files/en-us/web/css/filter-function/blur()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.blur
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/brightness()/index.html
+++ b/files/en-us/web/css/filter-function/brightness()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.brightness
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/contrast()/index.html
+++ b/files/en-us/web/css/filter-function/contrast()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.contrast
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/drop-shadow()/index.html
+++ b/files/en-us/web/css/filter-function/drop-shadow()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.drop-shadow
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/grayscale()/index.html
+++ b/files/en-us/web/css/filter-function/grayscale()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.grayscale
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/hue-rotate()/index.html
+++ b/files/en-us/web/css/filter-function/hue-rotate()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.hue-rotate
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/index.html
+++ b/files/en-us/web/css/filter-function/index.html
@@ -8,7 +8,7 @@ tags:
   - Filter Effects
   - NeedsCompatTable
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/invert()/index.html
+++ b/files/en-us/web/css/filter-function/invert()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.invert
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/opacity()/index.html
+++ b/files/en-us/web/css/filter-function/opacity()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.opacity
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/saturate()/index.html
+++ b/files/en-us/web/css/filter-function/saturate()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.saturate
 ---
 <div>{{CSSRef}}</div>
 

--- a/files/en-us/web/css/filter-function/sepia()/index.html
+++ b/files/en-us/web/css/filter-function/sepia()/index.html
@@ -7,7 +7,7 @@ tags:
   - Filter Effects
   - Function
   - Reference
-browser-compat: css.properties.filter
+browser-compat: css.types.filter-function.sepia
 ---
 <div>{{CSSRef}}</div>
 


### PR DESCRIPTION
This makes use of the new bcd keys introduced in mdn/browser-compat-data#11368.

This has to land after the bcd landed.