### PR TITLE
Remove useless * to indicate existence of a note

### DIFF
--- a/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
+++ b/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
@@ -130,11 +130,11 @@ tags:
 
 <h3 id="Use_modern_JS_features">Use modern JS features</h3>
 
-<p>For general usage*, you can use modern well-supported JS features (such as <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/const">const</a></code>, <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, and <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax">spread syntax</a>) in MDN examples. We include them in many places in these guidelines, as we believe the web industry has generally gotten to the point where such features are familiar enough to be understandable. And for those that don't use them yet, we'd like to play our part in helping people to evolve their skills.</p>
+<p>For general usage, you can use modern well-supported JS features (such as <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/const">const</a></code>, <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, and <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax">spread syntax</a>) in MDN examples. We include them in many places in these guidelines, as we believe the web industry has generally gotten to the point where such features are familiar enough to be understandable. And for those that don't use them yet, we'd like to play our part in helping people to evolve their skills.</p>
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>* By "general usage", we mean general example writing. Reference pages covering specific JS features obviously need to use the features they are documenting!</p>
+  <p>By "general usage", we mean general example writing. Reference pages covering specific JS features obviously need to use the features they are documenting!</p>
 </div>
 
 <h2 id="Variables">Variables</h2>


### PR DESCRIPTION
_*_ was used to link to a note. But there is no link to the note (anymore?), and the note is in a notecard just below the paragraph.

The stars are useless.