### PR TITLE
Replace brackets by braces

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -64,14 +64,14 @@ function (a){
   return a + 100;
 }
 
-// 2. Remove the body brackets and word "return" -- the return is implied.
+// 2. Remove the body braces and word "return" -- the return is implied.
 (a) =&gt; a + 100;
 
 // 3. Remove the argument parentheses
 a =&gt; a + 100;</pre>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> As shown above, the { brackets } and ( parentheses ) and "return" are optional, but
+  <p><strong>Note:</strong> As shown above, the { braces } and ( parentheses ) and "return" are optional, but
     may be required.</p>
 </div>
 
@@ -99,7 +99,7 @@ let b = 2;
 () =&gt; a + b + 100;</pre>
 
 <p>Likewise, if the body requires <strong>additional lines</strong> of processing, you'll
-  need to re-introduce brackets <strong>PLUS the "return"</strong> (arrow functions do not
+  need to re-introduce braces <strong>PLUS the "return"</strong> (arrow functions do not
   magically guess what or when you want to "return"):</p>
 
 <pre class="brush: js">// Traditional Function
@@ -139,7 +139,7 @@ let bob = a =&gt; a + 100;</pre>
 
 <pre class="brush: js">(param1, paramN) =&gt; expression</pre>
 
-<p class="brush: js">Multiline statements require body brackets and return:
+<p class="brush: js">Multiline statements require body braces and return:
 </p>
 
 <pre class="brush: js">param =&gt; {
@@ -148,7 +148,7 @@ let bob = a =&gt; a + 100;</pre>
 }</pre>
 
 <p class="brush: js">Multiple params require parentheses. Multiline statements
-  require body brackets and return:</p>
+  require body braces and return:</p>
 
 <pre class="brush: js">(param1, paramN) =&gt; {
    let a = 1;


### PR DESCRIPTION
_Brackets_ in this article were used for _curly brackets_, more commonly called _braces_.

This PR fixes this (with _braces_), making the article more precise.

Fixes #6741 