### PR TITLE
Fix typo in extension.lastError's description

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
@@ -30,7 +30,7 @@ browser-compat: webextensions.api.extension
 
 <dl>
 	<dt>{{WebExtAPIRef("extension.lastError")}}</dt>
-	<dd>Set for the lifetime of a callback if an asynchronous extension API has resulted in an error. If no error has, occurred <code>lastError</code> will be {{jsxref("undefined")}}.</dd>
+	<dd>Set for the lifetime of a callback if an asynchronous extension API has resulted in an error. If no error has occurred, <code>lastError</code> will be {{jsxref("undefined")}}.</dd>
 	<dt>{{WebExtAPIRef("extension.inIncognitoContext")}}</dt>
 	<dd><code>True</code> for content scripts running inside incognito tabs, and for extension pages running inside an incognito process. (The latter only applies to extensions with '<code>split</code>' <code>incognito_behavior</code>.)</dd>
 </dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was an incorrect placement of a coma


> Issue number (if there is an associated issue)



> Anything else that could help us review it
