### PR TITLE
LargestContentfulPaint subpages and API Overview

### DIFF
--- a/files/en-us/web/api/largest_contentful_paint_api/index.html
+++ b/files/en-us/web/api/largest_contentful_paint_api/index.html
@@ -10,11 +10,11 @@ browser-compat: api.LargestContentfulPaint
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong>Largest Contentful Paint (LCP) API</strong> enables monitoring the largest paint an element triggered on screen.</p>
+<p class="summary">The <strong>Largest Contentful Paint (LCP) API</strong> enables monitoring the largest paint element triggered on screen.</p>
 
 <h2> Concepts and Usage</h2>
 
-<p>The Largest Contentful Paint metric is the render time of the largest image or text block visible within the viewport, recorded from when the page first begins to load. The API supports the same timing elements as the {{domxref("Element Timing API")}}:</p>
+<p>The Largest Contentful Paint metric provides the render time of the largest image or text block visible within the viewport, recorded from when the page first begins to load. The API supports the following elements:</p>
 <ul>
   <li>{{HTMLElement("img")}} elements.</li>
   <li><code><a href="/en-US/docs/Web/SVG/Element/image">&lt;image&gt;</a></code> elements inside an SVG.</li>

--- a/files/en-us/web/api/largest_contentful_paint_api/index.html
+++ b/files/en-us/web/api/largest_contentful_paint_api/index.html
@@ -1,0 +1,60 @@
+---
+title: Largest Contentful Paint API
+slug: Web/API/Largest_Contentful_Paint_API
+tags:
+  - API
+  - LargestContentfulPaint
+  - Overview
+  - Reference
+browser-compat: api.LargestContentfulPaint
+---
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
+
+<p class="summary">The <strong>Largest Contentful Paint (LCP) API</strong> enables monitoring the largest paint an element triggered on screen.</p>
+
+<h2> Concepts and Usage</h2>
+
+<p>The Largest Contentful Paint metric is the render time of the largest image or text block visible within the viewport, recorded from when the page first begins to load. The API supports the same timing elements as the {{domxref("Element Timing API")}}:</p>
+<ul>
+  <li>{{HTMLElement("img")}} elements.</li>
+  <li><code><a href="/en-US/docs/Web/SVG/Element/image">&lt;image&gt;</a></code> elements inside an SVG.</li>
+  <li>The poster images of {{HTMLElement("video")}} elements.</li>
+  <li>Elements with a {{cssxref("background-image")}}.</li>
+  <li>Groups of text nodes, such as {{HTMLElement("p")}}.</li>
+</ul>
+
+<h2 id="Interfaces"> Interfaces</h2>
+
+<dl>
+  <dt>{{domxref("LargestContentfulPaint")}}</dt>
+  <dd>Reports details about the largest image or text paint before user input on a web page.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an image and a large paragraph of text. An observer is registered to get the largest contentful paint while the page is loading.</p>
+
+<pre class="brush: html">&lt;img src="large_image.jpg"&gt;
+&lt;p id='large-paragraph'&gt;This is large body of text.&lt;/p&gt;</pre>
+
+<pre class="brush: js">const observer = new PerformanceObserver((list) => {
+  let perfEntries = list.getEntries();
+  let lastEntry = perfEntries[perfEntries.length - 1];
+  // Process the latest candidate for largest contentful paint
+});
+observer.observe({entryTypes: ['largest-contentful-paint']});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/lcp/">Largest Contentful Paint (LCP)</a></li>
+  <li><a href="https://web.dev/lighthouse-largest-contentful-paint/">LCP in Lighthouse</a></li>
+</ul>

--- a/files/en-us/web/api/largestcontentfulpaint/element/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/element/index.html
@@ -9,36 +9,35 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.element
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>element</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>element</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns an object representing the {{domxref("Element")}} that is the largest contentful paint.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let aelement = LargestContentfulPaint.element;
-// Remove this one if the property is read only.
-LargestContentfulPaint.element = a;
-</pre>
+<pre class="brush: js">let element = LargestContentfulPaint.element;</pre>
 
 <h3>Value</h3>
-<p></p>
+<p>An {{domxref("Element")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>element</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.element);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,8 +45,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/largestcontentfulpaint/element/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/element/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.element
+slug: Web/API/LargestContentfulPaint/element
+tags:
+  - API
+  - Property
+  - Reference
+  - element
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.element
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>element</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let aelement = LargestContentfulPaint.element;
+// Remove this one if the property is read only.
+LargestContentfulPaint.element = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.id
+slug: Web/API/LargestContentfulPaint/id
+tags:
+  - API
+  - Property
+  - Reference
+  - id
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.id
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>id</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let aid = LargestContentfulPaint.id;
+// Remove this one if the property is read only.
+LargestContentfulPaint.id = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.html
@@ -9,44 +9,41 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.id
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the ID of the element that is the largest contentful paint.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let aid = LargestContentfulPaint.id;
-// Remove this one if the property is read only.
-LargestContentfulPaint.id = a;
-</pre>
+<pre class="brush: js">let id = LargestContentfulPaint.id;</pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("DOMString","string")}} containing the ID of the element.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>id</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.id);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/largestcontentfulpaint/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/index.html
@@ -11,31 +11,35 @@ tags:
   - Web Performance
 browser-compat: api.LargestContentfulPaint
 ---
-<div>{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p>The <code>LargestContentfulPaint</code> interface of the Largest Contentful Paint API provides details about the largest image or text paint before user input on a web page. The timing of this paint is a good heuristic for when the main page content is available during load.</p>
+<p>The <code>LargestContentfulPaint</code> interface of the {{domxref("Largest Contentful Paint API")}} provides details about the largest image or text paint before user input on a web page. The timing of this paint is a good heuristic for when the main page content is available during load.</p>
 
 <h2 id="Properties">Properties</h2>
 
+<p><em>This interface also inherits properties from {{domxref("PerformanceEntry")}}.</em></p>
+
 <dl>
- <dt><strong><code>{{domxref("LargestContentfulPaint.element")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.element")}}{{ReadOnlyInline}}</dt>
  <dd>The element that is the current largest contentful paint.</dd>
- <dt><strong><code>{{domxref("LargestContentfulPaint.renderTime")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.renderTime")}}{{ReadOnlyInline}}</dt>
  <dd>The time the element was rendered to the screen. May not be available if the element is a cross-origin image loaded without the <code>Timing-Allow-Origin</code> header.</dd>
- <dt><strong><code>{{domxref("LargestContentfulPaint.loadTime")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.loadTime")}}{{ReadOnlyInline}}</dt>
  <dd>The time the element was loaded.</dd>
- <dt><strong><code>{{domxref("LargestContentfulPaint.size")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.size")}}{{ReadOnlyInline}}</dt>
  <dd>The intrinsic size of the element returned as the area (width * height).</dd>
- <dt><strong><code>{{domxref("LargestContentfulPaint.id")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.id")}}{{ReadOnlyInline}}</dt>
  <dd>The id of the element. This property returns an empty string when there is no id.</dd>
- <dt><strong><code>{{domxref("LargestContentfulPaint.url")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.url")}}{{ReadOnlyInline}}</dt>
  <dd>If the element is an image, the request url of the image.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
 
+<p><em>This interface also inherits methods from {{domxref("PerformanceEntry")}}.</em></p>
+
 <dl>
- <dt><strong><code>{{domxref("LargestContentfulPaint.toJSON()")}}</code></strong></dt>
+ <dt>{{domxref("LargestContentfulPaint.toJSON()")}}</dt>
  <dd>Returns the above properties as JSON.</dd>
 </dl>
 
@@ -83,3 +87,10 @@ try {
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/lcp/">Largest Contentful Paint (LCP)</a></li>
+  <li><a href="https://web.dev/lighthouse-largest-contentful-paint/">LCP in Lighthouse</a></li>
+</ul>

--- a/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.loadTime
+slug: Web/API/LargestContentfulPaint/loadTime
+tags:
+  - API
+  - Property
+  - Reference
+  - loadTime
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.loadTime
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>loadTime</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let aloadTime = LargestContentfulPaint.loadTime;
+// Remove this one if the property is read only.
+LargestContentfulPaint.loadTime = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
@@ -9,36 +9,35 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.loadTime
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>loadTime</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>loadTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the time that the element was loaded.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let aloadTime = LargestContentfulPaint.loadTime;
-// Remove this one if the property is read only.
-LargestContentfulPaint.loadTime = a;
-</pre>
+<pre class="brush: js">let loadTime = LargestContentfulPaint.loadTime;</pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time in milliseconds that the element was loaded.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>loadTime</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.loadTime);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,8 +45,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
@@ -9,36 +9,35 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.renderTime
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>renderTime</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>renderTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface represents the time that the element was rendered to the screen.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let arenderTime = LargestContentfulPaint.renderTime;
-// Remove this one if the property is read only.
-LargestContentfulPaint.renderTime = a;
-</pre>
+<pre class="brush: js">let renderTime = LargestContentfulPaint.renderTime;</pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time in milliseconds that the element was rendered to the screen.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>renderTime</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.renderTime);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,8 +45,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.renderTime
+slug: Web/API/LargestContentfulPaint/renderTime
+tags:
+  - API
+  - Property
+  - Reference
+  - renderTime
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.renderTime
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>renderTime</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let arenderTime = LargestContentfulPaint.renderTime;
+// Remove this one if the property is read only.
+LargestContentfulPaint.renderTime = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.html
@@ -9,44 +9,43 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.size
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>size</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>size</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the intrinsic size of the element that is the largest contentful paint.</p>
+
+<p>The <code>size</code> of the element is the <code>width</code> * <code>height</code> of the {{domxref("DOMRectReadOnly","rectangle")}} that this element creates on the screen.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let asize = LargestContentfulPaint.size;
-// Remove this one if the property is read only.
-LargestContentfulPaint.size = a;
-</pre>
+<pre class="brush: js">let size = LargestContentfulPaint.size;</pre>
 
 <h3>Value</h3>
-<p></p>
+<p>An integer representing the width * height of the element.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>size</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.size);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.size
+slug: Web/API/LargestContentfulPaint/size
+tags:
+  - API
+  - Property
+  - Reference
+  - size
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.size
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>size</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let asize = LargestContentfulPaint.size;
+// Remove this one if the property is read only.
+LargestContentfulPaint.size = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.html
@@ -13,14 +13,14 @@ browser-compat: api.LargestContentfulPaint.size
 
 <p class="summary">The <strong><code>size</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the intrinsic size of the element that is the largest contentful paint.</p>
 
-<p>The <code>size</code> of the element is the <code>width</code> * <code>height</code> of the {{domxref("DOMRectReadOnly","rectangle")}} that this element creates on the screen.</p>
+<p>The <code>size</code> of the element is the <code>width</code> times <code>height</code> of the {{domxref("DOMRectReadOnly","rectangle")}} that this element creates on the screen.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">let size = LargestContentfulPaint.size;</pre>
 
 <h3>Value</h3>
-<p>An integer representing the width * height of the element.</p>
+<p>An integer representing the width times height of the element.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -48,5 +48,4 @@ browser-compat: api.LargestContentfulPaint.size
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
@@ -9,9 +9,9 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.toJSON
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LargestContentfulPaint")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>LargestContentfulPaint</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -19,32 +19,30 @@ browser-compat: api.LargestContentfulPaint.toJSON
 
 <h3 id="Parameters">Parameters</h3>
 
-
+<p>None.</p>
 
 <h3 id="Returns">Return value</h3>
 
-<p></p>
-
-<h3 id="Exceptions">Exceptions</h3>
-
-
+<p>A JSON object that is the serialization of the {{domxref("LargestContentfulPaint")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints it as JSON to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.toJSON());
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -52,8 +50,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
@@ -1,0 +1,59 @@
+---
+title: LargestContentfulPaint.toJSON()
+slug: Web/API/LargestContentfulPaint/toJSON
+tags:
+  - API
+  - Method
+  - Reference
+  - toJSON
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.toJSON
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">LargestContentfulPaint.toJSON();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+
+
+<h3 id="Returns">Return value</h3>
+
+<p></p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.html
@@ -9,44 +9,42 @@ tags:
   - LargestContentfulPaint
 browser-compat: api.LargestContentfulPaint.url
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>url</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+<p class="summary">The <strong><code>url</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the request url of the element, if the element is an image.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let aurl = LargestContentfulPaint.url;
-// Remove this one if the property is read only.
-LargestContentfulPaint.url = a;
+<pre class="brush: js">let url = LargestContentfulPaint.url;
 </pre>
 
 <h3>Value</h3>
-<p></p>
+<p>A {{domxref("DOMString","string")}} containing a URL.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>The following example gets the <code>LargestContentfulPaint</code> object and prints the value of <code>url</code> to the console.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">try {
+  let lcp;
 
-<pre class="brush: js">
-my code block</pre>
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    console.log(lastEntry.url);
+  });
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.html
@@ -1,0 +1,53 @@
+---
+title: LargestContentfulPaint.url
+slug: Web/API/LargestContentfulPaint/url
+tags:
+  - API
+  - Property
+  - Reference
+  - url
+  - LargestContentfulPaint
+browser-compat: api.LargestContentfulPaint.url
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>url</code></strong>  property of the {{domxref("LargestContentfulPaint")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let aurl = LargestContentfulPaint.url;
+// Remove this one if the property is read only.
+LargestContentfulPaint.url = a;
+</pre>
+
+<h3>Value</h3>
+<p></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+


### PR DESCRIPTION
A page for the LargestContentfulPaint interfaces existed, but no subpages or API overview. This PR adds those.

I will now go and add the URLs and spec info to BCD.

Reviewer: @jpmedley 