### PR TITLE
“Arrow function expressions”: Use notecard; add missing colon

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -49,8 +49,11 @@ browser-compat: javascript.functions.arrow_functions
   functions to arrow functions</h3>
 
 <p>Let's decompose a "traditional function" down to the simplest "arrow function"
-  step-by-step:<br>
-  NOTE: Each step along the way is a valid "arrow function"</p>
+  step-by-step:</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> Each step along the way is a valid "arrow function".</p>
+</div>
 
 <pre class="brush: js">// Traditional Function
 function (a){
@@ -115,7 +118,7 @@ function (a, b){
 }</pre>
 
 <p>And finally, for <strong>named functions</strong> we treat arrow expressions like
-  variables</p>
+  variables:</p>
 
 <pre class="brush: js">// Traditional Function
 function bob (a){


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The current documentation uses an inline "NOTE: .." rather than the designated notecard.

I added the notecard and also added a missing : further down the page.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A