### PR TITLE
Update SVG event attributes page to point to correct BCD

### DIFF
--- a/files/en-us/web/svg/attribute/events/index.html
+++ b/files/en-us/web/svg/attribute/events/index.html
@@ -8,7 +8,7 @@ tags:
   - Landing
   - NeedsUpdate
   - SVG
-browser-compat: svg.attributes.events
+browser-compat: svg.attributes.events.global
 ---
 <p>Event attributes always have their name starting with "on" followed by the name of the event for which they are intended. They specifies some script to run when the event of the given type is dispatched to the element on which the attributes are specified.</p>
 


### PR DESCRIPTION
This PR fixes the issue described in BCD at https://github.com/mdn/browser-compat-data/issues/11421.  The article's BCD entry was set incorrectly, and thus ended up rendering a blank compat table.