### PR TITLE
Fix typo in "Promise Terminology Recap"

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/promises/index.html
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.html
@@ -279,7 +279,7 @@ document.body.appendChild(image);</pre>
 
 <h2 id="Promise_terminology_recap">Promise terminology recap</h2>
 
-<p>There was a lot to cover in the above section, so let's go back over it quickly to give you a <a href="/en-US/docs/Learn/JavaScript/Asynchronous/Promises#promise_terminology_recap">short guide that you can bookmark</a> and use to refresh your memory in the future. You should also go over the above section again a few more time to make sure these concepts stick.</p>
+<p>There was a lot to cover in the above section, so let's go back over it quickly to give you a <a href="/en-US/docs/Learn/JavaScript/Asynchronous/Promises#promise_terminology_recap">short guide that you can bookmark</a> and use to refresh your memory in the future. You should also go over the above section again a few more times to make sure these concepts stick.</p>
 
 <ol>
  <li>When a promise is created, it is neither in a success or failure state. It is said to be <strong>pending</strong>.</li>


### PR DESCRIPTION
Just fixing a simple typo I saw. Changed from "a few more time" to "a few more times"

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Without this fix, the sentence would be grammatically incorrect


> Issue number (if there is an associated issue)



> Anything else that could help us review it
