### PR TITLE
Remove HTML tags from code blocks (JS Operator references)

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition/index.html
+++ b/files/en-us/web/javascript/reference/operators/addition/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.addition
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var> + <var>y</var>
-</pre>
+<pre class="brush: js">x + y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.html
@@ -20,8 +20,7 @@ browser-compat: javascript.operators.addition_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x += y
-<strong>Meaning:</strong>  x  = x + y</pre>
+<pre class="brush: js">x += y // x = x + y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.html
@@ -20,8 +20,7 @@ browser-compat: javascript.operators.assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x = y
-</pre>
+<pre class="brush: js">x = y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/async_function/index.html
+++ b/files/en-us/web/javascript/reference/operators/async_function/index.html
@@ -21,9 +21,11 @@ browser-compat: javascript.operators.async_function
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">async function [<var>name</var>]([<var>param1</var>[, <var>param2</var>[, ..., <var>paramN</var>]]]) {
-   <var>statements</var>
-}</pre>
+<pre class="brush: js">
+async function [name]([param1[, param2[, ..., paramN]]]) {
+  statements
+}
+</pre>
 
 <p>As of ES2015, you can also use <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a>.</p>
 

--- a/files/en-us/web/javascript/reference/operators/await/index.html
+++ b/files/en-us/web/javascript/reference/operators/await/index.html
@@ -15,7 +15,7 @@ browser-compat: javascript.operators.await
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">[<em>rv</em>] = await <em>expression</em>;</pre>
+<pre class="brush: js">[rv] = await expression</pre>
 
 <dl>
   <dt><code>expression</code></dt>

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.bitwise_and
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> &amp; <var>b</var></code>
-</pre>
+<pre class="brush: js">a &amp; b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.html
@@ -19,9 +19,7 @@ browser-compat: javascript.operators.bitwise_and_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x &amp;= y
-<strong>Meaning:</strong>  x  = x &amp; y
-</pre>
+<pre class="brush: js">x &amp;= y // x = x &amp; y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.bitwise_not
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">~a
-</pre>
+<pre class="brush: js">~a</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.bitwise_or
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> | <var>b</var></code>
-</pre>
+<pre class="brush: js">a | b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.html
@@ -20,8 +20,7 @@ browser-compat: javascript.operators.bitwise_or_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x |= y
-<strong>Meaning:</strong>  x = x | y</pre>
+<pre class="brush: js">x |= y // x = x | y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
@@ -19,7 +19,7 @@ browser-compat: javascript.operators.bitwise_xor
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>a</var> ^ <var>b</var></pre>
+<pre class="brush: js">a ^ b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.bitwise_xor_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x ^= y
-<strong>Meaning:</strong>  x  = x ^ y</pre>
+<pre class="brush: js">x ^= y // x = x ^ y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/class/index.html
+++ b/files/en-us/web/javascript/reference/operators/class/index.html
@@ -25,9 +25,10 @@ browser-compat: javascript.operators.class
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">const <var>MyClass</var> = class [<var>className</var>] [extends <var>otherClassName</var>] {
-    // class body
-};</pre>
+<pre class="brush: js">
+const MyClass = class [className] [extends otherClassName] {
+  // class body
+}</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.html
@@ -25,7 +25,7 @@ browser-compat: javascript.operators.comma
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em>, <em>expr2, expr3...</em></pre>
+<pre class="brush: js">expr1, expr2, expr3...</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/conditional_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/conditional_operator/index.html
@@ -30,8 +30,7 @@ browser-compat: javascript.operators.conditional
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-    class="brush: js"><var>condition</var> ? <var>exprIfTrue</var> : <var>exprIfFalse</var></pre>
+<pre class="brush: js">condition ? exprIfTrue : exprIfFalse</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/decrement/index.html
+++ b/files/en-us/web/javascript/reference/operators/decrement/index.html
@@ -17,7 +17,9 @@ browser-compat: javascript.operators.decrement
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var>-- or --<var>x</var>
+<pre class="brush: js">
+x--
+--x
 </pre>
 
 <h2 id="Description">Description</h2>

--- a/files/en-us/web/javascript/reference/operators/delete/index.html
+++ b/files/en-us/web/javascript/reference/operators/delete/index.html
@@ -23,7 +23,7 @@ browser-compat: javascript.operators.delete
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">delete <var>expression</var> </pre>
+<pre class="brush: js">delete expression</pre>
 
 <p>Where <code><var>expression</var></code> should evaluate to a <a
 		href="/en-US/docs/Glossary/property/JavaScript">property</a> reference, e.g.:</p>

--- a/files/en-us/web/javascript/reference/operators/delete/index.html
+++ b/files/en-us/web/javascript/reference/operators/delete/index.html
@@ -50,8 +50,8 @@ delete <var>object</var>['<var>property</var>']
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<p>Throws {{jsxref("TypeError")}} in {{jsxref("Functions_and_function_scope/Strict_mode",
-	"strict mode")}} if the property is an own non-configurable property.</p>
+<p>Throws {{jsxref("TypeError")}} in <a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">
+	strict mode</a> if the property is an own non-configurable property.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/division/index.html
+++ b/files/en-us/web/javascript/reference/operators/division/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.division
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var> / <var>y</var>
-</pre>
+<pre class="brush: js">x / y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.division_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x /= y
-<strong>Meaning:</strong>  x  = x / y</pre>
+<pre class="brush: js">x /= y // x = x / y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/equality/index.html
+++ b/files/en-us/web/javascript/reference/operators/equality/index.html
@@ -21,8 +21,7 @@ browser-compat: javascript.operators.equality
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">x == y
-</pre>
+<pre class="brush: js">x == y</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/exponentiation/index.html
+++ b/files/en-us/web/javascript/reference/operators/exponentiation/index.html
@@ -18,8 +18,7 @@ browser-compat: javascript.operators.exponentiation
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>var1</var> ** <var>var2</var>
-</pre>
+<pre class="brush: js">x ** y</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.exponentiation_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x **= y
-<strong>Meaning:</strong>  x  = x ** y</pre>
+<pre class="brush: js">x **= y // x = x ** y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/function/index.html
+++ b/files/en-us/web/javascript/reference/operators/function/index.html
@@ -25,9 +25,11 @@ browser-compat: javascript.operators.function
 
 <p>The expression is not allowed at the start of a statement.</p>
 
-<pre class="brush: js">function [<var>name</var>]([<var>param1</var>[, <var>param2[</var>, ..., <var>paramN</var>]]]) {
-   <var>statements</var>
-}</pre>
+<pre class="brush: js">
+function [name]([param1[, param2[, ..., paramN]]]) {
+  statements
+}
+</pre>
 
 <p>As of ES2015, you can also use {{jsxref("Functions/Arrow_functions", "arrow functions",
   "", 1)}}.</p>

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.html
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.html
@@ -22,9 +22,11 @@ browser-compat: javascript.operators.generator_function
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">function* [<var>name</var>]([<var>param1</var>[, <var>param2[</var>, ..., <var>paramN</var>]]]) {
-   <var>statements</var>
-}</pre>
+<pre class="brush: js">
+function* [name]([param1[, param2[, ..., paramN]]]) {
+  statements
+}
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.html
+++ b/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.html
@@ -18,7 +18,7 @@ browser-compat: javascript.operators.greater_than_or_equal
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"> x &gt;= y</pre>
+<pre class="brush: js">x &gt;= y</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/grouping/index.html
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.html
@@ -17,7 +17,7 @@ browser-compat: javascript.operators.grouping
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"> ( )</pre>
+<pre class="brush: js">( )</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/in/index.html
+++ b/files/en-us/web/javascript/reference/operators/in/index.html
@@ -18,7 +18,7 @@ browser-compat: javascript.operators.in
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>prop</var> in <var>object</var></pre>
+<pre class="brush: js">prop in object</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/increment/index.html
+++ b/files/en-us/web/javascript/reference/operators/increment/index.html
@@ -17,7 +17,9 @@ browser-compat: javascript.operators.increment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var>++ or ++<var>x</var>
+<pre class="brush: js">
+x++
+++x
 </pre>
 
 <h2 id="Description">Description</h2>

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.html
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.html
@@ -21,8 +21,7 @@ browser-compat: javascript.operators.instanceof
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>object</var> instanceof <var>constructor</var></pre>
+<pre class="brush: js">object instanceof constructor</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/left_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/left_shift/index.html
@@ -18,8 +18,7 @@ browser-compat: javascript.operators.left_shift
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> &lt;&lt; <var>b</var></code>
-</pre>
+<pre class="brush: js">a &lt;&lt; b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.left_shift_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x &lt;&lt;= y
-<strong>Meaning:</strong>  x   = x &lt;&lt; y</pre>
+<pre class="brush: js">x &lt;&lt;= y // x = x &lt;&lt; y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/less_than/index.html
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.html
@@ -16,7 +16,7 @@ browser-compat: javascript.operators.less_than
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"> x &lt; y</pre>
+<pre class="brush: js">x &lt; y</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.html
+++ b/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.html
@@ -17,7 +17,7 @@ browser-compat: javascript.operators.less_than_or_equal
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"> x &lt;= y</pre>
+<pre class="brush: js">x &lt;= y</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.html
@@ -23,8 +23,7 @@ browser-compat: javascript.operators.logical_and
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em> &amp;&amp; <em>expr2</em>
-</pre>
+<pre class="brush: js">expr1 &amp;&amp; expr2</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.logical_and_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em> &amp;&amp;= <em>expr2</em>
-</pre>
+<pre class="brush: js">expr1 &amp;&amp;= expr2</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.html
@@ -21,8 +21,7 @@ browser-compat: javascript.operators.logical_not
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">!<var>expr</var>
-</pre>
+<pre class="brush: js">!expr</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
@@ -22,8 +22,7 @@ browser-compat: javascript.operators.logical_nullish_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em> ??= <em>expr2</em>
-</pre>
+<pre class="brush: js">expr1 ??= expr2</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.html
@@ -23,8 +23,7 @@ browser-compat: javascript.operators.logical_or
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em> || <em>expr2</em>
-</pre>
+<pre class="brush: js">expr1 || expr2</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.logical_or_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>expr1</em> ||= <em>expr2</em>
-</pre>
+<pre class="brush: js">expr1 ||= expr2</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/multiplication/index.html
+++ b/files/en-us/web/javascript/reference/operators/multiplication/index.html
@@ -16,8 +16,7 @@ browser-compat: javascript.operators.multiplication
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var> * <var>y</var>
-</pre>
+<pre class="brush: js">x * y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.multiplication_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x *= y
-<strong>Meaning:</strong>  x  = x * y</pre>
+<pre class="brush: js">x *= y // x = x * y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/new/index.html
+++ b/files/en-us/web/javascript/reference/operators/new/index.html
@@ -19,8 +19,7 @@ browser-compat: javascript.operators.new
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">new <var>constructor</var>[([<var>arguments</var>])]</pre>
+<pre class="brush: js">new constructor[([arguments])]</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -37,8 +37,7 @@ browser-compat: javascript.operators.nullish_coalescing
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>leftExpr</var> ?? <var>rightExpr</var>
-</pre>
+<pre class="brush: js">leftExpr ?? rightExpr</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.html
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.html
@@ -30,9 +30,9 @@ let a = 'foo', b = 42, c = {}
 let o = {a: a, b: b, c: c}
 
 let o = {
-  <var>property: function </var>(<var>parameters</var>) {},
-  get <var>property</var>() {},
-  set <var>property</var>(<var>value</var>) {}
+  property: function (parameters) {},
+  get property() {},
+  set property(value) {}
 };
 </pre>
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
@@ -36,10 +36,11 @@ browser-compat: javascript.operators.optional_chaining
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>obj.val</var>?.<var>prop</var>
-<var>obj.val</var>?.[<var>expr</var>]
-<em>obj.arr</em>?.[<var>index</var>]
-<var>obj.func</var>?.(<var>args</var>)
+<pre class="brush: js">
+obj.val?.prop
+obj.val?.[expr]
+obj.arr?.[index]
+obj.func?.(args)
 </pre>
 
 <h2 id="Description">Description</h2>

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.html
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.html
@@ -18,8 +18,9 @@ browser-compat: javascript.operators.property_accessors
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>object</var>.<var>property</var>
-<var>object</var>['<var>property</var>']
+<pre class="brush: js">
+object.property
+object['property']
 </pre>
 
 <h2 id="Description">Description</h2>

--- a/files/en-us/web/javascript/reference/operators/remainder/index.html
+++ b/files/en-us/web/javascript/reference/operators/remainder/index.html
@@ -24,8 +24,7 @@ browser-compat: javascript.operators.remainder
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>var1</var> % <var>var2</var>
-</pre>
+<pre class="brush: js">x % y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/remainder_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/remainder_assignment/index.html
@@ -18,8 +18,7 @@ browser-compat: javascript.operators.remainder_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x %= y
-<strong>Meaning:</strong>  x  = x % y</pre>
+<pre class="brush: js">x %= y // x = x % y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/right_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/right_shift/index.html
@@ -22,8 +22,7 @@ browser-compat: javascript.operators.right_shift
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> &gt;&gt; <var>b</var></code>
-</pre>
+<pre class="brush: js">a &gt;&gt; b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.html
@@ -18,8 +18,7 @@ browser-compat: javascript.operators.right_shift_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x &gt;&gt;= y
-<strong>Meaning:</strong>  x   = x &gt;&gt; y</pre>
+<pre class="brush: js">x &gt;&gt;= y // x = x &gt;&gt; y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/subtraction/index.html
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.subtraction
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> <var>x</var> - <var>y</var>
-</pre>
+<pre class="brush: js">x - y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.html
@@ -18,8 +18,7 @@ browser-compat: javascript.operators.subtraction_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x -= y
-<strong>Meaning:</strong>  x  = x - y</pre>
+<pre class="brush: js">x -= y // x = x - y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/typeof/index.html
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.html
@@ -20,8 +20,9 @@ browser-compat: javascript.operators.typeof
 
 <p>The <code>typeof</code> operator is followed by its operand:</p>
 
-<pre class="brush: js">typeof <var>operand</var>
-typeof(<var>operand</var>)
+<pre class="brush: js">
+typeof operand
+typeof(operand)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/operators/unary_negation/index.html
+++ b/files/en-us/web/javascript/reference/operators/unary_negation/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.unary_negation
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> -<var>x</var>
-</pre>
+<pre class="brush: js">-x</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/unary_plus/index.html
+++ b/files/en-us/web/javascript/reference/operators/unary_plus/index.html
@@ -17,8 +17,7 @@ browser-compat: javascript.operators.unary_plus
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> +<var>x</var>
-</pre>
+<pre class="brush: js">+x</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.html
@@ -23,8 +23,7 @@ browser-compat: javascript.operators.unsigned_right_shift
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>a</var> &gt;&gt;&gt; <var>b</var></code>
-</pre>
+<pre class="brush: js">a &gt;&gt;&gt; b</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.html
@@ -21,8 +21,7 @@ browser-compat: javascript.operators.unsigned_right_shift_assignment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><strong>Operator:</strong> x &gt;&gt;&gt;= y
-<strong>Meaning:</strong>  x    = x &gt;&gt;&gt; y</pre>
+<pre class="brush: js">x &gt;&gt;&gt;= y // x = x &gt;&gt;&gt; y</pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/operators/void/index.html
+++ b/files/en-us/web/javascript/reference/operators/void/index.html
@@ -18,7 +18,7 @@ browser-compat: javascript.operators.void
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">void <em>expression</em></pre>
+<pre class="brush: js">void expression</pre>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/yield/index.html
+++ b/files/en-us/web/javascript/reference/operators/yield/index.html
@@ -22,8 +22,7 @@ browser-compat: javascript.operators.yield
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">[<var>rv</var>] = <strong>yield</strong> [<var>expression</var>]</pre>
+<pre class="brush: js">[rv] = yield [expression]</pre>
 
 <dl>
   <dt><code><var>expression</var></code> {{optional_inline}}</dt>

--- a/files/en-us/web/javascript/reference/operators/yield_star_/index.html
+++ b/files/en-us/web/javascript/reference/operators/yield_star_/index.html
@@ -22,7 +22,7 @@ browser-compat: javascript.operators.yield_star
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"> yield* <var>expression</var>;</pre>
+<pre class="brush: js">yield* expression</pre>
 
 <dl>
   <dt><code><var>expression</var></code></dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

1. There was a purpose to html tags such as `<strong>` and `<var|em>`s in code blocks. Since Yari strips all inner HTML tags of code blocks, they serve nothing now, and only introduce burdens for update and localization.

2. Also, as there's no way of explicitly highlighting something in the code blocks, some of writing conventions within JS operator references have become confusing. This PR removes them. (See below for details) It also improves overall consistency of the references.

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

```js
Operator: a + b

// Changed to

a + b
```

```js
Operator: a += b
Meaning:  a = a + b

// Changed to

a += b // a = a + b
```