### PR TITLE
Clean up external links from SVG landing page

### DIFF
--- a/files/en-us/web/svg/index.html
+++ b/files/en-us/web/svg/index.html
@@ -42,49 +42,19 @@ tags:
   <dd>SVG works together with {{Glossary("HTML")}}, {{Glossary("CSS")}} and {{Glossary("JavaScript")}}. Use SVG to <a href="/en-US/docs/Web/SVG/Tutorial/SVG_In_HTML_Introduction">enhance a regular HTML page or web application</a>.</dd>
 </dl>
 
-<h2 id="Community">Community</h2>
-
-<ul>
-  <li>View Mozilla forums... {{DiscussionList("dev-tech-svg", "mozilla.dev.tech.svg")}}</li>
-</ul>
-
 <h2 id="Tools">Tools</h2>
 
 <ul>
   <li><a href="https://github.com/w3c/svgwg/wiki/Testing">SVG Test Suite</a></li>
   <li><a href="https://validator.w3.org/#validate_by_input">Markup Validator</a></li>
-  <li>Other resources: <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/CSS">CSS</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/Web/API/Canvas_API">Canvas</a></li>
 </ul>
 
-<h2 class="Related_Topics" id="Examples">Examples</h2>
+<h2 id="Examples">Examples</h2>
 
 <ul>
-  <li>Google <a href="https://maps.google.com">Maps</a> (route overlay) &amp; <a href="https://docs.google.com">Docs</a> (spreadsheet charting)</li>
-  <li><a href="http://starkravingfinkle.org/projects/demo/svg-bubblemenu-in-html.xml">SVG bubble menus</a></li>
   <li><a href="https://jwatt.org/svg/authoring/">SVG authoring guidelines</a></li>
   <li><a href="/en-US/docs/Web/SVG/SVG_as_an_Image">SVG as an image</a></li>
   <li><a href="/en-US/docs/Web/SVG/SVG_animation_with_SMIL">SVG animation with SMIL</a></li>
   <li><a href="https://plurib.us/1shot/2007/svg_gallery/">SVG art gallery</a></li>
-</ul>
-
-<h3 id="Animation_and_interactions">Animation and interactions</h3>
-
-<p>Like HTML, SVG has a document model (DOM) and events, and is accessible from JavaScript. This allows developers to create rich animations and interactive images.</p>
-
-<ul>
-  <li>Some real eye-candy SVG at <a href="http://svg-wow.org/">svg-wow.org</a></li>
-  <li>Firefox extension (<a href="http://schepers.cc/grafox/">Grafox</a>) to add a subset of <a href="/en-US/docs/Web/SVG/SVG_animation_with_SMIL">SMIL animation support</a></li>
-  <li>Interactive <a href="https://demo.huihoo.com/amplesdk/examples/applications/svgalbum/index.html">photos</a> manipulation</li>
-  <li><a href="http://starkravingfinkle.org/blog/2007/07/firefox-3-svg-foreignobject/">HTML transformations</a> using SVG's <code>foreignObject</code></li>
-</ul>
-
-<h3 id="Mapping_charting_games_3D_experiments">Mapping, charting, games &amp; 3D experiments</h3>
-
-<p>While a little SVG can go a long way to enhanced web content, here are some examples of heavy SVG usage.</p>
-
-<ul>
-  <li><a href="https://web.archive.org/web/20131019072450/http://www.treebuilder.de/svg/connect4.svg" title="Archive link provided because source now requires authentication.">Connect 4</a></li>
-  <li><a href="https://jvectormap.com/">jVectorMap</a> (interactive maps for data visualization)</li>
-  <li><a href="https://jointjs.com">JointJS</a> (JavaScript diagramming library)</li>
-  <li><a href="https://d3js.org">D3</a> ( JavaScript library for visualizing data with HTML, SVG, and CSS )</li>
+  <li><a href="https://d3js.org">D3</a> (JavaScript library for visualizing data with HTML, SVG, and CSS)</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

They really serve nothing:
- Too old / Not maintained
- Uses Canvas API now (Google Docs / Maps)
- Does not provide any meaningful descriptions (or its source codes) to be given as examples
  - Mixed feeling about the "SVG art gallery" link. Examples of SVG _images_?
- Turned into a paid service (JointJS)

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

None.