### PR TITLE
Fix incorrect bcd for JS Int32Array

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.html
@@ -7,7 +7,7 @@ tags:
 - TypedArray
 - TypedArrays
 - Polyfill
-browser-compat: javascript.builtins.Int32Array.Int32Array
+browser-compat: javascript.builtins.Int32Array
 ---
 <div>{{JSRef}}</div>
 


### PR DESCRIPTION
The bcd in front-runner was pointing to the constructor instead of the whole object.

This PR fixes this.