### PR TITLE
Uniformize constructor titles

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -34,7 +34,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 
 <dl>
 	<dt><strong>title</strong></dt>
-	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface()</em><strong>.</strong><em>NameOfTheParentInterface</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <code>Request.Request()</code>.</dd>
+	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface()</em><strong>.</strong><em>NameOfTheParentInterface</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <code>Request()</code>.</dd>
 	<dt>slug</dt>
 	<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheParentInterface</code>. Note that the name of the method in the slug omits the parenthesis (it ends in "NameOfTheParentInterface" not "NameOfTheParentInterface()").</dd>
 	<dt>tags</dt>

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -14,13 +14,13 @@ browser-compat: path.to.feature.NameOfTheConstructor
 <!-- Remove div below here before publishing -->
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
-	
+
 <h3 id="Page_front_matter">Page front matter</h3>
-	
+
 <p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the constructor.</p>
-	
+
 <pre>---
-title: NameOfTheParentInterface.NameOfTheConstructor
+title: NameOfTheConstructor()
 slug: Web/API/NameOfTheParentInterface/NameOfTheConstructor
 tags:
   - API
@@ -34,23 +34,23 @@ browser-compat: path.to.feature.NameOfTheConstructor
 
 <dl>
 	<dt><strong>title</strong></dt>
-	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheParentInterface</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <code>Request.Request()</code>.</dd>
+	<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface()</em><strong>.</strong><em>NameOfTheParentInterface</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/Request/Request">Request()</a> constructor has a <em>title</em> of <code>Request.Request()</code>.</dd>
 	<dt>slug</dt>
 	<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheParentInterface</code>. Note that the name of the method in the slug omits the parenthesis (it ends in "NameOfTheParentInterface" not "NameOfTheParentInterface()").</dd>
 	<dt>tags</dt>
     <dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Constructor</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>IDBIndex</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-	
+
 	  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
 	<dt>browser-compat</dt>
 	<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheConstructor</code> with the query string for the constructor in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
-	  
+
 	  <p>Note that you may first need to create/update an entry for the API constructor in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
 	</dl>
 
 <h3 id="Top_macros">Top macros</h3>
-	
+
 <p>A number of macro calls appear at the top of the content section. You should update or delete them according to the advice below:</p>
-	
+
 <ul>
 	<li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
 	<li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>

--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -1,5 +1,5 @@
 ---
-title: AnalyserNode.AnalyserNode()
+title: AnalyserNode()
 slug: Web/API/AnalyserNode/AnalyserNode
 tags:
   - API
@@ -13,7 +13,7 @@ browser-compat: api.AnalyserNode.AnalyserNode
 ---
 <p>{{APIRef("'Web Audio API'")}}</p>
 
-<p class="summary">The <strong><code>AnalyserNode</code></strong> constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new {{domxref("AnalyserNode")}} object instance.</p>
+<p class="summary">The <strong><code>AnalyserNode()</code></strong> constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new {{domxref("AnalyserNode")}} object instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.html
+++ b/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: AnimationPlaybackEvent.AnimationPlaybackEvent()
+title: AnimationPlaybackEvent()
 slug: Web/API/AnimationPlaybackEvent/AnimationPlaybackEvent
 tags:
   - API

--- a/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
@@ -1,5 +1,5 @@
 ---
-title: AudioBufferSourceNode.AudioBufferSourceNode()
+title: AudioBufferSourceNode()
 slug: Web/API/AudioBufferSourceNode/AudioBufferSourceNode
 tags:
 - API

--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: BackgroundFetchEvent.BackgroundFetchEvent()
+title: BackgroundFetchEvent()
 slug: Web/API/BackgroundFetchEvent/BackgroundFetchEvent
 tags:
   - API

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -1,5 +1,5 @@
 ---
-title: BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent()
+title: BackgroundFetchUpdateUIEvent()
 slug: Web/API/BackgroundFetchUpdateUIEvent/BackgroundFetchUpdateUIEvent
 tags:
   - API

--- a/files/en-us/web/api/blobevent/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/blobevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: BlobEvent.BlobEvent()
+title: BlobEvent()
 slug: Web/API/BlobEvent/BlobEvent
 tags:
 - API

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
@@ -1,5 +1,5 @@
 ---
-title: ByteLengthQueuingStrategy.ByteLengthQueuingStrategy()
+title: ByteLengthQueuingStrategy()
 slug: Web/API/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy
 tags:
   - API

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
@@ -1,5 +1,5 @@
 ---
-title: ChannelSplitterNode.ChannelSplitterNode()
+title: ChannelSplitterNode()
 slug: Web/API/ChannelSplitterNode/ChannelSplitterNode
 tags:
   - API

--- a/files/en-us/web/api/compositionevent/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: CompositionEvent.CompositionEvent()
+title: CompositionEvent()
 slug: Web/API/CompositionEvent/CompositionEvent
 tags:
 - API

--- a/files/en-us/web/api/compressionstream/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.html
@@ -1,5 +1,5 @@
 ---
-title: CompressionStream.CompressionStream()
+title: CompressionStream()
 slug: Web/API/CompressionStream/CompressionStream
 tags:
   - API

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: CookieChangeEvent.CookieChangeEvent()
+title: CookieChangeEvent()
 slug: Web/API/CookieChangeEvent/CookieChangeEvent
 tags:
   - API

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
@@ -1,5 +1,5 @@
 ---
-title: CountQueuingStrategy.CountQueuingStrategy()
+title: CountQueuingStrategy()
 slug: Web/API/CountQueuingStrategy/CountQueuingStrategy
 tags:
   - API

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
@@ -1,5 +1,5 @@
 ---
-title: CSSKeywordValue.CSSKeywordValue()
+title: CSSKeywordValue()
 slug: Web/API/CSSKeywordValue/CSSKeywordValue
 tags:
 - API
@@ -13,7 +13,7 @@ browser-compat: api.CSSKeywordValue.CSSKeywordValue
 ---
 <div>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p><span class="seoSummary">The <strong><code>CSSKeywordValue</code></strong> constructor
+<p><span class="seoSummary">The <strong><code>CSSKeywordValue()</code></strong> constructor
     creates a new {{domxref("CSSKeywordValue")}} object which represents CSS keywords and
     other identifiers.</span></p>
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.html
@@ -1,5 +1,5 @@
 ---
-title: CSSMathSum.CSSMathSum()
+title: CSSMathSum()
 slug: Web/API/CSSMathSum/CSSMathSum
 tags:
 - API

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
@@ -1,5 +1,5 @@
 ---
-title: CSSPositionValue.CSSPositionValue()
+title: CSSPositionValue()
 slug: Web/API/CSSPositionValue/CSSPositionValue
 tags:
   - API
@@ -14,7 +14,7 @@ browser-compat: api.CSSPositionValue.CSSPositionValue
 ---
 <div>{{APIRef("CSS Typed Object Model API")}}{{deprecated_header}}</div>
 
-<p><span class="seoSummary">The <strong><code>CSSPositionValue</code></strong> constructor
+<p><span class="seoSummary">The <strong><code>CSSPositionValue()</code></strong> constructor
     creates a new {{domxref("CSSPositionValue")}} object which represents values for
     properties that take a position, for example {{cssxref('object-position')}}.</span>
 </p>

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
@@ -1,5 +1,5 @@
 ---
-title: CSSUnitValue.CSSUnitValue()
+title: CSSUnitValue()
 slug: Web/API/CSSUnitValue/CSSUnitValue
 tags:
 - API

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
@@ -1,5 +1,5 @@
 ---
-title: CSSUnparsedValue.CSSUnparsedValue()
+title: CSSUnparsedValue()
 slug: Web/API/CSSUnparsedValue/CSSUnparsedValue
 tags:
 - API
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.CSSUnparsedValue
 
 <p class="summary">The <strong><code>CSSUnparsedValue()</code></strong> constructor
   creates a new {{domxref("CSSUnparsedValue")}} object which represents property values
-  that reference custom properties. </p>
+  that reference custom properties.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.html
@@ -1,5 +1,5 @@
 ---
-title: DecompressionStream.DecompressionStream()
+title: DecompressionStream()
 slug: Web/API/DecompressionStream/DecompressionStream
 tags:
   - API

--- a/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: DeviceMotionEvent.DeviceMotionEvent()
+title: DeviceMotionEvent()
 slug: Web/API/DeviceMotionEvent/DeviceMotionEvent
 tags:
 - API
@@ -16,7 +16,7 @@ browser-compat: api.DeviceMotionEvent.DeviceMotionEvent
 ---
 <p>{{APIRef("Device Orientation Events")}}{{Non-standard_header}}</p>
 
-<p>The <strong><code>DeviceMotionEvent</code></strong> constructor creates a new
+<p>The <strong><code>DeviceMotionEvent()</code></strong> constructor creates a new
   {{DOMxRef("DeviceMotionEvent")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: DeviceOrientationEvent.DeviceOrientationEvent()
+title: DeviceOrientationEvent()
 slug: Web/API/DeviceOrientationEvent/DeviceOrientationEvent
 tags:
 - API
@@ -12,7 +12,7 @@ browser-compat: api.DeviceOrientationEvent.DeviceOrientationEvent
 ---
 <p>{{APIRef("Device Orientation Events")}}{{Non-standard_header}}</p>
 
-<p>The <strong><code>DeviceOrientationEvent</code></strong> constructor creates a new
+<p>The <strong><code>DeviceOrientationEvent()</code></strong> constructor creates a new
   {{domxref("DeviceOrientationEvent")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.html
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.html
@@ -1,5 +1,5 @@
 ---
-title: DocumentTimeline.DocumentTimeline()
+title: DocumentTimeline()
 slug: Web/API/DocumentTimeline/DocumentTimeline
 tags:
   - API

--- a/files/en-us/web/api/dompoint/dompoint/index.html
+++ b/files/en-us/web/api/dompoint/dompoint/index.html
@@ -1,5 +1,5 @@
 ---
-title: DOMPoint.DOMPoint()
+title: DOMPoint()
 slug: Web/API/DOMPoint/DOMPoint
 tags:
 - API

--- a/files/en-us/web/api/domrect/domrect/index.html
+++ b/files/en-us/web/api/domrect/domrect/index.html
@@ -1,5 +1,5 @@
 ---
-title: DOMRect.DOMRect()
+title: OMRect()
 slug: Web/API/DOMRect/DOMRect
 tags:
   - API

--- a/files/en-us/web/api/domrect/domrect/index.html
+++ b/files/en-us/web/api/domrect/domrect/index.html
@@ -1,5 +1,5 @@
 ---
-title: OMRect()
+title: DOMRect()
 slug: Web/API/DOMRect/DOMRect
 tags:
   - API

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: ExtendableCookieChangeEvent.ExtendableCookieChangeEvent()
+title: ExtendableCookieChangeEvent()
 slug: Web/API/ExtendableCookieChangeEvent/ExtendableCookieChangeEvent
 tags:
   - API

--- a/files/en-us/web/api/file/file/index.html
+++ b/files/en-us/web/api/file/file/index.html
@@ -1,5 +1,5 @@
 ---
-title: File.File()
+title: File()
 slug: Web/API/File/File
 tags:
 - API

--- a/files/en-us/web/api/fontface/fontface/index.html
+++ b/files/en-us/web/api/fontface/fontface/index.html
@@ -1,5 +1,5 @@
 ---
-title: FontFace.FontFace()
+title: FontFace()
 slug: Web/API/FontFace/FontFace
 tags:
 - API

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: FontFaceSetLoadEvent.FontFaceSetLoadEvent()
+title: FontFaceSetLoadEvent()
 slug: Web/API/FontFaceSetLoadEvent/FontFaceSetLoadEvent
 tags:
 - API
@@ -14,9 +14,9 @@ browser-compat: api.FontFaceSetLoadEvent.FontFaceSetLoadEvent
 ---
 <p>{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</p>
 
-<p>The <strong><code>FontFaceSetLoadEvent</code></strong> constructor creates a new
+<p>The <strong><code>FontFaceSetLoadEvent()</code></strong> constructor creates a new
   {{domxref("FontFaceLoadEvent")}} object which is fired whenever a
-  {{domxref("FontFaceSet")}} loads.</p>
+  {{domxref("FontFaceSet")}} loads.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
+++ b/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: HIDConnectionEvent.HIDConnectionEvent()
+title: HIDConnectionEvent()
 slug: Web/API/HIDConnectionEvent/HIDConnectionEvent
 tags:
   - API

--- a/files/en-us/web/api/installevent/installevent/index.html
+++ b/files/en-us/web/api/installevent/installevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: InstallEvent.InstallEvent()
+title: InstallEvent()
 slug: Web/API/InstallEvent/InstallEvent
 tags:
   - API

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
@@ -1,5 +1,5 @@
 ---
-title: IntersectionObserver.IntersectionObserver()
+title: IntersectionObserver()
 slug: Web/API/IntersectionObserver/IntersectionObserver
 tags:
 - API

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
@@ -1,5 +1,5 @@
 ---
-title: KeyframeEffect.KeyframeEffect()
+title: KeyframeEffect()
 slug: Web/API/KeyframeEffect/KeyframeEffect
 tags:
   - API

--- a/files/en-us/web/api/mediametadata/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.html
@@ -1,5 +1,5 @@
 ---
-title: MediaMetadata.MediaMetadata()
+title: MediaMetadata()
 slug: Web/API/MediaMetadata/MediaMetadata
 tags:
 - Audio

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: MediaQueryListEvent.MediaQueryListEvent()
+title: MediaQueryListEvent()
 slug: Web/API/MediaQueryListEvent/MediaQueryListEvent
 tags:
   - API
@@ -12,7 +12,7 @@ browser-compat: api.MediaQueryListEvent.MediaQueryListEvent
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p>The <strong><code>MediaQueryListEvent</code></strong> constructor creates a new
+<p>The <strong><code>MediaQueryListEvent()</code></strong> constructor creates a new
   <code>MediaQueryListEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/mediasource/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/mediasource/index.html
@@ -1,5 +1,5 @@
 ---
-title: MediaSource.MediaSource()
+title: MediaSource()
 slug: Web/API/MediaSource/MediaSource
 tags:
 - API

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
@@ -1,5 +1,5 @@
 ---
-title: MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode()
+title: MediaStreamAudioDestinationNode()
 slug: Web/API/MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode
 tags:
   - API

--- a/files/en-us/web/api/messageevent/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/messageevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: MessageEvent.MessageEvent()
+title: MessageEvent()
 slug: Web/API/MessageEvent/MessageEvent
 tags:
 - API

--- a/files/en-us/web/api/mutationobserver/mutationobserver/index.html
+++ b/files/en-us/web/api/mutationobserver/mutationobserver/index.html
@@ -1,5 +1,5 @@
 ---
-title: MutationObserver.MutationObserver()
+title: MutationObserver()
 slug: Web/API/MutationObserver/MutationObserver
 tags:
 - API

--- a/files/en-us/web/api/notification/notification/index.html
+++ b/files/en-us/web/api/notification/notification/index.html
@@ -1,5 +1,5 @@
 ---
-title: Notification.Notification()
+title: Notification()
 slug: Web/API/Notification/Notification
 tags:
 - API

--- a/files/en-us/web/api/notificationevent/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: NotificationEvent.NotificationEvent()
+title: NotificationEvent()
 slug: Web/API/NotificationEvent/NotificationEvent
 tags:
 - API

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: OfflineAudioCompletionEvent.OfflineAudioCompletionEvent()
+title: OfflineAudioCompletionEvent()
 slug: Web/API/OfflineAudioCompletionEvent/OfflineAudioCompletionEvent
 tags:
 - API

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
@@ -1,5 +1,5 @@
 ---
-title: OfflineAudioContext.OfflineAudioContext()
+title: OfflineAudioContext()
 slug: Web/API/OfflineAudioContext/OfflineAudioContext
 tags:
   - API

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -1,5 +1,5 @@
 ---
-title: OscillatorNode.OscillatorNode()
+title: OscillatorNode()
 slug: Web/API/OscillatorNode/OscillatorNode
 tags:
   - Audio

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
@@ -1,5 +1,5 @@
 ---
-title: OverconstrainedError.OverconstrainedError()
+title: OverconstrainedError()
 slug: Web/API/OverconstrainedError/OverconstrainedError
 tags:
 - API

--- a/files/en-us/web/api/pannernode/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/pannernode/index.html
@@ -1,5 +1,5 @@
 ---
-title: PannerNode.PannerNode()
+title: PannerNode()
 slug: Web/API/PannerNode/PannerNode
 tags:
   - API

--- a/files/en-us/web/api/paymentrequest/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentrequest/index.html
@@ -1,5 +1,5 @@
 ---
-title: PaymentRequest.PaymentRequest()
+title: PaymentRequest()
 slug: Web/API/PaymentRequest/PaymentRequest
 tags:
 - API

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()
+title: PaymentRequestUpdateEvent()
 slug: Web/API/PaymentRequestUpdateEvent/PaymentRequestUpdateEvent
 tags:
 - API
@@ -14,7 +14,7 @@ browser-compat: api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent
 ---
 <p>{{APIRef("Payment Request API")}}{{securecontext_header}}</p>
 
-<p>The <strong><code>PaymentRequestUpdateEvent</code></strong> constructor creates a new
+<p>The <strong><code>PaymentRequestUpdateEvent()</code></strong> constructor creates a new
   {{domxref("PaymentRequestUpdateEvent")}} object which enables a web page to update the
   details of a {{domxref("PaymentRequest")}} in response to a user action. Actual updates
   are made by passing options to the

--- a/files/en-us/web/api/periodicwave/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.html
@@ -1,5 +1,5 @@
 ---
-title: PeriodicWave.PeriodicWave()
+title: PeriodicWave()
 slug: Web/API/PeriodicWave/PeriodicWave
 tags:
   - API

--- a/files/en-us/web/api/pointerevent/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: PointerEvent.PointerEvent()
+title: PointerEvent()
 slug: Web/API/PointerEvent/PointerEvent
 tags:
   - API

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.html
@@ -1,5 +1,5 @@
 ---
-title: PresentationRequest.PresentationRequest()
+title: PresentationRequest()
 slug: Web/API/PresentationRequest/PresentationRequest
 tags:
 - API
@@ -12,7 +12,7 @@ browser-compat: api.PresentationRequest.PresentationRequest
 ---
 <p>{{APIRef("Presentation API")}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The <strong><code>PresentationRequest</code></strong>
+<p><span class="seoSummary">The <strong><code>PresentationRequest()</code></strong>
     constructor creates a new {{domxref("PresentationRequest")}} object which creates a
     new PresentationRequest.</span></p>
 

--- a/files/en-us/web/api/pushevent/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/pushevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: PushEvent.PushEvent()
+title: PushEvent()
 slug: Web/API/PushEvent/PushEvent
 tags:
 - API

--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -1,5 +1,5 @@
 ---
-title: ReadableStream.ReadableStream()
+title: ReadableStream()
 slug: Web/API/ReadableStream/ReadableStream
 tags:
 - API

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
@@ -1,5 +1,5 @@
 ---
-title: ReadableStreamBYOBReader.ReadableStreamBYOBReader()
+title: ReadableStreamBYOBReader()
 slug: Web/API/ReadableStreamBYOBReader/ReadableStreamBYOBReader
 tags:
 - API

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
@@ -1,5 +1,5 @@
 ---
-title: ReadableStreamDefaultReader.ReadableStreamDefaultReader()
+title: ReadableStreamDefaultReader()
 slug: Web/API/ReadableStreamDefaultReader/ReadableStreamDefaultReader
 tags:
 - API

--- a/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: RTCDTMFToneChangeEvent.RTCDTMFToneChangeEvent()
+title: RTCDTMFToneChangeEvent()
 slug: Web/API/RTCDTMFToneChangeEvent/RTCDTMFToneChangeEvent
 tags:
   - Constructor

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
@@ -1,5 +1,5 @@
 ---
-title: RTCIceCandidate.RTCIceCandidate()
+title: RTCIceCandidate()
 slug: Web/API/RTCIceCandidate/RTCIceCandidate
 tags:
   - API

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: SecurityPolicyViolationEvent.SecurityPolicyViolationEvent()
+title: SecurityPolicyViolationEvent()
 slug: Web/API/SecurityPolicyViolationEvent/SecurityPolicyViolationEvent
 tags:
 - API

--- a/files/en-us/web/api/serviceworkermessageevent/serviceworkermessageevent/index.html
+++ b/files/en-us/web/api/serviceworkermessageevent/serviceworkermessageevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: ServiceWorkerMessageEvent.ServiceWorkerMessageEvent()
+title: ServiceWorkerMessageEvent()
 slug: Web/API/ServiceWorkerMessageEvent/ServiceWorkerMessageEvent
 tags:
   - API

--- a/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.html
+++ b/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.html
@@ -1,5 +1,5 @@
 ---
-title: SpeechGrammarList.SpeechGrammarList()
+title: SpeechGrammarList()
 slug: Web/API/SpeechGrammarList/SpeechGrammarList
 tags:
 - API

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
@@ -1,5 +1,5 @@
 ---
-title: SpeechSynthesisUtterance.SpeechSynthesisUtterance()
+title: SpeechSynthesisUtterance()
 slug: Web/API/SpeechSynthesisUtterance/SpeechSynthesisUtterance
 tags:
 - API

--- a/files/en-us/web/api/staticrange/staticrange/index.html
+++ b/files/en-us/web/api/staticrange/staticrange/index.html
@@ -1,5 +1,5 @@
 ---
-title: StaticRange.StaticRange()
+title: StaticRange()
 slug: Web/API/StaticRange/StaticRange
 tags:
 - API

--- a/files/en-us/web/api/stereopannernode/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/stereopannernode/index.html
@@ -1,5 +1,5 @@
 ---
-title: StereoPannerNode.StereoPannerNode()
+title: StereoPannerNode()
 slug: Web/API/StereoPannerNode/StereoPannerNode
 tags:
 - API

--- a/files/en-us/web/api/syncevent/syncevent/index.html
+++ b/files/en-us/web/api/syncevent/syncevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: SyncEvent.SyncEvent()
+title: SyncEvent()
 slug: Web/API/SyncEvent/SyncEvent
 tags:
 - API

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -1,5 +1,5 @@
 ---
-title: TextDecoderStream.TextDecoderStream()
+title: TextDecoderStream()
 slug: Web/API/TextDecoderStream/TextDecoderStream
 tags:
   - API

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.html
@@ -1,5 +1,5 @@
 ---
-title: TextEncoderStream.TextEncoderStream()
+title: TextEncoderStream()
 slug: Web/API/TextEncoderStream/TextEncoderStream
 tags:
   - API

--- a/files/en-us/web/api/trackdefault/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefault/trackdefault/index.html
@@ -1,5 +1,5 @@
 ---
-title: TrackDefault.TrackDefault()
+title: TrackDefault()
 slug: Web/API/TrackDefault/TrackDefault
 tags:
   - API

--- a/files/en-us/web/api/trackdefaultlist/trackdefaultlist/index.html
+++ b/files/en-us/web/api/trackdefaultlist/trackdefaultlist/index.html
@@ -1,5 +1,5 @@
 ---
-title: TrackDefaultList.TrackDefaultList()
+title: TrackDefaultList()
 slug: Web/API/TrackDefaultList/TrackDefaultList
 tags:
   - API

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -1,5 +1,5 @@
 ---
-title: TransformStream.TransformStream()
+title: TransformStream()
 slug: Web/API/TransformStream/TransformStream
 tags:
   - API

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
@@ -1,5 +1,5 @@
 ---
-title: USBConfiguration.USBConfiguration()
+title: USBConfiguration()
 slug: Web/API/USBConfiguration/USBConfiguration
 tags:
 - API

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
@@ -1,5 +1,5 @@
 ---
-title: USBConnectionEvent.USBConnectionEvent()
+title: USBConnectionEvent()
 slug: Web/API/USBConnectionEvent/USBConnectionEvent
 tags:
   - API

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.html
@@ -1,5 +1,5 @@
 ---
-title: WaveShaperNode.WaveShaperNode()
+title: WaveShaperNode()
 slug: Web/API/WaveShaperNode/WaveShaperNode
 tags:
 - API

--- a/files/en-us/web/api/writablestream/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/writablestream/index.html
@@ -1,5 +1,5 @@
 ---
-title: WritableStream.WritableStream()
+title: WritableStream()
 slug: Web/API/WritableStream/WritableStream
 tags:
 - API

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.html
@@ -1,5 +1,5 @@
 ---
-title: WritableStreamDefaultWriter.WritableStreamDefaultWriter()
+title: WritableStreamDefaultWriter()
 slug: Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter
 tags:
 - API


### PR DESCRIPTION
We had two ways to write the title of pages about constructors:

- without prefix:
<img width="766" alt="Screenshot 2021-07-06 at 10 34 00" src="https://user-images.githubusercontent.com/1466293/124568915-becabf00-de45-11eb-9fcb-8f38a2054e1b.png">
- with prefix:
<img width="1033" alt="Screenshot 2021-07-06 at 10 33 32" src="https://user-images.githubusercontent.com/1466293/124568919-bf635580-de45-11eb-9e19-7751ffa05d57.png">

311 without prefix, 72 with prefix.

As the prefix goes in the way (especially in case of long API names) and doesn't bring real information, I uniformize all constructor to be without prefix, that is the most common case.

**Note:** this doesn't affect slugs and bcd keys, only the titles.


I fixed the first sentence of the page in some case (missing parenthesis) and remove 2-3 gremlins (non-breakable or extraneous spaces).
