### PR TITLE
querySelector returns SVG elements too, and Element is the base class…

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.html
+++ b/files/en-us/web/api/document/queryselector/index.html
@@ -53,7 +53,7 @@ browser-compat: api.Document.querySelector
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An {{domxref("HTMLElement")}} object representing the first element in the document
+<p>An {{domxref("Element")}} object representing the first element in the document
   that matches the specified set of <a href="/en-US/docs/Web/CSS/CSS_Selectors">CSS
     selectors</a>, or <code>null</code> is returned if there are no matches.</p>
 


### PR DESCRIPTION
… for HTML and SVG elements

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Wrong base class in the description.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
