### PR TITLE
Update HTTP specification sections to source from BCD where possible

### DIFF
--- a/files/en-us/web/http/headers/accept-ch/index.html
+++ b/files/en-us/web/http/headers/accept-ch/index.html
@@ -57,20 +57,7 @@ Vary: Viewport-Width, Width
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("8942", "Accept-CH")}}</td>
-      <td>HTTP Client Hints</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/accept-encoding/index.html
+++ b/files/en-us/web/http/headers/accept-encoding/index.html
@@ -87,20 +87,7 @@ Accept-Encoding: br;q=1.0, gzip;q=0.8, *;q=0.1
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "Accept-Encoding", "5.3.4")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/accept-language/index.html
+++ b/files/en-us/web/http/headers/accept-language/index.html
@@ -90,24 +90,7 @@ Accept-Language: en-US,en;q=0.5
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "Accept-Language", "5.3.5")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context</td>
-    </tr>
-    <tr>
-      <td><a href="https://datatracker.ietf.org/doc/html/bcp47">BCP 47</a></td>
-      <td>Tags for the Identification of Language</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/accept-ranges/index.html
+++ b/files/en-us/web/http/headers/accept-ranges/index.html
@@ -59,20 +59,7 @@ Accept-Ranges: none</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Title</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{RFC("7233", "Accept-Ranges", "2.3")}}</td>
-			<td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/accept/index.html
+++ b/files/en-us/web/http/headers/accept/index.html
@@ -67,20 +67,7 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "Accept", "5.3.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.html
@@ -86,23 +86,7 @@ xhr.send(null);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Fetch','#http-access-control-allow-credentials',
-        'Access-Control-Allow-Credentials')}}</td>
-      <td>{{Spec2("Fetch")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.html
@@ -98,22 +98,7 @@ Access-Control-Max-Age: 86400</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#http-access-control-allow-headers', 'Access-Control-Allow-Headers')}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.html
@@ -54,23 +54,7 @@ Access-Control-Allow-Methods: *
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Fetch','#http-access-control-allow-methods',
-        'Access-Control-Allow-Methods')}}</td>
-      <td>{{Spec2("Fetch")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-origin/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-origin/index.html
@@ -74,22 +74,7 @@ Vary: Origin</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#http-access-control-allow-origin', 'Access-Control-Allow-Origin')}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.html
@@ -63,22 +63,7 @@ Access-Control-Expose-Headers: *
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#http-access-control-expose-headers', 'Access-Control-Expose-Headers')}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-max-age/index.html
+++ b/files/en-us/web/http/headers/access-control-max-age/index.html
@@ -50,22 +50,7 @@ browser-compat: http.headers.Access-Control-Max-Age
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#http-access-control-max-age', 'Access-Control-Max-Age')}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-request-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.html
@@ -43,22 +43,7 @@ browser-compat: http.headers.Access-Control-Request-Headers
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#http-access-control-request-headers', 'Access-Control-Request-Headers')}}</td>
-   <td>{{Spec2("Fetch")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/access-control-request-method/index.html
+++ b/files/en-us/web/http/headers/access-control-request-method/index.html
@@ -49,21 +49,7 @@ browser-compat: http.headers.Access-Control-Request-Method
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Fetch','#http-access-control-request-method',
-        'Access-Control-Request-Method')}}</td>
-      <td>{{Spec2("Fetch")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/age/index.html
+++ b/files/en-us/web/http/headers/age/index.html
@@ -52,18 +52,7 @@ browser-compat: http.headers.Age
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7234", "Age", "5.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Caching</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/alt-svc/index.html
+++ b/files/en-us/web/http/headers/alt-svc/index.html
@@ -53,22 +53,7 @@ Alt-Svc: h3-25=":443"; ma=3600, h2=":443"; ma=3600</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC(7838)}}</td>
-      <td><span class="spec-RFC">IETF RFC</span></td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/cache-control/index.html
+++ b/files/en-us/web/http/headers/cache-control/index.html
@@ -178,32 +178,7 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC(8246, "HTTP Immutable Responses")}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{RFC(7234, "Hypertext Transfer Protocol (HTTP/1.1): Caching")}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{RFC(5861, "HTTP Cache-Control Extensions for Stale Content")}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/clear-site-data/index.html
+++ b/files/en-us/web/http/headers/clear-site-data/index.html
@@ -87,18 +87,7 @@ Clear-Site-Data: "*"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://w3c.github.io/webappsec-clear-site-data">Clear Site Data</a> (Latest Editor's Draft)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-disposition/index.html
+++ b/files/en-us/web/http/headers/content-disposition/index.html
@@ -103,26 +103,7 @@ value2
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
-  <tr>
-   <td>{{RFC("7578")}}</td>
-   <td>Returning Values from Forms: multipart/form-data</td>
-  </tr>
-  <tr>
-   <td>{{RFC("6266")}}</td>
-   <td>Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)</td>
-  </tr>
-  <tr>
-   <td>{{RFC("2183")}}</td>
-   <td>Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-encoding/index.html
+++ b/files/en-us/web/http/headers/content-encoding/index.html
@@ -85,28 +85,7 @@ Content-Encoding: deflate, gzip
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "Content-Encoding", "3.1.2.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-    <tr>
-      <td>{{RFC("2616", "Content-Encoding", "14.11")}}</td>
-      <td>Content-Encoding</td>
-    </tr>
-    <tr>
-      <td>{{RFC("7932", "Brotli Compressed Data Format")}}</td>
-      <td>Brotli Compressed Data Format</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-language/index.html
+++ b/files/en-us/web/http/headers/content-language/index.html
@@ -75,20 +75,7 @@ Content-Language: de-DE, en-CA
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "Content-Language", "3.1.3.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -46,20 +46,7 @@ browser-compat: http.headers.Content-Length
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7230", "Content-Length", "3.3.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-location/index.html
+++ b/files/en-us/web/http/headers/content-location/index.html
@@ -165,20 +165,7 @@ Content-Location: /my-receipts/38
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "Content-Location", "3.1.4.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-range/index.html
+++ b/files/en-us/web/http/headers/content-range/index.html
@@ -59,18 +59,7 @@ Content-Range: &lt;unit&gt; */&lt;size&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7233", "Content-Range", "4.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.html
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.html
@@ -114,27 +114,7 @@ browser-compat: http.headers.Content-Security-Policy-Report-Only
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("CSP 3.0")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.html
@@ -73,25 +73,7 @@ Header set Content-Security-Policy "base-uri 'self'";
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-base-uri", "base-uri")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1", "#directive-base-uri", "base-uri")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.html
@@ -37,18 +37,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.block-all-mixed-content
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://www.w3.org/TR/mixed-content/#block-all-mixed-content">Mixed Content Level 1</a></td>
-  </tr>
- </tbody>
-</table>
+<p>Not part of any current specification. Used to be defined in the outdated <a href="https://www.w3.org/TR/mixed-content/#block-all-mixed-content">Mixed Content Level 1</a> specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.html
@@ -70,25 +70,7 @@ Content-Security-Policy: child-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-child-src", "child-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-child-src", "child-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.html
@@ -91,27 +91,7 @@ Content-Security-Policy: connect-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-connect-src", "connect-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-connect-src", "connect-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.html
@@ -140,27 +140,7 @@ Content-Security-Policy: default-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-default-src", "default-src")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>Added <code>frame-src</code>, <code>manifest-src</code> and <code>worker-src</code> as defaults.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1", "#directive-default-src", "default-src")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.html
@@ -70,25 +70,7 @@ Content-Security-Policy: font-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-font-src", "font-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-font-src", "font-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.html
@@ -81,25 +81,7 @@ Header set Content-Security-Policy "form-action 'none';"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{specName("CSP 3.0", "#directive-form-action", "form-action")}}</td>
-			<td>{{Spec2('CSP 3.0')}}</td>
-			<td>No changes.</td>
-		</tr>
-		<tr>
-			<td>{{specName("CSP 1.1", "#directive-form-action", "form-action")}}</td>
-			<td>{{Spec2('CSP 1.1')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
@@ -91,25 +91,7 @@ Content-Security-Policy: frame-ancestors 'self' https://www.example.org;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-frame-ancestors", "frame-ancestors")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1", "#directive-frame-ancestors", "frame-ancestors")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
@@ -66,27 +66,7 @@ Content-Security-Policy: frame-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-frame-src", "frame-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Undeprecates <code>frame-src</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-frame-src", "frame-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Deprecates <code>frame-src</code>.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.html
@@ -64,27 +64,7 @@ Content-Security-Policy: img-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-img-src", "img-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-img-src", "img-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/index.html
@@ -311,55 +311,7 @@ Content-Security-Policy: default-src https:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Adds <code>manifest-src</code>, <code>navigate-to</code>,
-        <code>report-to</code>, <code>strict-dynamic</code>, <code>worker-src</code>.
-        Undeprecates <code>frame-src</code>. Deprecates <code>report-uri</code> in favor
-        if <code>report-to</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("Mixed Content")}}</td>
-      <td>{{Spec2("Mixed Content")}}</td>
-      <td>Adds <code>block-all-mixed-content</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("Subresource Integrity")}}</td>
-      <td>{{Spec2("Subresource Integrity")}}</td>
-      <td>Adds <code>require-sri-for</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("Upgrade Insecure Requests")}}</td>
-      <td>{{Spec2("Upgrade Insecure Requests")}}</td>
-      <td>Adds <code>upgrade-insecure-requests</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1")}}</td>
-      <td>{{Spec2("CSP 1.1")}}</td>
-      <td>Adds <code>base-uri</code>, <code>child-src</code>, <code>form-action</code>,
-        <code>frame-ancestors</code>, <code>plugin-types</code>, <code>referrer</code>,
-        and <code>report-uri</code>. Deprecates <code>frame-src</code>.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.0")}}</td>
-      <td>{{Spec2("CSP 1.0")}}</td>
-      <td>Defines <code>connect-src</code>, <code>default-src</code>,
-        <code>font-src</code>, <code>frame-src</code>, <code>img-src</code>,
-        <code>media-src</code>, <code>object-src</code>, report-uri, <code>sandbox</code>,
-        <code>script-src,</code> and <code>style-src</code>.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
@@ -65,22 +65,7 @@ Content-Security-Policy: manifest-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-manifest-src", "manifest-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.html
@@ -68,27 +68,7 @@ Content-Security-Policy: media-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-media-src", "media-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-media-src", "media-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
@@ -78,20 +78,7 @@ Content-Security-Policy: navigate-to &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-navigate-to", "navigate-to")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.html
@@ -78,27 +78,7 @@ Content-Security-Policy: object-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-object-src", "object-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-object-src", "object-src")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
@@ -96,22 +96,7 @@ Content-Security-Policy: plugin-types &lt;type&gt;/&lt;subtype&gt; &lt;type&gt;/
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-plugin-types", "plugin-types")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>Not part of any current specification. Used to be defined in <a href="https://www.w3.org/TR/CSP2/#directive-plugin-types">CSP 2</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.html
@@ -65,22 +65,7 @@ Content-Security-Policy: prefetch-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#prefetch-src", "prefetch-src")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.html
@@ -71,6 +71,10 @@ browser-compat: http.headers.csp.Content-Security-Policy.report-to
 
 <a href="https://w3c.github.io/webappsec-csp/#content-security-policy" id="ref-for-content-security-policy">Content-Security-Policy</a>: ...; <a href="https://w3c.github.io/webappsec-csp/#directives-reporting" id="ref-for-directives-reporting">report-to</a> endpoint-1</pre>
 
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
@@ -111,25 +111,7 @@ if ($json_data = json_decode($json_data)) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-report-uri", "report-uri")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-report-uri", "report-uri")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
@@ -49,22 +49,7 @@ if (typeof trustedTypes !== 'undefined') {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/webappsec-trusted-types/dist/spec/">Trusted Types</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
@@ -91,27 +91,7 @@ Content-Security-Policy: sandbox &lt;value&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-sandbox", "sandbox")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 1.1", "#directive-sandbox", "sandbox")}}</td>
-      <td>{{Spec2('CSP 1.1')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
@@ -125,22 +125,7 @@ dl>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-script-src-attr", "script-src-attr")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
@@ -117,22 +117,7 @@ Content-Security-Policy: script-src-elem &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-script-src-elem", "script-src-elem")}}</td>
-   <td>{{Spec2("CSP 3.0")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.html
@@ -190,27 +190,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-script-src", "script-src")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1", "#directive-script-src", "script-src")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
@@ -72,20 +72,7 @@ Content-Security-Policy: <code>style</code>-src-attr &lt;source&gt;;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-style-src-attr", "style-src-attr")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
@@ -73,20 +73,7 @@ Content-Security-Policy: <code>style</code>-src-elem &lt;source&gt;;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-style-src-elem", "style-src-elem")}}</td>
-      <td>{{Spec2("CSP 3.0")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.html
@@ -142,27 +142,7 @@ document.querySelector('div').style.cssText = 'display:none;';</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("CSP 3.0", "#directive-style-src", "style-src")}}</td>
-   <td>{{Spec2('CSP 3.0')}}</td>
-   <td>No changes.</td>
-  </tr>
-  <tr>
-   <td>{{specName("CSP 1.1", "#directive-style-src", "style-src")}}</td>
-   <td>{{Spec2('CSP 1.1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
@@ -48,22 +48,7 @@ if (typeof trustedTypes !== 'undefined') {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/webappsec-trusted-types/dist/spec/">Trusted Types</a></td>
-   <td>Draft</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
@@ -82,21 +82,7 @@ Content-Security-Policy-Report-Only: default-src https:; report-uri /endpoint</p
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-		<tr>
-			<td>{{specName("Upgrade Insecure Requests", "#delivery",
-				"upgrade-insecure-requests")}}</td>
-			<td>{{Spec2('Upgrade Insecure Requests')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
@@ -71,22 +71,7 @@ Content-Security-Policy: worker-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-worker-src", "worker-src")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/content-type/index.html
+++ b/files/en-us/web/http/headers/content-type/index.html
@@ -89,24 +89,7 @@ Content-Type: text/plain
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7233", "Content-Type in multipart", "4.1")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-  </tr>
-  <tr>
-   <td>{{RFC("7231", "Content-Type", "3.1.1.5")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/cookie/index.html
+++ b/files/en-us/web/http/headers/cookie/index.html
@@ -45,20 +45,7 @@ Cookie: name=value; name2=value2; name3=value3</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("6265", "Cookie", "5.4")}}</td>
-   <td>HTTP State Management Mechanism</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.html
@@ -69,18 +69,7 @@ Cross-Origin-Opener-Policy: same-origin
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#coep', 'Cross-Origin-Embedder-Policy header')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
@@ -68,18 +68,7 @@ Cross-Origin-Embedder-Policy: require-corp
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#the-headers', 'Cross-Origin-Opener-Policy header')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.html
@@ -57,22 +57,7 @@ browser-compat: http.headers.Cross-Origin-Resource-Policy
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName("Fetch", '#cross-origin-resource-policy-header')}}</td>
-      <td>{{Spec2("Fetch", '#cross-origin-resource-policy-header')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/date/index.html
+++ b/files/en-us/web/http/headers/date/index.html
@@ -80,20 +80,7 @@ browser-compat: http.headers.Date
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Title</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{RFC("7231", "Date", "7.1.1.2")}}</td>
-			<td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/dnt/index.html
+++ b/files/en-us/web/http/headers/dnt/index.html
@@ -57,21 +57,7 @@ DNT: null
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Tracking','#dnt-header-field', 'DNT Header Field for HTTP
-        Requests')}}</td>
-      <td>{{Spec2("Tracking")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/early-data/index.html
+++ b/files/en-us/web/http/headers/early-data/index.html
@@ -48,20 +48,7 @@ Early-Data: 1</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("8470", "The Early-Data Header Field", "5.1")}}</td>
-      <td>Using Early Data in HTTP</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/etag/index.html
+++ b/files/en-us/web/http/headers/etag/index.html
@@ -104,20 +104,7 @@ ETag: W/"0815"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "ETag", "2.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/expect/index.html
+++ b/files/en-us/web/http/headers/expect/index.html
@@ -79,20 +79,7 @@ Expect: 100-continue
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "Expect", "5.1.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/expires/index.html
+++ b/files/en-us/web/http/headers/expires/index.html
@@ -57,20 +57,7 @@ browser-compat: http.headers.Expires
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7234", "Expires", "5.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Caching</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/forwarded/index.html
+++ b/files/en-us/web/http/headers/forwarded/index.html
@@ -87,20 +87,7 @@ Forwarded: for=192.0.2.43, for="[2001:db8:cafe::17]"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7239", "Forwarded", "4")}}</td>
-   <td>Forwarded HTTP Extension</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/from/index.html
+++ b/files/en-us/web/http/headers/from/index.html
@@ -52,18 +52,7 @@ browser-compat: http.headers.From
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "From", "5.5.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/host/index.html
+++ b/files/en-us/web/http/headers/host/index.html
@@ -52,20 +52,7 @@ browser-compat: http.headers.Host
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7230", "Host", "5.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/if-match/index.html
+++ b/files/en-us/web/http/headers/if-match/index.html
@@ -81,20 +81,7 @@ If-Match: *
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "If-Match", "3.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/if-modified-since/index.html
+++ b/files/en-us/web/http/headers/if-modified-since/index.html
@@ -76,20 +76,7 @@ browser-compat: http.headers.If-Modified-Since
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "If-Modified-Since", "3.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/if-none-match/index.html
+++ b/files/en-us/web/http/headers/if-none-match/index.html
@@ -65,20 +65,7 @@ If-None-Match: *
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7232", "If-None-Match", "3.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/if-range/index.html
+++ b/files/en-us/web/http/headers/if-range/index.html
@@ -79,18 +79,7 @@ If-Range: &lt;etag&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7233", "If-Range", "3.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/if-unmodified-since/index.html
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.html
@@ -80,20 +80,7 @@ browser-compat: http.headers.If-Unmodified-Since
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "If-Unmodified-Since", "3.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/keep-alive/index.html
+++ b/files/en-us/web/http/headers/keep-alive/index.html
@@ -67,24 +67,7 @@ Server: Apache
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://datatracker.ietf.org/doc/html/draft-thomson-hybi-http-timeout-03#section-2">HTTP Keep-Alive Header</a></td>
-   <td>Keep-Alive Header (IETF Internet Draft)</td>
-  </tr>
-  <tr>
-   <td><a href="https://datatracker.ietf.org/doc/html/rfc7230#appendix-A.1.2">RFC 7230, appendix A.1.2: Keep-Alive</a></td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/last-modified/index.html
+++ b/files/en-us/web/http/headers/last-modified/index.html
@@ -71,20 +71,7 @@ browser-compat: http.headers.Last-Modified
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "Last-Modified", "2.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/link/index.html
+++ b/files/en-us/web/http/headers/link/index.html
@@ -45,27 +45,7 @@ browser-compat: http.headers.Link
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comments</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC(8288, "Link Serialisation in HTTP Headers", 3)}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{RFC(5988, "The Link Header Field", 5)}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/location/index.html
+++ b/files/en-us/web/http/headers/location/index.html
@@ -72,18 +72,7 @@ browser-compat: http.headers.Location
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "Location", "7.1.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/nel/index.html
+++ b/files/en-us/web/http/headers/nel/index.html
@@ -32,18 +32,7 @@ browser-compat: http.headers.NEL
 <pre class="brush: html">NEL: { "report_to": "name_of_reporting_group", "max_age": 12345, "include_subdomains": false, "success_fraction": 0.0, "failure_fraction": 1.0 }
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/network-error-logging/#nel-response-header">Network Error Logging</a></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -59,24 +59,7 @@ Origin: &lt;scheme&gt; "://" &lt;hostname&gt; [ ":" &lt;port&gt; ]
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("6454", "Origin", "7")}}</td>
-   <td>The Web Origin Concept</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fetch','#origin-header','Origin header')}}</td>
-   <td>Supplants the <code>Origin</code> header as defined in RFC6454.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/pragma/index.html
+++ b/files/en-us/web/http/headers/pragma/index.html
@@ -64,18 +64,7 @@ browser-compat: http.headers.Pragma
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7234", "Pragma", "5.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Caching</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/proxy-authenticate/index.html
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.html
@@ -61,22 +61,7 @@ Proxy-Authenticate: Basic realm="Access to the internal site"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7235", "Proxy-Authenticate", "4.3")}}</td>
-      <td>HTTP/1.1: Authentication</td>
-    </tr>
-    <tr>
-      <td>{{RFC("7617")}}</td>
-      <td>The 'Basic' HTTP Authentication Scheme</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.html
+++ b/files/en-us/web/http/headers/proxy-authorization/index.html
@@ -69,22 +69,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7235", "Proxy-Authorization", "4.4")}}</td>
-      <td>HTTP/1.1: Authentication</td>
-    </tr>
-    <tr>
-      <td>{{RFC("7617")}}</td>
-      <td>The 'Basic' HTTP Authentication Scheme</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/public-key-pins-report-only/index.html
+++ b/files/en-us/web/http/headers/public-key-pins-report-only/index.html
@@ -87,18 +87,7 @@ browser-compat: http.headers.Public-Key-Pins-Report-Only
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7469", "Public-Key-Pins-Report-Only", "2.1")}}</td>
-      <td>Public Key Pinning Extension for HTTP</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/public-key-pins/index.html
+++ b/files/en-us/web/http/headers/public-key-pins/index.html
@@ -95,18 +95,7 @@ browser-compat: http.headers.Public-Key-Pins
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7469", "Public-Key-Pins", "2.1")}}</td>
-      <td>Public Key Pinning Extension for HTTP</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/range/index.html
+++ b/files/en-us/web/http/headers/range/index.html
@@ -61,20 +61,7 @@ Range: &lt;unit&gt;=-&lt;suffix-length&gt;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7233", "Range", "3.1")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/referer/index.html
+++ b/files/en-us/web/http/headers/referer/index.html
@@ -59,20 +59,7 @@ Referer: https://example.com/
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "Referer", "5.5.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -231,20 +231,7 @@ Referrer-Policy: unsafe-url
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-header">Referrer Policy </a></td>
-   <td>Editor's draft</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/retry-after/index.html
+++ b/files/en-us/web/http/headers/retry-after/index.html
@@ -71,18 +71,7 @@ Retry-After: 120
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "Retry-After", "7.1.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/sec-websocket-accept/index.html
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.html
@@ -55,20 +55,7 @@ browser-compat: http.headers.Sec-WebSocket-Accept
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("6455", "Sec-WebSocket-Accept", "11.3.3")}}</td>
-      <td>The WebSocket Protocol</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/server-timing/index.html
+++ b/files/en-us/web/http/headers/server-timing/index.html
@@ -59,20 +59,7 @@ Server-Timing: total;dur=123.4
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Title</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Server Timing','#the-server-timing-header-field', 'Server-Timing Header Field')}}</td>
-   <td>{{Spec2("Server Timing")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/server/index.html
+++ b/files/en-us/web/http/headers/server/index.html
@@ -58,20 +58,7 @@ browser-compat: http.headers.Server
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "Server", "7.4.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/set-cookie/index.html
+++ b/files/en-us/web/http/headers/set-cookie/index.html
@@ -182,24 +182,7 @@ Set-Cookie: __Host-id=1; Secure; Path=/; Domain=example.com
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("6265", "Set-Cookie", "4.1")}}</td>
-   <td>HTTP State Management Mechanism</td>
-  </tr>
-  <tr>
-   <td><a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-05">draft-ietf-httpbis-rfc6265bis-05</a></td>
-   <td>Cookie Prefixes, Same-Site Cookies, and Strict Secure Cookies</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.html
+++ b/files/en-us/web/http/headers/strict-transport-security/index.html
@@ -135,22 +135,7 @@ Strict-Transport-Security: max-age=&lt;expire-time&gt;; preload
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HSTS')}}</td>
-      <td>{{Spec2('HSTS')}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/te/index.html
+++ b/files/en-us/web/http/headers/te/index.html
@@ -72,18 +72,7 @@ TE: trailers, deflate;q=0.5
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7230", "TE", "4.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/timing-allow-origin/index.html
+++ b/files/en-us/web/http/headers/timing-allow-origin/index.html
@@ -53,22 +53,7 @@ Timing-Allow-Origin: &lt;origin&gt;[, &lt;origin&gt;]*
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Resource Timing 3', '#sec-timing-allow-origin', 'Timing-Allow-Origin')}}</td>
-   <td>{{Spec2("Resource Timing 3")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/tk/index.html
+++ b/files/en-us/web/http/headers/tk/index.html
@@ -82,20 +82,7 @@ Tk: U  (updated)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Tracking','#Tk-header-defn', 'Tk header field')}}</td>
-      <td>{{Spec2("Tracking")}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -86,22 +86,7 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7230", "Trailer", "4.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-    <tr>
-      <td>{{RFC("7230", "Chunked trailer part", "4.1.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -115,20 +115,7 @@ Network\r\n
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7230", "Transfer-Encoding", "3.3.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/upgrade-insecure-requests/index.html
+++ b/files/en-us/web/http/headers/upgrade-insecure-requests/index.html
@@ -44,22 +44,7 @@ Vary: Upgrade-Insecure-Requests</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{specName("Upgrade Insecure Requests", "#preference", "upgrade-insecure-requests")}}</td>
-   <td>{{Spec2('Upgrade Insecure Requests')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/upgrade/index.html
+++ b/files/en-us/web/http/headers/upgrade/index.html
@@ -99,32 +99,7 @@ Upgrade: websocket
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{RFC(7230, "Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing",6.7)}}</td>
-			<td>IETF RFC</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{RFC("7231", "426 Upgrade Required" , "6.5.15")}}</td>
-			<td>IETF RFC</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>{{RFC(7540, "Hypertext Transfer Protocol Version 2 (HTTP/2)","8.1.1")}}</td>
-			<td>IETF RFC</td>
-			<td></td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/user-agent/index.html
+++ b/files/en-us/web/http/headers/user-agent/index.html
@@ -121,24 +121,7 @@ Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC(7231, "User-Agent", "5.5.3")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
-  <tr>
-   <td>{{RFC(2616, "User-Agent", "14.43")}}</td>
-   <td>Hypertext Transfer Protocol -- HTTP/1.1</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/vary/index.html
+++ b/files/en-us/web/http/headers/vary/index.html
@@ -69,18 +69,7 @@ Vary: &lt;header-name&gt;, &lt;header-name&gt;, ...
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "Vary", "7.1.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/via/index.html
+++ b/files/en-us/web/http/headers/via/index.html
@@ -58,18 +58,7 @@ Via: 1.0 fred, 1.1 p.example.net
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7230", "Via", "5.7.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/warning/index.html
+++ b/files/en-us/web/http/headers/warning/index.html
@@ -141,18 +141,7 @@ Warning: 112 - "cache down" "Wed, 21 Oct 2015 07:28:00 GMT"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7234", "Warning", "5.5")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Caching</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/www-authenticate/index.html
+++ b/files/en-us/web/http/headers/www-authenticate/index.html
@@ -55,24 +55,7 @@ browser-compat: http.headers.WWW-Authenticate
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Title</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{RFC("7235", "WWW-Authenticate", "4.1")}}</td>
-			<td>HTTP/1.1: Authentication</td>
-		</tr>
-		<tr>
-			<td>{{RFC("7617")}}</td>
-			<td>The 'Basic' HTTP Authentication Scheme</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/x-content-type-options/index.html
+++ b/files/en-us/web/http/headers/x-content-type-options/index.html
@@ -85,21 +85,7 @@ browser-compat: http.headers.X-Content-Type-Options
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName("Fetch", "#x-content-type-options-header", "X-Content-Type-Options
-        definition")}}</td>
-      <td>{{Spec2("Fetch")}}</td>
-      <td>Initial definition</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/x-frame-options/index.html
+++ b/files/en-us/web/http/headers/x-frame-options/index.html
@@ -127,20 +127,7 @@ app.use(frameguard({ action: 'SAMEORIGIN' }))
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7034")}}</td>
-   <td>HTTP Header Field X-Frame-Options</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/connect/index.html
+++ b/files/en-us/web/http/methods/connect/index.html
@@ -70,20 +70,7 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "CONNECT", "4.3.6")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/delete/index.html
+++ b/files/en-us/web/http/methods/delete/index.html
@@ -80,20 +80,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "DELETE", "4.3.5")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/get/index.html
+++ b/files/en-us/web/http/methods/get/index.html
@@ -51,20 +51,7 @@ browser-compat: http.methods.GET
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "GET", "4.3.1")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/head/index.html
+++ b/files/en-us/web/http/methods/head/index.html
@@ -54,20 +54,7 @@ browser-compat: http.methods.HEAD
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "HEAD", "4.3.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/options/index.html
+++ b/files/en-us/web/http/methods/options/index.html
@@ -108,20 +108,7 @@ Connection: Keep-Alive</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "OPTIONS", "4.3.7")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/post/index.html
+++ b/files/en-us/web/http/methods/post/index.html
@@ -95,24 +95,7 @@ value2
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "POST", "4.3.3")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
-  <tr>
-   <td>{{RFC("2046", "Common Syntax", "5.1.1")}}</td>
-   <td>Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/put/index.html
+++ b/files/en-us/web/http/methods/put/index.html
@@ -73,20 +73,7 @@ Content-Location: /existing.html
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "PUT", "4.3.4")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/methods/trace/index.html
+++ b/files/en-us/web/http/methods/trace/index.html
@@ -49,20 +49,7 @@ browser-compat: http.methods.TRACE
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "TRACE", "4.3.8")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/100/index.html
+++ b/files/en-us/web/http/status/100/index.html
@@ -24,18 +24,7 @@ browser-compat: http.status.100
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "100 Continue" , "6.2.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/200/index.html
+++ b/files/en-us/web/http/status/200/index.html
@@ -28,18 +28,7 @@ browser-compat: http.status.200
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
-  <tr>
-   <td>{{RFC("7231", "200 OK" , "6.3.1")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/201/index.html
+++ b/files/en-us/web/http/status/201/index.html
@@ -25,20 +25,7 @@ browser-compat: http.status.201
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "201 Created" , "6.3.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/204/index.html
+++ b/files/en-us/web/http/status/204/index.html
@@ -27,18 +27,7 @@ browser-compat: http.status.204
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "204 No Content" , "6.3.5")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/206/index.html
+++ b/files/en-us/web/http/status/206/index.html
@@ -60,20 +60,7 @@ Content-Range: bytes 4590-7999/8000
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7233", "206 Partial Content" , "4.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/301/index.html
+++ b/files/en-us/web/http/status/301/index.html
@@ -32,20 +32,7 @@ Location: http://www.example.org/index.asp</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "301 Moved Permanently" , "6.4.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/302/index.html
+++ b/files/en-us/web/http/status/302/index.html
@@ -34,20 +34,7 @@ browser-compat: http.status.302
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "302 Found" , "6.4.3")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/303/index.html
+++ b/files/en-us/web/http/status/303/index.html
@@ -23,20 +23,7 @@ browser-compat: http.status.303
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "303 See Other" , "6.4.4")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/304/index.html
+++ b/files/en-us/web/http/status/304/index.html
@@ -34,18 +34,7 @@ browser-compat: http.status.304
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7232", "304 Not Modified" , "4.1")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/307/index.html
+++ b/files/en-us/web/http/status/307/index.html
@@ -36,20 +36,7 @@ browser-compat: http.status.307
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7231", "307 Temporary Redirect" , "6.4.7")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/308/index.html
+++ b/files/en-us/web/http/status/308/index.html
@@ -35,18 +35,7 @@ browser-compat: http.status.308
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7538", "308 Permanent Redirect" , "3")}}</td>
-      <td>The Hypertext Transfer Protocol Status Code 308 (Permanent Redirect)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/401/index.html
+++ b/files/en-us/web/http/status/401/index.html
@@ -32,18 +32,7 @@ WWW-Authenticate: Basic realm="Access to staging site"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7235", "401 Unauthorized" , "3.1")}}</td>
-      <td>HTTP/1.1: Authentication</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/403/index.html
+++ b/files/en-us/web/http/status/403/index.html
@@ -26,20 +26,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "403 Forbidden" , "6.5.3")}}</td>
-   <td>HTTP/1.1: Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/404/index.html
+++ b/files/en-us/web/http/status/404/index.html
@@ -32,20 +32,7 @@ browser-compat: http.status.404
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "404 Not Found" , "6.5.4")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/406/index.html
+++ b/files/en-us/web/http/status/406/index.html
@@ -38,24 +38,9 @@ browser-compat: http.status.406
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7231", "406 Not Acceptable" , "6.5.6")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).
-</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/407/index.html
+++ b/files/en-us/web/http/status/407/index.html
@@ -30,18 +30,7 @@ Proxy-Authenticate: Basic realm="Access to internal site"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-    <tr>
-      <td>{{RFC("7235", "407 Proxy Authentication Required" , "3.2")}}</td>
-      <td>HTTP/1.1: Authentication</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/409/index.html
+++ b/files/en-us/web/http/status/409/index.html
@@ -20,18 +20,7 @@ browser-compat: http.status.409
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
-  <tr>
-   <td>{{RFC("7231", "409 Conflict" , "6.5.8")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/410/index.html
+++ b/files/en-us/web/http/status/410/index.html
@@ -24,24 +24,9 @@ browser-compat: http.status.410
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Title</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{RFC("7231", "410 Gone" , "6.5.9")}}</td>
-			<td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-		</tr>
-	</tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/412/index.html
+++ b/files/en-us/web/http/status/412/index.html
@@ -49,20 +49,7 @@ ETag: W/"0815"</code></pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("7232", "412 Precondition Failed" , "4.2")}}</td>
-      <td>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/416/index.html
+++ b/files/en-us/web/http/status/416/index.html
@@ -21,24 +21,9 @@ browser-compat: http.status.416
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7233", "416 Request Not Satisfiable" , "4.4")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>). </p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/425/index.html
+++ b/files/en-us/web/http/status/425/index.html
@@ -20,20 +20,7 @@ browser-compat: http.status.425
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{RFC("8470", "425: Early Data", "5.2")}}</td>
-      <td>Using Early Data in HTTP</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/status/451/index.html
+++ b/files/en-us/web/http/status/451/index.html
@@ -41,24 +41,9 @@ Content-Type: text/html</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7725", "451 Unavailable For Legal Reasons")}}</td>
-   <td>An HTTP Status Code to Report Legal Obstacles</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/500/index.html
+++ b/files/en-us/web/http/status/500/index.html
@@ -19,24 +19,9 @@ browser-compat: http.status.500
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "500 Internal Server Error" , "6.6.1")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/501/index.html
+++ b/files/en-us/web/http/status/501/index.html
@@ -30,23 +30,8 @@ browser-compat: http.status.501
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "501 Not Implemented" , "6.6.2")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/http/status/502/index.html
+++ b/files/en-us/web/http/status/502/index.html
@@ -22,24 +22,9 @@ browser-compat: http.status.502
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "502 Bad Gateway" , "6.6.3")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/503/index.html
+++ b/files/en-us/web/http/status/503/index.html
@@ -26,24 +26,9 @@ browser-compat: http.status.503
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "503 Service Unavailable" , "6.6.4")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/http/status/504/index.html
+++ b/files/en-us/web/http/status/504/index.html
@@ -21,24 +21,9 @@ browser-compat: http.status.504
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Title</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{RFC("7231", "504 Gateway Timeout" , "6.6.5")}}</td>
-   <td>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
 <p>{{Compat}}</p>
 


### PR DESCRIPTION
Thanks to browser-specs version 2.1.0 (where IETF have been added - thanks! ❤️), we can now also use the specification URLs that BCD provides for MDN's HTTP docs. 