### PR TITLE
it's firefox 92, not 91

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -1,6 +1,6 @@
 ---
-title: Firefox 91 for developers
-slug: Mozilla/Firefox/Releases/91
+title: Firefox 92 for developers
+slug: Mozilla/Firefox/Releases/92
 tags:
   - '92'
   - Firefox


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In https://github.com/mdn/content/pull/6734/files we created a folder that didn't match its `slug`. 

> Issue number (if there is an associated issue)



> Anything else that could help us review it

It's a P1 bug that the CI didn't manage to capture this simple error in the first place. We'll track that in mdn/yari. 