### PR TITLE
Restore a necessary http (non-https) URL

### DIFF
--- a/files/en-us/tools/storage_inspector/index.html
+++ b/files/en-us/tools/storage_inspector/index.html
@@ -52,7 +52,7 @@ tags:
 
 <p><img alt="" src="storage_types.png" style="display: block; margin: 0 auto;"></p>
 
-<p>Under each type, objects are organized by origin. For cookies, the protocol does not differentiate the origin. For Indexed DB or local storage an origin is a combination of protocol + hostname. For example, "https://mozilla.org" and "https://mozilla.org" are two different origins so local storage items cannot be shared between them.</p>
+<p>Under each type, objects are organized by origin. For cookies, the protocol does not differentiate the origin. For Indexed DB or local storage an origin is a combination of protocol + hostname. For example, "<code>http://mozilla.org</code>" and "<code>https://mozilla.org</code>" are two different origins so local storage items cannot be shared between them.</p>
 
 <p>Under "Cache Storage", objects are organized by origin and then by the name of the cache:</p>
 


### PR DESCRIPTION
It seems that https://github.com/mdn/content/commit/9917877 (PR https://github.com/mdn/content/pull/618) inadvertently changed a URL that intentionally used an `http` scheme rather than `https`.

This changes it back to what it should be.

Fixes https://github.com/mdn/content/issues/6692