### PR TITLE
Source spec from {{Specifications}} for missed api pages

### DIFF
--- a/files/en-us/web/api/cache/addall/index.html
+++ b/files/en-us/web/api/cache/addall/index.html
@@ -98,22 +98,9 @@ browser-compat: api.Cache.addAll
 });
 </pre>
 
-<h3 id="Specifications">Specifications</h3>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Service Workers', '#cache-addAll', 'Cache: addAll')}}</td>
-      <td>{{Spec2('Service Workers')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/compressionstream/writable/index.html
+++ b/files/en-us/web/api/compressionstream/writable/index.html
@@ -27,20 +27,9 @@ browser-compat: api.CompressionStream.writable
 <pre class="brush:js">let stream = new CompressionStream('gzip');
 console.log(stream.writeable); //a WritableStream</pre>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#dom-generictransformstream-writable','writable')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -25,28 +25,21 @@ browser-compat: api.Gamepad
  <dt>{{domxref("Gamepad.connected")}} {{readonlyInline}}</dt>
  <dd>A boolean indicating whether the gamepad is still connected to the system.</dd>
  <dt>{{domxref("Gamepad.displayId")}} {{readonlyInline}}</dt>
- <dd><dfn>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dfn></dd>
+ <dd>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dd>
+ <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
+ <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
+ <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
+ <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
  <dt>{{domxref("Gamepad.id")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMString")}} containing identifying information about the controller.</dd>
  <dt>{{domxref("Gamepad.index")}} {{readonlyInline}}</dt>
  <dd>An integer that is auto-incremented to be unique for each device currently connected to the system.</dd>
  <dt>{{domxref("Gamepad.mapping")}} {{readonlyInline}}</dt>
  <dd>A string indicating whether the browser has remapped the controls on the device to a known layout.</dd>
+ <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}{{ExperimentalInline}}</dt>
+ <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
  <dt>{{domxref("Gamepad.timestamp")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the last time the data for this gamepad was updated.</dd>
-</dl>
-
-<h3 id="Experimental_extensions_to_Gamepad">Experimental extensions to Gamepad</h3>
-
-<p>The following interfaces are defined in the {{SpecName("GamepadExtensions")}} specification, and provide access to experimental features like haptic feedback and WebVR controller pose information.</p>
-
-<dl>
- <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
- <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
- <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
- <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
- <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -25,21 +25,28 @@ browser-compat: api.Gamepad
  <dt>{{domxref("Gamepad.connected")}} {{readonlyInline}}</dt>
  <dd>A boolean indicating whether the gamepad is still connected to the system.</dd>
  <dt>{{domxref("Gamepad.displayId")}} {{readonlyInline}}</dt>
- <dd>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dd>
- <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
- <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
- <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
- <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
+ <dd><dfn>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dfn></dd>
  <dt>{{domxref("Gamepad.id")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMString")}} containing identifying information about the controller.</dd>
  <dt>{{domxref("Gamepad.index")}} {{readonlyInline}}</dt>
  <dd>An integer that is auto-incremented to be unique for each device currently connected to the system.</dd>
  <dt>{{domxref("Gamepad.mapping")}} {{readonlyInline}}</dt>
  <dd>A string indicating whether the browser has remapped the controls on the device to a known layout.</dd>
- <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}{{ExperimentalInline}}</dt>
- <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
  <dt>{{domxref("Gamepad.timestamp")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the last time the data for this gamepad was updated.</dd>
+</dl>
+
+<h3 id="Experimental_extensions_to_Gamepad">Experimental extensions to Gamepad</h3>
+
+<p>The following interfaces are defined in the {{SpecName("GamepadExtensions")}} specification, and provide access to experimental features like haptic feedback and WebVR controller pose information.</p>
+
+<dl>
+ <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
+ <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
+ <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
+ <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
+ <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}</dt>
+ <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/htmlelement/style/index.html
+++ b/files/en-us/web/api/htmlelement/style/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Style
+browser-compat: api.HTMLElement.style
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -80,26 +81,11 @@ color = 'red' &gt; 'rgb(255, 0, 0)'
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('CSSOM', '#dom-elementcssinlinestyle-style', 'the <code>style</code> attribute')}}</td>
-   <td>{{Spec2('CSSOM')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.HTMLElement.style")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.html
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.html
@@ -39,22 +39,9 @@ browser-compat: api.HTMLMediaElement.setMediaKeys
 <p>A {{jsxref("Promise")}} that resolves to the passed instance of <code>MediaKeys</code>.
 </p>
 
-<h3 id="Specifications">Specifications</h3>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('EME','#dom-htmlmediaelement-setmediakeys','setMediaKeys()')}}</td>
-      <td>{{Spec2('EME')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/has/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/has/index.html
@@ -37,22 +37,9 @@ browser-compat: api.KeyboardLayoutMap.has
 
 <p>A {{jsxref('Boolean')}} indicating whether the specified key was found.</p>
 
-<h2 id="Example">Example</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Keyboard Map','#keyboardlayoutmap-interface','has()')}}</td>
-      <td>{{Spec2('Keyboard Map')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/closed/index.html
+++ b/files/en-us/web/api/window/closed/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Window
+browser-compat: api.Window.closed
 ---
 <div>{{APIRef}}</div>
 
@@ -66,17 +67,8 @@ function refreshPopupWindow() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-window-closed', 'window.closed')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
Use {{Specifications}} on missed API Pages (because no bcd key, H3 instead of H2, wrong headers).

Part of #1146.