### PR TITLE
adding matrix

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -50,7 +50,7 @@ browser-compat: webextensions.manifest.protocol_handlers
  <p>A string defining the protocol. This must be either:</p>
 
  <ul>
-  <li>one of the following: "bitcoin", "dat", "dweb", "ftp", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "magnet", "mailto", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".</li>
+  <li>one of the following: "bitcoin", "dat", "dweb", "ftp", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "magnet", "mailto", "matrix", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".</li>
   <li>a string consisting of a custom name prefixed with "web+" or "ext+". For example: "web+foo" or "ext+foo". The custom name must consist only of lower-case ASCII characters. It's recommended that extensions use the "ext+" form.</li>
  </ul>
  </dd>

--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -67,6 +67,7 @@ tags:
 
 <ul>
   <li>Support was added for the deprecated {{DOMxref("WheelEvent")}} properties: <code>WheelEvent.wheelDelta</code>, <code>WheelEvent.wheelDeltaX</code>, and <code>WheelEvent.wheelDeltaY</code>. This allows Firefox to work with a small subset of pages that were broken by recent compatibility improvements to <code>WheelEvent</code> ({{bug(1708829)}}).</li>
+  <li>Support for the <code>matrix</code> protocol has been added and can now be passed into the {{domxref('Navigator.registerProtocolHandler()')}} method as a valid scheme.</li>
 </ul>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
@@ -82,6 +83,8 @@ tags:
 <h4 id="removals_webdriver">Removals</h4>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
+
+<li>The <code>matrix</code> URI scheme is now supported and can be defined as a protocol within the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers"><code>protocol_handlers</code></a> key in an extensions <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json"><code>manifest.json</code></a></li>
 
 <h4 id="removals_webext">Removals</h4>
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.html
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.html
@@ -110,6 +110,7 @@ browser-compat: api.Navigator.registerProtocolHandler
     <li><code>ircs</code></li>
     <li><code>magnet</code></li>
     <li><code>mailto</code></li>
+    <li><code>matrix</code></li>
     <li><code>mms</code></li>
     <li><code>news</code></li>
     <li><code>nntp</code></li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The matrix URI scheme is now supported in FF90 - updating a couple of pages as well as release notes

> Issue number (if there is an associated issue)

See #5377 


