### PR TITLE
fixed grammar

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
@@ -70,7 +70,7 @@ tags:
 
 <h2 id="What_is_a_pseudo-element">What is a pseudo-element?</h2>
 
-<p>Pseudo-elements behave in a similar way, however they act as if you had added a whole new HTML element into the markup, rather than applying a class to existing elements. Pseudo-elements start with a double colon <code>::</code>.</p>
+<p>Pseudo-elements behave in a similar way. However, they act as if you had added a whole new HTML element into the markup, rather than applying a class to existing elements. Pseudo-elements start with a double colon <code>::</code>.</p>
 
 <pre><em>::pseudo-element-name</em></pre>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The sentence "_Pseudo-elements behave in a similar way, however they act as if you had added a whole new HTML element into the markup, rather than applying a class to existing elements._" is a **run-on sentence**.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
Independent clauses cannot be joined by commas. This is called a **comma splice**, which is a type of **run-on sentence**.