### PR TITLE
Added an entry for the accent-color CSS property

### DIFF
--- a/files/en-us/glossary/accent/index.html
+++ b/files/en-us/glossary/accent/index.html
@@ -6,15 +6,17 @@ tags:
   - Input
   - accent
 ---
-<p><span class="seoSummary">An <strong>accent</strong> is a typically bright color that contrasts markedly with the more utilitarian background and foreground colors within a color scheme.</span> These are present on many platforms (though not all).</p>
+<p><span class="seoSummary">An <strong>accent</strong> is a typically bright color that contrasts with the more utilitarian background and foreground colors within a color scheme.</span> These are present in the visual style of many platforms (though not all).</p>
+
+<p>On the web, an accent is sometimes used in {{HTMLElement("input")}} elements for the active portion of the control, for instance the background of a checked <a href="/en-US/docs/Web/HTML/Element/input/checkbox">checkbox</a>.</p>
 
 <h2 id="Learn_more">Learn more</h2>
-
+s
 <h3 id="CSS_related_to_the_accent">CSS related to the accent</h3>
 
 <p>You can set the color of the accent for a given element by setting the element's CSS {{cssxref("accent-color")}} property to the appropriate {{cssxref("&lt;color&gt;")}} value.</p>
 
-<h3 id="HTML_elements_that_may_present_a_accent">HTML elements that may have an accent</h3>
+<h3 id="HTML_elements_that_may_present_an_accent">HTML elements that may have an accent</h3>
 
 <ul>
 	<li><code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">&lt;input type="checkbox"&gt;</a></code></li>

--- a/files/en-us/glossary/accent/index.html
+++ b/files/en-us/glossary/accent/index.html
@@ -10,11 +10,11 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="CSS_related_to_the_caret">CSS related to the accent</h3>
+<h3 id="CSS_related_to_the_accent">CSS related to the accent</h3>
 
 <p>You can set the color of the accent for a given element by setting the element's CSS {{cssxref("accent-color")}} property to the appropriate {{cssxref("&lt;color&gt;")}} value.</p>
 
-<h3 id="HTML_elements_that_may_present_a_caret">HTML elements that may have an accent</h3>
+<h3 id="HTML_elements_that_may_present_a_accent">HTML elements that may have an accent</h3>
 
 <ul>
 	<li><code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">&lt;input type="checkbox"&gt;</a></code></li>

--- a/files/en-us/glossary/accent/index.html
+++ b/files/en-us/glossary/accent/index.html
@@ -1,0 +1,23 @@
+---
+title: accent
+slug: Glossary/accent
+tags:
+  - Glossary
+  - Input
+  - accent
+---
+<p><span class="seoSummary">An <strong>accent</strong> is a typically bright color that contrasts markedly with the more utilitarian background and foreground colors within a color scheme.</span> These are present on many platforms (though not all).</p>
+
+<h2 id="Learn_more">Learn more</h2>
+
+<h3 id="CSS_related_to_the_caret">CSS related to the accent</h3>
+
+<p>You can set the color of the accent for a given element by setting the element's CSS {{cssxref("accent-color")}} property to the appropriate {{cssxref("&lt;color&gt;")}} value.</p>
+
+<h3 id="HTML_elements_that_may_present_a_caret">HTML elements that may have an accent</h3>
+
+<ul>
+	<li><code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">&lt;input type="checkbox"&gt;</a></code></li>
+	<li><code><a href="/en-US/docs/Web/HTML/Element/input/radio">&lt;input type="radio"&gt;</a></code></li>
+	<li><code><a href="/en-US/docs/Web/HTML/Element/input/range">&lt;input type="range"&gt;</a></code></li>
+</ul>

--- a/files/en-us/glossary/accent/index.html
+++ b/files/en-us/glossary/accent/index.html
@@ -6,7 +6,7 @@ tags:
   - Input
   - accent
 ---
-<p><span class="seoSummary">An <strong>accent</strong> is a typically bright color that contrasts with the more utilitarian background and foreground colors within a color scheme.</span> These are present in the visual style of many platforms (though not all).</p>
+<p>An <strong>accent</strong> is a typically bright color that contrasts with the more utilitarian background and foreground colors within a color scheme. These are present in the visual style of many platforms (though not all).</p>
 
 <p>On the web, an accent is sometimes used in {{HTMLElement("input")}} elements for the active portion of the control, for instance the background of a checked <a href="/en-US/docs/Web/HTML/Element/input/checkbox">checkbox</a>.</p>
 

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -15,7 +15,7 @@ browser-compat: css.properties.accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the color of the elements <a href="/en-US/docs/Glossary/accent">accent</a>. An accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
+<p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the color of the elements {{Glossary("accent")}}. An accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
 

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -17,10 +17,6 @@ browser-compat: css.properties.accent-color
 
 <p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the color of the elements {{Glossary("accent")}}. An accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
 
-<div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
-
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: css no-line-numbers">/* Keyword values */

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -1,0 +1,101 @@
+---
+title: accent-color
+slug: Web/CSS/accent-color
+tags:
+- CSS
+- CSS Property
+- CSS User Interface
+- HTML Colors
+- Input
+- Reference
+- Styling HTML
+- accent-color
+- 'recipe:css-property'
+browser-compat: css.properties.accent-color
+---
+<div>{{CSSRef}}</div>
+
+<p>The <strong><code>accent-color</code></strong> CSS property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of type <code>checkbox</code>.</p>
+
+<div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
+
+<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css no-line-numbers">/* Keyword values */
+accent-color: auto;
+
+/* &lt;color&gt; values */
+accent-color: red;
+accent-color: #5729e9;
+accent-color: rgb(0, 200, 0);
+accent-color: hsl(228, 4%, 24%);
+
+/* Global values */
+accent-color: inherit;
+accent-color: initial;
+accent-color: revert;
+accent-color: unset;</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+  <dt><code>auto</code></dt>
+  <dd>Represents a UA-chosen color, which should match the accent color of the platform, if any.
+  </dd>
+  <dt>{{cssxref("&lt;color&gt;")}}</dt>
+  <dd>Specifies the color to be used as the accent color.</dd>
+</dl>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Setting_a_custom_accent_color">Setting a custom accent color</h3>
+
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">&lt;input type="checkbox" checked /&gt;
+&lt;input type="checkbox" class="custom" checked /&gt;</pre>
+
+<h4 id="CSS">CSS</h4>
+
+<pre class="brush: css">input {
+  accent-color: auto;
+  display: block;
+  width: 30px;
+  height: 30px;
+}
+
+input.custom {
+  accent-color: rebeccapurple;
+}
+</pre>
+
+<h4 id="Result">Result</h4>
+
+<p>{{EmbedLiveSample('Setting_a_custom_accent_color', 500, 200)}}</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>The {{HTMLElement("input")}} element</li>
+  <li><a href="/en-US/docs/Web/HTML/Applying_color">Applying color to HTML elements using CSS</a></li>
+  <li>The {{cssxref("&lt;color&gt;")}} data type</li>
+  <li>Other color-related properties: {{cssxref("color")}}, {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}}, and {{cssxref("column-rule-color")}}</li>
+</ul>

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -15,7 +15,7 @@ browser-compat: css.properties.accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>accent-color</code></strong> CSS property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of type <code>checkbox</code>, or type <code>radio</code>.</p>
+<p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
 

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -15,7 +15,7 @@ browser-compat: css.properties.accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
+<p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the color of the elements <a href="/en-US/docs/Glossary/accent">accent</a>. An accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
 

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -13,9 +13,9 @@ tags:
 - 'recipe:css-property'
 browser-compat: css.properties.accent-color
 ---
-<div>{{CSSRef}}</div>
+<div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>accent-color</code></strong> CSS property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of type <code>checkbox</code>.</p>
+<p>The <strong><code>accent-color</code></strong> CSS property sets the accent color of the element. The accent appears in elements such as {{HTMLElement("input")}} of type <code>checkbox</code>, or type <code>radio</code>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/accent-color.html")}}</div>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This PR adds a page for the `accent-color` property from https://drafts.csswg.org/css-ui-4/#widget-accent.

PR to add the css formal definition: https://github.com/mdn/data/pull/490
PR to add the live example: https://github.com/mdn/interactive-examples/pull/1864
PR to add the browser compat data: https://github.com/mdn/browser-compat-data/pull/11470

This is my first time writing a full entry on MDN so apologies if I've missed a section that should be included.
