### PR TITLE
remove {{event}} macros for Event_handlers

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -118,6 +118,7 @@ tags:
       <tr>
         <td><a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>.</td>
         <td><a href="/en-US/docs/Web/Events">Events reference</a> (/Web/Events)</td>
+        <td>
         <div class="notecard note">
             <h4>Note</h4>
             <p>This macro is not particularly useful because events are now under their associated DOM element. So to link to the wheel event you would use <code>\{{DOMxRef("Document.wheel_event")}}</code>: {{DOMxRef("Document.wheel_event")}}</p>

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -118,7 +118,7 @@ tags:
       <tr>
         <td><a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>.</td>
         <td><a href="/en-US/docs/Web/Events">Events reference</a> (/Web/Events)</td>
-        <td><code>\{{Event("Event_handlers", "Event handlders")}}</code> results in {{Event("Event_handlers", "Event handlers")}}
+        <td><code>\{{Event("Event_handlers", "Event handlers")}}</code> results in {{Event("Event_handlers", "Event handlers")}}
         <div class="notecard note">
             <h4>Note</h4>
             <p>This macro is not particularly useful because events are now under their associated DOM element. So to link to the wheel event you would use <code>\{{DOMxRef("Document.wheel_event")}}</code>: {{DOMxRef("Document.wheel_event")}}</p>

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -118,7 +118,6 @@ tags:
       <tr>
         <td><a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>.</td>
         <td><a href="/en-US/docs/Web/Events">Events reference</a> (/Web/Events)</td>
-        <td><code>\{{Event("Event_handlers", "Event handlers")}}</code> results in {{Event("Event_handlers", "Event handlers")}}
         <div class="notecard note">
             <h4>Note</h4>
             <p>This macro is not particularly useful because events are now under their associated DOM element. So to link to the wheel event you would use <code>\{{DOMxRef("Document.wheel_event")}}</code>: {{DOMxRef("Document.wheel_event")}}</p>

--- a/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
@@ -18,7 +18,7 @@ browser-compat: api.AudioScheduledSourceNode.onended
 <p>{{APIRef("Web Audio API")}}</p>
 
 <p>The <code>onended</code> event handler for the <code>AudioScheduledSourceNode</code>
-  interface specifies an {{event("Event_handlers", "event handler")}} to be executed when the
+  interface specifies an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be executed when the
   {{event("ended")}} event occurs on the node. This event is sent to the node when the
   concrete interface (such as {{domxref("AudioBufferSourceNode")}},
   {{domxref("OscillatorNode")}}, or {{domxref("ConstantSourceNode")}}) determines that it

--- a/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.onprogress
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>onprogress</code></strong> EventHandler of the {{domxref("BackgroundFetchRegistration")}} interface is an {{event("Event_handlers", "event handler")}} that processes background fetch events.</p>
+<p class="summary">The <strong><code>onprogress</code></strong> EventHandler of the {{domxref("BackgroundFetchRegistration")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes background fetch events.</p>
 
 <p> The event fires when any of the following properties change:</p>
 

--- a/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
+++ b/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
@@ -10,7 +10,7 @@ browser-compat: api.Bluetooth.onavailabilitychanged
 <p>{{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
 <p><span class="seoSummary">The <strong><code>onavailabilitychanged</code></strong>
-    property of the {{DOMxRef("Bluetooth")}} interface is an {{event("Event_handlers", "event handler")}}
+    property of the {{DOMxRef("Bluetooth")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
     that processes <code>availabilitychanged</code> events that fire when the Bluetooth
     system as a whole becomes available or unavailable to the {{Glossary("User
     Agent")}}.</span></p>

--- a/files/en-us/web/api/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/index.html
@@ -38,9 +38,9 @@ browser-compat: api.BroadcastChannel
 
 <dl>
  <dt>{{domxref("BroadcastChannel.onmessage")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} property that specifies the function to execute when a {{event("message")}} event is fired on this object.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> property that specifies the function to execute when a {{event("message")}} event is fired on this object.</dd>
  <dt>{{domxref("BroadcastChannel.onmessageerror")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when a {{domxref("MessageEvent")}} of type {{domxref("MessageError")}} is fired—that is, when it receives a message that cannot be deserialized.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{domxref("MessageEvent")}} of type {{domxref("MessageError")}} is fired—that is, when it receives a message that cannot be deserialized.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.html
@@ -44,9 +44,9 @@ browser-compat: api.DedicatedWorkerGlobalScope
 
 <dl>
  <dt>{{domxref("DedicatedWorkerGlobalScope.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("message")}} event is raised. These events are of type {{domxref("MessageEvent")}} and will be called when the worker receives a message from the document that started it (i.e. from the {{domxref("Worker.postMessage")}} method.)</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("message")}} event is raised. These events are of type {{domxref("MessageEvent")}} and will be called when the worker receives a message from the document that started it (i.e. from the {{domxref("Worker.postMessage")}} method.)</dd>
  <dt>{{domxref("DedicatedWorkerGlobalScope.onmessageerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("messageerror")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("messageerror")}} event is raised.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
@@ -12,7 +12,7 @@ browser-compat: api.DedicatedWorkerGlobalScope.onmessage
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>onmessage</code></strong> property of the {{domxref("DedicatedWorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("message")}} event occurs — i.e. when a message is sent to the worker using the {{domxref("Worker.postMessage")}} method.</p>
+<p>The <strong><code>onmessage</code></strong> property of the {{domxref("DedicatedWorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("message")}} event occurs — i.e. when a message is sent to the worker using the {{domxref("Worker.postMessage")}} method.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -136,17 +136,17 @@ browser-compat: api.Document
  <dt>{{DOMxRef("Document.oncut")}} {{Non-standard_Inline}}</dt>
  <dd>Represents the event handling code for the {{event("cut")}} event.</dd>
  <dt>{{DOMxRef("Document.onfullscreenchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("fullscreenchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("fullscreenchange")}} event is raised.</dd>
  <dt>{{DOMxRef("Document.onfullscreenerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("fullscreenerror")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("fullscreenerror")}} event is raised.</dd>
  <dt>{{DOMxRef("Document.onpaste")}} {{Non-standard_Inline}}</dt>
  <dd>Represents the event handling code for the {{event("paste")}} event.</dd>
  <dt>{{DOMxRef("Document.onreadystatechange")}}</dt>
  <dd>Represents the event handling code for the {{event("readystatechange")}} event.</dd>
  <dt>{{DOMxRef("GlobalEventHandlers.onselectionchange")}} {{Experimental_Inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("selectionchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("selectionchange")}} event is raised.</dd>
  <dt>{{DOMxRef("Document.onvisibilitychange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("visibilitychange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("visibilitychange")}} event is raised.</dd>
 </dl>
 
 <p>The <code>Document</code> interface is extended with the {{DOMxRef("GlobalEventHandlers")}} interface:</p>

--- a/files/en-us/web/api/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/index.html
@@ -48,11 +48,11 @@ browser-compat: api.EventSource
 
 <dl>
  <dt>{{domxref("EventSource.onerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called when an error occurs and the {{domxref("EventSource/error_event", "error")}} event is dispatched on an <code>EventSource</code> object.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an error occurs and the {{domxref("EventSource/error_event", "error")}} event is dispatched on an <code>EventSource</code> object.</dd>
  <dt>{{domxref("EventSource.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called when a {{domxref("EventSource/message_event", "message")}} event is received, that is when a message is coming from the source.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{domxref("EventSource/message_event", "message")}} event is received, that is when a message is coming from the source.</dd>
  <dt>{{domxref("EventSource.onopen")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called when an {{domxref("EventSource/open_event", "open")}} event is received, that is when the connection was just opened.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{domxref("EventSource/open_event", "open")}} event is received, that is when the connection was just opened.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/eventsource/onerror/index.html
+++ b/files/en-us/web/api/eventsource/onerror/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EventSource.onerror
 
 
 <p>The <code><strong>onerror</strong></code> property of the {{domxref("EventSource")}}
-  interface is an {{event("Event_handlers", "event handler")}} called when an error occurs and the
+  interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an error occurs and the
   {{event("error")}} event is dispatched on an <code>EventSource</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/eventsource/onmessage/index.html
+++ b/files/en-us/web/api/eventsource/onmessage/index.html
@@ -14,7 +14,7 @@ browser-compat: api.EventSource.onmessage
 <div>{{APIRef('WebSockets API')}}</div>
 
 <p>The <code><strong>onmessage</strong></code> property of the {{domxref("EventSource")}}
-  interface is an {{event("Event_handlers", "event handler")}} called when a {{event("message")}} event is
+  interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{event("message")}} event is
   received, that is when a message is coming from the source.</p>
 
 <p>Event objects of <code>onmessage</code> event handlers are of type

--- a/files/en-us/web/api/eventsource/onopen/index.html
+++ b/files/en-us/web/api/eventsource/onopen/index.html
@@ -14,7 +14,7 @@ browser-compat: api.EventSource.onopen
 <div>{{APIRef('Server Sent Events')}}</div>
 
 <p>The <code><strong>onopen</strong></code> property of the {{domxref("EventSource")}}
-  interface is an {{event("Event_handlers", "event handler")}} called when an {{event("open")}} event is
+  interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("open")}} event is
   received, that is when the connection was just opened.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/extendableevent/index.html
+++ b/files/en-us/web/api/extendableevent/index.html
@@ -49,7 +49,7 @@ browser-compat: api.ExtendableEvent
 <dl>
  <dt>{{domxref("ExtendableEvent.waitUntil", "ExtendableEvent.waitUntil()")}}</dt>
  <dd>
- <p>Extends the lifetime of the event.  It is intended to be called in the <code><a href="/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event">install</a></code> {{event("Event_handlers", "event handler")}} for the {{domxref("ServiceWorkerRegistration.installing", "installing")}} worker and on the <code><a href="/en-US/docs/Web/API/ServiceWorkerGlobalScope/activate_event">activate</a></code> {{event("Event_handlers", "event handler")}} for the {{domxref("ServiceWorkerRegistration.active", "active")}} worker.</p>
+ <p>Extends the lifetime of the event.  It is intended to be called in the <code><a href="/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event">install</a></code> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for the {{domxref("ServiceWorkerRegistration.installing", "installing")}} worker and on the <code><a href="/en-US/docs/Web/API/ServiceWorkerGlobalScope/activate_event">activate</a></code> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for the {{domxref("ServiceWorkerRegistration.active", "active")}} worker.</p>
  </dd>
 </dl>
 

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -29,183 +29,183 @@ browser-compat: api.GlobalEventHandlers
 <div id="Properties">
 <dl>
  <dt>{{domxref("GlobalEventHandlers.onabort")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{domxref("HTMLMediaElement/abort_event", "abort")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{domxref("HTMLMediaElement/abort_event", "abort")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onanimationcancel")}} {{Non-standard_inline}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when an {{event("animationcancel")}} event is sent, indicating that a running <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has been canceled.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("animationcancel")}} event is sent, indicating that a running <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has been canceled.</dd>
  <dt>{{domxref("GlobalEventHandlers.onanimationend")}} {{Non-standard_inline}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when an {{event("animationend")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has stopped playing.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("animationend")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has stopped playing.</dd>
  <dt>{{domxref("GlobalEventHandlers.onanimationiteration")}} {{Non-standard_inline}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when an {{event("animationiteration")}} event has been sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has begun playing a new iteration of the animation sequence.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("animationiteration")}} event has been sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has begun playing a new iteration of the animation sequence.</dd>
  <dt>{{domxref("GlobalEventHandlers.onanimationstart")}} {{Non-standard_inline}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when an {{event("animationstart")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has started playing.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("animationstart")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> has started playing.</dd>
  <dt>{{domxref("GlobalEventHandlers.onauxclick")}} {{Non-standard_inline}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when an {{event("auxclick")}} event is sent, indicating that a non-primary button has been pressed on an input device (e.g. a middle mouse button).</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when an {{event("auxclick")}} event is sent, indicating that a non-primary button has been pressed on an input device (e.g. a middle mouse button).</dd>
  <dt>{{domxref("GlobalEventHandlers.onblur")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("blur")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("blur")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onerror")}}</dt>
  <dd>Is an {{domxref("OnErrorEventHandler")}} representing the code to be called when the {{event("error")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onfocus")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("focus")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("focus")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oncancel")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("cancel")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("cancel")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oncanplay")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("canplay")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("canplay")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oncanplaythrough")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("canplaythrough")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("canplaythrough")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("change")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("change")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onclick")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("click")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("click")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onclose")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("close")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("close")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oncontextmenu")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("contextmenu")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("contextmenu")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oncuechange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("cuechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("cuechange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondblclick")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dblclick")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dblclick")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondrag")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("drag")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("drag")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragend")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragend")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragend")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragenter")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragenter")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragenter")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragexit")}} {{Deprecated_Inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragexit")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragexit")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragleave")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragleave")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragleave")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragover")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragover")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragover")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondragstart")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("dragstart")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("dragstart")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondrop")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("drop")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("drop")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ondurationchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("durationchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("durationchange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onemptied")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("emptied")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("emptied")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onended")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("ended")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("ended")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onformdata")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} for processing {{event("formdata")}} events, fired after the entry list representing the form's data is constructed.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for processing {{event("formdata")}} events, fired after the entry list representing the form's data is constructed.</dd>
  <dt>{{domxref("GlobalEventHandlers.ongotpointercapture")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("gotpointercapture")}} event type is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("gotpointercapture")}} event type is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oninput")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("input")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("input")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.oninvalid")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("invalid")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("invalid")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onkeydown")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("keydown")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("keydown")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onkeypress")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("keypress")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("keypress")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onkeyup")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("keyup")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("keyup")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("load")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("load")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onloadeddata")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("loadeddata")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("loadeddata")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onloadedmetadata")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("loadedmetadata")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("loadedmetadata")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onloadend")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("loadend")}} event is raised (when progress has stopped on the loading of a resource.)</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("loadend")}} event is raised (when progress has stopped on the loading of a resource.)</dd>
  <dt>{{domxref("GlobalEventHandlers.onloadstart")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("loadstart")}} event is raised (when progress has begun on the loading of a resource.)</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("loadstart")}} event is raised (when progress has begun on the loading of a resource.)</dd>
  <dt>{{domxref("GlobalEventHandlers.onlostpointercapture")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("lostpointercapture")}} event type is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("lostpointercapture")}} event type is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmousedown")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mousedown")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mousedown")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmouseenter")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mouseenter")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mouseenter")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmouseleave")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mouseleave")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mouseleave")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmousemove")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mousemove")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mousemove")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmouseout")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mouseout")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mouseout")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmouseover")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mouseover")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mouseover")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmouseup")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mouseup")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mouseup")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmousewheel")}} {{Non-standard_inline}} {{Deprecated_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("mousewheel")}} event is raised. Deprecated. Use <code>onwheel</code> instead.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("mousewheel")}} event is raised. Deprecated. Use <code>onwheel</code> instead.</dd>
  <dt>{{ domxref("GlobalEventHandlers.onwheel") }}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("wheel")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("wheel")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpause")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pause")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pause")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onplay")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("play")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("play")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onplaying")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("playing")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("playing")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerdown")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerdown")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerdown")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointermove")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointermove")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointermove")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerup")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerup")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerup")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointercancel")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointercancel")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointercancel")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerover")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerover")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerover")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerout")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerout")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerout")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerenter")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerenter")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerenter")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerleave")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerleave")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerleave")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerlockchange")}} {{experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerlockchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerlockchange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onpointerlockerror")}} {{experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pointerlockerror")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pointerlockerror")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onprogress")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("progress")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("progress")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onratechange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("ratechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("ratechange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onreset")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("reset")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("reset")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onresize")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("resize")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("resize")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onscroll")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("scroll")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("scroll")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onseeked")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("seeked")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("seeked")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onseeking")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("seeking")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("seeking")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onselect")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("select")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("select")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onselectstart")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("selectionchange")}} event is raised, i.e. when the user starts to make a new text selection on a web page.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("selectionchange")}} event is raised, i.e. when the user starts to make a new text selection on a web page.</dd>
  <dt>{{domxref("GlobalEventHandlers.onselectionchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("selectionchange")}} event is raised, i.e. when the text selected on a web page changes.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("selectionchange")}} event is raised, i.e. when the text selected on a web page changes.</dd>
  <dt>{{domxref("GlobalEventHandlers.onshow")}} {{Deprecated_Inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("show")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("show")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onstalled")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("stalled")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("stalled")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onsubmit")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("submit")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("submit")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onsuspend")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("suspend")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("suspend")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontimeupdate")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("timeupdate")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("timeupdate")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onvolumechange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("volumechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("volumechange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontouchcancel")}} {{Non-standard_inline}} {{Experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("touchcancel")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("touchcancel")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontouchend")}} {{Non-standard_inline}} {{Experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("touchend")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("touchend")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontouchmove")}} {{Non-standard_inline}} {{Experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("touchmove")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("touchmove")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontouchstart")}} {{Non-standard_inline}} {{Experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("touchstart")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("touchstart")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontransitioncancel")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when a {{event("transitioncancel")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has been cancelled.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{event("transitioncancel")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has been cancelled.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontransitionend")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when a {{event("transitionend")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has finished playing.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{event("transitionend")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has finished playing.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontransitionrun")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when a {{event("transitionrun")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> is running, though not nessarilty started.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{event("transitionrun")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> is running, though not nessarilty started.</dd>
  <dt>{{domxref("GlobalEventHandlers.ontransitionstart")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} called when a {{event("transitionstart")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has started transitioning.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when a {{event("transitionstart")}} event is sent, indicating that a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transition</a> has started transitioning.</dd>
  <dt>{{domxref("GlobalEventHandlers.onwaiting")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("waiting")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("waiting")}} event is raised.</dd>
 </dl>
 </div>
 
@@ -225,6 +225,6 @@ browser-compat: api.GlobalEventHandlers
 
 <ul>
  <li>{{domxref("Element")}}</li>
- <li>{{event("Event_handlers", "event handler")}}</li>
+ <li><a href="/en-US/docs/Web/Events/Event_handlers">event handler</a></li>
  <li>{{domxref("Event")}}</li>
 </ul>

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.html
@@ -17,7 +17,7 @@ browser-compat: api.GlobalEventHandlers.onabort
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}} {{draft}}</div>
 
 <p>The <strong><code>onabort</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("abort")}} events sent to the window.</p>
 
 <p>While the <a

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -20,7 +20,7 @@ browser-compat: api.GlobalEventHandlers.onanimationcancel
 <div>{{APIRef("CSS3 Animations")}}</div>
 
 <p>The <code><strong>onanimationcancel</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("animationcancel")}} events.</p>
 
 <p>An <code>animationcancel</code> event is sent when a <a

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -22,7 +22,7 @@ browser-compat: api.GlobalEventHandlers.onanimationend
 <div>{{APIRef("CSS3 Animations")}}</div>
 
 <p>The <code><strong>onanimationend</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("animationend")}} events.</p>
 
 <p>The <code>animationend</code> event fires when a <a

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -22,7 +22,7 @@ browser-compat: api.GlobalEventHandlers.onanimationiteration
 <div>{{APIRef("CSS3 Animations")}} {{Draft}}</div>
 
 <p>The <code><strong>onanimationiteration</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("animationiteration")}} events.</p>
 
 <p>The <code>animationiteration</code> event is sent when a <a

--- a/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onauxclick
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>onauxclick</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("auxclick")}} events.</p>
 
 <p>The <code>auxclick</code> event is raised when a non-primary button has been pressed on

--- a/files/en-us/web/api/globaleventhandlers/onblur/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onblur/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onblur
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onblur</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("blur")}} events. It's available on {{domxref("Element")}},
   {{domxref("Document")}}, and {{domxref("Window")}}.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/oncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncancel/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.oncancel
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>oncancel</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("cancel")}} events sent to a {{HTMLElement("dialog")}} element.</p>
 
 <p>The <code>cancel</code> event fires when the user indicates a wish to dismiss a

--- a/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.oncanplay
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>oncanplay</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("canplay")}} events.</p>
 
 <p>The <code>canplay</code> event is fired when the user agent can play the media, but

--- a/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.oncanplaythrough
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>oncanplaythrough</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("canplaythrough")}} events.</p>
 
 <p>The <code>canplaythrough</code> event is fired when the user agent can play the media

--- a/files/en-us/web/api/globaleventhandlers/onchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onchange/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onchange
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onchange</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("change")}} events.</p>
 
 <p><code>change</code> events fire when the user commits a value change to a form control.

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onclick
 <p>{{ ApiRef("HTML DOM") }}</p>
 
 <p>The <code><strong>onclick</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{domxref("Element/click_event", "click")}} events on a given element.</p>
 
 <p>The <code>click</code> event is raised when the user clicks on an element. It fires

--- a/files/en-us/web/api/globaleventhandlers/onclose/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclose/index.html
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.onclose
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>onclose</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("close")}} events sent to a {{HTMLElement("dialog")}} element.</p>
 
 <p>The <code>close</code> event fires when the user closes a <code>&lt;dialog&gt;</code>.

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.oncontextmenu
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>oncontextmenu</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("contextmenu")}} events.</p>
 
 <p>The <code>contextmenu</code> event typically fires when the right mouse button is

--- a/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
@@ -17,7 +17,7 @@ browser-compat: api.GlobalEventHandlers.oncuechange
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>oncuechange</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("cuechange")}} events.</p>
 
 <p>The <code>cuechange</code> event fires when a {{domxref("TextTrack")}} has changed the

--- a/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.ondblclick
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>ondblclick</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("dblclick")}} events on the given element.</p>
 
 <p>The <code>dblclick</code> event is raised when the user double clicks an element. It

--- a/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.ondurationchange
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>ondurationchange</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("durationchange")}} events.</p>
 
 <p>The <code>durationchange</code> event is fired when the <code>duration</code> attribute

--- a/files/en-us/web/api/globaleventhandlers/onended/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onended/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onended
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onended</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("ended")}} events.</p>
 
 <p>The <code>ended</code> event is fired when playback has stopped because the end of the

--- a/files/en-us/web/api/globaleventhandlers/onerror/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onerror
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
-<p>The <code><strong>onerror</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that processes {{event("error")}} events.</p>
+<p>The <code><strong>onerror</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes {{event("error")}} events.</p>
 
 <p>Error events are fired at various targets for different kinds of errors:</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onfocus/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onfocus
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onfocus</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("focus")}} events on the given element.</p>
 
 <p>The <code>focus</code> event is raised when the user sets focus on an element.</p>

--- a/files/en-us/web/api/globaleventhandlers/onformdata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onformdata/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onformdata
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onformdata</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("formdata")}} events, fired after the entry list representing the
   form's data is constructed. This happens when the form is submitted, but can also be
   triggered by the invocation of a {{domxref("FormData.FormData", "FormData()")}}

--- a/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.ongotpointercapture
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>ongotpointercapture</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("gotpointercapture")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/oninput/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninput/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.oninput
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>oninput</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("input")}} events on the {{HTMLElement("input")}},
   {{HTMLElement("select")}}, and {{HTMLElement("textarea")}} elements. It also handles
   these events on elements where {{domxref("HTMLElement.contentEditable",

--- a/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.oninvalid
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <code><strong>oninvalid</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("invalid")}} events.</p>
 
 <p>The <code>invalid</code> event fires when a submittable element has been checked and

--- a/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onkeydown
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onkeydown</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("keydown")}} events.</p>
 
 <p>The <code>keydown</code> event fires when the user presses a keyboard key.</p>

--- a/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onkeyup
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onkeyup</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("keyup")}} events.</p>
 
 <p>The <code>keyup</code> event fires when the user releases a key that was previously

--- a/files/en-us/web/api/globaleventhandlers/onload/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onload/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onload
 <div>{{ApiRef()}}</div>
 
 <p>The <strong><code>onload</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("load")}} events on a {{domxref("Window")}},
   {{domxref("XMLHttpRequest")}}, {{htmlelement("img")}} element, etc.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onloadeddata
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onloadeddata</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("loadeddata")}} events.</p>
 
 <p>The <code>loadeddata</code> event is fired when the first frame of the media has

--- a/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onloadedmetadata
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onloadedmetadata</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("loadedmetadata")}} events.</p>
 
 <p>The <code>loadedmetadata</code> event is fired when the metadata has been loaded.</p>

--- a/files/en-us/web/api/globaleventhandlers/onloadend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadend/index.html
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.onloadend
 <div>{{ApiRef}}</div>
 
 <p>The <strong><code>onloadend</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} representing
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing
   the code to be called when the {{event("loadend")}} event is raised (when progress has
   stopped on the loading of a resource.)</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.onloadstart
 <div>{{ApiRef}}</div>
 
 <p>The <strong><code>onloadstart</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} representing
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing
   the code to be called when the {{event("loadstart")}} event is raised (when progress has
   begun on the loading of a resource.)</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onlostpointercapture
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onlostpointercapture</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("lostpointercapture")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onmousedown
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onmousedown</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("mousedown")}} events.</p>
 
 <p>The <code>mousedown</code> event fires when the user depresses the mouse button.</p>

--- a/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onmouseenter
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onmouseenter</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("mouseenter")}} events.</p>
 
 <p>The <code>mouseenter</code> event is fired when a pointing device (usually a mouse) is

--- a/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onmouseleave
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onmouseleave</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("mouseleave")}} events.</p>
 
 <p>The <code>mouseleave</code> event is fired when a pointing device (usually a mouse) is

--- a/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onmousemove
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onmousemove</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("mousemove")}} events.</p>
 
 <p>The <code>mousemove</code> event fires when the user moves the mouse.</p>

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onmouseout
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <code><strong>onmouseout</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("mouseout")}} events.</p>
 
 <p>The <code>mouseout</code> event fires when the mouse leaves an element. For example,

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onmouseover
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onmouseover</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("mouseover")}} events.</p>
 
 <p>The <code>mouseover</code> event fires when the user moves the mouse over a particular

--- a/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onmouseup
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onmouseup</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("mouseup")}} events.</p>
 
 <p>The <code>mouseup</code> event fires when the user releases the mouse button.</p>

--- a/files/en-us/web/api/globaleventhandlers/onpause/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpause/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onpause
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onpause</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("pause")}} events.</p>
 
 <p>The <code>pause</code> event is fired when media playback has been paused.</p>

--- a/files/en-us/web/api/globaleventhandlers/onplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplay/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onplay
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <code><strong>onplay</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("play")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onplaying/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplaying/index.html
@@ -12,7 +12,7 @@ browser-compat: api.GlobalEventHandlers.onplaying
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onplaying</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("playing")}} events.</p>
 
 <p>The <code>playing</code> event is fired when playback is ready to start after having

--- a/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointercancel
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onpointercancel</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("pointercancel")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointerenter
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onpointerenter</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{domxref("HTMLElement/pointerenter_event", "pointerenter")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointermove
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onpointermove</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("pointermove")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointerout
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onpointerout</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("pointerout")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointerover
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onpointerover</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("pointerover")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onpointerup
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onpointerup</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("pointerup")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/onreset/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onreset/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onreset
 <div>{{ ApiRef() }}</div>
 
 <p>The <code><strong>onreset</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("reset")}} events.</p>
 
 <p>The <code>reset</code> event fires when the user clicks a reset button in a form

--- a/files/en-us/web/api/globaleventhandlers/onresize/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onresize/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onresize
 <div>{{ ApiRef() }}</div>
 
 <p>The <code><strong>onresize</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} interface is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes <code><a href="/en-US/docs/Web/API/Window/resize_event">resize</a></code>
   events.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onscroll/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onscroll/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onscroll
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onscroll</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes <code>scroll</code> events.</p>
 
 <p>The <code>scroll</code> event fires when the document view or an element has been

--- a/files/en-us/web/api/globaleventhandlers/onselect/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselect/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onselect
 <div>{{ ApiRef("HTML DOM") }}</div>
 
 <p>The <strong><code>onselect</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes <a href="/en-US/docs/Web/API/Element/select_event"><code>select</code>
     events</a>.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onselectionchange
 ---
 <div>{{ApiRef('DOM')}} {{SeeCompatTable}}</div>
 
-<p>The <code><strong>onselectionchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that processes {{event("selectionchange")}} events.</p>
+<p>The <code><strong>onselectionchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes {{event("selectionchange")}} events.</p>
 
 <p>The <code>selectionchange</code> event fires when the text selected on a webpage changes.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.onselectstart
 <div>{{ApiRef('DOM')}}{{SeeCompatTable}}</div>
 
 <p>The <code><strong>onselectstart</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("selectstart")}} events.</p>
 
 <p>The <code>selectstart</code> event fires when the user starts to make a new text

--- a/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
@@ -13,7 +13,7 @@ browser-compat: api.GlobalEventHandlers.onsubmit
 <div>{{ApiRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onsubmit</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("submit")}} events.</p>
 
 <p>The <code>submit</code> event fires when the user submits a form.</p>

--- a/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.ontouchcancel
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
 <p>The <strong><code>ontouchcancel</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("touchcancel")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.ontouchstart
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>ontouchstart</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("touchstart")}} events.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.ontransitioncancel
 <div>{{APIRef("CSS3 Transitions")}}</div>
 
 <p>The <strong><code>ontransitioncancel</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("transitioncancel")}} events.</p>
 
 <p>The <code>transitioncancel</code> event is sent when a <a

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -18,7 +18,7 @@ browser-compat: api.GlobalEventHandlers.ontransitionend
 <div>{{APIRef("CSS3 Transitions")}}</div>
 
 <p>The <strong><code>ontransitionend</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("transitionend")}} events.</p>
 
 <p>The <code>transitionend</code> event is sent to when a <a

--- a/files/en-us/web/api/globaleventhandlers/onwheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onwheel/index.html
@@ -14,7 +14,7 @@ browser-compat: api.GlobalEventHandlers.onwheel
 <div>{{ ApiRef("DOM") }}</div>
 
 <p>The <strong><code>onwheel</code></strong> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes <code>wheel</code> events.</p>
 
 <p>The <code>wheel</code> event fires when the user rotates the mouse (or other pointing

--- a/files/en-us/web/api/hid/onconnect/index.html
+++ b/files/en-us/web/api/hid/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.onconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> {{event("Event_Handlers", "Event Handler")}} of the {{domxref("HID")}} interface processes the events fired when the user agent connects to the HID device.</p>
+<p class="summary">The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events fired when the user agent connects to the HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hid/ondisconnect/index.html
+++ b/files/en-us/web/api/hid/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.ondisconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> {{event("Event_Handlers", "Event Handler")}} of the {{domxref("HID")}} interface processes the events when the user agent disconnects from the HID device.</p>
+<p class="summary">The <strong><code>ondisconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events when the user agent disconnects from the HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmlbodyelement/index.html
+++ b/files/en-us/web/api/htmlbodyelement/index.html
@@ -44,39 +44,39 @@ browser-compat: api.HTMLBodyElement
 
 <dl>
  <dt>{{domxref("WindowEventHandlers.onafterprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onhashchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called whenever an object receives a {{event("message")}} event.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called whenever an object receives a {{event("message")}} event.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessageerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called whenever an object receives a {{event("messageerror")}} event.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called whenever an object receives a {{event("messageerror")}} event.</dd>
  <dt>{{domxref("WindowEventHandlers.onoffline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("offline")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("offline")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.ononline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("online")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("online")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpagehide")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpageshow")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpopstate")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("popstate")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("popstate")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onrejectionhandled")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} representing the code executed when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code executed when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.</dd>
  <dt>{{domxref("GlobalEventHandlers.onresize")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("resize")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("resize")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onstorage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("storage")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("storage")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onunhandledrejection")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} representing the code executed when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code executed when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.</dd>
  <dt>{{domxref("WindowEventHandlers.onunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("unload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("unload")}} event is raised.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/htmlelement/oncopy/index.html
+++ b/files/en-us/web/api/htmlelement/oncopy/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLElement.oncopy
 <div>{{ APIRef("HTML DOM") }}{{SeeCompatTable}}</div>
 
 <p>The <strong><code>oncopy</code></strong> property of the {{domxref("HTMLElement")}}
-  interface is an {{event("Event_handlers", "event handler")}} that processes
+  interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes
   {{domxref("Element/copy_event", "copy")}} events.</p>
 
 <p>The <code>copy</code> event fires when the user attempts to copy text.</p>

--- a/files/en-us/web/api/htmlelement/oncut/index.html
+++ b/files/en-us/web/api/htmlelement/oncut/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLElement.oncut
 <div>{{ APIRef("HTML DOM") }} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>HTMLElement.oncut</strong></code> property of the
-  {{domxref("HTMLElement")}} interface is an {{event("Event_handlers", "event handler")}} that processes
+  {{domxref("HTMLElement")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes
   {{event("cut")}} events.</p>
 
 <p>The <code>cut</code> event fires when the user attempts to cut text.</p>

--- a/files/en-us/web/api/htmlelement/onpaste/index.html
+++ b/files/en-us/web/api/htmlelement/onpaste/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLElement.onpaste
 <div>{{ APIRef("HTML DOM") }} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>HTMLElement.onpaste</strong></code> property of the
-  {{domxref("HTMLElement")}} interface is an {{event("Event_handlers", "event handler")}} that processes
+  {{domxref("HTMLElement")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes
   {{event("paste")}} events.</p>
 
 <p>The <code>paste</code> event fires when the user attempts to paste text.</p>

--- a/files/en-us/web/api/htmlframesetelement/index.html
+++ b/files/en-us/web/api/htmlframesetelement/index.html
@@ -35,33 +35,33 @@ browser-compat: api.HTMLFrameSetElement
 
 <dl>
  <dt>{{domxref("WindowEventHandlers.onafterprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onhashchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("message")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("message")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onoffline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("offline")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("offline")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.ononline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("online")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("online")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpagehide")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpageshow")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpopstate")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("popstate")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("popstate")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onresize")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("resize")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("resize")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onstorage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("storage")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("storage")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("unload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("unload")}} event is raised.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -132,7 +132,7 @@ browser-compat: api.HTMLMediaElement
 
 <dl>
  <dt>{{domxref("HTMLMediaElement.onmozinterruptbegin")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Sets the {{event("Event_handlers", "event handler")}} called when the media element is interrupted because of the Audio Channel manager. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
+ <dd>Sets the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when the media element is interrupted because of the Audio Channel manager. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
  <dt>{{domxref("HTMLMediaElement.onmozinterruptend")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>Sets the {{domxref('EventHandler')}} called when the interruption is concluded. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
 </dl>

--- a/files/en-us/web/api/htmlmediaelement/onerror/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onerror/index.html
@@ -18,7 +18,7 @@ browser-compat: api.HTMLMediaElement.onerror
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onerror</code></strong> property of the
-  {{domxref("HTMLMediaElement")}} interface is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("HTMLMediaElement")}} interface is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("error")}} events.</p>
 
 <p>The <code>error</code> event fires when some form of error occurs while attempting to

--- a/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
@@ -17,7 +17,7 @@ browser-compat: api.HTMLVideoElement.onenterpictureinpicture
 <div>{{ ApiRef() }}</div>
 
 <p>The <code><strong>onenterpictureinpicture</strong></code> property of the
-  {{domxref("HTMLVideoElement")}} interface is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("HTMLVideoElement")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{domxref("HTMLVideoElement.enterpictureinpicture_event",
   "HTMLVideoElement.enterpictureinpicture")}} events.</p>
 

--- a/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
@@ -17,7 +17,7 @@ browser-compat: api.HTMLVideoElement.onleavepictureinpicture
 <div>{{ ApiRef() }}</div>
 
 <p>The <code><strong>onleavepictureinpicture</strong></code> property of the
-  {{domxref("HTMLVideoElement")}} interface is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("HTMLVideoElement")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{domxref("HTMLVideoElement.leavepictureinpicture_event",
   "HTMLVideoElement.leavepictureinpicture")}} events.</p>
 

--- a/files/en-us/web/api/mediadevices/ondevicechange/index.html
+++ b/files/en-us/web/api/mediadevices/ondevicechange/index.html
@@ -17,7 +17,7 @@ browser-compat: api.MediaDevices.ondevicechange
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
 <p><span class="seoSummary">The <strong><code>MediaDevices.ondevicechange</code></strong>
-    property is an {{event("Event_handlers", "event handler")}} which specifies a function to be called
+    property is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called
     when the {{event("devicechange")}} event occurs on a {{domxref("MediaDevices")}}
     instance. This happens whenever the set of media devices available to the
     {{Glossary("user agent")}} and, by extension, to the web site or app has changed. You

--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -70,18 +70,18 @@ browser-compat: api.MediaRecorder
  <dt>{{domxref("MediaRecorder.ondataavailable")}}</dt>
  <dd>Called to handle the {{event("dataavailable")}} event, which is periodically triggered each time <code>timeslice</code> milliseconds of media have been recorded (or when the entire media has been recorded, if <code>timeslice</code> wasn't specified). The event, of type {{domxref("BlobEvent")}}, contains the recorded media in its {{domxref("BlobEvent.data", "data")}} property. You can then collect and act upon that recorded media data using this event handler.</dd>
  <dt>{{domxref("MediaRecorder.onerror")}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd> 
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd> 
  <dt>{{domxref("MediaRecorder.onpause")}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("pause")}} event, which occurs when media recording is paused.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("pause")}} event, which occurs when media recording is paused.</dd>
  <dt>{{domxref("MediaRecorder.onresume")}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("resume")}} event, which occurs when media recording resumes after being paused.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("resume")}} event, which occurs when media recording resumes after being paused.</dd>
  <dt>{{domxref("MediaRecorder.onstart")}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("start")}} event, which occurs when media recording starts.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("start")}} event, which occurs when media recording starts.</dd>
  <dt>{{domxref("MediaRecorder.onstop")}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("stop")}} event, which occurs when media recording ends, either when the {{domxref("MediaStream")}} ends — or after the {{domxref("MediaRecorder.stop()")}} method is called.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("stop")}} event, which occurs when media recording ends, either when the {{domxref("MediaStream")}} ends — or after the {{domxref("MediaRecorder.stop()")}} method is called.</dd>
 
  <dt>{{domxref("MediaRecorder.onwarning")}} {{deprecated_inline}}</dt>
- <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("warning")}} event, which occurs when media recording has a non-fatal error, or after the {{domxref("MediaRecorder.onwarning()")}} method is called.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called to handle the {{event("warning")}} event, which occurs when media recording has a non-fatal error, or after the {{domxref("MediaRecorder.onwarning()")}} method is called.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>

--- a/files/en-us/web/api/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/index.html
@@ -45,9 +45,9 @@ browser-compat: api.MediaStream
 
 <dl>
  <dt>{{domxref("MediaStream.onaddtrack")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} containing the action to perform when an {{event("addtrack")}} event is fired when a new {{domxref("MediaStreamTrack")}} object is added.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> containing the action to perform when an {{event("addtrack")}} event is fired when a new {{domxref("MediaStreamTrack")}} object is added.</dd>
  <dt>{{domxref("MediaStream.onremovetrack")}}</dt>
- <dd>An {{event("Event_handlers", "event handler")}} containing the action to perform when a {{event("removetrack")}} event is fired when a {{domxref("MediaStreamTrack")}} object is removed from it.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> containing the action to perform when a {{event("removetrack")}} event is fired when a {{domxref("MediaStreamTrack")}} object is removed from it.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/mediastream/onaddtrack/index.html
+++ b/files/en-us/web/api/mediastream/onaddtrack/index.html
@@ -13,7 +13,7 @@ browser-compat: api.MediaStream.onaddtrack
 <p>{{APIRef("Media Streams API")}}</p>
 
 <p><span class="seoSummary">The <strong><code>MediaStream.onaddtrack</code></strong>
-    property is an {{event("Event_handlers", "event handler")}} which specifies a function to be called
+    property is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called
     when the {{event("addtrack")}} event occurs on a {{domxref("MediaStream")}} instance.
     This happens when a new track of any kind is added to the media stream.</span> This
   event is fired when the browser adds a track to the stream (such as when a

--- a/files/en-us/web/api/mediastream/onremovetrack/index.html
+++ b/files/en-us/web/api/mediastream/onremovetrack/index.html
@@ -14,7 +14,7 @@ browser-compat: api.MediaStream.onremovetrack
 <p>{{APIRef("Media Streams API")}}</p>
 
 <p><span class="seoSummary">The <strong><code>MediaStream.onremovetrack</code></strong>
-    property is an {{event("Event_handlers", "event handler")}} which specifies a function to be called
+    property is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called
     when the {{event("removetrack")}} event occurs on a {{domxref("MediaStream")}}
     instance. This happens when a track of any kind is removed from the media
     stream.</span> This event is fired when the browser removes a track from the stream

--- a/files/en-us/web/api/mediastreamtrack/onended/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onended/index.html
@@ -14,7 +14,7 @@ browser-compat: api.MediaStreamTrack.onended
 <p>{{ APIRef("Media Capture and Streams") }}</p>
 
 <p>The <code><strong>MediaStreamTrack.onended</strong></code> event handler is used to
-  specify a function which serves as an {{event("Event_handlers", "event handler")}} to be called when the
+  specify a function which serves as an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the
   <code><a href="/en-US/docs/Web/API/MediaStreamTrack/ended_event">ended</a></code> event
   occurs on the track. This event occurs when the track will no longer provide data to the
   stream for any reason, including the end of the media input being reached, the user
@@ -28,7 +28,7 @@ browser-compat: api.MediaStreamTrack.onended
 
 <h3 id="Value">Value</h3>
 
-<p>A function to serve as an {{event("Event_handlers", "event handler")}} for the
+<p>A function to serve as an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for the
   <code><a href="/en-US/docs/Web/API/MediaStreamTrack/ended_event">ended</a></code> event.
   The event handler function receives a single parameter: the event object, which is a
   simple {{domxref("Event")}} object.</p>

--- a/files/en-us/web/api/mediastreamtrack/onmute/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onmute/index.html
@@ -27,7 +27,7 @@ browser-compat: api.MediaStreamTrack.onmute
 
 <h3 id="Value">Value</h3>
 
-<p>A function to serve as an {{event("Event_handlers", "event handler")}} for the {{event("mute")}} event.
+<p>A function to serve as an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for the {{event("mute")}} event.
   The event handler function receives a single parameter: the event object, which is a
   simple {{domxref("Event")}} object.</p>
 

--- a/files/en-us/web/api/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/index.html
@@ -36,7 +36,7 @@ browser-compat: api.OfflineAudioContext
 
 <dl>
  <dt>{{domxref("OfflineAudioContext.oncomplete")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} called when processing is terminated, that is when the {{event("complete")}} event (of type {{domxref("OfflineAudioCompletionEvent")}}) is raised, after the event-based version of {{domxref("OfflineAudioContext.startRendering()")}} is used.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when processing is terminated, that is when the {{event("complete")}} event (of type {{domxref("OfflineAudioCompletionEvent")}}) is raised, after the event-based version of {{domxref("OfflineAudioContext.startRendering()")}} is used.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
@@ -26,7 +26,7 @@ browser-compat: api.Performance.onresourcetimingbufferfull
 
 <dl>
   <dt>callback</dt>
-  <dd>An {{event("Event_handlers", "event handler")}} that is invoked when the
+  <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that is invoked when the
     {{event("resourcetimingbufferfull")}} event is fired.</dd>
 </dl>
 

--- a/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
@@ -14,7 +14,7 @@ browser-compat: api.PictureInPictureWindow.onresize
 <div>{{ ApiRef() }}</div>
 
 <p>The <code><strong>onresize</strong></code> property of the
-  {{domxref("PictureInPictureWindow")}} interface is an {{event("Event_handlers", "event handler")}} that
+  {{domxref("PictureInPictureWindow")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{domxref("PictureInPictureWindow.resize_event",
   "PictureInPictureWindow.resize")}} events.</p>
 

--- a/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
@@ -16,7 +16,7 @@ browser-compat: api.RTCDataChannel.onbufferedamountlow
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <strong><code>RTCDataChannel.onbufferedamountlow</code></strong> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function the browser calls when the
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function the browser calls when the
   {{event("bufferedamountlow")}} event is sent to the {{domxref("RTCDataChannel")}}. This
   event, which is represented by a simple {{domxref("Event")}} object, is sent when the
   amount of data buffered to be sent falls to or below the threshold specified by the

--- a/files/en-us/web/api/rtcdatachannel/onclose/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclose/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onclose
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCDataChannel.onclose</strong></code> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function to be called by the browser when
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called by the browser when
   the {{event("close")}} event is received by the {{domxref("RTCDataChannel")}}. This is a
   simple {{domxref("Event")}} which indicates that the data channel has closed down.</p>
 

--- a/files/en-us/web/api/rtcdatachannel/onclosing/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclosing/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onclosing
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}{{Draft}}</p>
 
 <p>The <code><strong>RTCDataChannel.onclosing</strong></code> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function to be called by the browser when
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called by the browser when
   the {{Event("closing")}} event is received by the {{DOMxRef("RTCDataChannel")}}. This is
   a simple {{DOMxRef("Event")}} which indicates that the data channel is being closed,
   that is, {{DOMxRef("RTCDataChannel")}} transitions to "closing" state. For example,

--- a/files/en-us/web/api/rtcdatachannel/onerror/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onerror/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onerror
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCDataChannel.onerror</strong></code> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function to be called when the
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
   {{event("error")}} event is received. When an error occurs on the data channel, the
   function receives as input an {{domxref("ErrorEvent")}} object describing the error
   which occurred.</p>

--- a/files/en-us/web/api/rtcdatachannel/onmessage/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onmessage/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onmessage
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCDataChannel.onmessage</strong></code> property stores an
-  {{event("Event_handlers", "event handler")}} which specifies a function to be called when the
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
   {{event("message")}} event is fired on the channel. This event is represented by the
   {{domxref("MessageEvent")}} interface. This event is sent to the channel when a message
   is received from the other peer.</p>

--- a/files/en-us/web/api/rtcdatachannel/onopen/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onopen/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onopen
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCDataChannel.onopen</strong></code> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function to be called when the
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
   {{event("open")}} event is fired; this is a simple {{domxref("Event")}} which is sent
   when the data channel's underlying data transport—the link over which the
   {{domxref("RTCDataChannel")}}'s messages flow—is established or re-established.</p>

--- a/files/en-us/web/api/rtcicetransport/onstatechange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onstatechange/index.html
@@ -23,7 +23,7 @@ browser-compat: api.RTCIceTransport.onstatechange
 
 <p><span class="seoSummary">The <code><strong>onstatechange</strong></code> event handler
     for the {{domxref("RTCIceTransport")}} interface is a property which specifies a
-    function to serve as the {{event("Event_handlers", "event handler")}} for the {{event("statechange")}}
+    function to serve as the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for the {{event("statechange")}}
     event that is fired whenever the transport's {{domxref("RTCIceTransport.state",
     "state")}} changes.</span></p>
 

--- a/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
@@ -17,7 +17,7 @@ browser-compat: api.RTCPeerConnection.onconnectionstatechange
 
 <p><span class="seoSummary">The
     <strong><code>RTCPeerConnection.onconnectionstatechange</code></strong> property
-    specifies an {{event("Event_handlers", "event handler")}} which is called to handle the
+    specifies an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which is called to handle the
     {{event("connectionstatechange")}} event when it occurs on an instance of
     {{domxref("RTCPeerConnection")}}. This happens whenever the aggregate state of the
     connection changes.</span> The aggregate state is a combination of the states of all

--- a/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCPeerConnection.ondatachannel
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCPeerConnection.ondatachannel</strong></code> property is an
-  {{event("Event_handlers", "event handler")}} which specifies a function which is called when the
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function which is called when the
   {{event("datachannel")}} event occurs on an {{domxref("RTCPeerConnection")}}. This
   event, of type {{domxref("RTCDataChannelEvent")}}, is sent when an
   {{domxref("RTCDataChannel")}} is added to the connection by the remote peer calling

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
@@ -20,7 +20,7 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 
 <p><span class="seoSummary">The <code>RTCPeerConnection</code> property
     <strong>{{domxref("RTCPeerConnection.onicecandidate", "onicecandidate")}}</strong>
-    property is an {{event("Event_handlers", "event handler")}} which specifies a function to be called
+    property is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called
     when the {{event("icecandidate")}} event occurs on an {{domxref("RTCPeerConnection")}}
     instance. This happens whenever the local {{Glossary("ICE")}} agent needs to deliver a
     message to the other peer through the signaling server.</span> This lets the ICE agent

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
@@ -13,7 +13,7 @@ browser-compat: api.RTCPeerConnection.onicecandidateerror
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCPeerConnection.onicecandidateerror</strong></code> property is an
-	{{event("Event_handlers", "event handler")}} which specifies a function which is called to handle the
+	<a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function which is called to handle the
 	{{event("icecandidateerror")}} event when it occurs on an
 	{{domxref("RTCPeerConnection")}} instance. This event is fired when an error occurs
 	during the {{Glossary("ICE")}} candidate gathering process.</p>

--- a/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
@@ -15,7 +15,7 @@ browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>RTCPeerConnection.onicegatheringstatechange</strong></code> property
-  is an {{event("Event_handlers", "event handler")}} which specifies a function to be called when the
+  is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
   {{event("icegatheringstatechange")}} event is sent to an
   {{domxref("RTCPeerConnection")}} instance. This happens when the ICE gathering
   state—that is, whether or not the ICE agent is actively gathering candidates—changes.

--- a/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCPeerConnection.ontrack
 <div>{{APIRef("WebRTC")}}</div>
 
 <p><span class="seoSummary">The {{domxref("RTCPeerConnection")}} property
-    <strong><code>ontrack</code></strong> is an {{event("Event_handlers", "event handler")}} which
+    <strong><code>ontrack</code></strong> is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which
     specifies a function to be called when the {{event("track")}} event occurs, indicating
     that a track has been added to the {{domxref("RTCPeerConnection")}}.</span> The
   function receives as input the event object, of type {{domxref("RTCTrackEvent")}}; this

--- a/files/en-us/web/api/screenorientation/index.html
+++ b/files/en-us/web/api/screenorientation/index.html
@@ -29,7 +29,7 @@ browser-compat: api.ScreenOrientation
 
 <dl>
  <dt>{{DOMxRef("ScreenOrientation.onchange")}}</dt>
- <dd>The {{event("Event_handlers", "event handler")}} called whenever the screen changes orientation.</dd>
+ <dd>The <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called whenever the screen changes orientation.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/screenorientation/onchange/index.html
+++ b/files/en-us/web/api/screenorientation/onchange/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ScreenOrientation.onchange
 
 <p>The <strong><code>onchange</code></strong> property of the
   {{domxref("ScreenOrientation")}} is an event handler fired whenever is the
-  {{event("Event_handlers", "event handler")}} called when the screen changes orientation.</p>
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when the screen changes orientation.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ScriptProcessorNode.onaudioprocess
 ---
 <p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
-<p>The <code>onaudioprocess</code> event handler of the {{domxref("ScriptProcessorNode")}} interface represents the {{event("Event_handlers", "event handler")}} to be called for the <code>audioprocess</code> event that is dispatched to <code>ScriptProcessorNode</code> node types. An event of type {{domxref("AudioProcessingEvent")}} will be dispatched to the event handler.</p>
+<p>The <code>onaudioprocess</code> event handler of the {{domxref("ScriptProcessorNode")}} interface represents the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called for the <code>audioprocess</code> event that is dispatched to <code>ScriptProcessorNode</code> node types. An event of type {{domxref("AudioProcessingEvent")}} will be dispatched to the event handler.</p>
 
 <div class="note">
   <p><strong>Note</strong>: This feature was replaced by <a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklets</a> and the {{domxref("AudioWorkletNode")}} interface.</p>

--- a/files/en-us/web/api/sensor/onactivate/index.html
+++ b/files/en-us/web/api/sensor/onactivate/index.html
@@ -16,7 +16,7 @@ browser-compat: api.Sensor.onactivate
 ---
 <div>{{APIRef("Sensor API")}}</div>
 
-<p>The <strong><code>onactivate</code></strong> {{event("Event_handlers", "event handler")}} is
+<p>The <strong><code>onactivate</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> is
   called when one of the Sensor interface's child interfaces becomes active.</span></p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/sensor/onerror/index.html
+++ b/files/en-us/web/api/sensor/onerror/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Sensor.onerror
 <div>{{APIRef("Sensor API")}}</div>
 
 <p>The <strong><code>onerror</code></strong>
-    {{event("Event_handlers", "event handler")}} is called when an error occurs on one of the child
+    <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> is called when an error occurs on one of the child
     interfaces of the {{domxref("Sensor")}} interface.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/sensor/onreading/index.html
+++ b/files/en-us/web/api/sensor/onreading/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Sensor.onreading
 <div>{{APIRef("Sensor API")}}</div>
 
 <p>The <strong><code>onreading</code></strong>
-    {{event("Event_handlers", "event handler")}} is called when a reading is taken on one of the child
+    <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> is called when a reading is taken on one of the child
     interfaces of the {{domxref("Sensor")}} interface.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/serial/onconnect/index.html
+++ b/files/en-us/web/api/serial/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Serial.onconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> {{event("Event_handlers", "event handler")}} of the {{domxref("Serial")}} interface is called when a port has been connected from a device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.
+<p class="summary">The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("Serial")}} interface is called when a port has been connected from a device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.
 
 <p>This event is only fired for ports associated with removable devices such as those connected via USB. The user must grant the origin permission to access this device during a call to {{domxref("Serial.requestPort()","requestPort()")}} before this event will be fired.</p>
 

--- a/files/en-us/web/api/serviceworker/onerror/index.html
+++ b/files/en-us/web/api/serviceworker/onerror/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ServiceWorker.onerror
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
-<p>The <code><strong>onerror</strong></code> property of the {{domxref("ServiceWorker")}} interface represents an {{event("Event_handlers", "event handler")}}, that is a function to be called when the {{event("error")}} event occurs.</p>
+<p>The <code><strong>onerror</strong></code> property of the {{domxref("ServiceWorker")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>, that is a function to be called when the {{event("error")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/sharedworker/onerror/index.html
+++ b/files/en-us/web/api/sharedworker/onerror/index.html
@@ -14,7 +14,7 @@ browser-compat: api.SharedWorker.onerror
 ---
 <div>{{APIRef("Web Workers API")}}</div>
 
-<p>The <code><strong>onerror</strong></code> property of the {{domxref("SharedWorker")}} interface represents an {{event("Event_handlers", "event handler")}}, that is a function to be called when the {{event("error")}} event occurs.</p>
+<p>The <code><strong>onerror</strong></code> property of the {{domxref("SharedWorker")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>, that is a function to be called when the {{event("error")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.html
@@ -45,7 +45,7 @@ browser-compat: api.SharedWorkerGlobalScope
 
 <dl>
  <dt>{{domxref("SharedWorkerGlobalScope.onconnect")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("connect")}} event is raised — that is, when a {{domxref("MessagePort")}} connection is opened between the associated {{domxref("SharedWorker")}} and the main thread.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("connect")}} event is raised — that is, when a {{domxref("MessagePort")}} connection is opened between the associated {{domxref("SharedWorker")}} and the main thread.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/websocket/onclose/index.html
+++ b/files/en-us/web/api/websocket/onclose/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WebSocket.onclose
 <p>{{APIRef("Web Sockets API")}}</p>
 
 <p>The <code><strong>WebSocket.onclose</strong></code> property is
-  an {{event("Event_handlers", "event handler")}} that is called when the WebSocket connection's
+  an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that is called when the WebSocket connection's
   {{domxref("WebSocket.readyState","readyState")}} changes
   to {{domxref("WebSocket.readyState","CLOSED")}}. It is called with a
   {{domxref("CloseEvent")}}.</p>

--- a/files/en-us/web/api/websocket/onerror/index.html
+++ b/files/en-us/web/api/websocket/onerror/index.html
@@ -30,7 +30,7 @@ browser-compat: api.WebSocket.onerror
 
 <h3 id="Value">Value</h3>
 
-<p>A function or {{event("Event_handlers", "event handler")}} which is executed whenever an
+<p>A function or <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which is executed whenever an
   <code>error</code> event occurs on the WebSocket connection.</p>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/websocket/onmessage/index.html
+++ b/files/en-us/web/api/websocket/onmessage/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WebSocket.onmessage
 <div>{{APIRef("Web Sockets API")}}</div>
 
 <p>The <strong><code>WebSocket.onmessage</code></strong> property is an
-  {{event("Event_handlers", "event handler")}} that is called when a message is received from the server.
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that is called when a message is received from the server.
   It is called with a {{domxref("MessageEvent")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/websocket/onopen/index.html
+++ b/files/en-us/web/api/websocket/onopen/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WebSocket.onopen
 <div>{{APIRef("Web Sockets API")}}</div>
 
 <p>The <strong><code>WebSocket.onopen</code></strong> property is an
-  {{event("Event_handlers", "event handler")}} that is called when the {{domxref("WebSocket")}}
+  <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that is called when the {{domxref("WebSocket")}}
   connection's {{domxref("WebSocket.readyState","readyState")}} changes to
   {{domxref("WebSocket.readyState","1")}}; this indicates that the connection is ready to
   send and receive data. It is called with an {{domxref("Event")}}.</p>

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -430,7 +430,7 @@ browser-compat: api.Window
  <dt>{{domxref("GlobalEventHandlers.onload")}}</dt>
  <dd>Called after all resources and the DOM are fully loaded. WILL NOT get called when the page is loaded from cache, such as with back button.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("message")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("message")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmousedown")}}</dt>
  <dd>Called when ANY mouse button is pressed.</dd>
  <dt>{{domxref("GlobalEventHandlers.onmousemove")}}</dt>
@@ -462,7 +462,7 @@ browser-compat: api.Window
  <dt>{{domxref("GlobalEventHandlers.onselect")}}</dt>
  <dd>Called after text in an input field is selected</dd>
  <dt>{{domxref("GlobalEventHandlers.onselectionchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("selectionchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("selectionchange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onstorage")}}</dt>
  <dd>Called when there is a change in session storage or local storage. See {{event("storage")}} event</dd>
  <dt>{{domxref("GlobalEventHandlers.onsubmit")}}</dt>

--- a/files/en-us/web/api/windoweventhandlers/index.html
+++ b/files/en-us/web/api/windoweventhandlers/index.html
@@ -24,37 +24,37 @@ browser-compat: api.WindowEventHandlers
 
 <dl>
  <dt>{{domxref("WindowEventHandlers.onafterprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("afterprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeprint")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeprint")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onbeforeunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("beforeunload")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onhashchange")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("hashchange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("languagechange")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("message")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("message")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onmessageerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("MessageError")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("MessageError")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onoffline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("offline")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("offline")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.ononline")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("online")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("online")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpagehide")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pagehide")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpageshow")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("pageshow")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onpopstate")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("popstate")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("popstate")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onrejectionhandled")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.</dd>
  <dt>{{domxref("WindowEventHandlers.onstorage")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("storage")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("storage")}} event is raised.</dd>
  <dt>{{domxref("WindowEventHandlers.onunhandledrejection")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.</dd>
  <dt>{{domxref("WindowEventHandlers.onunload")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("unload")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("unload")}} event is raised.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/windoweventhandlers/onafterprint/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onafterprint/index.html
@@ -14,7 +14,7 @@ browser-compat: api.WindowEventHandlers.onafterprint
 <div>{{ApiRef}}</div>
 
 <p>The <code><strong>onafterprint</strong></code> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("afterprint")}} events for the current window. These events are
   raised after the user prints, or if they abort the print dialog.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onbeforeprint/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onbeforeprint/index.html
@@ -14,7 +14,7 @@ browser-compat: api.WindowEventHandlers.onbeforeprint
 <div>{{ApiRef}}</div>
 
 <p>The <code><strong>onbeforeprint</strong></code> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("beforeprint")}} events for the current window. These events are
   raised before the print dialog window is opened.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WindowEventHandlers.onbeforeunload
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <code><strong>onbeforeunload</strong></code> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("beforeunload")}} events. These events fire when a window is about to
   {{event("unload")}} its resources. At this point, the document is still visible and the
   event is still cancelable.</p>

--- a/files/en-us/web/api/windoweventhandlers/onhashchange/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onhashchange/index.html
@@ -14,7 +14,7 @@ browser-compat: api.WindowEventHandlers.onhashchange
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <code><strong>WindowEventHandlers.onhashchange</strong></code> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing
   <code><a href="/en-US/docs/Web/API/Window/hashchange_event">hashchange</a></code>
   events.</p>

--- a/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WindowEventHandlers.onlanguagechange
 <div>{{APIRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
 <p>The <code><strong>onlanguagechange</strong></code> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("languagechange")}} events.</p>
 
 <p>These events are received by the object implementing this interface, usually a

--- a/files/en-us/web/api/windoweventhandlers/onmessage/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onmessage/index.html
@@ -16,7 +16,7 @@ browser-compat: api.WindowEventHandlers.onmessage
 <div>{{APIRef("HTML DOM")}}{{ SeeCompatTable() }}</div>
 
 <p>The <strong><code>onmessage</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} called
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called
   whenever an object receives a {{event("message")}} event.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/windoweventhandlers/onpopstate/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onpopstate/index.html
@@ -15,7 +15,7 @@ browser-compat: api.WindowEventHandlers.onpopstate
 <div>{{APIRef}}</div>
 
 <p>The <strong><code>onpopstate</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing <code><a href="/en-US/docs/Web/API/Window/popstate_event">popstate</a></code>
   events on the window.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WindowEventHandlers.onrejectionhandled
 <div>{{APIRef}}</div>
 
 <p>The <strong><code>onrejectionhandled</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("rejectionhandled")}} events. These events are raised when
   {{jsxref("Promise")}}s are rejected.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onstorage/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onstorage/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WindowEventHandlers.onstorage
 <div>{{ ApiRef() }}</div>
 
 <p>The <strong><code>onstorage</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is an {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing <code><a href="/en-US/docs/Web/API/Window/storage_event">storage</a></code>
   events.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.html
@@ -16,7 +16,7 @@ browser-compat: api.WindowEventHandlers.onunhandledrejection
 <div>{{APIRef}}</div>
 
 <p>The <strong><code>onunhandledrejection</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("unhandledrejection")}} events. These events are raised for unhandled
   {{jsxref("Promise")}} rejections.</p>
 
@@ -27,7 +27,7 @@ browser-compat: api.WindowEventHandlers.onunhandledrejection
 
 <h3 id="Value">Value</h3>
 
-<p><code>function</code> is an {{event("Event_handlers", "event handler")}} or function to call when
+<p><code>function</code> is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> or function to call when
   <code>unhandledrejection</code> events are received by the window. The event handler
   receives as an input parameter as a {{domxref("PromiseRejectionEvent")}}.</p>
 

--- a/files/en-us/web/api/windoweventhandlers/onunload/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onunload/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WindowEventHandlers.onunload
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <strong><code>onunload</code></strong> property of the
-  {{domxref("WindowEventHandlers")}} mixin is the {{event("Event_handlers", "event handler")}} for
+  {{domxref("WindowEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{Event("unload")}} events. These events fire when the window is unloading
   its content and resources. The resource removal is processed <em>after</em> the
   <code>unload</code> event occurs.</p>

--- a/files/en-us/web/api/worker/index.html
+++ b/files/en-us/web/api/worker/index.html
@@ -39,7 +39,7 @@ browser-compat: api.Worker
  <dt>{{domxref("Worker.onmessage")}}</dt>
  <dd>An {{ domxref("EventListener") }} called whenever a {{domxref("MessageEvent")}} of type <code>message</code> occurs — i.e. when a message is sent to the parent document from the worker via {{domxref("DedicatedWorkerGlobalScope.postMessage")}}. The message is stored in the event's {{domxref("MessageEvent.data", "data")}} property.</dd>
  <dt>{{domxref("Worker.onmessageerror")}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("messageerror")}} event is raised.</dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("messageerror")}} event is raised.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/worker/onerror/index.html
+++ b/files/en-us/web/api/worker/onerror/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Worker.onerror
 ---
 <div>{{APIRef("Web Workers API")}}</div>
 
-<p>The <code><strong>onerror</strong></code> property of the {{domxref("Worker")}} interface represents an {{event("Event_handlers", "event handler")}}, that is a function to be called when the {{event("error")}} event occurs.</p>
+<p>The <code><strong>onerror</strong></code> property of the {{domxref("Worker")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>, that is a function to be called when the {{event("error")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/worker/onmessage/index.html
+++ b/files/en-us/web/api/worker/onmessage/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Worker.onmessage
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>onmessage</code></strong> property of the {{domxref("Worker")}} interface represents an {{event("Event_handlers", "event handler")}}, that is a function to be called when the {{event("message")}} event occurs. These events are of type {{domxref("MessageEvent")}} and will be called when the worker's parent receives a message (i.e. from the {{domxref("DedicatedWorkerGlobalScope.postMessage")}} method).</p>
+<p>The <strong><code>onmessage</code></strong> property of the {{domxref("Worker")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>, that is a function to be called when the {{event("message")}} event occurs. These events are of type {{domxref("MessageEvent")}} and will be called when the worker's parent receives a message (i.e. from the {{domxref("DedicatedWorkerGlobalScope.postMessage")}} method).</p>
 
 <p>Note that deserializing the message sent by {{domxref("DedicatedWorkerGlobalScope.postMessage", "postMessage()")}} blocks the thread receiving it.</p>
 

--- a/files/en-us/web/api/workerglobalscope/index.html
+++ b/files/en-us/web/api/workerglobalscope/index.html
@@ -68,7 +68,7 @@ browser-compat: api.WorkerGlobalScope
  <dd>Fired at the global/worker scope object when the user's preferred languages change.<br>
  Also available via the {{domxref("WorkerGlobalScope.onlanguagechange")}} property.</dd>
  <dt><code>close</code> {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("close")}} event is raised.<br>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("close")}} event is raised.<br>
  Also available via the {{domxref("WorkerGlobalScope.onclose")}} property.</dd>
  <dt><code>rejectionhandled</code> {{non-standard_inline}}</dt>
  <dd>An event handler for handled <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise" title="The Promise object is used for deferred and asynchronous computations. A Promise represents an operation that hasn't completed yet, but is expected in the future."><code>Promise</code></a> rejection events.<br>

--- a/files/en-us/web/api/workerglobalscope/onclose/index.html
+++ b/files/en-us/web/api/workerglobalscope/onclose/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WorkerGlobalScope.onclose
 
 <h2 id="Summary">Summary</h2>
 
-<p>The <strong><code>onclose</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("close")}} event occurs.</p>
+<p>The <strong><code>onclose</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("close")}} event occurs.</p>
 
 <div class="warning">
 <p>This non-standard event handler was only implemented by a few browsers and has been removed from all or nearly all of them.</p>

--- a/files/en-us/web/api/workerglobalscope/onerror/index.html
+++ b/files/en-us/web/api/workerglobalscope/onerror/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WorkerGlobalScope.onerror
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>onerror</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("error")}} event occurs.</p>
+<p>The <strong><code>onerror</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("error")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/workerglobalscope/onlanguagechange/index.html
+++ b/files/en-us/web/api/workerglobalscope/onlanguagechange/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WorkerGlobalScope.onlanguagechange
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>onlanguagechange</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("languagechange")}} event occurs.</p>
+<p>The <strong><code>onlanguagechange</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("languagechange")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/workerglobalscope/onoffline/index.html
+++ b/files/en-us/web/api/workerglobalscope/onoffline/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WorkerGlobalScope.onoffline
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>onoffline</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("offline")}} event occurs.</p>
+<p>The <strong><code>onoffline</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("offline")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/workerglobalscope/ononline/index.html
+++ b/files/en-us/web/api/workerglobalscope/ononline/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WorkerGlobalScope.ononline
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <strong><code>ononline</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an {{event("Event_handlers", "event handler")}} to be called when the {{event("online")}} event occurs.</p>
+<p>The <strong><code>ononline</code></strong> property of the {{domxref("WorkerGlobalScope")}} interface represents an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> to be called when the {{event("online")}} event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
+++ b/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
@@ -13,7 +13,7 @@ browser-compat: api.XMLHttpRequest.onreadystatechange
 ---
 <div>{{APIRef}}</div>
 
-<p>An {{event("Event_handlers", "event handler")}} that is called whenever the <code>readyState</code>
+<p>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that is called whenever the <code>readyState</code>
   attribute changes. The callback is called from the user interface thread. The
   <strong><code>XMLHttpRequest.onreadystatechange</code></strong> property contains the
   event handler to be called when the {{domxref("Document/readystatechange_event",


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

replace {{event}} macros for Event_handlers with normal links because they aren't keywords in codes.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
