### PR TITLE
"?." instead of "Optional chaining" in ref title

### DIFF
--- a/files/en-us/web/javascript/reference/index.html
+++ b/files/en-us/web/javascript/reference/index.html
@@ -248,7 +248,7 @@ tags:
 
 <ul>
  <li>{{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}</li>
- <li>{{JSxRef("Operators/Optional_chaining", "?.", "", 1)}}</li>
+ <li>{{JSxRef("Operators/Optional_chaining", "<code>?.</code> (Optional chaining)", "", 1)}}</li>
  <li>{{JSxRef("Operators/new", "new")}}</li>
  <li>{{JSxRef("Operators/new%2Etarget", "new.target")}}</li>
  <li>{{JSxRef("Statements/import%2Emeta", "import.meta")}}</li>

--- a/files/en-us/web/javascript/reference/index.html
+++ b/files/en-us/web/javascript/reference/index.html
@@ -248,7 +248,7 @@ tags:
 
 <ul>
  <li>{{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}</li>
- <li>{{JSxRef("Operators/Optional_chaining", "Optional chaining", "", 1)}}</li>
+ <li>{{JSxRef("Operators/Optional_chaining", "?.", "", 1)}}</li>
  <li>{{JSxRef("Operators/new", "new")}}</li>
  <li>{{JSxRef("Operators/new%2Etarget", "new.target")}}</li>
  <li>{{JSxRef("Statements/import%2Emeta", "import.meta")}}</li>


### PR DESCRIPTION
Some people (like myself) are not familiar from the start with the general operator names, especially for the (relatively) new ones. Personally I have looked for ?. in the list of all operators on this page and could not find it quite for a while not knowing that its "right" name is "optional chaining". Therefore I hope that putting the operator itself as the title into the operator list will be more readable, especially for javascript learners.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
