### PR TITLE
Remove SpecName usage

### DIFF
--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -18,7 +18,7 @@ browser-compat: api.CacheStorage
 <p>The interface:</p>
 
 <ul>
- <li>Provides a master directory of all the named caches that can be accessed by a {{domxref("ServiceWorker")}} or other type of worker or {{domxref("window")}} scope (you’re not limited to only using it with service workers, even though the {{SpecName('Service Workers')}} spec defines it).
+ <li>Provides a master directory of all the named caches that can be accessed by a {{domxref("ServiceWorker")}} or other type of worker or {{domxref("window")}} scope (you’re not limited to only using it with service workers).
   <div class="notecard note">
     <h4>Note</h4>
     <p><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">Chrome and Safari only expose `CacheStorage` to the windowed context over HTTPS</a>. {{domxref("WindowOrWorkerGlobalScope/caches", "WorkerGlobalScope.caches")}} will be undefined unless an SSL certificate is configured.</p>

--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -25,28 +25,21 @@ browser-compat: api.Gamepad
  <dt>{{domxref("Gamepad.connected")}} {{readonlyInline}}</dt>
  <dd>A boolean indicating whether the gamepad is still connected to the system.</dd>
  <dt>{{domxref("Gamepad.displayId")}} {{readonlyInline}}</dt>
- <dd><dfn>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dfn></dd>
+ <dd>Returns the {{domxref("VRDisplay.displayId")}} of an associated {{domxref("VRDisplay")}} (if relevant) — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dd>
+ <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
+ <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
+ <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
+ <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
  <dt>{{domxref("Gamepad.id")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMString")}} containing identifying information about the controller.</dd>
  <dt>{{domxref("Gamepad.index")}} {{readonlyInline}}</dt>
  <dd>An integer that is auto-incremented to be unique for each device currently connected to the system.</dd>
  <dt>{{domxref("Gamepad.mapping")}} {{readonlyInline}}</dt>
  <dd>A string indicating whether the browser has remapped the controls on the device to a known layout.</dd>
+ <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}{{ExperimentalInline}}</dt>
+ <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
  <dt>{{domxref("Gamepad.timestamp")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the last time the data for this gamepad was updated.</dd>
-</dl>
-
-<h3 id="Experimental_extensions_to_Gamepad">Experimental extensions to Gamepad</h3>
-
-<p>The following interfaces are defined in the {{SpecName("GamepadExtensions")}} specification, and provide access to experimental features like haptic feedback and WebVR controller pose information.</p>
-
-<dl>
- <dt>{{domxref("Gamepad.hand")}} {{readonlyInline}}</dt>
- <dd>An enum defining what hand the controller is being held in, or is most likely to be held in.</dd>
- <dt>{{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}</dt>
- <dd>An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.</dd>
- <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/webkitpoint/index.html
+++ b/files/en-us/web/api/webkitpoint/index.html
@@ -13,10 +13,10 @@ browser-compat: api.WebKitPoint
 ---
 <div>{{APIRef("CSS3 Transforms")}}{{Deprecated_Header}}{{Non-standard_header}}</div>
 
-<p><strong><code>Point</code></strong> is an interface, which existed only briefly in the {{SpecName("CSS3 Transforms")}} specification, which represents a point in 2-dimensional space. It is non-standard, not broadly compatible, and should not be used.</p>
+<p><strong><code>Point</code></strong> is an interface which represents a point in 2-dimensional space. It is non-standard, not broadly compatible, and should not be used.</p>
 
 <div class="note">
-<p>Although it is not directly related to this defunct interface, you are probably looking for {{domxref("DOMPoint")}}, which is part of the {{SpecName("Geometry Interfaces")}} specification.</p>
+<p>Although it is not directly related to this defunct interface, you are probably looking for {{domxref("DOMPoint")}}.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>
@@ -30,7 +30,7 @@ browser-compat: api.WebKitPoint
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>This class was specified in <a href="https://www.w3.org/TR/2009/WD-css3-2d-transforms-20090320/">the defunct 20 March 2009 Working Draft of CSS 2D Transforms Module Level 3</a>. It is not present in the current working draft of the {{SpecName("CSS3 Transforms")}} specification.</p>
+<p>This class was specified in <a href="https://www.w3.org/TR/2009/WD-css3-2d-transforms-20090320/">the defunct 20 March 2009 Working Draft of CSS 2D Transforms Module Level 3</a>. It is not present in any current specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
We have a few {{Spec2}} {{SpecName}} used outside spec table.

Most of the time, they are in not really useful contexts for the reader, so here I remove a few occurrences.