### PR TITLE
Remove bcd from front-runner for JS class fields

### DIFF
--- a/files/en-us/web/javascript/guide/working_with_private_class_features/index.html
+++ b/files/en-us/web/javascript/guide/working_with_private_class_features/index.html
@@ -5,7 +5,6 @@ tags:
   - Document
   - Guide
   - JavaScript
-browser-compat: javascript.classes
 ---
 <div>{{jsSidebar("JavaScript Guide")}}</div>
 
@@ -64,11 +63,11 @@ console.log(total.current);  // expected output: 13
 total.reset();               // #count now = 7
 </pre>
 
-<p>The “hash mark” (<code>#</code>) is what marks a field as being private.  It also prevents private fields and property names from ever being in conflict: private names <strong>must</strong> start with <code>#</code>, whereas property names can <strong>never</strong> start that way.</p>
+<p>The "ash mark" (<code>#</code>) is what marks a field as being private.  It also prevents private fields and property names from ever being in conflict: private names <strong>must</strong> start with <code>#</code>, whereas property names can <strong>never</strong> start that way.</p>
 
-<p>Having declared the private fields, they act as we saw in the public example.  The only way to change the <code>#count</code> value is via the publicly available methods like <code>decrease()</code>, and because (in this example) there are no defined ways to alter it, the <code>#init</code> value is immutable.  It’s set when a new <code>PrivateCounter</code> is constructed, and can never be changed thereafter.</p>
+<p>Having declared the private fields, they act as we saw in the public example.  The only way to change the <code>#count</code> value is via the publicly available methods like <code>decrease()</code>, and because (in this example) there are no defined ways to alter it, the <code>#init</code> value is immutable.  It's set when a new <code>PrivateCounter</code> is constructed, and can never be changed thereafter.</p>
 
-<p>It’s also the case that you <strong>cannot</strong> read a private value directly from code outside the class object.  Consider:</p>
+<p>It's also the case that you <strong>cannot</strong> read a private value directly from code outside the class object.  Consider:</p>
 
 <pre class="brush: js">
 let score = new PrivateCounter(); // #count and #init are now both 0
@@ -80,20 +79,20 @@ console.log(score.#count);
   // "Uncaught SyntaxError: Private field '#count' must be declared in an enclosing class"
 </pre>
 
-<p>If you wish to read private data from outside a class, you must first invent a method or other function to return it.  We had already done that with the <code>current()</code> getter that returns the current value of <code>#count</code>, but <code>#init</code> is locked away.  Unless we add something like a <code>getInit()</code> method to the class, we can’t even see the initial value from outside the class, let alone alter it, and the compiler will throw errors if we try.</p>
+<p>If you wish to read private data from outside a class, you must first invent a method or other function to return it.  We had already done that with the <code>current()</code> getter that returns the current value of <code>#count</code>, but <code>#init</code> is locked away.  Unless we add something like a <code>getInit()</code> method to the class, we can't even see the initial value from outside the class, let alone alter it, and the compiler will throw errors if we try.</p>
 
-<p>What are the other restrictions around private fields?  For one, you can’t refer to a private field you didn’t previously define.  You might be used to inventing new fields on the fly in JavaScript, but that just won’t fly with private fields.
+<p>What are the other restrictions around private fields?  For one, you can't refer to a private field you didn't previously define.  You might be used to inventing new fields on the fly in JavaScript, but that just won't fly with private fields.
 
 <pre class="brush: js example-bad">
 class BadIdea {
   constructor(arg) {
     this.#init = arg;  // syntax error occurs here
     #startState = arg; // syntax error would also occur here
-  }                    // because private fields weren’t defined
+  }                    // because private fields weren't defined
 }                      // before being referenced
 </pre>
 
-<p>You can’t define the same name twice in a single class, and you can’t delete private fields.</p>
+<p>You can't define the same name twice in a single class, and you can't delete private fields.</p>
 
 <pre class="brush: js example-bad">
 class BadIdeas {
@@ -106,7 +105,7 @@ class BadIdeas {
 }
 </pre>
 
-<p>There is another limitation: you can’t declare private fields or methods via <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#using_object_initializers">object literals</a>.  You might be used to something like this:</p>
+<p>There is another limitation: you can't declare private fields or methods via <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#using_object_initializers">object literals</a>.  You might be used to something like this:</p>
 
 <pre class="brush: js">
 var planet = {
@@ -148,7 +147,7 @@ class colorMixer {
 
 <h2>Private methods</h2>
 
-<p>Just like private fields, private methods are marked with a leading <code>#</code> and cannot be accessed from outside their class.  They’re useful when you have something complex that the class needs to do internally, but it’s something that no other part of the code should be allowed to call.</p>
+<p>Just like private fields, private methods are marked with a leading <code>#</code> and cannot be accessed from outside their class.  They're useful when you have something complex that the class needs to do internally, but it's something that no other part of the code should be allowed to call.</p>
 
 <p>For example, imagine creating <a href="/en-US/docs/Web/Web_Components/Using_custom_elements">HTML custom elements</a> that should do something somewhat complicated when clicked/tapped/otherwise activated.  Furthermore, the somewhat complicated things that happen when the element is clicked should be restricted to this class, because no other part of the JavaScript will (or should) ever access it.  Therefore, something like:</p>
 
@@ -195,7 +194,7 @@ class Counter extends HTMLElement {
 customElements.define('num-counter', Counter);
 </pre>
 
-<p>In this case, pretty much every field and method is private to the class.  Thus, it presents an interface to the rest of the code that’s essentially just like a built-in HTML element.  No other part of the JavaScript has the power to affect any of its internals.</p>
+<p>In this case, pretty much every field and method is private to the class. Thus, it presents an interface to the rest of the code that's essentially just like a built-in HTML element. No other part of the JavaScript has the power to affect any of its internals.</p>
 
 <h2 id="See_also">See also</h2>
 
@@ -208,5 +207,5 @@ customElements.define('num-counter', Counter);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>{{Compat("javascript.classes")}}</p>
 

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
@@ -244,7 +244,7 @@ console.log(Derived.publicStaticMethod2());
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications("javscript.classes")}}</p>
+<p>{{Specifications("javascript.classes")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
@@ -6,7 +6,6 @@ tags:
 - Private
 - JavaScript
 - Language feature
-browser-compat: javascript.classes
 ---
 <div>{{JsSidebar("Classes")}}</div>
 
@@ -46,7 +45,7 @@ class ClassWithPrivateStaticMethod {
   <code>#</code> is a part of the name itself.  Private fields are accessible on
   the class constructor from inside the class
   declaration itself. They are used for declaration of field names as well
-  as for accessing a field’s value.</p>
+  as for accessing a field's value.</p>
 
 <p>It is a syntax error to refer to <code>#</code> names from out of scope.
   It is also a syntax error to refer to private fields
@@ -245,11 +244,11 @@ console.log(Derived.publicStaticMethod2());
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<p>{{Specifications("javscript.classes")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>{{Compat("javascript.classes")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
@@ -5,7 +5,6 @@ tags:
   - Classes
   - JavaScript
   - Language feature
-browser-compat: javascript.classes
 ---
 <div>{{JsSidebar("Classes")}}</div>
 
@@ -16,7 +15,7 @@ browser-compat: javascript.classes
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">class ClassWithInstanceField {
-  instanceField = 'instance field'
+  instanceField = 'instance field'
 }
 
 class ClassWithStaticField {
@@ -24,9 +23,9 @@ class ClassWithStaticField {
 }
 
 class ClassWithPublicInstanceMethod {
-  publicMethod() {
-    return 'hello world'
-  }
+  publicMethod() {
+    return 'hello world'
+  }
 }
 </pre>
 
@@ -38,13 +37,13 @@ class ClassWithPublicInstanceMethod {
   on every class instance you create. This is useful for caches, fixed-configuration, or
   any other data you don't need to be replicated across instances.</p>
 
-<p>Public static fields are declared using the <code>static</code> keyword. They are added
+<p>Public static fields are declared using the <code>static</code> keyword. They are added
   to the class constructor at the time of class evaluation using
   {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}}. They are
   accessed again from the class constructor.</p>
 
 <pre class="brush: js">class ClassWithStaticField {
-  static staticField = 'static field'
+  static staticField = 'static field'
 }
 
 console.log(ClassWithStaticField.staticField)
@@ -54,7 +53,7 @@ console.log(ClassWithStaticField.staticField)
 <p>Fields without initializers are initialized to <code>undefined</code>.</p>
 
 <pre class="brush: js">class ClassWithStaticField {
-  static staticField
+  static staticField
 }
 
 console.assert(ClassWithStaticField.hasOwnProperty('staticField'))
@@ -65,11 +64,11 @@ console.log(ClassWithStaticField.staticField)
   prototype chain.</p>
 
 <pre class="brush: js">class ClassWithStaticField {
-  static baseStaticField = 'base field'
+  static baseStaticField = 'base field'
 }
 
 class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = 'sub class field'
+  static subStaticField = 'sub class field'
 }
 
 console.log(SubClassWithStaticField.subStaticField)
@@ -78,19 +77,19 @@ console.log(SubClassWithStaticField.subStaticField)
 console.log(SubClassWithStaticField.baseStaticField)
 // expected output: "base field"</pre>
 
-<p>When initializing fields, <code>this</code> refers to the class constructor. You can
-  also reference it by name, and use <code>super</code> to get the superclass constructor
+<p>When initializing fields, <code>this</code> refers to the class constructor. You can
+  also reference it by name, and use <code>super</code> to get the superclass constructor
   (if one exists).</p>
 
 <pre class="brush: js">class ClassWithStaticField {
-  static baseStaticField = 'base static field'
-  static anotherBaseStaticField = this.baseStaticField
+  static baseStaticField = 'base static field'
+  static anotherBaseStaticField = this.baseStaticField
 
-  static baseStaticMethod() { return 'base static method output' }
+  static baseStaticMethod() { return 'base static method output' }
 }
 
 class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = super.baseStaticMethod()
+  static subStaticField = super.baseStaticMethod()
 }
 
 console.log(ClassWithStaticField.anotherBaseStaticField)
@@ -102,12 +101,12 @@ console.log(SubClassWithStaticField.subStaticField)
 
 <h3 id="Public_instance_fields">Public instance fields</h3>
 
-<p>Public instance fields exist on every created instance of a class. By declaring a
+<p>Public instance fields exist on every created instance of a class. By declaring a
   public field, you can ensure the field is always present, and the class definition is
   more self-documenting.</p>
 
 <p>Public instance fields are added with {{jsxref("Global_Objects/Object/defineProperty",
-  "Object.defineProperty()")}} either at construction time in the base class (before the
+  "Object.defineProperty()")}} either at construction time in the base class (before the
   constructor body runs), or just after <code>super()</code> returns in a subclass.</p>
 
 <pre class="brush: js">class ClassWithInstanceField {
@@ -121,7 +120,7 @@ console.log(instance.instanceField)
 <p>Fields without initializers are initialized to <code>undefined</code>.</p>
 
 <pre class="brush: js">class ClassWithInstanceField {
-  instanceField
+  instanceField
 }
 
 const instance = new ClassWithInstanceField()
@@ -134,25 +133,25 @@ console.log(instance.instanceField)
 <pre class="brush: js">const PREFIX = 'prefix'
 
 class ClassWithComputedFieldName {
-    [`${PREFIX}Field`] = 'prefixed field'
+    [`${PREFIX}Field`] = 'prefixed field'
 }
 
 const instance = new ClassWithComputedFieldName()
 console.log(instance.prefixField)
 // expected output: "prefixed field"</pre>
 
-<p>When initializing fields <code>this</code> refers to the class instance under
+<p>When initializing fields <code>this</code> refers to the class instance under
   construction. Just as in public instance methods, if you're in a subclass you can access
   the superclass prototype using <code>super</code>.</p>
 
 <pre class="brush: js">class ClassWithInstanceField {
-  baseInstanceField = 'base field'
-  anotherBaseInstanceField = this.baseInstanceField
-  baseInstanceMethod() { return 'base method output' }
+  baseInstanceField = 'base field'
+  anotherBaseInstanceField = this.baseInstanceField
+  baseInstanceMethod() { return 'base method output' }
 }
 
 class SubClassWithInstanceField extends ClassWithInstanceField {
-  subInstanceField = super.baseInstanceMethod()
+  subInstanceField = super.baseInstanceMethod()
 }
 
 const base = new ClassWithInstanceField()
@@ -168,9 +167,9 @@ console.log(sub.subInstanceField)
 
 <h4 id="Public_static_methods">Public static methods</h4>
 
-<p>The <code><strong>static</strong></code> keyword defines a static method for a class.
+<p>The <code><strong>static</strong></code> keyword defines a static method for a class.
   Static methods aren't called on instances of the class. Instead, they're called on the
-  class itself. These are often utility functions, such as functions to create or clone
+  class itself. These are often utility functions, such as functions to create or clone
   objects.</p>
 
 <pre class="brush: js">class ClassWithStaticMethod {
@@ -183,7 +182,7 @@ console.log(ClassWithStaticMethod.staticMethod());
 // expected output: "static method has been called."</pre>
 
 <p>The static methods are added to the class constructor with
-  {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}} at class
+  {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}} at class
   evaluation time. These methods are writable, non-enumerable, and configurable.</p>
 
 <h4 id="Public_instance_methods">Public instance methods</h4>
@@ -213,21 +212,21 @@ console.log(instance.publicMethod())
   async *asyncGeneratorMethod() { }
 }</pre>
 
-<p>Inside instance methods, <code>this</code> refers to the instance itself. In
-  subclasses, <code>super</code> lets you access the superclass prototype, allowing you to
+<p>Inside instance methods, <code>this</code> refers to the instance itself. In
+  subclasses, <code>super</code> lets you access the superclass prototype, allowing you to
   call methods from the superclass.</p>
 
 <pre class="brush: js">class BaseClass {
-  msg = 'hello world'
-  basePublicMethod() {
-    return this.msg
-  }
+  msg = 'hello world'
+  basePublicMethod() {
+    return this.msg
+  }
 }
 
 class SubClass extends BaseClass {
-  subPublicMethod() {
-    return super.basePublicMethod()
-  }
+  subPublicMethod() {
+    return super.basePublicMethod()
+  }
 }
 
 const instance = new SubClass()
@@ -236,19 +235,19 @@ console.log(instance.subPublicMethod())
 </pre>
 
 <p>Getters and setters are special methods that bind to a class property and are called
-  when that property is accessed or set. Use the <a
+  when that property is accessed or set. Use the <a
     href="/en-US/docs/Web/JavaScript/Reference/Functions/get">get</a> and <a
     href="/en-US/docs/Web/JavaScript/Reference/Functions/set">set</a> syntax to declare a
   public instance getter or setter.</p>
 
 <pre class="brush: js">class ClassWithGetSet {
-  #msg = 'hello world'
-  get msg() {
-    return this.#msg
-  }
-  set msg(x) {
-    this.#msg = `hello ${x}`
-  }
+  #msg = 'hello world'
+  get msg() {
+    return this.#msg
+  }
+  set msg(x) {
+    this.#msg = `hello ${x}`
+ }
 }
 
 const instance = new ClassWithGetSet()
@@ -262,11 +261,11 @@ console.log(instance.msg)
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<p>{{Specifications("javascript.classes")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>{{Compat("javascript.classes")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
I removed the `browser-compat:` clause from front-runner on these pages (1 in guide, the only page in this area with the clause, 2 in subpages of Classes as the key represented something larger than the content of the page). I added the key as parameter of `{{Specification}}` and `{{Compat}}` on these pages, so that the tables stayed the same.

Also there were more gremlins (non-breakable space, English apostrophe and quote signs) in these than in the area, so I fixed them too.