### PR TITLE
Consistently use em dash in list in Array.prototype.concat() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
@@ -149,5 +149,5 @@ console.log(numbers);
   <li>{{jsxref("Array.splice", "splice")}} — add/remove elements from the specified
     location of the array</li>
   <li>{{jsxref("String.prototype.concat()")}}</li>
-  <li>{{jsxref("Symbol.isConcatSpreadable")}} – control flattening.</li>
+  <li>{{jsxref("Symbol.isConcatSpreadable")}} — control flattening.</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Last list item had smaller length hyphen than its siblings


> Issue number (if there is an associated issue)
Fixes #6689 

