### PR TITLE
Drop placeholder text in “ARIA: tabpanel role” doc

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.html
@@ -69,14 +69,6 @@ tags:
 &lt;div role="tab" aria-selected="true" aria-controls="tabpanel-id"
 id="tab-id" tabindex="0"&gt;Tab label&lt;/div&gt; </pre>
 
-<h2 id="Accessibility_concerns">Accessibility concerns</h2>
-
-<p>Optionally, warn of any potential accessibility concerns that exist with using this property, and how to work around them. Remove this section if there are none to list.</p>
-
-<h2 id="Best_practices">Best practices</h2>
-
-<p>Optionally, here list any best practices that exist for this role. Remove the section if none exist.</p>
-
 <h3 id="Added_benefits">Added benefits</h3>
 
 <p>Any additional benefits this feature has for non-typical screen reader users, like Google or mobile speech recognition.</p>


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The Accessibility concerns and Best practices sections are both placeholder text, with the quote "Remove the section if none exist."


> Issue number (if there is an associated issue)



> Anything else that could help us review it
