### PR TITLE
Remove the note about "opinions"

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_presentation_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_presentation_role/index.html
@@ -14,8 +14,6 @@ tags:
 
 <h2 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology </h2>
 
-<div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
-
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Example_1">Example 1: </h3>


### PR DESCRIPTION
It's unclear what "opinions" are mentioned here. For my own part, I've not come across any differing opinions about this use of `role="presentation"` ... it works, it does what it's supposed to. If there are genuine concerns/issues with it, keep the note and include them. Otherwise, this only spread doubt unnecessarily.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
