### PR TITLE
docs: fix code block indentation

### DIFF
--- a/files/en-us/web/api/element/scrollwidth/index.html
+++ b/files/en-us/web/api/element/scrollwidth/index.html
@@ -13,96 +13,96 @@ browser-compat: api.Element.scrollWidth
 <div>{{APIRef("DOM")}}</div>
 
 <p>The <strong><code>Element.scrollWidth</code></strong> read-only property is a
-	measurement of the width of an element's content, including content not visible on the
-	screen due to overflow.</p>
+  measurement of the width of an element's content, including content not visible on the
+  screen due to overflow.</p>
 
 <p>The <code>scrollWidth</code> value is equal to the minimum width the element would
-	require in order to fit all the content in the viewport without using a horizontal
-	scrollbar. The width is measured in the same way as {{domxref("Element.clientWidth",
-	"clientWidth")}}: it includes the element's padding, but not its border, margin or
-	vertical scrollbar (if present). It can also include the width of pseudo-elements such
-	as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's content can fit
-	without a need for horizontal scrollbar, its <code>scrollWidth</code> is equal to
-	{{domxref("Element.clientWidth", "clientWidth")}}</p>
+  require in order to fit all the content in the viewport without using a horizontal
+  scrollbar. The width is measured in the same way as {{domxref("Element.clientWidth",
+  "clientWidth")}}: it includes the element's padding, but not its border, margin or
+  vertical scrollbar (if present). It can also include the width of pseudo-elements such
+  as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's content can fit
+  without a need for horizontal scrollbar, its <code>scrollWidth</code> is equal to
+  {{domxref("Element.clientWidth", "clientWidth")}}</p>
 
 <div class="note">
-	<p>This property will round the value to an integer. If you need a fractional value,
-		use {{ domxref("element.getBoundingClientRect()") }}.</p>
+  <p>This property will round the value to an integer. If you need a fractional value,
+    use {{ domxref("element.getBoundingClientRect()") }}.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-	class="brush: js">var <var>xScrollWidth</var> = <var>element</var>.scrollWidth;</pre>
+  class="brush: js">var <var>xScrollWidth</var> = <var>element</var>.scrollWidth;</pre>
 
 <p><code><var>xScrollWidth</var></code> is the width of the content of
-	<code><var>element</var></code> in pixels.</p>
+  <code><var>element</var></code> in pixels.</p>
 
 <h2 id="Example">Example</h2>
 
 <pre class="brush:html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
-&lt;head&gt;
-    &lt;title&gt;Example&lt;/title&gt;
-    &lt;style&gt;
-        div {
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-        }
+  &lt;head&gt;
+    &lt;title&gt;Example&lt;/title&gt;
+    &lt;style&gt;
+      div {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
 
-        #aDiv {
-            width: 100px;
-        }
+      #aDiv {
+        width: 100px;
+      }
 
-        button {
-            margin-bottom: 2em;
-        }
-    &lt;/style&gt;
-&lt;/head&gt;
+      button {
+        margin-bottom: 2em;
+      }
+    &lt;/style&gt;
+  &lt;/head&gt;
 
-&lt;body&gt;
-    &lt;div id="aDiv"&gt;
-        FooBar-FooBar-FooBar-FooBar
-    &lt;/div&gt;
-    &lt;button id="aButton"&gt;
-        Check for overflow
-    &lt;/button&gt;
+  &lt;body&gt;
+    &lt;div id="aDiv"&gt;
+      FooBar-FooBar-FooBar-FooBar
+    &lt;/div&gt;
+    &lt;button id="aButton"&gt;
+      Check for overflow
+    &lt;/button&gt;
 
-    &lt;div id="anotherDiv"&gt;
-        FooBar-FooBar-FooBar-FooBar
-    &lt;/div&gt;
-    &lt;button id="anotherButton"&gt;
-        Check for overflow
-    &lt;/button&gt;
-&lt;/body&gt;
-&lt;script&gt;
-    var buttonOne = document.getElementById('aButton'),
-    buttonTwo = document.getElementById('anotherButton'),
-    divOne = document.getElementById('aDiv'),
-    divTwo = document.getElementById('anotherDiv');
+    &lt;div id="anotherDiv"&gt;
+      FooBar-FooBar-FooBar-FooBar
+    &lt;/div&gt;
+    &lt;button id="anotherButton"&gt;
+      Check for overflow
+    &lt;/button&gt;
+  &lt;/body&gt;
+  &lt;script&gt;
+    var buttonOne = document.getElementById('aButton'),
+    buttonTwo = document.getElementById('anotherButton'),
+    divOne = document.getElementById('aDiv'),
+    divTwo = document.getElementById('anotherDiv');
 
-    //check to determine if an overflow is happening
-    function isOverflowing(element) {
-        return (element.scrollWidth &gt; element.offsetWidth);
-    }
+    //check to determine if an overflow is happening
+    function isOverflowing(element) {
+      return (element.scrollWidth &gt; element.offsetWidth);
+    }
 
-    function alertOverflow(element) {
-        if (isOverflowing(element)) {
-            alert('Contents are overflowing the container.');
-        } else {
-            alert('No overflows!');
-        }
-    }
+    function alertOverflow(element) {
+      if (isOverflowing(element)) {
+        alert('Contents are overflowing the container.');
+      } else {
+        alert('No overflows!');
+      }
+    }
 
-    buttonOne.addEventListener('click', function() {
-        alertOverflow(divOne);
-    });
+    buttonOne.addEventListener('click', function() {
+      alertOverflow(divOne);
+    });
 
-    buttonTwo.addEventListener('click', function() {
-        alertOverflow(divTwo);
-    });
-&lt;/script&gt;
+    buttonTwo.addEventListener('click', function() {
+      alertOverflow(divTwo);
+    });
+  &lt;/script&gt;
 &lt;/html&gt;
 </pre>
 
@@ -121,9 +121,11 @@ browser-compat: api.Element.scrollWidth
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li>{{domxref("Element.clientWidth")}}</li>
-	<li>{{domxref("HTMLElement.offsetWidth")}}</li>
-	<li><a
-			href="/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements">Determining
-			the dimensions of elements</a></li>
+  <li>{{domxref("Element.clientWidth")}}</li>
+  <li>{{domxref("HTMLElement.offsetWidth")}}</li>
+  <li>
+    <a href="/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements">
+      Determining the dimensions of elements
+    </a>
+  </li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This PR converts the indentation of the file to spaces instead of tabs, and formats the code blocks to 2-space indentation.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A