### PR TITLE
DeviceMotionEvent: Improve explanation of acceleration attributes.

### DIFF
--- a/files/en-us/web/api/devicemotionevent/acceleration/index.html
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.html
@@ -17,7 +17,9 @@ browser-compat: api.DeviceMotionEvent.acceleration
 
 <p>The <code>acceleration</code> property returns the amount of acceleration recorded by
   the device, in <a href="https://en.wikipedia.org/wiki/Meter_per_second_squared">meters
-    per second squared (m/s²)</a>.</p>
+    per second squared (m/s²)</a>. The acceleration value does not include the effect of
+    the gravity force, in constrast to
+    {{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}}.</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> If the hardware doesn't know how to remove gravity from the
@@ -61,9 +63,10 @@ browser-compat: api.DeviceMotionEvent.acceleration
   <li>{{DOMxRef("window.ondevicemotion")}}</li>
   <li>{{Event("deviceorientation")}}</li>
   <li>{{DOMxRef("DeviceOrientationEvent")}}</li>
-  <li><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device
+  <li>{{DOMxRef("LinearAccelerationSensor")}}</li>
+  <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device
       orientation</a></li>
-  <li><a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained"
+  <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained"
       title="Orientation and motion data explained">Orientation and motion data
       explained</a></li>
 </ul>

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
@@ -20,11 +20,18 @@ browser-compat: api.DeviceMotionEvent.accelerationIncludingGravity
     href="https://en.wikipedia.org/wiki/Meter_per_second_squared">meters per second
     squared (m/s²)</a>. Unlike {{DOMxRef("DeviceMotionEvent.acceleration")}}
   which compensates for the influence of gravity, its value is the sum of the acceleration
-  of the device as induced by the user and the acceleration caused by gravity.</p>
+  of the device as induced by the user and an acceleration equal and opposite to that
+  caused by gravity. In other words, it measures the
+  {{interwiki("wikipedia", "G-Force", "g-force")}}. In practice, this value represents
+  the raw data measured by an {{interwiki("wikipedia", "accelerometer")}}.</p>
 
 <p>This value is not typically as useful as {{DOMxRef("DeviceMotionEvent.acceleration")}},
-  but may be the only value available on devices that aren't able of removing gravity from
+  but may be the only value available on devices that aren't able to remove gravity from
   the acceleration data, such as on devices that don't have a gyroscope.</p>
+
+<div class="notecard note">
+    <p><strong>Note:</strong> <code>accelerationIncludingGravity</code>'s name can be misleading. This property represents acceleration including <em>the effects of</em> gravity. For example, if a device is lying flat on a horizontal surface with the screen pointing up, gravity would be -9.8 along the Z axis, while <code>acceleration.z</code> would be 0 and <code>accelerationIncludingGravity.z</code> would be 9.8. Similarly, if a device is in free fall with its screen horizontal and pointing up, gravity would be -9.8 along the Z axis, while <code>acceleration.z</code> would be -9.8 and <code>accelerationIncludingGravity.z</code> would be 0.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -62,9 +69,10 @@ browser-compat: api.DeviceMotionEvent.accelerationIncludingGravity
   <li>{{DOMxRef("window.ondevicemotion")}}</li>
   <li>{{Event("deviceorientation")}}</li>
   <li>{{DOMxRef("DeviceOrientationEvent")}}</li>
-  <li><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device
+  <li>{{DOMxRef("Accelerometer")}}</li>
+  <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device
       orientation</a></li>
-  <li><a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained"
+  <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained"
       title="Orientation and motion data explained">Orientation and motion data
       explained</a></li>
 </ul>

--- a/files/en-us/web/api/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/index.html
@@ -61,6 +61,8 @@ browser-compat: api.DeviceMotionEvent
  <li>{{Event("deviceorientation")}}</li>
  <li>{{DOMxRef("DeviceOrientationEvent")}}</li>
  <li>{{Event("devicemotion")}}</li>
- <li><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device orientation</a></li>
- <li><a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained" title="Orientation and motion data explained">Orientation and motion data explained</a></li>
+ <li>{{DOMxRef("Accelerometer")}}</li>
+ <li>{{DOMxRef("LinearAccelerationSensor")}}</li>
+ <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
+ <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained" title="Orientation and motion data explained">Orientation and motion data explained</a></li>
 </ul>


### PR DESCRIPTION
`accelerationIncludingGravity` is a bad name that we unfortunately have to
live with (see w3c/deviceorientation#96). It essentially represents raw
accelerometer data, whose values can be surprising: when a device is at rest
with the screen pointing up, it reports +9.8 in the Z axis rather than 0;
when the device is in free fall, it reports 0 in the Z axis.

Try to explain this in a succint way while also pointing to more detailed
information in related Wikipedia articles. The changes also change a
sentence that said the attribute represented a sum of acceleration on the
device and acceleration caused by gravity. This is confusing because the
DeviceOrientation Event spec defines `accelerationIncludingGravity` as
acceleration on the device plus an acceleration equal and _opposite_ to
gravity.

While here, be clear that the `accelerometer` attribute does not include the
effects of gravity, and reference the corresponding Generic Sensor API
interfaces that provide the same data in an arguably better way and with
better names: `Accelerometer` and `LinearAccelerationSensor`.