### PR TITLE
Some CSS related release notes for 91

### DIFF
--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -21,7 +21,16 @@ tags:
 
 <h3 id="CSS">CSS</h3>
 
+<ul>
+  <li>A fix to how the {{cssxref("@counter-style/pad")}} descriptor handles the negative sign ({{bug(1714445)}}).</li>
+  <li>The <code>-moz-tab-size</code> property has been unprefixed to the standard {{cssxref("tab-size")}}, and the prefixed version maintained as an alias ({{bug(737785)}}).</li>
+</ul>
+
 <h4 id="removals_css">Removals</h4>
+
+<ul>
+  <li>THe non-standard {{cssxref("-moz-outline-radius")}} property has been removed ({{bug(1715984)}}). The property has not been usable by web developers since Firefox 88, this completes the removal.</li>
+</ul>
 
 <h3 id="JavaScript">JavaScript</h3>
 

--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -29,7 +29,7 @@ tags:
 <h4 id="removals_css">Removals</h4>
 
 <ul>
-  <li>THe non-standard {{cssxref("-moz-outline-radius")}} property has been removed ({{bug(1715984)}}). The property has not been usable by web developers since Firefox 88, this completes the removal.</li>
+  <li>The non-standard {{cssxref("-moz-outline-radius")}} property has been removed ({{bug(1715984)}}). The property has not been usable by web developers since Firefox 88, this completes the removal.</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>


### PR DESCRIPTION
Fixes: #6724 
Fixes: #6719 

Also adds details of the unprefixing of `tab-size`.
