### PR TITLE
Update example in “Inheritance and the prototype chain”

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -254,11 +254,9 @@ function f() {
   this.edges = [];
 }
 
-Graph.prototype = {
-  addVertex: function(v) {
-    this.vertices.push(v);
-  }
-};
+Graph.prototype.addVertex = function(v) {
+  this.vertices.push(v);
+}
 
 var g = new Graph();
 // g is an object with own properties 'vertices' and 'edges'.

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -247,7 +247,7 @@ function f() {
 
 <h3 id="With_a_constructor">With a constructor</h3>
 
-<p>A "constructor" in JavaScript is "just" a function that happens to be called with the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new operator</a>.</p>
+<p>A <strong>constructor</strong> in JavaScript is <strong>just</strong> a function that happens to be called with the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new operator</a>.</p>
 
 <pre class="brush: js">function Graph() {
   this.vertices = [];

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -247,7 +247,7 @@ function f() {
 
 <h3 id="With_a_constructor">With a constructor</h3>
 
-<p>A <strong>constructor</strong> in JavaScript is <strong>just</strong> a function that happens to be called with the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new operator</a>.</p>
+<p>A constructor in JavaScript is just a function that happens to be called with the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new operator</a>.</p>
 
 <pre class="brush: js">function Graph() {
   this.vertices = [];


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The existing example assigns a new object to the prototype property of Graph constructor function.
Graph.prototype = {
  addVertex: function(v) {
    this.vertices.push(v);
  }
};
This is not a good approach. Instead, the addVertex function should be added as a new property in the existing prototype object.
Graph.prototype.addVertex = function(v) {
  this.vertices.push(v);
}


> Issue number (if there is an associated issue)
NA

> Anything else that could help us review it
NA