### PR TITLE
Fix wrong number

### DIFF
--- a/files/en-us/web/css/font-size/index.html
+++ b/files/en-us/web/css/font-size/index.html
@@ -152,7 +152,7 @@ span {
 
 <p>{{EmbedLiveSample("Rems", 400, 40)}}</p>
 
-<p>In this example, the words “outer inner outer” are all displayed at 16px (assuming that the browser's <code>font-size</code> has been left at the default value of 10px).</p>
+<p>In this example, the words “outer inner outer” are all displayed at 16px (assuming that the browser's <code>font-size</code> has been left at the default value of 16px).</p>
 
 <h3 id="Ex">Ex</h3>
 


### PR DESCRIPTION
Change text stating the default browser size should be 10px instead of 16px.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
