### PR TITLE
Add missing restriction to cssText method

### DIFF
--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -25,7 +25,7 @@ browser-compat: api.CSSStyleDeclaration
 
 <dl>
  <dt>{{DOMxRef("CSSStyleDeclaration.cssText")}}</dt>
- <dd>Textual representation of the declaration block, if and only if it is exposed via {{DOMxRef("HTMLElement.style")}}. Setting this attribute changes the inline style.</dd>
+ <dd>Textual representation of the declaration block, if and only if it is exposed via {{DOMxRef("HTMLElement.style")}}. Setting this attribute changes the inline style. If you want a text representation of a computed declaration block, you can get it with <code>JSON.stringify()</code>.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.length")}}{{ReadOnlyInline}}</dt>
  <dd>The number of properties. See the {{DOMxRef("CSSStyleDeclaration.item()", 'item()')}} method below.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.parentRule")}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -25,7 +25,7 @@ browser-compat: api.CSSStyleDeclaration
 
 <dl>
  <dt>{{DOMxRef("CSSStyleDeclaration.cssText")}}</dt>
- <dd>Textual representation of the declaration block. Setting this attribute changes the style.</dd>
+ <dd>Textual representation of the declaration block, if and only if it is exposed via {{DOMxRef("HTMLElement.style")}}. Setting this attribute changes the inline style.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.length")}}{{ReadOnlyInline}}</dt>
  <dd>The number of properties. See the {{DOMxRef("CSSStyleDeclaration.item()", 'item()')}} method below.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.parentRule")}}{{ReadOnlyInline}}</dt>


### PR DESCRIPTION
Without this addition to the description, the implication is that the cssText method gets and sets the style whether inline or computed, but that is not true. If the declaration is computed, the cssText method returns an empty string and throws an error if one tries to set it.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Description was too general, omitting an important restriction. It can lead a user to apply the cssText method where it cannot be applied.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
