### PR TITLE
Un-link the word “instantiating” in “Working with objects” doc

### DIFF
--- a/files/en-us/web/javascript/reference/classes/index.html
+++ b/files/en-us/web/javascript/reference/classes/index.html
@@ -127,7 +127,7 @@ console.log([...pentagon.getSides()]); // [1,2,3,4,5]</pre>
 
 <h3 id="Static_methods_and_properties">Static methods and properties</h3>
 
-<p>The {{jsxref("Classes/static", "static", "", "true")}} keyword defines a static method or property for a class. Static members (properties and methods) are called without <a href="/en-US/docs/Learn/JavaScript/Objects#the_object_(class_instance)" title='An example of class instance is "var john = new Person();"'>instantiating </a>their class and <strong>cannot</strong> be called through a class instance. Static methods are often used to create utility functions for an application, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.</p>
+<p>The {{jsxref("Classes/static", "static", "", "true")}} keyword defines a static method or property for a class. Static members (properties and methods) are called without instantiating their class and <strong>cannot</strong> be called through a class instance. Static methods are often used to create utility functions for an application, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.</p>
 
 <pre class="brush: js">class Point {
   constructor(x, y) {


### PR DESCRIPTION
This change removes a broken link to an anchor for an article section
which no longer exists. It’s anyway an unnecessary link, since we use
the word “instantiat(e|ing)” in plenty of other places in the docs,
without it being hypertext.

Fixes https://github.com/mdn/content/issues/6696