### PR TITLE
Fix numbered commments in Generator:Constructor example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.html
@@ -28,8 +28,8 @@ browser-compat: javascript.builtins.Generator
 const gen = generator(); // "Generator { }"
 
 console.log(gen.next().value); // 1
-console.log(generator().next().value); // 1
-console.log(generator().next().value); // 1</pre>
+console.log(generator().next().value); // 2
+console.log(generator().next().value); // 3</pre>
 
 <h2 id="Instance_methods">Instance methods</h2>
 


### PR DESCRIPTION
Fix comments in the example for "Generator", under the "Constructor" heading to read `// 1`, `// 2`, `// 3` instead of `// 1`, `// 1`, `// 1`.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The comments in the example given in "Constructor" all read `// 1` but should read `//1`, `// 2`, `// 3`:

```
<pre class="brush: js">function* generator() {
  yield 1;
  yield 2;
  yield 3;
}

const gen = generator(); // "Generator { }"

console.log(gen.next().value); // 1
console.log(generator().next().value); // 1
console.log(generator().next().value); // 1</pre>
```

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

n/a