### PR TITLE
Remove spec tables from IDBMutableFile

### DIFF
--- a/files/en-us/web/api/idbmutablefile/getfile/index.html
+++ b/files/en-us/web/api/idbmutablefile/getfile/index.html
@@ -28,20 +28,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('FileSystem')}}</td>
-      <td>{{Spec2('FileSystem')}}</td>
-      <td>Draft proposal</td>
-    </tr>
-  </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/index.html
+++ b/files/en-us/web/api/idbmutablefile/index.html
@@ -48,7 +48,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Not part of any specification at present.</p>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/name/index.html
+++ b/files/en-us/web/api/idbmutablefile/name/index.html
@@ -26,20 +26,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('FileSystem')}}</td>
-      <td>{{Spec2('FileSystem')}}</td>
-      <td>Draft Proposal.</td>
-    </tr>
-  </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/onabort/index.html
+++ b/files/en-us/web/api/idbmutablefile/onabort/index.html
@@ -24,22 +24,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('FileSystem')}}</td>
-   <td>{{Spec2('FileSystem')}}</td>
-   <td>Draft proposal.</td>
-  </tr>
- </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/onerror/index.html
+++ b/files/en-us/web/api/idbmutablefile/onerror/index.html
@@ -24,22 +24,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('FileSystem')}}</td>
-   <td>{{Spec2('FileSystem')}}</td>
-   <td>Draft proposal.</td>
-  </tr>
- </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/open/index.html
+++ b/files/en-us/web/api/idbmutablefile/open/index.html
@@ -35,20 +35,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('FileSystem')}}</td>
-      <td>{{Spec2('FileSystem')}}</td>
-      <td>Draft proposal</td>
-    </tr>
-  </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbmutablefile/type/index.html
+++ b/files/en-us/web/api/idbmutablefile/type/index.html
@@ -26,20 +26,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('FileSystem')}}</td>
-      <td>{{Spec2('FileSystem')}}</td>
-      <td>Draft Proposal.</td>
-    </tr>
-  </tbody>
-</table>
+<p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Part of #1146

IDBMutableFile is only supported by Firefox, and not on any standard track. I replaced the spec tables by a message.