### PR TITLE
Updated word 'mixin' to 'interface'

### DIFF
--- a/files/en-us/web/api/htmlelement/tabindex/index.html
+++ b/files/en-us/web/api/htmlelement/tabindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLElement.tabIndex
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <strong><code>tabIndex</code></strong> property of the
-{{DOMxRef("HTMLElement")}} mixin represents the tab order of the current element.</p>
+{{DOMxRef("HTMLElement")}} interface represents the tab order of the current element.</p>
 
 <p>Tab order is as follows:</p>
 


### PR DESCRIPTION
This was recently folded from a mixin.

The word mixin has been forgotten. This fixes it.

(I was doing a grep about something else and found it)