### PR TITLE
Clarify that the user must remove both variants himself

### DIFF
--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.html
@@ -60,9 +60,9 @@ browser-compat: api.EventTarget.removeEventListener
   <dd>Specifies whether the {{domxref("EventListener")}} to be removed is registered as a
     capturing listener or not. If this parameter is absent, a default value of
     <code>false</code> is assumed.</dd>
-  <dd>If a listener is registered twice, one with capture and one without, remove each one
-    separately. Removal of a capturing listener does not affect a non-capturing version of
-    the same listener, and vice versa.</dd>
+  <dd>If a listener is registered twice, one with capture and one without, you must remove
+    each one separately. Removal of a capturing listener does not affect a non-capturing
+    version of the same listener, and vice versa.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The imperative tone used previously did not make it absolutely clear on the first read whether the user must remove both variant himself, or if the method would automatically remove both variants.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
