### PR TITLE
fix: remove duplicate media query list link

### DIFF
--- a/files/en-us/web/api/window/matchmedia/index.html
+++ b/files/en-us/web/api/window/matchmedia/index.html
@@ -118,5 +118,4 @@ document.querySelector(".mq-value").innerText = mql.matches;
   </li>
   <li><a href="/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries">Using media queries from code</a></li>
   <li>{{domxref("MediaQueryList")}}</li>
-  <li>{{domxref("MediaQueryList")}}</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Duplicate Link for `MediaQueryList` on https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia

![Screenshot 2021-07-12 at 10 32 00](https://user-images.githubusercontent.com/18121502/125233588-87a05600-e2fc-11eb-9694-55c149fd1583.png)


> Issue number (if there is an associated issue)



> Anything else that could help us review it
