### PR TITLE
Fix typo in “TypeScript support in Svelte” doc

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
@@ -183,7 +183,7 @@ npm run dev                                       # start the app in development
 
 <p><img alt='vs code screenshot showing that when you add type="ts" to a component, it gives you three dot alert hints' src="03-vscode-hints-in-main-ts.png" style="display: block; margin: 0 auto;"></p>
 
-<p>We also get type-checking for free. If we pass an unknown property in the options parameter of the <code>App</code> constructor (for example a typo like <code>target</code> instead of <code>target</code>) TypeScript will complain:</p>
+<p>We also get type-checking for free. If we pass an unknown property in the options parameter of the <code>App</code> constructor (for example a typo like <code>traget</code> instead of <code>target</code>) TypeScript will complain:</p>
 
 <p><img alt="type checking in vs code - App object has been given an unknown property target" src="04-vscode-type-checking-in-main-ts.png"></p>
 


### PR DESCRIPTION
Updates description to match example.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The description for a provided code example did not match. The example showcased how a typo would trigger a typecheck warning. 

> Issue number (if there is an associated issue)



> Anything else that could help us review it
