### PR TITLE
Add note about months > 11 in Date() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.html
@@ -113,7 +113,8 @@ new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds)
       </dd>
       <dt><code><var>monthIndex</var></code></dt>
       <dd>Integer value representing the month, beginning with <code>0</code> for January
-        to <code>11</code> for December.</dd>
+        to <code>11</code> for December. If a value greater than <code>11</code> is passed in, 
+        then those months will be added to the date. E.g. <code>new Date(1990, 12, 1)</code> will return January 1'st 1991</dd>
       <dt><code><var>day</var></code> {{optional_inline}}</dt>
       <dd>Integer value representing the day of the month. The default is <code>1</code>.
       </dd>

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.html
@@ -114,7 +114,7 @@ new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds)
       <dt><code><var>monthIndex</var></code></dt>
       <dd>Integer value representing the month, beginning with <code>0</code> for January
         to <code>11</code> for December. If a value greater than <code>11</code> is passed in, 
-        then those months will be added to the date. E.g. <code>new Date(1990, 12, 1)</code> will return January 1'st 1991</dd>
+        then those months will be added to the date; for example, <code>new Date(1990, 12, 1)</code> will return January 1st, 1991</dd>
       <dt><code><var>day</var></code> {{optional_inline}}</dt>
       <dd>Integer value representing the day of the month. The default is <code>1</code>.
       </dd>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Missing behaviour of date constructor.

Example:

![Screen Shot 2021-07-07 at 8 55 08 PM](https://user-images.githubusercontent.com/10621548/124846313-8bcc1c80-df66-11eb-90a7-833213139a8a.png)

Description: `20 - 11 = 9` ... 9 months were added to the date.
