### PR TITLE
Fix typos around 'however'

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.html
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>Also significant here is the concept of <strong>inheritance</strong>, which means that some CSS properties by default inherit values set on the current element's parent element, and some don't. This can also cause some behavior that you might not expect.</p>
 
-<p>Let's start by taking a quick look at the key things we are dealing with, then we'll look at each in turn and see how they interact with each other and your CSS. This can seem like a set of tricky concepts to understand. As you get more practice writing CSS, however, the way it works will become more obvious to you.</p>
+<p>Let's start by taking a quick look at the key things we are dealing with, then we'll look at each in turn and see how they interact with each other and your CSS. This can seem like a set of tricky concepts to understand. As you get more practice writing CSS, the way it works will become more obvious to you.</p>
 
 <h3 id="The_cascade">The cascade</h3>
 
@@ -46,7 +46,7 @@ tags:
 
 <p>In the below example, we have two rules that could apply to the <code>h1</code>. The <code>h1</code> ends up being colored blue — these rules have an identical selector and therefore carry the same specificity, so the last one in the source order wins.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/cascade-simple.html", '100%', 400)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/cascade-simple.html", '100%', 400)}}</p>
 
 <h3 id="Specificity">Specificity</h3>
 
@@ -59,7 +59,7 @@ tags:
 
 <p>Example time! Below we again have two rules that could apply to the <code>h1</code>. The below <code>h1</code> ends up being colored red — the class selector gives its rule a higher specificity, and so it will be applied even though the rule with the element selector appears further down in the source order.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/specificity-simple.html", '100%', 500)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/specificity-simple.html", '100%', 500)}}</p>
 
 <p>We'll explain specificity scoring and other such things later on.</p>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>For example, if you set a <code>color</code> and <code>font-family</code> on an element, every element inside it will also be styled with that color and font, unless you've applied different color and font values directly to them.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/inheritance-simple.html", '100%', 550)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/inheritance-simple.html", '100%', 550)}}</p>
 
 <p>Some properties do not inherit — for example, if you set a {{cssxref("width")}} of 50% on an element, all of its descendants do not get a width of 50% of their parent's width. If this was the case, CSS would be very frustrating to use!</p>
 
@@ -89,9 +89,9 @@ tags:
 
 <p>We'll start with inheritance. In the example below we have a {{HTMLElement("ul")}}, with two levels of unordered lists nested inside it. We have given the outer <code>&lt;ul&gt;</code> a border, padding, and font color.</p>
 
-<p>The color has applied to the direct children, but also the indirect children — the immediate child <code>&lt;li&gt;</code>s, and those inside the first nested list. We have then added a class- <code>special</code> to the second nested list and applied a different color to it. This then inherits down through its children.</p>
+<p>The color has applied to the direct children, but also the indirect children — the immediate child <code>&lt;li&gt;</code>s, and those inside the first nested list. We have then added a class- <code>special</code> to the second nested list and applied a different color to it. This then inherits down through its children.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/inheritance.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/inheritance.html", '100%', 700)}}</p>
 
 <p>Things like widths (as mentioned above), margins, padding, and borders do not inherit. If a border were to be inherited by the children of our list, every single list and list item would gain a border — probably not an effect we would ever want!</p>
 
@@ -111,7 +111,7 @@ tags:
 </dl>
 
 <div class="notecard note">
-<p><strong>Note</strong>: There is also a newer value, {{cssxref("revert")}}, which has limited browser support.</p>
+<p><strong>Note</strong>: There is also a newer value, {{cssxref("revert")}}, which has limited browser support.</p>
 </div>
 
 <div class="notecard note">
@@ -128,7 +128,7 @@ tags:
  <li>Which of the links will change color if you define a new color for the <code>&lt;a&gt;</code> element — for example <code>a { color: red; }</code>?</li>
 </ol>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/keywords.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/keywords.html", '100%', 700)}} </p>
 
 <h3 id="Resetting_all_property_values">Resetting all property values</h3>
 
@@ -136,13 +136,13 @@ tags:
 
 <p>In the below example we have two blockquotes. The first has styling applied to the blockquote element itself, the second has a class applied to the blockquote which sets the value of <code>all</code> to <code>unset</code>.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/all.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/all.html", '100%', 700)}} </p>
 
 <p>Try setting the value of <code>all</code> to some of the other available values and observe what the difference is.</p>
 
 <h2 id="Understanding_the_cascade">Understanding the cascade</h2>
 
-<p>We now understand why a paragraph nested deep in the structure of your HTML is the same color as the CSS applied to the body, and from the introductory lessons, we have an understanding of how to change the CSS applied to something at any point in the document — whether by assigning CSS to an element or creating a class. We will now take a proper look at how the cascade defines which CSS rules apply when more than one thing could style an element.</p>
+<p>We now understand why a paragraph nested deep in the structure of your HTML is the same color as the CSS applied to the body, and from the introductory lessons, we have an understanding of how to change the CSS applied to something at any point in the document — whether by assigning CSS to an element or creating a class. We will now take a proper look at how the cascade defines which CSS rules apply when more than one thing could style an element.</p>
 
 <p>There are three factors to consider, listed here in increasing order of importance. Later ones overrule earlier ones:</p>
 
@@ -168,7 +168,7 @@ tags:
 
 <p>This behavior helps avoid repetition in your CSS. A common practice is to define generic styles for the basic elements, and then create classes for those which are different. For example, in the stylesheet below we have defined generic styles for level 2 headings, and then created some classes which change only some of the properties and values. The values defined initially are applied to all headings, then the more specific values are applied to the headings with the classes.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/mixing-rules.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/mixing-rules.html", '100%', 700)}} </p>
 
 <p>Let's now have a look at how the browser will calculate specificity. We already know that an element selector has low specificity and can be overwritten by a class. Essentially a value in points is awarded to different types of selectors, and adding these up gives you the weight of that particular selector, which can then be assessed against other potential matches.</p>
 
@@ -185,7 +185,7 @@ tags:
 <p><strong>Note</strong>: The universal selector (<code>*</code>), combinators (<code>+</code>, <code>&gt;</code>, <code>~</code>, ' '), and negation pseudo-class (<code>:not</code>) have no effect on specificity.</p>
 </div>
 
-<p>The following table shows a few isolated examples to get you in the mood. Try going through these, and making sure you understand why they have the specificity that we have given them. We've not covered selectors in detail yet, but you can find details of each selector on the MDN  <a href="/en-US/docs/Web/CSS/CSS_Selectors">selectors reference</a>.</p>
+<p>The following table shows a few isolated examples to get you in the mood. Try going through these, and making sure you understand why they have the specificity that we have given them. We've not covered selectors in detail yet, but you can find details of each selector on the MDN <a href="/en-US/docs/Web/CSS/CSS_Selectors">selectors reference</a>.</p>
 
 <table class="standard-table">
  <thead>
@@ -244,7 +244,7 @@ tags:
 
 <p>Before we move on, let's look at an example in action.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/specificity-boxes.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/specificity-boxes.html", '100%', 700)}}</p>
 
 <p>So what's going on here? First of all, we are only interested in the first seven rules of this example, and as you'll notice, we have included their specificity values in a comment before each one.</p>
 
@@ -262,18 +262,18 @@ tags:
 
 <h3 id="!important">!important</h3>
 
-<p>There is a special piece of CSS that you can use to overrule all of the above calculations, however, you should be very careful with using it — <code>!important</code>. This is used to make a particular property and value the most specific thing, thus overriding the normal rules of the cascade.</p>
+<p>There is a special piece of CSS that you can use to overrule all of the above calculations. However, you should be very careful with using it — <code>!important</code>. This is used to make a particular property and value the most specific thing, thus overriding the normal rules of the cascade.</p>
 
 <p>Take a look at this example where we have two paragraphs, one of which has an ID.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/cascade/important.html", '100%', 700)}} </p>
+<p>{{EmbedGHLiveSample("css-examples/learn/cascade/important.html", '100%', 700)}}</p>
 
 <p>Let's walk through this to see what's happening — try removing some of the properties to see what happens if you are finding it hard to understand:</p>
 
 <ol>
  <li>You'll see that the third rule's {{cssxref("color")}} and {{cssxref("padding")}} values have been applied, but the {{cssxref("background-color")}} hasn't. Why? Really all three should surely apply, because rules later in the source order generally override earlier rules.</li>
- <li>However, The rules above it win, because class selectors have higher specificity than element selectors.</li>
- <li>Both elements have a {{htmlattrxref("class")}} of <code>better</code>, but the 2nd one has an {{htmlattrxref("id")}} of <code>winning</code> too. Since IDs have an <em>even higher</em> specificity than classes (you can only have one element with each unique ID on a page, but many elements with the same class — ID selectors are <em>very specific</em> in what they target), the red background color and the 1px black border should both be applied to the 2nd element, with the first element getting the gray background color, and no border, as specified by the class.</li>
+ <li>However, the rules above it win, because class selectors have higher specificity than element selectors.</li>
+ <li>Both elements have a {{htmlattrxref("class")}} of <code>better</code>, but the 2nd one has an {{htmlattrxref("id")}} of <code>winning</code> too. Since IDs have an <em>even higher</em> specificity than classes (you can only have one element with each unique ID on a page, but many elements with the same class — ID selectors are <em>very specific</em> in what they target), the red background color and the 1px black border should both be applied to the 2nd element, with the first element getting the gray background color, and no border, as specified by the class.</li>
  <li>The 2nd element <em>does</em> get the red background color, but no border. Why? Because of the <code>!important</code> declaration in the second rule — including this after <code>border: none</code> means that this declaration will win over the border value in the previous rule, even though the ID has higher specificity.</li>
 </ol>
 
@@ -305,7 +305,7 @@ tags:
 
 <h2 id="Test_your_skills!">Test your skills!</h2>
 
-<p>We have covered a lot in this article, but can you remember the most important information? You can find some further tests to verify that you've retained this information before you move on — see <a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_tasks">Test your skills: the Cascade</a>.</p>
+<p>We have covered a lot in this article, but can you remember the most important information? You can find some further tests to verify that you've retained this information before you move on — see <a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_tasks">Test your skills: the Cascade</a>.</p>
 
 <h2 id="Whats_next">What's next</h2>
 


### PR DESCRIPTION
This fixes #6659 and fixes #6660

I:
- fixes some gremlins on the page (non-breaking spaces)
- removed a _however_ from the page (there are so many of them)
- corrected two sentences around the word _however_