### PR TITLE
fix fetch_metadata_request_header

### DIFF
--- a/files/en-us/glossary/fetch_metadata_request_header/index.html
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>A <strong>fetch metadata request header</strong> is an {{Glossary("Request header", "HTTP request header")}} that provides additional information about the context from which the request originated. This allows the server to make decisions about whether a request should be allowed based on where the request came from and how the resource will be used.</p>
 
-<p>With this information a server can implement a {{Glossary("resource isolation policy")}}, allowing external sites to request only those resources that are intended for sharing, and that are used appropriately. This approach can help mitigate common cross-site web vulnerabilities such as {{Glossary("CSRF")}}, {{Glossary("Cross-site_scripting","Cross-site scripting ('XSSI') attacks")}}, timing attacks, and cross-origin information leaks.</p>
+<p>With this information a server can implement a {{Glossary("resource isolation policy")}}, allowing external sites to request only those resources that are intended for sharing, and that are used appropriately. This approach can help mitigate common cross-site web vulnerabilities such as {{Glossary("CSRF")}}, Cross-site Script Inclusion('XSSI'), timing attacks, and cross-origin information leaks.</p>
 
 <p>These headers are prefixed with <code>Sec-</code>, and hence have {{Glossary("Forbidden header name", "forbidden header names")}}. As such, they cannot be modified from JavaScript.</p>
 


### PR DESCRIPTION
I think the explanation is wrong.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)  

Fetch_metadata_request_header is a countermeasure for XSSI.  
https://web.dev/fetch-metadata/

XSSI is "cross-site script inclusion", it's not XSS.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
