### PR TITLE
fixing typo

### DIFF
--- a/files/en-us/web/css/at-rule/index.html
+++ b/files/en-us/web/css/at-rule/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p><strong>At-rules</strong> are <a href="/en-US/docs/Web/CSS/Syntax#css_statements">CSS statements</a> that instructs CSS how to behave. They begin with an at sign, '<code>@</code>' (<code>U+0040 COMMERCIAL AT</code>), followed by an identifier and includes everything up to the next semicolon, '<code>;</code>' (<code>U+003B SEMICOLON</code>), or the next <a href="/en-US/docs/Web/CSS/Syntax#css_declarations_blocks">CSS block</a>, whichever comes first.</p>
+<p><strong>At-rules</strong> are <a href="/en-US/docs/Web/CSS/Syntax#css_statements">CSS statements</a> that instruct CSS how to behave. They begin with an at sign, '<code>@</code>' (<code>U+0040 COMMERCIAL AT</code>), followed by an identifier and includes everything up to the next semicolon, '<code>;</code>' (<code>U+003B SEMICOLON</code>), or the next <a href="/en-US/docs/Web/CSS/Syntax#css_declarations_blocks">CSS block</a>, whichever comes first.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
just fixing this sentence: "At-rules are CSS statements that instructs CSS how to behave" which actually has a grammatical problem and should be "At-rules are CSS statements that instruct CSS how to behave"
