### PR TITLE
Add Edgium to browser detection sample

### DIFF
--- a/files/en-us/web/api/window/navigator/index.html
+++ b/files/en-us/web/api/window/navigator/index.html
@@ -43,8 +43,11 @@ if (sUsrAg.indexOf("Firefox") &gt; -1) {
   sBrowser = "Microsoft Internet Explorer";
   // "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Zoom 3.6.0; wbx 1.0.0; rv:11.0) like Gecko"
 } else if (sUsrAg.indexOf("Edge") &gt; -1) {
-  sBrowser = "Microsoft Edge";
+  sBrowser = "Microsoft Edge (Legacy)";
   // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
+} else if (sUsrAg.indexOf("Edg") &gt; -1) {
+  sBrowser = "Microsoft Edge (Chromium)";
+  // Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.64
 } else if (sUsrAg.indexOf("Chrome") &gt; -1) {
   sBrowser = "Google Chrome or Chromium";
   // "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/66.0.3359.181 Chrome/66.0.3359.181 Safari/537.36"


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

On page (Window.navigator)[https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator#example_1_browser_detect_and_return_a_string], The "Browser detect and return a string" sample does not handle Edgium

> Issue number (if there is an associated issue)

N/A. -- I can create one if needed, please let me know if so.

> Anything else that could help us review it

N/A -- I tested!