### PR TITLE
Fix bcd key in “CSP: require-trusted-types-for” doc

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
@@ -6,7 +6,7 @@ tags:
   - Directive
   - HTTP
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.trusted-types
+browser-compat: http.headers.csp.Content-Security-Policy.require-trusted-types-for
 ---
 <div>{{HTTPSidebar}}</div>
 


### PR DESCRIPTION
BCD key was pointing to another header. Correcting it.