### PR TITLE
Remove duplicate spec tables

### DIFF
--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
@@ -32,23 +32,6 @@ browser-compat: api.TransformStreamDefaultController.desiredSize
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#ts-default-controller-desired-size','TransformStreamDefaultController.desiredSize')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
-
-<h2 id="Specifications">Specifications</h2>
-
 {{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -32,23 +32,6 @@ browser-compat: api.TransformStreamDefaultController.error
   controller.error("Cannot send a symbol as a chunk part")
   break</pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('Streams','#ts-default-controller-error','TransformStreamDefaultController.error()')}}</td>
-    <td>{{Spec2('Streams')}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
-
  <h2 id="Specifications">Specifications</h2>
 
  {{Specifications}}


### PR DESCRIPTION
I don't know how it happened, but these two files got 2 spec tables: one of the old style, one with `{{Specifications}}`.

This keeps only the latter.