### PR TITLE
Source specifications from macro for TransformStreamDefaultController 

### DIFF
--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - desiredSize
   - TransformStreamDefaultController
+browser-compat: api.TransformStreamDefaultController.desiredSize
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
@@ -46,8 +47,10 @@ tags:
   </tbody>
  </table>
 
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
-<p>{{Compat("api.TransformStreamDefaultController.desiredSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - enqueue
   - TransformStreamDefaultController
+browser-compat: api.TransformStreamDefaultController.enqueue
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
@@ -40,23 +41,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#ts-default-controller-enqueue','TransformStreamDefaultController.enqueue()')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
-<p>{{Compat("api.TransformStreamDefaultController.enqueue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - error
   - TransformStreamDefaultController
+browser-compat: api.TransformStreamDefaultController.error
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
@@ -48,8 +49,10 @@ tags:
   </tbody>
  </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+ <h2 id="Specifications">Specifications</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+ {{Specifications}}
 
-<p>{{Compat("api.TransformStreamDefaultController.error")}}</p>
+ <h2 id="Browser_compatibility">Browser compatibility</h2>
+
+ <p>{{Compat}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TransformStreamDefaultController
+browser-compat: api.TransformStreamDefaultController
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
@@ -73,23 +74,8 @@ class AnyToU8Stream extends TransformStream {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Streams','#ts-default-controller-class','TransformStreamDefaultController')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
-<p>{{Compat("api.TransformStreamDefaultController")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - terminate
   - TransformStreamDefaultController
+browser-compat: api.TransformStreamDefaultController.terminate
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
@@ -28,23 +29,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#ts-default-controller-terminate','TransformStreamDefaultController.terminate()')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
-<p>{{Compat("api.TransformStreamDefaultController.terminate")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
For TransformStreamDefaultController and its children:
- Moved the bcd key in front-runner
- Replace the spec table par the `{{Specifications}}` macro

Note the `spec_url` clauses are added in bcd by the PR mdn/browser-compat-data#11392


(This is part of #1146)