### PR TITLE
Use “is fulfilled or rejected” for promises

### DIFF
--- a/files/en-us/mozilla/firefox/releases/71/index.html
+++ b/files/en-us/mozilla/firefox/releases/71/index.html
@@ -67,7 +67,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
- <li>The {{jsxref("Promise.allSettled()")}} method is now supported ({{bug(1549176)}}). This method lets you easily wait until every promise in a set of promises has either resolved or rejected before running further code.</li>
+ <li>The {{jsxref("Promise.allSettled()")}} method is now supported ({{bug(1549176)}}). This method lets you easily wait until every promise in a set of promises is either fulfilled or rejected before running further code.</li>
 </ul>
 
 <h4 id="Removals_2">Removals</h4>

--- a/files/en-us/web/api/htmlmediaelement/load/index.html
+++ b/files/en-us/web/api/htmlmediaelement/load/index.html
@@ -55,7 +55,7 @@ browser-compat: api.HTMLMediaElement.load
 
 <p>The process of aborting any ongoing activities will cause any outstanding
   {{jsxref("Promise")}}s returned by {{domxref("HTMLMediaElement.play", "play()")}} being
-  resolved or rejected as appropriate based on their status before the loading of new
+ fulfilled or rejected as appropriate based on their status before the loading of new
   media can begin. Pending play promises are aborted with an <code>"AbortError"</code>
   {{domxref("DOMException")}}.</p>
 

--- a/files/en-us/web/api/htmlmediaelement/play/index.html
+++ b/files/en-us/web/api/htmlmediaelement/play/index.html
@@ -72,7 +72,7 @@ browser-compat: api.HTMLMediaElement.play
   promise to be immediately rejected with a <code>NotAllowedError</code>. Web sites should
   be prepared to handle this situation. For example, a site should not present a user
   interface that assumes playback has begun automatically, but should instead update their
-  UI based on whether the returned promise is resolved or rejected. See the
+  UI based on whether the returned promise is fulfilled or rejected. See the
   {{anch("Example", "example")}} below for more information.</p>
 
 <div class="note">

--- a/files/en-us/web/javascript/guide/using_promises/index.html
+++ b/files/en-us/web/javascript/guide/using_promises/index.html
@@ -228,7 +228,7 @@ wait(10*1000).then(() =&gt; saySomething("10 seconds")).catch(failureCallback);
 
 <h2 id="Composition">Composition</h2>
 
-<p>{{jsxref("Promise.resolve()")}} and {{jsxref("Promise.reject()")}} are shortcuts to manually create an already fulfilled or rejected promise respectively. This can be useful at times.</p>
+<p>{{jsxref("Promise.resolve()")}} and {{jsxref("Promise.reject()")}} are shortcuts to manually create an already resolved or rejected promise respectively. This can be useful at times.</p>
 
 <p>{{jsxref("Promise.all()")}} and {{jsxref("Promise.race()")}} are two composition tools for running asynchronous operations in parallel.</p>
 

--- a/files/en-us/web/javascript/guide/using_promises/index.html
+++ b/files/en-us/web/javascript/guide/using_promises/index.html
@@ -228,7 +228,7 @@ wait(10*1000).then(() =&gt; saySomething("10 seconds")).catch(failureCallback);
 
 <h2 id="Composition">Composition</h2>
 
-<p>{{jsxref("Promise.resolve()")}} and {{jsxref("Promise.reject()")}} are shortcuts to manually create an already resolved or rejected promise respectively. This can be useful at times.</p>
+<p>{{jsxref("Promise.resolve()")}} and {{jsxref("Promise.reject()")}} are shortcuts to manually create an already fulfilled or rejected promise respectively. This can be useful at times.</p>
 
 <p>{{jsxref("Promise.all()")}} and {{jsxref("Promise.race()")}} are two composition tools for running asynchronous operations in parallel.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.html
@@ -201,13 +201,13 @@ window.addEventListener("message", (event) =&gt; {
  <dt>{{JSxRef("Promise.allSettled", "Promise.allSettled(iterable)")}}</dt>
  <dd>
    <p>Wait until all promises have settled (each may resolve or reject).</p>
-   <p>Returns a Promise that resolves after all of the given promises have either resolved or rejected, with an array of objects that each describe the outcome of each promise.</p>
+   <p>Returns a Promise that resolves after all of the given promises is either fulfilled or rejected, with an array of objects that each describe the outcome of each promise.</p>
  </dd>
  <dt>{{JSxRef("Promise.any", "Promise.any(iterable)")}}</dt>
  <dd>Takes an iterable of Promise objects and, as soon as one of the promises in the iterable fulfills, returns a single promise that resolves with the value from that promise.</dd>
  <dt>{{JSxRef("Promise.race", "Promise.race(iterable)")}}</dt>
  <dd>
-   <p>Wait until any of the promises is resolved or rejected.</p>
+   <p>Wait until any of the promises is fulfilled or rejected.</p>
    <p>If the returned promise resolves, it is resolved with the value of the first promise in the iterable that resolved.</p>
    <p>If it rejects, it is rejected with the reason from the first promise that was rejected.</p>
  </dd>


### PR DESCRIPTION
Rather than “(is|has) resolved or rejected” for promises, consistently use “is fulfilled or rejected”. Fixes https://github.com/mdn/content/issues/6521.