### PR TITLE
replace link to Using_HTML_sections_and_outlines with to Heading_Elem…

### DIFF
--- a/files/en-us/glossary/semantics/index.html
+++ b/files/en-us/glossary/semantics/index.html
@@ -69,7 +69,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element#inline_text_semantics">HTML element reference</a> on MDN</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#problems_solved_by_html5">Using HTML sections and outlines</a> on MDN</li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements#problems_solved_by_html5">Using HTML sections and outlines</a> on MDN</li>
  <li>{{interwiki("wikipedia", "Semantics#Computer_science", "The meaning of semantics in computer science")}} on Wikipedia</li>
 </ul>
 

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.html
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.html
@@ -274,7 +274,7 @@ and his markup didn't read very well.&lt;/p&gt;</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a>: Advanced guide to HTML5 semantic elements and the HTML5 outline algorithm.</li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a>: Advanced guide to HTML5 semantic elements and the HTML5 outline algorithm.</li>
 </ul>
 
 <p>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML")}}</p>

--- a/files/en-us/mozilla/firefox/releases/4/index.html
+++ b/files/en-us/mozilla/firefox/releases/4/index.html
@@ -27,7 +27,7 @@ tags:
  <dd>A look at what the HTML5 parser means to you, and how to embed SVG and MathML into your content inline.</dd>
  <dt><a href="/en-US/docs/Learn/Forms">Forms in HTML5</a></dt>
  <dd>A look at improvements to web forms in HTML5. Among these changes are added input types in the {{HTMLElement("input")}} element, data validation, and more.</dd>
- <dt><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">HTML5 Sections</a></dt>
+ <dt><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">HTML5 Sections</a></dt>
  <dd>Gecko now supports the new HTML5 elements related to sections in a document: {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("nav")}}, {{HTMLElement("aside")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}} and {{HTMLElement("footer")}}.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes#attr-hidden">HTML5 hidden attribute</a></dt>
  <dd>This attribute, common to all elements, is used to hide content in a webpage that is not currently relevant to the user.</dd>

--- a/files/en-us/web/accessibility/aria/roles/complementary_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/complementary_role/index.html
@@ -106,7 +106,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/aside">&lt;aside&gt;: The Aside element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#complementary">complementary (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.html
@@ -137,7 +137,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/footer">&lt;footer&gt;: The Footer element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#contentinfo">contentinfo (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/accessibility/aria/roles/form_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/form_role/index.html
@@ -146,7 +146,7 @@ tags:
  <li><a href="/en-US/docs/Web/HTML/Element/form">&lt;form&gt;: The Form element</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/legend">&lt;legend&gt;: The Legend element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#form">form (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>

--- a/files/en-us/web/accessibility/aria/roles/main_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/main_role/index.html
@@ -121,7 +121,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/main">&lt;main&gt;: The Main element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#main">main (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
@@ -141,7 +141,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/nav">&lt;nav&gt;: The Navigation section element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#navigation">navigation (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/accessibility/aria/roles/region_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/region_role/index.html
@@ -126,7 +126,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/section">&lt;section&gt;: The Generic Section element</a></li>
  <li><a href="https://www.w3.org/TR/wai-aria/#region">region (role): Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/accessibility/aria/roles/search_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/search_role/index.html
@@ -113,7 +113,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/form">&lt;form&gt;: The Form element</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/input/search">&lt;input type="search"&gt;</a></li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmark roles: Using ARIA: Roles, States, and Properties</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>

--- a/files/en-us/web/css/_colon_is/index.html
+++ b/files/en-us/web/css/_colon_is/index.html
@@ -179,7 +179,7 @@ dir ol dir,   dir ul dir,   dir menu dir,   dir dir dir {
 
 <h3 id="Simplifying_section_selectors">Simplifying section selectors</h3>
 
-<p>The <code>:is()</code> pseudo-class is particularly useful when dealing with HTML5 <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">sections and headings</a>. Since {{HTMLElement("section")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, and {{HTMLElement("nav")}} are commonly nested together, without <code>:is()</code>, styling them to match one another can be tricky.</p>
+<p>The <code>:is()</code> pseudo-class is particularly useful when dealing with HTML5 <a href="/en-US/docs/Web/HTML/Element/Heading_Elements">sections and headings</a>. Since {{HTMLElement("section")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, and {{HTMLElement("nav")}} are commonly nested together, without <code>:is()</code>, styling them to match one another can be tricky.</p>
 
 <p>For example, without <code>:is()</code>, styling all the {{HTMLElement("h1")}} elements at different depths could be very complicated:</p>
 

--- a/files/en-us/web/guide/html/content_categories/index.html
+++ b/files/en-us/web/guide/html/content_categories/index.html
@@ -51,12 +51,12 @@ tags:
 
 <h3 id="Sectioning_content">Sectioning content</h3>
 
-<p>Sectioning content is a subset of flow content, and can be used everywhere flow content is expected. Elements belonging to the sectioning content model create a <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines" title="Sections and Outlines of an HTML5 document">section in the current outline</a> that defines the scope of {{HTMLElement("header")}} elements, {{HTMLElement("footer")}} elements, and <a href="#heading_content">heading content</a>.</p>
+<p>Sectioning content is a subset of flow content, and can be used everywhere flow content is expected. Elements belonging to the sectioning content model create a <a href="/en-US/docs/Web/HTML/Element/Heading_Elements" title="Sections and Outlines of an HTML5 document">section in the current outline</a> that defines the scope of {{HTMLElement("header")}} elements, {{HTMLElement("footer")}} elements, and <a href="#heading_content">heading content</a>.</p>
 
 <p>Elements belonging to this category are {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("nav")}}, and {{HTMLElement("section")}}.</p>
 
 <div class="note">
-<p>Do not confuse this content model with the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_roots" title="Sections and Outlines of an HTML5 document#sectioning root">sectioning root</a> category, which isolates its content from the regular outline.</p>
+<p>Do not confuse this content model with the <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots" title="Sections and Outlines of an HTML5 document#sectioning root">sectioning root</a> category, which isolates its content from the regular outline.</p>
 </div>
 
 <h3 id="Heading_content">Heading content</h3>

--- a/files/en-us/web/html/element/address/index.html
+++ b/files/en-us/web/html/element/address/index.html
@@ -107,5 +107,5 @@ browser-compat: html.elements.address
 
 <ul>
  <li>Others section-related elements: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("footer")}}, {{HTMLElement("section")}}, {{HTMLElement("header")}};</li>
- <li class="last"><a class="deki-ns current" href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines" title="Sections and Outlines of an HTML5 document">Sections and outlines of an HTML5 document</a>.</li>
+ <li class="last"><a class="deki-ns current" href="/en-US/docs/Web/HTML/Element/Heading_Elements" title="Sections and Outlines of an HTML5 document">Sections and outlines of an HTML5 document</a>.</li>
 </ul>

--- a/files/en-us/web/html/element/article/index.html
+++ b/files/en-us/web/html/element/article/index.html
@@ -118,5 +118,5 @@ browser-compat: html.elements.article
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("section")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}}</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
 </ul>

--- a/files/en-us/web/html/element/aside/index.html
+++ b/files/en-us/web/html/element/aside/index.html
@@ -97,6 +97,6 @@ browser-compat: html.elements.aside
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("nav")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}};</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role">ARIA: Complementary role</a></li>
 </ul>

--- a/files/en-us/web/html/element/body/index.html
+++ b/files/en-us/web/html/element/body/index.html
@@ -18,7 +18,7 @@ browser-compat: html.elements.body
  <tbody>
   <tr>
    <th scope="row"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a></th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_roots">Sectioning root</a>.</td>
+   <td><a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots">Sectioning root</a>.</td>
   </tr>
   <tr>
    <th scope="row">Permitted content</th>

--- a/files/en-us/web/html/element/dialog/index.html
+++ b/files/en-us/web/html/element/dialog/index.html
@@ -19,7 +19,7 @@ browser-compat: html.elements.dialog
  <tbody>
   <tr>
    <th scope="row"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a></th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_roots">sectioning root</a></td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots">sectioning root</a></td>
   </tr>
   <tr>
    <th scope="row">Permitted content</th>

--- a/files/en-us/web/html/element/fieldset/index.html
+++ b/files/en-us/web/html/element/fieldset/index.html
@@ -87,7 +87,7 @@ browser-compat: html.elements.fieldset
  <tbody>
   <tr>
    <th scope="row"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a></th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_root">sectioning root</a>, <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form_listed">listed</a>, <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form-associated_content">form-associated</a> element, palpable content.</td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_root">sectioning root</a>, <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form_listed">listed</a>, <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form-associated_content">form-associated</a> element, palpable content.</td>
   </tr>
   <tr>
    <th scope="row">Permitted content</th>

--- a/files/en-us/web/html/element/figure/index.html
+++ b/files/en-us/web/html/element/figure/index.html
@@ -21,7 +21,7 @@ browser-compat: html.elements.figure
  <tbody>
   <tr>
    <th scope="row"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a></th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_roots">sectioning root</a>, palpable content.</td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots">sectioning root</a>, palpable content.</td>
   </tr>
   <tr>
    <th scope="row">Permitted content</th>
@@ -58,7 +58,7 @@ browser-compat: html.elements.figure
 
 <ul>
  <li>Usually a <code>&lt;figure&gt;</code> is an image, illustration, diagram, code snippet, etc., that is referenced in the main flow of a document, but that can be moved to another part of the document or to an appendix without affecting the main flow.</li>
- <li>Being a <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_roots">sectioning root</a>, the outline of the content of the <code>&lt;figure&gt;</code> element is excluded from the main outline of the document.</li>
+ <li>Being a <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots">sectioning root</a>, the outline of the content of the <code>&lt;figure&gt;</code> element is excluded from the main outline of the document.</li>
  <li>A caption can be associated with the <code>&lt;figure&gt;</code> element by inserting a {{HTMLElement("figcaption")}} inside it (as the first or the last child). The first <code>&lt;figcaption&gt;</code> element found in the figure is presented as the figure's caption.</li>
 </ul>
 

--- a/files/en-us/web/html/element/footer/index.html
+++ b/files/en-us/web/html/element/footer/index.html
@@ -10,7 +10,7 @@ browser-compat: html.elements.footer
 ---
 <div>{{HTMLRef}}</div>
 
-<p>The <strong><code>&lt;footer&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents a footer for its nearest <a href="/en-US/docs/Web/Guide/HTML/Content_categories#sectioning_content">sectioning content</a> or <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_root">sectioning root</a> element. A <code>&lt;footer&gt;</code> typically contains information about the author of the section, copyright data or links to related documents.</p>
+<p>The <strong><code>&lt;footer&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents a footer for its nearest <a href="/en-US/docs/Web/Guide/HTML/Content_categories#sectioning_content">sectioning content</a> or <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_root">sectioning root</a> element. A <code>&lt;footer&gt;</code> typically contains information about the author of the section, copyright data or links to related documents.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/footer.html", "tabbed-standard")}}</div>
 
@@ -55,7 +55,7 @@ browser-compat: html.elements.footer
 
 <ul>
  <li>Enclose information about the author in an {{HTMLElement("address")}} element that can be included into the <code>&lt;footer&gt;</code> element.</li>
- <li>The <code>&lt;footer&gt;</code> element is not sectioning content and therefore doesn't introduce a new section in the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines" title="Sections and Outlines of an HTML5 document">outline</a>.</li>
+ <li>The <code>&lt;footer&gt;</code> element is not sectioning content and therefore doesn't introduce a new section in the <a href="/en-US/docs/Web/HTML/Element/Heading_Elements" title="Sections and Outlines of an HTML5 document">outline</a>.</li>
 </ul>
 
 <h2 id="Examples">Examples</h2>
@@ -86,6 +86,6 @@ browser-compat: html.elements.footer
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("section")}}, {{HTMLElement("address")}};</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li class="last"><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role">ARIA: Contentinfo role</a></li>
 </ul>

--- a/files/en-us/web/html/element/header/index.html
+++ b/files/en-us/web/html/element/header/index.html
@@ -49,7 +49,7 @@ browser-compat: html.elements.header
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<p>The <code>&lt;header&gt;</code> element is not sectioning content and therefore does not introduce a new section in the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">outline</a>. That said, a <code>&lt;header&gt;</code> element is intended to usually contain the surrounding section's heading (an <code>h1</code>–<code>h6</code> element), but this is <strong>not</strong> required.</p>
+<p>The <code>&lt;header&gt;</code> element is not sectioning content and therefore does not introduce a new section in the <a href="/en-US/docs/Web/HTML/Element/Heading_Elements">outline</a>. That said, a <code>&lt;header&gt;</code> element is intended to usually contain the surrounding section's heading (an <code>h1</code>–<code>h6</code> element), but this is <strong>not</strong> required.</p>
 
 <h3 id="Historical_Usage">Historical Usage</h3>
 
@@ -93,5 +93,5 @@ browser-compat: html.elements.header
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("footer")}}, {{HTMLElement("section")}}, {{HTMLElement("address")}}.</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
 </ul>

--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -64,7 +64,7 @@ browser-compat: html.elements.hgroup
 
 <div class="note">
 <p>The <code>&lt;hgroup&gt;</code> element has been removed from the HTML5 (W3C) specification, but it still is in the WHATWG version of HTML. It is partially implemented in most browsers, though, so is unlikely to go away.<br>
- However, given that a key purpose of the <code>&lt;hgroup&gt;</code> element is to affect how headings are displayed by <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#the_html5_outline_algorithm">the outline algorithm defined in the HTML specification</a>—but <strong>the HTML outline algorithm is not implemented in any browsers</strong>—then the <code>&lt;hgroup&gt;</code> semantics are in practice only theoretical.<br>
+ However, given that a key purpose of the <code>&lt;hgroup&gt;</code> element is to affect how headings are displayed by <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#the_html5_outline_algorithm">the outline algorithm defined in the HTML specification</a>—but <strong>the HTML outline algorithm is not implemented in any browsers</strong>—then the <code>&lt;hgroup&gt;</code> semantics are in practice only theoretical.<br>
  So the HTML5 (W3C) specification provides advice on how to mark up <a href="https://www.w3.org/TR/html52/common-idioms-without-dedicated-elements.html#common-idioms-without-dedicated-elements">Subheadings, subtitles, alternative titles and taglines</a> without using <code>&lt;hgroup&gt;</code>.</p>
 </div>
 
@@ -72,7 +72,7 @@ browser-compat: html.elements.hgroup
 
 <p>In other words, the <code>&lt;hgroup&gt;</code> element prevents any of its secondary <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> children from creating separate sections of their own in the outline—as those <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> elements otherwise normally would if they were not children of any <code>&lt;hgroup&gt;</code>.</p>
 
-<p>So in the abstract outline produced by the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#the_html5_outline_algorithm">HTML outline algorithm defined in the HTML specification</a>, the <code>&lt;hgroup&gt;</code> as a whole forms a single logical heading, with the entire set of <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> children of the <code>&lt;hgroup&gt;</code> going into the outline as one <em>multi-level</em> unit, to comprise that single logical heading in the abstract outline.</p>
+<p>So in the abstract outline produced by the <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#the_html5_outline_algorithm">HTML outline algorithm defined in the HTML specification</a>, the <code>&lt;hgroup&gt;</code> as a whole forms a single logical heading, with the entire set of <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> children of the <code>&lt;hgroup&gt;</code> going into the outline as one <em>multi-level</em> unit, to comprise that single logical heading in the abstract outline.</p>
 
 <p>To produce any (non-abstract) <em>rendered</em> view of such an outline, some choice must be made in the design of the rendering tool about how to render <code>&lt;hgroup&gt;</code> headings in such a way as to convey their multi-level nature. There are a variety of ways an <code>&lt;hgroup&gt;</code> might be shown in a rendered outline; for example:</p>
 
@@ -133,5 +133,5 @@ browser-compat: html.elements.hgroup
 
 <ul>
  <li>Others section-related elements: {{HTMLElement("body")}}, {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("nav")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}};</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Sections and outlines of an HTML5 document</a>.</li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Sections and outlines of an HTML5 document</a>.</li>
 </ul>

--- a/files/en-us/web/html/element/nav/index.html
+++ b/files/en-us/web/html/element/nav/index.html
@@ -107,6 +107,6 @@ browser-compat: html.elements.nav
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}};</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Sections and outlines of an HTML5 document</a>.</li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Sections and outlines of an HTML5 document</a>.</li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role">ARIA: Navigation role</a></li>
 </ul>

--- a/files/en-us/web/html/element/section/index.html
+++ b/files/en-us/web/html/element/section/index.html
@@ -143,7 +143,7 @@ browser-compat: html.elements.section
 
 <ul>
  <li>Other section-related elements: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}}</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Using HTML sections and outlines</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">Using HTML sections and outlines</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role">ARIA: Region role</a></li>
  <li><a href="https://www.smashingmagazine.com/2020/01/html5-article-section/">Why You Should Choose HTML5 article Over section</a>, by Bruce Lawson</li>
 </ul>

--- a/files/en-us/web/html/link_types/index.html
+++ b/files/en-us/web/html/link_types/index.html
@@ -63,7 +63,7 @@ browser-compat: html.elements.link.rel
   </tr>
   <tr>
    <td><code>bookmark</code></td>
-   <td>Indicates that the hyperlink is a <a href="/en-US/docs/Permalink">permalink</a> for the nearest ancestor {{HTMLElement("article")}} element. If none, it is a permalink for the <a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">section</a> that the element is most closely associated to.<br>
+   <td>Indicates that the hyperlink is a <a href="/en-US/docs/Permalink">permalink</a> for the nearest ancestor {{HTMLElement("article")}} element. If none, it is a permalink for the <a href="/en-US/docs/Web/HTML/Element/Heading_Elements">section</a> that the element is most closely associated to.<br>
     <br>
     This allows for bookmarking a single article in a page containing multiple articles, such as on a monthly summary blog page, or a blog aggregator.</td>
    <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}</td>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There are many links to Guide/HTML/Using_HTML_sections_and_outlines which should be replaced with Element/Heading_Elements.

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
