### PR TITLE
Fix sidebar and {{Specifications}} for Background Fetch API

### DIFF
--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -12,7 +12,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.fetch
 ---
-<div>{{DefaultAPISidebar("Background Fetch")}}</div>
+<div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
 <p class="summary">The <strong><code>fetch()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects. </p>
 

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.html
@@ -12,7 +12,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.get
 ---
-<div>{{DefaultAPISidebar("Background Fetch")}}</div>
+<div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
 <p class="summary">The <strong><code>get()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided <code>id</code> or {{jsxref("undefined")}} if the <code>id</code> is not found. </p>
 

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.html
@@ -12,7 +12,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.getIds
 ---
-<div>{{DefaultAPISidebar("Background Fetch")}}</div>
+<div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
 <p class="summary">The <strong><code>getIds()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches. </p>
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/index.html
@@ -11,7 +11,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager
 ---
-<div>{{DefaultAPISidebar("Background Fetch")}}</div>
+<div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
 <p class="summary">The <strong><code>BackgroundFetchManager</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.</p>
 

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.html
@@ -33,7 +33,6 @@ browser-compat: api.BackgroundFetchRecord.request
   console.log(`Here's the request`, record.request);
 });</pre>
 
-
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.html
@@ -24,13 +24,13 @@ browser-compat: api.BackgroundFetchRegistration.match
   <dd>The {{domxref("Request")}} for which you are attempting to find records.
     This can be a {{domxref("Request")}} object or a URL.</dd>
   <dt><code>options</code> {{optional_inline}}</dt>
-  <dd>An object that sets options for the <code>match</code> operation. The available
+  <dd>An object that sets options for the <code>match</code> operation. The available
     options are:
     <dl>
       <dt><code>ignoreSearch</code></dt>
       <dd>A {{jsxref("Boolean")}} that specifies whether to
-        ignore the query string in the URL.  For example, if set to
-        <code>true</code> the <code>?value=bar</code> part of
+        ignore the query string in the URL. For example, if set to
+        <code>true</code> the <code>?value=bar</code> part of
         <code>http://foo.com/?value=bar</code> would be ignored when performing a match.
         It defaults to <code>false</code>.</dd>
       <dt><code>ignoreMethod</code></dt>

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
@@ -24,13 +24,13 @@ browser-compat: api.BackgroundFetchRegistration.matchAll
   <dd>The {{domxref("Request")}} for which you are attempting to find records.
     This can be a {{domxref("Request")}} object or a URL.</dd>
   <dt><code>options</code> {{optional_inline}}</dt>
-  <dd>An object that sets options for the <code>match</code> operation. The available
+  <dd>An object that sets options for the <code>match</code> operation. The available
     options are:
     <dl>
       <dt><code>ignoreSearch</code></dt>
       <dd>A {{jsxref("Boolean")}} that specifies whether to
-        ignore the query string in the URL.  For example, if set to
-        <code>true</code> the <code>?value=bar</code> part of
+        ignore the query string in the URL. For example, if set to
+        <code>true</code> the <code>?value=bar</code> part of
         <code>http://foo.com/?value=bar</code> would be ignored when performing a match.
         It defaults to <code>false</code>.</dd>
       <dt><code>ignoreMethod</code></dt>

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
@@ -26,20 +26,9 @@ browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 
 <pre class="brush: js">console.log(bgFetch.recordsAvailable);</pre>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-     <td>{{SpecName('Background Fetch','#dom-backgroundfetchregistration-recordsavailable','BackgroundFetchRegistration.recordsAvailable')}}</td>
-     <td>{{Spec2('Background Fetch')}}</td>
-     <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchUpdateUIEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchUpdateUIEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
+<p class="summary">The <strong><code>BackgroundFetchUpdateUIEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchUpdateUIEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
The sidebar for Background Fetch API were not appearing on these pages, because:
- there was no entry in GroupData.json. This will be fixed by mdn/yari#4125
- the key to it was wrong on some pages (this PR fixes this)

Also, one specification table was not sourced from front-runner (because it was missing the H2 header, it has not been detected previously). I fix this here too (this is part of #1146)

I removed some gremlins (non-breakable spaces) on the way.

Note: there are missing pages (events, event handlers, but also all the properties on other interfaces like `ServiceWorkerGlobalHandler`), but this was outside the scope of this PR.