### PR TITLE
Fix punctuation in /en-US/docs/Web/HTML

### DIFF
--- a/files/en-us/web/html/index.html
+++ b/files/en-us/web/html/index.html
@@ -82,7 +82,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes">Global attributes</a></dt>
  <dd>Global attributes may be specified on all <a href="/en-US/docs/Web/HTML/Element">HTML elements</a>, <em>even those not specified in the standard</em>. This means that any non-standard elements must still permit these attributes, even though those elements make the document HTML5-noncompliant.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Inline_elements">Inline elements</a> and <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level elements</a></dt>
- <dd>HTML elements are usually "inline" or "block-level" elements. An inline element occupies only the space bounded by the tags that define it. A block-level element occupies the entire space of its parent element (container), thereby creating a "block."</dd>
+ <dd>HTML elements are usually "inline" or "block-level" elements. An inline element occupies only the space bounded by the tags that define it. A block-level element occupies the entire space of its parent element (container), thereby creating a "block".</dd>
  <dt><a href="/en-US/docs/Web/HTML/Link_types">Link types</a></dt>
  <dd>In HTML, various link types can be used to establish and define the relationship between two documents. Link elements that types can be set on include {{HTMLElement("a")}}, {{HTMLElement("area")}} and {{HTMLElement("link")}}.</dd>
  <dt><a href="/en-US/docs/Web/Media/Formats">Guide to media types and formats on the web</a></dt>


### PR DESCRIPTION
Full stop at the wrong place.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
At line 85 the full stop was inside the " ." and I changed it to " ".


> Issue number (if there is an associated issue)



> Anything else that could help us review it
