### PR TITLE
Replace Boolean in fields of FormEventInit dictionary

### DIFF
--- a/files/en-us/web/api/formdataevent/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.html
@@ -29,11 +29,11 @@ browser-compat: api.FormDataEvent.FormDataEvent
   <dd>A <code>FormEventInit</code> dictionary, which can take the following optional
     fields:
     <ul>
-      <li><code>bubbles</code>: a {{jsxref("Boolean")}} indicating whether the event
+      <li><code>bubbles</code>: a <code>true</code> or <code>false</code> value indicating whether the event
         bubbles. The default is <code>false</code>.</li>
-      <li><code>cancelable</code>: a {{jsxref("Boolean")}} indicating whether the event
+      <li><code>cancelable</code>: a <code>true</code> or <code>false</code> value indicating whether the event
         can be cancelled. The default is <code>false</code>.</li>
-      <li><code>composed</code>: a {{jsxref("Boolean")}} indicating whether the event will
+      <li><code>composed</code>: a <code>true</code> or <code>false</code> value indicating whether the event will
         trigger listeners outside of a shadow root (see {{domxref("Event.composed")}} for
         more details). The default is <code>false</code>.</li>
       <li><code>formData</code>: A {{domxref("FormData")}} object to pre-populate the


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The original document says that three fields in FormEventInit are Boolean, however they are NOT actually Boolean wrapper objects.

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it
