### PR TITLE
Fix misleading statement in “Introducing asynchronous JavaScript”

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/introducing/index.html
+++ b/files/en-us/learn/javascript/asynchronous/introducing/index.html
@@ -271,7 +271,7 @@ console.log("all done");</pre>
 
 <p>There are times when we want things to load and happen right away. For example when applying some user-defined styles to a webpage you'll want the styles to be applied as soon as possible.</p>
 
-<p>If we're running an operation that takes time however, like querying a database and using the results to populate templates, it is better to push this off the main thread and complete the task asynchronously. Over time, you'll learn when it makes more sense to choose an asynchronous technique over a synchronous one.</p>
+<p>If we're running an operation that takes time however, like querying a database and using the results to populate templates, it is better to push this off the stack and complete the task asynchronously. Over time, you'll learn when it makes more sense to choose an asynchronous technique over a synchronous one.</p>
 
 <p>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Concepts", "Learn/JavaScript/Asynchronous/Timeouts_and_intervals", "Learn/JavaScript/Asynchronous")}}</p>
 


### PR DESCRIPTION
Asynchronous functions aren't necessary going to be excused on a different thread.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Asynchronous functions aren't necessary going to be excused on a different thread. They get pushed off the stack so they won't block the whole thread. To push `async` function off the main thread, another agent is needed. Using `WebWorkers`, we can run `async` function on a separate thread. `WebWorkers` were not discussed in this article. Hence, mentioning this possibility in the **Conclusion** section could lead to confusion and incorrect understanding. 
> Issue number (if there is an associated issue)

> Anything else that could help us review it
This [Stack Overflow answer](https://stackoverflow.com/questions/49092985/difference-between-javascript-async-functions-and-web-workers).