### PR TITLE
Fix bcd key for Remote Playback API

### DIFF
--- a/files/en-us/web/api/remote_playback_api/index.html
+++ b/files/en-us/web/api/remote_playback_api/index.html
@@ -6,7 +6,6 @@ tags:
   - Overview
   - Reference
   - Remote Playback API
-browser-compat: api.RemotePlayback
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
@@ -57,8 +56,8 @@ videoElem.remote.watchAvailability(availabilityCallback).catch(() => {
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<p>{{Specifications("api.RemotePlayback")}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>{{Compat("api.RemotePlayback")}}</p>


### PR DESCRIPTION
As the page is about the API as a whole, it shouldn't use the bcd key about an interface in front-runner.

So I removed it and added it to `{{Compat}}` and `{{Specificatiions}}`, like we have for other overview pages.