### PR TITLE
Fix bcd key for WebKitPoint

### DIFF
--- a/files/en-us/web/api/webkitpoint/index.html
+++ b/files/en-us/web/api/webkitpoint/index.html
@@ -9,7 +9,7 @@ tags:
   - Non-standard
   - Point
   - Reference
-browser-compat: api.Point
+browser-compat: api.WebKitPoint
 ---
 <div>{{APIRef("CSS3 Transforms")}}{{Deprecated_Header}}{{Non-standard_header}}</div>
 


### PR DESCRIPTION
Given mdn/browser-compat-data#11361 and #6529 were both merged, this PR fix the bcd key to point to the new value.