### PR TITLE
Adds LayoutShiftAttribution and API overview

### DIFF
--- a/files/en-us/web/api/layout_instability_api/index.html
+++ b/files/en-us/web/api/layout_instability_api/index.html
@@ -16,7 +16,7 @@ browser-compat: api.LayoutShift
 
 <p>A layout shift happens when any element that is visible in the viewport changes its start position between two frames. These elements are described as being <strong>unstable</strong>, and contribute to a poor <a href="https://web.dev/cls/">Cumulative Layout Shift (CLS)</a> score, indicating a lack of visual stability.</p>
 
-<p>The Layout Instabiliy API provides a way to measure and report on these layout shifts. All tools for debugging layout shifts, including those in DevTools, use this API. The API can also be used to observe and debug layout shifts by logging the information to the console.</p>
+<p>The Layout Instabiliy API provides a way to measure and report on these layout shifts. All tools for debugging layout shifts, including those in DevTools, use this API. The API can also be used to observe and debug layout shifts by logging the information to the console, to send the data to a server endpoint, or to Google Analytics.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 

--- a/files/en-us/web/api/layout_instability_api/index.html
+++ b/files/en-us/web/api/layout_instability_api/index.html
@@ -29,7 +29,7 @@ browser-compat: api.LayoutShift
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example observes all layout shift occurances, and prints them to the console.</p>
+<p>The following example observes all layout shifts, and prints them to the console.</p>
 
 <pre class="brush: js">new PerformanceObserver((list) => {
 	console.log(list.getEntries());

--- a/files/en-us/web/api/layout_instability_api/index.html
+++ b/files/en-us/web/api/layout_instability_api/index.html
@@ -1,0 +1,48 @@
+---
+title: Layout Instability API
+slug: Web/API/Layout_Instability_API
+tags:
+  - API
+  - Layout Instability API
+  - Overview
+  - Reference
+browser-compat: api.LayoutShift
+---
+<div>{{DefaultAPISidebar("Layout Instability API")}}</div>
+
+<p class="summary">The <strong>Layout Instability API</strong> provides interfaces for measuring and reporting layout shifts.</p>
+
+<h2> Concepts and Usage</h2>
+
+<p>A layout shift happens when any element that is visible in the viewport changes its start position between two frames. These elements are described as being <strong>unstable</strong>, and contribute to a poor <a href="https://web.dev/cls/">Cumulative Layout Shift (CLS)</a> score, indicating a lack of visual stability.</p>
+
+<p>The Layout Instabiliy API provides a way to measure and report on these layout shifts. All tools for debugging layout shifts, including those in DevTools, use this API. The API can also be used to observe and debug layout shifts by logging the information to the console.</p>
+
+<h2 id="Interfaces">Interfaces</h2>
+
+<dl>
+  <dt>{{domxref("LayoutShift")}}</dt>
+  <dd>Provides insights into the stability of web pages based on movements of the elements on the page.</dd>
+  <dt>{{domxref("LayoutShiftAttribution")}}</dt>
+  <dd>Provides debugging information about elements which have shifted.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example observes all layout shift occurances, and prints them to the console.</p>
+
+<pre class="brush: js">new PerformanceObserver((list) => {
+	console.log(list.getEntries());
+}).observe({type: 'layout-shift', buffered: true});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/cls/">Cumulative Layout Shift</a></li>
+  <li><a href="https://web.dev/debug-layout-shifts/">Debug layout shifts</a></li>
+  <li><a href="https://web.dev/debug-web-vitals-in-the-field/">Debug Web Vitals in the field</a></li>
+</ul>

--- a/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
@@ -1,0 +1,43 @@
+---
+title: LayoutShiftAttribution.currentRect
+slug: Web/API/LayoutShiftAttribution/currentRect
+tags:
+  - API
+  - Property
+  - Reference
+  - currentRect
+  - LayoutShiftAttribution
+browser-compat: api.LayoutShiftAttribution.currentRect
+---
+<div><div>{{APIRef("Layout Instability API")}}</div></div>
+
+<p class="summary">The <strong><code>currentRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let currentRect = LayoutShiftAttribution.currentRect;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMRectReadOnly")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints the <code>currentRect</code> of the first item in {{domxref("LayoutShift.sources")}} to the console.</p>
+
+<pre class="brush: js">new PerformanceObserver((list) => {
+  for (const {sources} of list.getEntries()) {
+    if (sources) {
+      console.log(sources[0].currentRect);
+    }
+  }
+}).observe({type: 'layout-shift', buffered: true});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/layoutshiftattribution/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/index.html
@@ -12,18 +12,47 @@ tags:
   - Web Performance
 browser-compat: api.LayoutShiftAttribution
 ---
-<p>The <code>LayoutShiftAttribution</code> interface of the Layout Instability API provides debugging information about elements which have shifted.</p>
+<div>{{APIRef("Layout Instability API")}}</div>
+
+<p>The <code>LayoutShiftAttribution</code> interface of the {{domxref("Layout Instability API")}} provides debugging information about elements which have shifted.</p>
+
+<p>Instances of <code>LayoutShiftAttribution</code> are returned in an array by calling {{domxref("LayoutShift.sources")}}.</p>
 
 <h2 id="Properties">Properties</h2>
+<dl>
+ <dt>{{domxref("LayoutShiftAttribution.Node")}}{{ReadOnlyInline}}</dt>
+ <dd>Returns the element that has shifted (null if it has been removed).</dd>
+ <dt>{{domxref("LayoutShiftAttribution.previousRect")}}{{ReadOnlyInline}}</dt>
+ <dd>Returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</dd>
+ <dt>{{domxref("LayoutShiftAttribution.currentRect")}}{{ReadOnlyInline}}</dt>
+ <dd>Returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element after the shift.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
 
 <dl>
- <dt><strong><code>{{domxref("LayoutShiftAttribution.Node")}}</code></strong></dt>
- <dd>Returns the element that has shifted (null if it has been removed).</dd>
- <dt><strong><code>{{domxref("LayoutShiftAttribution.previousRect")}}</code></strong></dt>
- <dd>Returns a <a href="/en-US/docs/Web/API/DOMRect">DOMRect</a> representing the position of the element before the shift.</dd>
- <dt><strong><code>{{domxref("LayoutShiftAttribution.currentRect")}}</code></strong></dt>
- <dd>Returns a <a href="/en-US/docs/Web/API/DOMRect">DOMRect</a> representing the position of the element after the shift.</dd>
+  <dt>{{domxref("LayoutShiftAttribution.toJSON()")}}</dt>
+ <dd>Returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</dd>
 </dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example finds the element that is causing the largest layout shift, and prints that <code>node</code> to the console. For more detail on this see the article <a href="https://web.dev/debug-web-vitals-in-the-field/">Debug Web Vitals in the field</a>.</p>
+
+<pre class="brush: js">function getCLSDebugTarget(entries) {
+  const largestEntry = entries.reduce((a, b) => {
+    return a && a.value > b.value ? a : b;
+  });
+  if (largestEntry && largestEntry.sources && largestEntry.sources.length) {
+    const largestSource = largestEntry.sources.reduce((a, b) => {
+      return a.node && a.previousRect.width * a.previousRect.height >
+          b.previousRect.width * b.previousRect.height ? a : b;
+    });
+    if (largestSource) {
+      return largestSource.node;
+    }
+  }
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -32,3 +61,10 @@ browser-compat: api.LayoutShiftAttribution
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/debug-layout-shifts/">Debug layout shifts</a></li>
+  <li><a href="https://web.dev/debug-web-vitals-in-the-field/">Debug Web Vitals in the field</a></li>
+</ul>

--- a/files/en-us/web/api/layoutshiftattribution/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/index.html
@@ -37,7 +37,7 @@ browser-compat: api.LayoutShiftAttribution
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example finds the element that is causing the largest layout shift, and prints that <code>node</code> to the console. For more detail on this see the article <a href="https://web.dev/debug-web-vitals-in-the-field/">Debug Web Vitals in the field</a>.</p>
+<p>The following example finds the element that is causing the largest layout shift, and prints that <code>node</code> to the console. For more detail on this see <a href="https://web.dev/debug-web-vitals-in-the-field/">Debug Web Vitals in the field</a>.</p>
 
 <pre class="brush: js">function getCLSDebugTarget(entries) {
   const largestEntry = entries.reduce((a, b) => {

--- a/files/en-us/web/api/layoutshiftattribution/node/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.html
@@ -1,0 +1,43 @@
+---
+title: LayoutShiftAttribution.node
+slug: Web/API/LayoutShiftAttribution/node
+tags:
+  - API
+  - Property
+  - Reference
+  - node
+  - LayoutShiftAttribution
+browser-compat: api.LayoutShiftAttribution.node
+---
+<div><div>{{APIRef("Layout Instability API")}}</div></div>
+
+<p class="summary">The <strong><code>node</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("node")}} representing the object that has shifted.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let node = LayoutShiftAttribution.node;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("node")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints the <code>node</code> of the first item in {{domxref("LayoutShift.sources")}} to the console.</p>
+
+<pre class="brush: js">new PerformanceObserver((list) => {
+  for (const {sources} of list.getEntries()) {
+    if (sources) {
+      console.log(sources[0].node);
+    }
+  }
+}).observe({type: 'layout-shift', buffered: true});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
@@ -1,0 +1,41 @@
+---
+title: LayoutShiftAttribution.previousRect
+slug: Web/API/LayoutShiftAttribution/previousRect
+tags:
+  - API
+  - Property
+  - Reference
+  - previousRect
+  - LayoutShiftAttribution
+browser-compat: api.LayoutShiftAttribution.previousRect
+---
+<div><div>{{APIRef("Layout Instability API")}}</div></div>
+
+<p class="summary">The <strong><code>previousRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let previousRect = LayoutShiftAttribution.previousRect;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMRectReadOnly")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints the <code>previousRect</code> of the first item in {{domxref("LayoutShift.sources")}} to the console.</p>
+
+<pre class="brush: js">new PerformanceObserver((list) => {
+  for (const {sources} of list.getEntries()) {
+    if (sources) {
+      console.log(sources[0].previousRect);
+    }
+  }
+}).observe({type: 'layout-shift', buffered: true});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.html
@@ -1,0 +1,48 @@
+---
+title: LayoutShiftAttribution.toJSON()
+slug: Web/API/LayoutShiftAttribution/toJSON
+tags:
+  - API
+  - Method
+  - Reference
+  - toJSON
+  - LayoutShiftAttribution
+browser-compat: api.LayoutShiftAttribution.toJSON
+---
+<div><div>{{APIRef("Layout Instability API")}}</div></div>
+
+<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">LayoutShiftAttribution.toJSON();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A JSON object that is the serialization of the {{domxref("LayoutShiftAttribution")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints a JSON representation of the first item in {{domxref("LayoutShift.sources")}} to the console.</p>
+
+<pre class="brush: js">new PerformanceObserver((list) => {
+  for (const {sources} of list.getEntries()) {
+    if (sources) {
+      console.log(sources[0].toJSON());
+    }
+  }
+}).observe({type: 'layout-shift', buffered: true});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LayoutShiftAttribution.toJSON
 ---
 <div><div>{{APIRef("Layout Instability API")}}</div></div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
+<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em> that returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -44,5 +44,4 @@ browser-compat: api.LayoutShiftAttribution.toJSON
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 


### PR DESCRIPTION
This PR adds the missing `LayoutShiftAttribution` subpages and also the Layout Instability API overview page. BCD for SpecData has been merged.

Spec: https://wicg.github.io/layout-instability/

Reviewer: @jpmedley 