### PR TITLE
Cookie Max-Age can be <= 0

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.html
+++ b/files/en-us/web/http/headers/set-cookie/index.html
@@ -41,7 +41,7 @@ browser-compat: http.headers.Set-Cookie
 
 <pre class="brush: html">Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;
 Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Expires=&lt;date&gt;
-Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Max-Age=&lt;non-zero-digit&gt;
+Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Max-Age=&lt;number&gt;
 Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Domain=&lt;domain-value&gt;
 Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Path=&lt;path-value&gt;
 Set-Cookie: &lt;cookie-name&gt;=&lt;cookie-value&gt;; Secure


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
The Max-Age is a number, it can be zero or a negative number as stated in the https://datatracker.ietf.org/doc/html/rfc2965 and in this page itself : 

Max-Age=number
 Number of seconds until the cookie expires. A zero or negative number will expire the cookie immediately.
