### PR TITLE
Fix missing preposition in “CSS building blocks” task three

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/values_tasks/index.html
@@ -61,7 +61,7 @@ tags:
 
 <h2 id="Task_Three">Task Three</h2>
 
-<p>In this task you need move the background image so that it is centered horizontally, and 20% from the top of the box.</p>
+<p>In this task you need to move the background image so that it is centered horizontally, and 20% from the top of the box.</p>
 
 <p><img alt="A stat centered horizontally in a box and a short distance from the top of the box." src="mdn-value-position.png"></p>
 


### PR DESCRIPTION
This commit adds a missing "to" preposition in the first paragraph of the Task Three exercise.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In the first paragraph of the Task Three exercise there is a missing "to" preposition.
It says "In this task you need move...". It should say "In this task you need to move..."


> Issue number (if there is an associated issue)



> Anything else that could help us review it
