### PR TITLE
Improve consistency of glossary abbreviations

### DIFF
--- a/files/en-us/glossary/dmz/index.html
+++ b/files/en-us/glossary/dmz/index.html
@@ -13,13 +13,5 @@ tags:
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li>{{Interwiki("wikipedia", "DMZ (computing)", "DMZ")}} on Wikipedia</li>
-</ul>
-
-<h3 id="Learn_about_it">Learn about it</h3>
-
-<ul>
- <li>
-  <p><a href="/en-US/docs/Learn/Drafts/website">Web servers and Firewall - Maximum Security Against Attack</a> on MDN</p>
- </li>
+  <li>{{Interwiki("wikipedia", "DMZ (computing)", "DMZ")}} on Wikipedia</li>
 </ul>

--- a/files/en-us/glossary/dmz/index.html
+++ b/files/en-us/glossary/dmz/index.html
@@ -6,7 +6,7 @@ tags:
   - Networking
   - Security
 ---
-<p><span class="seoSummary">A <abbr title="DeMilitarized Zone">DMZ</abbr> is a way to provide an insulated secure interface between an internal network (corporate or private) and the outside untrusted world — usually the Internet.</span> It exposes only certain defined endpoints, while denying access to the internal network from {{Glossary('node/networking', 'external nodes')}}.</p>
+<p><span class="seoSummary">A <strong>DMZ</strong> (DeMilitarized Zone) is a way to provide an insulated secure interface between an internal network (corporate or private) and the outside untrusted world — usually the Internet.</span> It exposes only certain defined endpoints, while denying access to the internal network from {{Glossary('node/networking', 'external nodes')}}.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/dns/index.html
+++ b/files/en-us/glossary/dns/index.html
@@ -7,7 +7,7 @@ tags:
   - Glossary
   - Infrastructure
 ---
-<p><strong>DNS (Domain Name System)</strong> is a hierarchical and decentralized naming system for Internet connected resources. DNS maintains a list of {{Glossary("domain name","domain names")}} along with the resources, such as IP addresses, that are associated with them.</p>
+<p><strong>DNS</strong> (Domain Name System) is a hierarchical and decentralized naming system for Internet connected resources. DNS maintains a list of {{Glossary("domain name","domain names")}} along with the resources, such as IP addresses, that are associated with them.</p>
 
 <p>The most prominent function of DNS is the translation of human-friendly domain names (such as mozilla.org) to a numeric {{Glossary("IP address")}} (such as 151.106.5.172); this process of mapping a domain name to the appropriate IP address is known as a <strong>DNS lookup</strong>. By contrast, a <strong>reverse DNS lookup</strong> (rDNS) is used to determine the domain name associated with an IP address.</p>
 

--- a/files/en-us/glossary/dom/index.html
+++ b/files/en-us/glossary/dom/index.html
@@ -6,7 +6,7 @@ tags:
   - DOM
   - Glossary
 ---
-<p>The DOM (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}} document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a node tree, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).</p>
+<p>The <strong>DOM</strong> (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}} document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a node tree, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).</p>
 
 <p>The DOM is one of the most-used {{Glossary("API")}}s on the {{glossary("World Wide Web","Web")}} because it allows code running in a browser to access and interact with every node in the document. Nodes can be created, moved and changed. Event listeners can be added to nodes and triggered on occurrence of a given event.</p>
 

--- a/files/en-us/glossary/jpeg/index.html
+++ b/files/en-us/glossary/jpeg/index.html
@@ -8,7 +8,7 @@ tags:
   - Images
   - JPEG
 ---
-<p><strong>JPEG</strong> (<em>Joint Photographic Experts Group</em>) is a commonly used method of lossy compression for digital images.</p>
+<p><strong>JPEG</strong> (Joint Photographic Experts Group) is a commonly used method of lossy compression for digital images.</p>
 
 <p>JPEG compression is composed of three compression techniques applied in successive layers, including chrominance subsampling, discrete cosine transformation and quantization, and run-length Delta &amp; Huffman encoding. Chroma subsampling involves implementing less resolution for chroma information than for luma information, taking advantage of the human visual system's lower acuity for color differences than for luminance. A discrete cosine transform expresses a finite sequence of data points in terms of a sum of cosine functions oscillating at different frequencies.</p>
 

--- a/files/en-us/glossary/png/index.html
+++ b/files/en-us/glossary/png/index.html
@@ -8,7 +8,7 @@ tags:
   - Infrastructure
   - PNG
 ---
-<p><strong>PNG </strong>(<em>Portable Network Graphics</em>) is a graphics file format that supports lossless data compression.</p>
+<p><strong>PNG</strong> (Portable Network Graphics) is a graphics file format that supports lossless data compression.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Formats of abbreviation expansions are different in each documents.


> Issue number (if there is an associated issue)

None.


> Anything else that could help us review it

It would suit better if I wrap expansions with **`<i>`**: They are *technical* rather than *emphasis*, must be remains of the WYSIWYG era. But I'd like to settle them this way for now. (For mdn/translated-content#1465)

Also in-lined `<abbr>` and removed outdated URL, from DMZ page.