### PR TITLE
Remove legacy spec macros from glossary/misc pages

### DIFF
--- a/files/en-us/glossary/css_selector/index.html
+++ b/files/en-us/glossary/css_selector/index.html
@@ -86,10 +86,5 @@ div.warning {
    <li><a href="/en-US/docs/Web/CSS/Pseudo-elements">Pseudo elements</a> <code>::</code></li>
   </ol>
  </li>
- <li>Technical reference
-  <ol>
-   <li>{{SpecName("CSS3 Selectors")}}</li>
-  </ol>
- </li>
 </ol>
 </section>

--- a/files/en-us/glossary/falsy/index.html
+++ b/files/en-us/glossary/falsy/index.html
@@ -77,21 +77,6 @@ if ("")
 // ↪ 0
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("ESDraft", "#sec-toboolean", "<code>ToBoolean</code> abstract operation")}}</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>

--- a/files/en-us/glossary/forbidden_response_header_name/index.html
+++ b/files/en-us/glossary/forbidden_response_header_name/index.html
@@ -9,21 +9,8 @@ tags:
 ---
 <p>A <dfn>forbidden response header name</dfn> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> name (either `<code>Set-Cookie</code>` or `<code>Set-Cookie2</code>`) that cannot be modified programmatically.</p>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="See_also">See also</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Fetch','#forbidden-response-header-name','forbidden-response-header-name')}}</td>
-   <td>{{Spec2('Fetch')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li><a href="https://fetch.spec.whatwg.org/#forbidden-response-header-name">Fetch specification: forbidden response-header name</a></li>
+</ul>

--- a/files/en-us/glossary/origin/index.html
+++ b/files/en-us/glossary/origin/index.html
@@ -51,27 +51,11 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="See_also">See also</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#origin', 'origin')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Learn_more">Learn more</h2>
-
-<p>See <a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a> for more information.</p>
+<ul>
+  <li><a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a></li>
+  <li><a href="https://html.spec.whatwg.org/multipage/origin.html#origin">HTML specification: origin</a></li>
+</ul>
 
 <div>{{QuickLinksWithSubpages("/en-US/docs/Glossary")}}</div>

--- a/files/en-us/glossary/site/index.html
+++ b/files/en-us/glossary/site/index.html
@@ -38,22 +38,3 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('URL', '#host-same-site')}}</td>
-   <td>{{Spec2('URL')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>

--- a/files/en-us/glossary/truthy/index.html
+++ b/files/en-us/glossary/truthy/index.html
@@ -27,21 +27,6 @@ if (Infinity)
 if (-Infinity)
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("ESDraft", "#sec-toboolean", "<code>ToBoolean</code> abstract operation")}}</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -227,7 +227,7 @@ tags:
 
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
 
-<p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed. (See {{bug(1223880)}} for more details.)</p>
+<p>The {{cssxref("initial-letter")}} CSS property is part of the <a href="https://drafts.csswg.org/css-inline/">CSS Inline Layout</a> specification and allows you to specify how dropped, raised, and sunken initial letters are displayed. (See {{bug(1223880)}} for more details.)</p>
 
 <table class="standard-table">
  <thead>
@@ -267,7 +267,7 @@ tags:
 
 <h3 id="Property_aspect-ratio">Property: aspect-ratio</h3>
 
-<p>The {{cssxref("aspect-ratio")}} CSS property is part of the {{SpecName("CSS4 Sizing")}} specification and allows you to create boxes which conform to an aspect ratio. (See {{bug(1639963)}} and {{bug(1646096)}} for more details.)</p>
+<p>The {{cssxref("aspect-ratio")}} CSS property is part of the <a href="https://drafts.csswg.org/css-sizing-4/">CSS4 Sizing</a> specification and allows you to create boxes which conform to an aspect ratio. (See {{bug(1639963)}} and {{bug(1646096)}} for more details.)</p>
 
 <table class="standard-table">
  <thead>
@@ -307,7 +307,7 @@ tags:
 
 <h3 id="Descriptor_size_adjust">Descriptor: size-adjust</h3>
 
-<p>The {{cssxref("@font-face/size-adjust")}} CSS descriptor is part of the {{SpecName("CSS5 Fonts")}} specification and defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size. (See {{bug(1698495)}} for more details.)</p>
+<p>The {{cssxref("@font-face/size-adjust")}} CSS descriptor is part of the <a href="https://drafts.csswg.org/css-fonts-5/">CSS5 Fonts</a> specification and defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size. (See {{bug(1698495)}} for more details.)</p>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/related/imsc/index.html
+++ b/files/en-us/related/imsc/index.html
@@ -139,22 +139,9 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('IMSC 1.1')}}</td>
-   <td>{{Spec2('IMSC 1.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('IMSC 1.0.1')}}</td>
-   <td>{{Spec2('IMSC 1.0.1')}}</td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li><a href="https://w3c.github.io/imsc/imsc1/spec/ttml-ww-profiles.html">TTML Profiles for Internet Media Subtitles and Captions 1.2</a></li>
+</ul>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
I was checking where we still use the old specification tables. This removes some of them from glossary/random pages or replaces them with a simple link (which should be enough, no need for a table).