### PR TITLE
Fix typos of brackets

### DIFF
--- a/files/en-us/web/api/geolocation/getcurrentposition/index.html
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.html
@@ -20,7 +20,7 @@ browser-compat: api.Geolocation.getCurrentPosition
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">navigator.geolocation.getCurrentPosition(<var>success</var>[, <var>error</var>[, [<var>options</var>]])</pre>
+  class="brush: js">navigator.geolocation.getCurrentPosition(<var>success</var>, <var>error</var>, [<var>options</var>])</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There were bracket typos for function parameters in Syntax section:
`navigator.geolocation.getCurrentPosition(success[, error[, [options]])`


> Issue number (if there is an associated issue)
No issue


> Anything else that could help us review it
