### PR TITLE
docs: correct the indentation in some code blocks

### DIFF
--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -22,44 +22,43 @@ tags:
 
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
+  .wrapper {
+    max-width: 1024px;
+    margin: 0 auto;
+    font: 1.2em Helvetica, arial, sans-serif;
+  }
 
-    .wrapper {
-        max-width: 1024px;
-        margin: 0 auto;
-        font: 1.2em Helvetica, arial, sans-serif;
-    }
+  .wrapper &gt; * {
+    border: 2px solid #f08c00;
+    background-color: #ffec99;
+    border-radius: 5px;
+    padding: 10px;
+  }
 
-    .wrapper &gt; * {
-        border: 2px solid #f08c00;
-        background-color: #ffec99;
-        border-radius: 5px;
-        padding: 10px;
-    }
-
-    nav ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-    }
+  nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 </pre>
 </div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
-        &lt;header class="main-head"&gt;The header&lt;/header&gt;
-        &lt;nav class="main-nav"&gt;
-            &lt;ul&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 1&lt;/a&gt;&lt;/li&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 2&lt;/a&gt;&lt;/li&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 3&lt;/a&gt;&lt;/li&gt;
-            &lt;/ul&gt;
-        &lt;/nav&gt;
-        &lt;article class="content"&gt;
-            &lt;h1&gt;Main article area&lt;/h1&gt;
-            &lt;p&gt;In this layout, we display the areas in source order for any screen less that 500 pixels wide. We go to a two column layout, and then to a three column layout by redefining the grid, and the placement of items on the grid.&lt;/p&gt;
-        &lt;/article&gt;
-        &lt;aside class="side"&gt;Sidebar&lt;/aside&gt;
-        &lt;div class="ad"&gt;Advertising&lt;/div&gt;
-        &lt;footer class="main-footer"&gt;The footer&lt;/footer&gt;
+  &lt;header class="main-head"&gt;The header&lt;/header&gt;
+  &lt;nav class="main-nav"&gt;
+    &lt;ul&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 1&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 2&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 3&lt;/a&gt;&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/nav&gt;
+  &lt;article class="content"&gt;
+    &lt;h1&gt;Main article area&lt;/h1&gt;
+    &lt;p&gt;In this layout, we display the areas in source order for any screen less that 500 pixels wide. We go to a two column layout, and then to a three column layout by redefining the grid, and the placement of items on the grid.&lt;/p&gt;
+  &lt;/article&gt;
+  &lt;aside class="side"&gt;Sidebar&lt;/aside&gt;
+  &lt;div class="ad"&gt;Advertising&lt;/div&gt;
+  &lt;footer class="main-footer"&gt;The footer&lt;/footer&gt;
 &lt;/div&gt;
 </pre>
 
@@ -216,43 +215,44 @@ tags:
 
 <div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
+  .wrapper {
+    max-width: 1024px;
+    margin: 0 auto;
+    font: 1.2em Helvetica, arial, sans-serif;
+  }
 
-    .wrapper {
-        max-width: 1024px;
-        margin: 0 auto;
-        font: 1.2em Helvetica, arial, sans-serif;
-    }
+  .wrapper &gt; * {
+    border: 2px solid #f08c00;
+    background-color: #ffec99;
+    border-radius: 5px;
+    padding: 10px;
+  }
 
-    .wrapper &gt; * {
-        border: 2px solid #f08c00;
-        background-color: #ffec99;
-        border-radius: 5px;
-        padding: 10px;
-    }
-
-    nav ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-    }
+  nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 </pre>
 </div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
-        &lt;header class="main-head"&gt;The header&lt;/header&gt;
-        &lt;nav class="main-nav"&gt;
-            &lt;ul&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 1&lt;/a&gt;&lt;/li&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 2&lt;/a&gt;&lt;/li&gt;
-                &lt;li&gt;&lt;a href=""&gt;Nav 3&lt;/a&gt;&lt;/li&gt;
-            &lt;/ul&gt;
-        &lt;/nav&gt;
-        &lt;article class="content"&gt;&lt;h1&gt;Main article area&lt;/h1&gt;
-        &lt;p&gt;In this layout, we display the areas in source order for any screen less that 500 pixels wide. We go to a two column layout, and then to a three column layout by redefining the grid, and the placement of items on the grid.&lt;/p&gt;&lt;/article&gt;
-        &lt;aside class="side"&gt;Sidebar&lt;/aside&gt;
-        &lt;div class="ad"&gt;Advertising&lt;/div&gt;
-        &lt;footer class="main-footer"&gt;The footer&lt;/footer&gt;
-    &lt;/div&gt;
+  &lt;header class="main-head"&gt;The header&lt;/header&gt;
+  &lt;nav class="main-nav"&gt;
+    &lt;ul&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 1&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 2&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=""&gt;Nav 3&lt;/a&gt;&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/nav&gt;
+  &lt;article class="content"&gt;
+    &lt;h1&gt;Main article area&lt;/h1&gt;
+    &lt;p&gt;In this layout, we display the areas in source order for any screen less that 500 pixels wide. We go to a two column layout, and then to a three column layout by redefining the grid, and the placement of items on the grid.&lt;/p&gt;
+  &lt;/article&gt;
+  &lt;aside class="side"&gt;Sidebar&lt;/aside&gt;
+  &lt;div class="ad"&gt;Advertising&lt;/div&gt;
+  &lt;footer class="main-footer"&gt;The footer&lt;/footer&gt;
+&lt;/div&gt;
 </pre>
 
 <p>I can then set up our grid, as for the example 12-column layout above.</p>
@@ -278,7 +278,6 @@ tags:
 <p>The ad panel is below the sidebar, so starts at grid row line 4. Then we have the content and footer starting at col-start 4 and spanning 9 tracks taking them to the end of the grid.</p>
 
 <pre class="brush: css">@media (min-width: 500px) {
-
   .side {
     grid-column: col-start / span 3;
     grid-row: 3;
@@ -342,32 +341,52 @@ tags:
 <pre class="brush: html">&lt;ul class="listing"&gt;
   &lt;li&gt;
     &lt;h2&gt;Item One&lt;/h2&gt;
-    &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;&lt;/div&gt;
-    &lt;div class="cta"&gt;&lt;a href=""&gt;Call to action!&lt;/a&gt;&lt;/div&gt;
+    &lt;div class="body"&gt;
+      &lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="cta"&gt;
+      &lt;a href=""&gt;Call to action!&lt;/a&gt;
+    &lt;/div&gt;
   &lt;/li&gt;
-   &lt;li&gt;
-     &lt;h2&gt;Item Two&lt;/h2&gt;
-     &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;&lt;/div&gt;
-     &lt;div class="cta"&gt;&lt;a href=""&gt;Call to action!&lt;/a&gt;&lt;/div&gt;
-   &lt;/li&gt;
-   &lt;li class="wide"&gt;
-     &lt;h2&gt;Item Three&lt;/h2&gt;
-     &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
-     &lt;p&gt;This one has more text than the other items.&lt;/p&gt;
-     &lt;p&gt;Quite a lot more&lt;/p&gt;
-     &lt;p&gt;Perhaps we could do something different with it?&lt;/p&gt;&lt;/div&gt;
-     &lt;div class="cta"&gt;&lt;a href=""&gt;Call to action!&lt;/a&gt;&lt;/div&gt;
-    &lt;/li&gt;
-    &lt;li&gt;
-     &lt;h2&gt;Item Four&lt;/h2&gt;
-     &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;&lt;/div&gt;
-     &lt;div class="cta"&gt;&lt;a href=""&gt;Call to action!&lt;/a&gt;&lt;/div&gt;
-    &lt;/li&gt;
-     &lt;li&gt;
-     &lt;h2&gt;Item Five&lt;/h2&gt;
-     &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;&lt;/div&gt;
-      &lt;div class="cta"&gt;&lt;a href=""&gt;Call to action!&lt;/a&gt;&lt;/div&gt;
-    &lt;/li&gt;
+  &lt;li&gt;
+    &lt;h2&gt;Item Two&lt;/h2&gt;
+    &lt;div class="body"&gt;
+      &lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="cta"&gt;
+      &lt;a href=""&gt;Call to action!&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+  &lt;li class="wide"&gt;
+    &lt;h2&gt;Item Three&lt;/h2&gt;
+    &lt;div class="body"&gt;
+      &lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
+      &lt;p&gt;This one has more text than the other items.&lt;/p&gt;
+      &lt;p&gt;Quite a lot more&lt;/p&gt;
+      &lt;p&gt;Perhaps we could do something different with it?&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="cta"&gt;
+      &lt;a href=""&gt;Call to action!&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;h2&gt;Item Four&lt;/h2&gt;
+    &lt;div class="body"&gt;
+      &lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="cta"&gt;
+      &lt;a href=""&gt;Call to action!&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;h2&gt;Item Five&lt;/h2&gt;
+    &lt;div class="body"&gt;
+      &lt;p&gt;The content of this listing item goes here.&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="cta"&gt;
+      &lt;a href=""&gt;Call to action!&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -546,6 +546,6 @@ tags:
 <p>The best way to learn to use grid layout is to continue to build examples like the ones we have covered here. Pick something that you normally build using your framework of choice, or using floats, and see if you can build it using grid. Don’t forget to find examples that are impossible to build with current methods. That might mean taking inspiration from magazines or other non-web sources. Grid Layout opens up possibilities that we have not had before, we don’t need to be tied to the same old layouts to use it.</p>
 
 <ul>
- <li>For inspiration see the <a href="http://labs.jensimmons.com/"><em>Layout Labs</em> from Jen Simmons</a>, she has been creating layouts based on a range of sources.</li>
- <li>For additional common layout patterns see <em><a href="http://gridbyexample.com">Grid by Example</a></em>, where there are many smaller examples of grid layout and also some larger UI patterns and full page layouts.</li>
+ <li>For inspiration see the <a href="https://labs.jensimmons.com/"><em>Layout Labs</em> from Jen Simmons</a>, she has been creating layouts based on a range of sources.</li>
+ <li>For additional common layout patterns see <em><a href="https://gridbyexample.com">Grid by Example</a></em>, where there are many smaller examples of grid layout and also some larger UI patterns and full page layouts.</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A couple of code blocks in the [Realizing common layouts using CSS Grid Layout article](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout) have some formatting issue (indentation mostly).

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Screenshots:

| Before | After | Note |
| --- | --- | --- |
| <img width="1030" alt="Screen Shot 2021-07-04 at 11 58 42" src="https://user-images.githubusercontent.com/25715018/124373753-38847080-dcbf-11eb-8966-7667b701b661.png"> | <img width="1035" alt="Screen Shot 2021-07-04 at 11 58 48" src="https://user-images.githubusercontent.com/25715018/124373757-42a66f00-dcbf-11eb-84f8-f646270899d0.png"> | This is under [this section](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout#a_responsive_layout_with_1_to_3_fluid_columns_using_grid-template-areas). |
| <img width="1052" alt="Screen Shot 2021-07-04 at 12 05 06" src="https://user-images.githubusercontent.com/25715018/124373845-1808e600-dcc0-11eb-88fa-582de92d85f6.png"> | <img width="1039" alt="Screen Shot 2021-07-04 at 12 10 02" src="https://user-images.githubusercontent.com/25715018/124373923-d3317f00-dcc0-11eb-8450-5e03a485131c.png"> | This is under [this section](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout#building_a_layout_using_the_12-column_system). I fixed the indentation as well as moving the `h1` to a new line. |
| <img width="1049" alt="Screen Shot 2021-07-04 at 11 48 03" src="https://user-images.githubusercontent.com/25715018/124373725-083cd200-dcbf-11eb-9bf2-c7e39cde49ed.png"> | <img width="1048" alt="Screen Shot 2021-07-04 at 12 01 52" src="https://user-images.githubusercontent.com/25715018/124373797-a761c980-dcbf-11eb-9572-31f91d4ec776.png"> | This is under [this section](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout#building_a_layout_using_the_12-column_system) |
| <img width="1042" alt="Screen Shot 2021-07-04 at 11 48 23" src="https://user-images.githubusercontent.com/25715018/124373825-e09a3980-dcbf-11eb-8a54-1875eff51005.png"> | <img width="937" alt="Screen Shot 2021-07-04 at 11 53 33" src="https://user-images.githubusercontent.com/25715018/124373830-ea23a180-dcbf-11eb-8c8b-bee330fc7362.png"> | This is under [this section](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout#a_product_listing_with_auto-placement). I fixed the indentation as well as moving the `p` and `a` elements inside the `div`s to a new line. |
