### PR TITLE
docs: fix code indentation and remove redundant attribute

### DIFF
--- a/files/en-us/web/css/flex-wrap/index.html
+++ b/files/en-us/web/css/flex-wrap/index.html
@@ -86,40 +86,40 @@ flex-wrap: unset;
 .content,
 .content1,
 .content2 {
-    color: #fff;
-    font: 100 24px/100px sans-serif;
-    height: 150px;
-    text-align: center;
+  color: #fff;
+  font: 100 24px/100px sans-serif;
+  height: 150px;
+  text-align: center;
 }
 
 .content div,
 .content1 div,
 .content2 div {
-    height: 50%;
-    width: 300px;
+  height: 50%;
+  width: 300px;
 }
 .red {
-    background: orangered;
+  background: orangered;
 }
 .green {
-    background: yellowgreen;
+  background: yellowgreen;
 }
 .blue {
-    background: steelblue;
+  background: steelblue;
 }
 
 /* Flexbox Styles */
 .content {
-    display: flex;
-    flex-wrap: wrap;
+  display: flex;
+  flex-wrap: wrap;
 }
 .content1 {
-    display: flex;
-    flex-wrap: nowrap;
+  display: flex;
+  flex-wrap: nowrap;
 }
 .content2 {
-    display: flex;
-    flex-wrap: wrap-reverse;
+  display: flex;
+  flex-wrap: wrap-reverse;
 }
 
 </pre>

--- a/files/en-us/web/html/element/input/date/index.html
+++ b/files/en-us/web/html/element/input/date/index.html
@@ -161,7 +161,7 @@ console.log(dateControl.valueAsNumber); // prints 1496275200000, a JavaScript ti
 <p>You can use the {{htmlattrxref("min", "input")}} and {{htmlattrxref("max", "input")}} attributes to restrict the dates that can be chosen by the user. In the following example, we set a minimum date of <code>2017-04-01</code> and a maximum date of <code>2017-04-30</code>:</p>
 
 <pre class="brush: html">&lt;form&gt;
-  &lt;label for="party"&gt;Choose your preferred party date:
+  &lt;label&gt;Choose your preferred party date:
     &lt;input type="date" name="party" min="2017-04-01" max="2017-04-30"&gt;
   &lt;/label&gt;
 &lt;/form&gt;</pre>
@@ -253,7 +253,7 @@ input:valid+span::after {
 <p>One way around this is the {{htmlattrxref("pattern", "input")}} attribute on your date input. Even though the date picker doesn't use it, the text input fallback will. For example, try viewing the following in a unsupporting browser:</p>
 
 <pre class="brush: html">&lt;form&gt;
-  &lt;label for="bday"&gt;Enter your birthday:
+  &lt;label&gt;Enter your birthday:
     &lt;input type="date" name="bday" required pattern="\d{4}-\d{2}-\d{2}"&gt;
     &lt;span class="validity"&gt;&lt;/span&gt;
   &lt;/label&gt;
@@ -298,41 +298,41 @@ input:valid + span::after {
 <p>The HTML looks like so:</p>
 
 <pre class="brush: html">&lt;form&gt;
-    &lt;div class="nativeDatePicker"&gt;
-      &lt;label for="bday"&gt;Enter your birthday:&lt;/label&gt;
-      &lt;input type="date" id="bday" name="bday"&gt;
-      &lt;span class="validity"&gt;&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;p class="fallbackLabel"&gt;Enter your birthday:&lt;/p&gt;
-    &lt;div class="fallbackDatePicker"&gt;
-      &lt;span&gt;
-        &lt;label for="day"&gt;Day:&lt;/label&gt;
-        &lt;select id="day" name="day"&gt;
-        &lt;/select&gt;
-      &lt;/span&gt;
-      &lt;span&gt;
-        &lt;label for="month"&gt;Month:&lt;/label&gt;
-        &lt;select id="month" name="month"&gt;
-          &lt;option selected&gt;January&lt;/option&gt;
-          &lt;option&gt;February&lt;/option&gt;
-          &lt;option&gt;March&lt;/option&gt;
-          &lt;option&gt;April&lt;/option&gt;
-          &lt;option&gt;May&lt;/option&gt;
-          &lt;option&gt;June&lt;/option&gt;
-          &lt;option&gt;July&lt;/option&gt;
-          &lt;option&gt;August&lt;/option&gt;
-          &lt;option&gt;September&lt;/option&gt;
-          &lt;option&gt;October&lt;/option&gt;
-          &lt;option&gt;November&lt;/option&gt;
-          &lt;option&gt;December&lt;/option&gt;
-        &lt;/select&gt;
-      &lt;/span&gt;
-      &lt;span&gt;
-        &lt;label for="year"&gt;Year:&lt;/label&gt;
-        &lt;select id="year" name="year"&gt;
-        &lt;/select&gt;
-      &lt;/span&gt;
-    &lt;/div&gt;
+  &lt;div class="nativeDatePicker"&gt;
+    &lt;label for="bday"&gt;Enter your birthday:&lt;/label&gt;
+    &lt;input type="date" id="bday" name="bday"&gt;
+    &lt;span class="validity"&gt;&lt;/span&gt;
+  &lt;/div&gt;
+  &lt;p class="fallbackLabel"&gt;Enter your birthday:&lt;/p&gt;
+  &lt;div class="fallbackDatePicker"&gt;
+    &lt;span&gt;
+      &lt;label for="day"&gt;Day:&lt;/label&gt;
+      &lt;select id="day" name="day"&gt;
+      &lt;/select&gt;
+    &lt;/span&gt;
+    &lt;span&gt;
+      &lt;label for="month"&gt;Month:&lt;/label&gt;
+      &lt;select id="month" name="month"&gt;
+        &lt;option selected&gt;January&lt;/option&gt;
+        &lt;option&gt;February&lt;/option&gt;
+        &lt;option&gt;March&lt;/option&gt;
+        &lt;option&gt;April&lt;/option&gt;
+        &lt;option&gt;May&lt;/option&gt;
+        &lt;option&gt;June&lt;/option&gt;
+        &lt;option&gt;July&lt;/option&gt;
+        &lt;option&gt;August&lt;/option&gt;
+        &lt;option&gt;September&lt;/option&gt;
+        &lt;option&gt;October&lt;/option&gt;
+        &lt;option&gt;November&lt;/option&gt;
+        &lt;option&gt;December&lt;/option&gt;
+      &lt;/select&gt;
+    &lt;/span&gt;
+    &lt;span&gt;
+      &lt;label for="year"&gt;Year:&lt;/label&gt;
+      &lt;select id="year" name="year"&gt;
+      &lt;/select&gt;
+    &lt;/span&gt;
+  &lt;/div&gt;
 &lt;/form&gt;</pre>
 
 <p>The months are hardcoded (as they are always the same), while the day and year values are dynamically generated depending on the currently selected month and year, and the current year (see the code comments below for detailed explanations of how these functions work.)</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This PR:
- Formats some code blocks to use 2-space indentation for consistency
- Removes the `for` attribute from `label` element where the element already wraps around the `input`.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Screenshots

| Before | After |
| --- | --- |
| <img width="1043" alt="Screen Shot 2021-07-07 at 22 48 19" src="https://user-images.githubusercontent.com/25715018/124790815-b1145700-df75-11eb-906f-2db4c341bbab.png"> | <img width="1028" alt="Screen Shot 2021-07-07 at 22 48 28" src="https://user-images.githubusercontent.com/25715018/124791106-f6d11f80-df75-11eb-8731-710c9f687bd6.png"> |