### PR TITLE
Updating examples in "Inheritance and the prototype chain"

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -386,9 +386,6 @@ console.log(Object.getPrototypeOf(g).hasOwnProperty('addVertex'));
 
 <pre class="brush: js">
 function foo(){}
-foo.prototype = {
-  foo_prop: "foo val"
-};
 foo.prototype.foo_prop = "foo val";
 function bar(){}
 var proto = new foo();

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -389,11 +389,12 @@ function foo(){}
 foo.prototype = {
   foo_prop: "foo val"
 };
+foo.prototype.foo_prop = "foo val";
 function bar(){}
-var proto = new foo;
+var proto = new foo();
 proto.bar_prop = "bar val";
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop);
 </pre>
@@ -417,25 +418,21 @@ console.log(inst.bar_prop);
 <pre class="brush: js">
 // Technique 1
 function foo(){}
-foo.prototype = {
-  foo_prop: "foo val"
-};
+foo.prototype.foo_prop = "foo val";
 function bar(){}
 var proto = Object.create(
   foo.prototype
 );
 proto.bar_prop = "bar val";
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop);
 </pre>
 <pre class="brush: js">
 // Technique 2
 function foo(){}
-foo.prototype = {
-  foo_prop: "foo val"
-};
+foo.prototype.foo_prop = "foo val";
 function bar(){}
 var proto = Object.create(
   foo.prototype,
@@ -446,7 +443,7 @@ var proto = Object.create(
   }
 );
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop)</pre>
 <table class="standard-table">
@@ -466,9 +463,7 @@ console.log(inst.bar_prop)</pre>
 <pre class="brush: js">
 // Technique 1
 function foo(){}
-foo.prototype = {
-  foo_prop: "foo val"
-};
+foo.prototype.foo_prop = "foo val";
 function bar(){}
 var proto = {
   bar_prop: "bar val"
@@ -477,24 +472,22 @@ Object.setPrototypeOf(
   proto, foo.prototype
 );
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop);
 </pre>
 <pre class="brush: js">
 // Technique 2
 function foo(){}
-foo.prototype = {
-  foo_prop: "foo val"
-};
+foo.prototype.foo_prop = "foo val";
 function bar(){}
 var proto;
-proto=Object.setPrototypeOf(
+proto = Object.setPrototypeOf(
   { bar_prop: "bar val" },
   foo.prototype
 );
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop)</pre>
 <table class="standard-table">
@@ -514,16 +507,14 @@ console.log(inst.bar_prop)</pre>
 <pre class="brush: js">
 // Technique 1
 function A(){}
-A.prototype = {
-  foo_prop: "foo val"
-};
+A.prototype.foo_prop = "foo val";
 function bar(){}
 var proto = {
   bar_prop: "bar val",
   __proto__: A.prototype
 };
 bar.prototype = proto;
-var inst = new bar;
+var inst = new bar();
 console.log(inst.foo_prop);
 console.log(inst.bar_prop);
 </pre>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There were few instances where a new object was assigned to the prototype property of a function. This is not a good approach. Instead, in order to add a new property, it should be added to the existing prototype of the function.
For example, 
foo.prototype = {
  foo_prop: "foo val"
};
should be
foo.prototype.foo_prop = "foo val";

Also, in some places, the constructor function was not being called while being initialized with the new keyword.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
This is in continuation to another PR (#6751)