### PR TITLE
Fix basic generator example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.html
@@ -28,8 +28,8 @@ browser-compat: javascript.builtins.Generator
 const gen = generator(); // "Generator { }"
 
 console.log(gen.next().value); // 1
-console.log(generator().next().value); // 2
-console.log(generator().next().value); // 3</pre>
+console.log(gen.next().value); // 2
+console.log(gen.next().value); // 3</pre>
 
 <h2 id="Instance_methods">Instance methods</h2>
 


### PR DESCRIPTION
Each call to generator function returns new Generator object, so generator().next().value is always equal to 1.