### PR TITLE
Add .github/workflows/ping-other-repos.yml

### DIFF
--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -1,0 +1,17 @@
+name: Ping other repos
+
+on:
+  push:
+    branches: [main]
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping w3c/mdn-spec-links
+        uses: peter-evans/repository-dispatch@v1
+        if: ${{ github.repository == 'mdn/content' }}
+        with:
+          token: ${{ secrets.SIDESHOWBARKER }}
+          repository: w3c/mdn-spec-links
+          event-type: ping
+          client-payload: '{"repository": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -1,17 +1,27 @@
 name: Ping other repos
+# This workflow exists for this use case: When another repo wants to take
+# some action each time an MDN PR is merged and a change is pushed to the
+# MDN main branch. For example, other repos that pull in content directly
+# from MDN as part of their own builds might want to automatically re-run
+# their repo build scripts each time a change is pushed to MDN upstream.
+#
+# https://github.com/mdn/browser-compat-data/blob/main/.github/workflows/ping-other-repos.yml
+# has the BCD equivalent of this workflow.
 
 on:
   push:
     branches: [main]
 jobs:
+  if: ${{ github.repository == 'mdn/content' }}  # Won’t be run from forks
   ping:
     runs-on: ubuntu-latest
     steps:
       - name: Ping w3c/mdn-spec-links
+        # This is one of many possible repos we can ping. When adding other
+        # repos, you can follow this w3c/mdn-spec-links one as an example.
         uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'mdn/content' }}
         with:
-          token: ${{ secrets.SIDESHOWBARKER }}
+          token: ${{ secrets.REPO_PINGER_MDN_SPEC_LINKS }}
           repository: w3c/mdn-spec-links
           event-type: ping
           client-payload: '{"repository": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
For every push to the repo, the `.github/workflows/ping-other-repos.yml` file added in this change creates a GitHub `repository_dispatch` event to send a ping to the https://github.com/w3c/mdn-spec-links/ repo (where it triggers the build of the contents of that repo).

Along with https://github.com/w3c/mdn-spec-links/, other repos can be added to this later — any repos that want to have some action triggered each time a push to the BCD repo occurs.

https://github.com/marketplace/actions/repository-dispatch has docs on the GitHub Action this uses, and docs for the underlying API it uses are at https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event

---

This is identical to the https://github.com/mdn/browser-compat-data/blob/main/.github/workflows/ping-other-repos.yml workflow that @ddbeck and I worked on together for BCD. Adding additional repos we may want to start pinging also later would just be a matter of copy/pasting the existing w3c/mdn-spec-links step, and just changing repo-name part.