### PR TITLE
Fix spec mentions in events

### DIFF
--- a/files/en-us/web/api/eventsource/open_event/index.html
+++ b/files/en-us/web/api/eventsource/open_event/index.html
@@ -49,20 +49,9 @@ evtSource.onopen = (e) =&gt; {
 };
 </pre>
 
-<h2 class="brush: js" id="Specifications">Specifications</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-open", "open event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
@@ -17,13 +17,6 @@ browser-compat: api.GlobalEventHandlers.ontouchcancel
   {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
   processes {{event("touchcancel")}} events.</p>
 
-<div class="note">
-  <p><strong>Note:</strong> This property has <em>not</em> been formally standardized. It
-    is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}}
-    specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This
-    property is not widely implemented.</p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <var>cancelHandler</var> = <var>someElement</var>.ontouchcancel;

--- a/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
@@ -15,13 +15,6 @@ browser-compat: api.GlobalEventHandlers.ontouchend
   {{domxref("GlobalEventHandlers","global event handler", "", 1)}} for the
   {{event("touchend")}} event.</p>
 
-<div class="note">
-  <p><strong>Note:</strong> This property has <em>not</em> been formally standardized. It
-    is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}}
-    specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This
-    property is not widely implemented.</p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <var>endHandler</var> = <var>targetElement</var>.ontouchend;

--- a/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
@@ -14,10 +14,6 @@ browser-compat: api.GlobalEventHandlers.ontouchmove
 
 <p>{{SeeCompatTable}}</p>
 
-<div class="note">
-<p><strong>Note:</strong> This attribute has <em>not</em> been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.</p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var moveHandler = someElement.ontouchmove;

--- a/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
@@ -17,13 +17,6 @@ browser-compat: api.GlobalEventHandlers.ontouchstart
   {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
   processes {{event("touchstart")}} events.</p>
 
-<div class="note">
-  <p><strong>Note:</strong> This attribute has <em>not</em> been formally standardized. It
-    is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}}
-    specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This
-    attribute is not widely implemented.</p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <em>startHandler</em> = <em>someElement</em>.ontouchstart;

--- a/files/en-us/web/api/htmlelement/change_event/index.html
+++ b/files/en-us/web/api/htmlelement/change_event/index.html
@@ -120,20 +120,7 @@ function updateValue(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-change", "change")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.GlobalEventHandlers.onchange")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.html
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.html
@@ -24,11 +24,10 @@ tags:
       {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}} constructor
       instead.</strong><br>
     <br>
-    This method is based on early drafts of {{SpecName("DOM2 Events")}} and is implemented
-    in Gecko-based browsers; other browsers implemented
-    {{domxref("KeyboardEvent.initKeyboardEvent")}} based on early drafts of
-    {{SpecName("DOM3 Events")}}. Favor the modern constructor structure as the only
-    cross-browser way of building events.
+    This method is based on the key events spec in the <a class="external"
+    href="https://www.w3.org/TR/1999/WD-DOM-Level-2-19990923/events.html">early versions
+    of DOM 2 Events</a>, later removed from that spec.Favor the modern constructor structure as
+    the only cross-browser way of building events.
   </p>
 </div>
 
@@ -93,15 +92,14 @@ document.getElementById('blah').dispatchEvent(event);
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This implementation of keyboard events is based on the key events spec in the <a
-    class="external"
+<p>This implementation of keyboard events is based on the key events spec in the <a class="external"
     href="https://www.w3.org/TR/1999/WD-DOM-Level-2-19990923/events.html">early versions
     of DOM 2 Events</a>, later removed from that spec.</p>
 
 <p>The <code>initKeyEvent</code> is the current Gecko equivalent of the DOM Level 3 Events
   (initially drafted and also deprecated in favor of
   {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}}
-  {{domxref("Keyboard.initKeyboardEvent()")}} method with the following arguments :</p>
+  {{domxref("Keyboard.initKeyboardEvent()")}} method with the following arguments:</p>
 
 <pre class="eval">typeArg of type DOMString
 canBubbleArg of type boolean

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()
+title: PaymentRequestUpdateEvent()
 slug: Web/API/PaymentRequestUpdateEvent/PaymentRequestUpdateEvent
 tags:
 - API
@@ -14,7 +14,7 @@ browser-compat: api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent
 ---
 <p>{{APIRef("Payment Request API")}}{{securecontext_header}}</p>
 
-<p>The <strong><code>PaymentRequestUpdateEvent</code></strong> constructor creates a new
+<p>The <strong><code>PaymentRequestUpdateEvent()</code></strong> constructor creates a new
   {{domxref("PaymentRequestUpdateEvent")}} object which enables a web page to update the
   details of a {{domxref("PaymentRequest")}} in response to a user action. Actual updates
   are made by passing options to the
@@ -31,9 +31,7 @@ browser-compat: api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A new <code>PaymentRequestUpdateEvent</code>
-  object.{{SpecName('Payment','#paymentrequestupdateevent-interface','PaymentRequestUpdateEvent')}}
-</p>
+<p>A new <code>PaymentRequestUpdateEvent</code></p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.html
@@ -74,7 +74,7 @@ browser-compat: api.TransitionEvent.initTransitionEvent
 <h2 id="Specifications">Specifications</h2>
 
 <p><em>This method is non-standard and not part of any specification, though it was
-    present in early drafts of {{SpecName("CSS3 Transitions")}}.</em></p>
+    present in early drafts of <a href="https://drafts.csswg.org/css-transitions/">CSS Transitions</a>.</em></p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/offline_event/index.html
+++ b/files/en-us/web/api/window/offline_event/index.html
@@ -47,20 +47,9 @@ window.onoffline = (event) =&gt; {
 };
 </pre>
 
-<h2 class="brush: js" id="Specifications">Specifications</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-offline", "offline event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/online_event/index.html
+++ b/files/en-us/web/api/window/online_event/index.html
@@ -49,20 +49,9 @@ window.ononline = (event) =&gt; {
 };
 </pre>
 
-<h2 class="brush: js" id="Specifications">Specifications</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "indices.html#event-online", "online event")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Part of #1146

There were a few {{Specifications}} missing and a few non-standard way of signaling spec links.

This fixes it.