### PR TITLE
Remove experimental icon from pseudo classes that are no longer experimental

### DIFF
--- a/files/en-us/web/css/pseudo-classes/index.html
+++ b/files/en-us/web/css/pseudo-classes/index.html
@@ -220,7 +220,7 @@ button:hover {
  <li>{{CSSxRef(":first")}}</li>
  <li>{{CSSxRef(":first-child")}}</li>
  <li>{{CSSxRef(":first-of-type")}}</li>
- <li>{{CSSxRef(":fullscreen")}} {{Experimental_Inline}}</li>
+ <li>{{CSSxRef(":fullscreen")}}</li>
  <li>{{CSSxRef(":future")}} {{Experimental_Inline}}</li>
  <li>{{CSSxRef(":focus")}}</li>
  <li>{{CSSxRef(":focus-visible")}} </li>
@@ -241,7 +241,7 @@ button:hover {
  <li>{{CSSxRef(":indeterminate")}}</li>
  <li>{{CSSxRef(":in-range")}}</li>
  <li>{{CSSxRef(":invalid")}}</li>
- <li>{{CSSxRef(":is", ":is()")}} {{Experimental_Inline}}</li>
+ <li>{{CSSxRef(":is", ":is()")}}</li>
 </ul>
 <span>L</span>
 
@@ -277,7 +277,7 @@ button:hover {
 <ul>
  <li>{{CSSxRef(":past")}} {{Experimental_Inline}}</li>
  <li>{{CSSxRef(":picture-in-picture")}}</li>
- <li>{{CSSxRef(":placeholder-shown")}} {{Experimental_Inline}}</li>
+ <li>{{CSSxRef(":placeholder-shown")}}</li>
  <li>{{CSSxRef(":paused")}}</li>
  <li>{{CSSxRef(":playing")}}</li>
 </ul>
@@ -316,7 +316,7 @@ button:hover {
 <span>W</span>
 
 <ul>
- <li>{{CSSxRef(":where", ":where()")}} {{Experimental_Inline}}</li>
+ <li>{{CSSxRef(":where", ":where()")}}</li>
 </ul>
 </div>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Some no longer experimental pseudo classes had an experimental icon.

> Anything else that could help us review it

https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen - Implemented in two browser engines.

https://developer.mozilla.org/en-US/docs/Web/CSS/:is - Implemented in all three browser engines.

https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown - Implemented in all three browser engines.

https://developer.mozilla.org/en-US/docs/Web/CSS/:where - Implemented in all three browser engines.

