### PR TITLE
Fix typo in /HTML/Introduction_to_HTML/The_head_metadata_in_HTML

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
@@ -138,7 +138,7 @@ started with developing web sites and applications."&gt;</pre>
 
 <ol>
  <li>Go to the <a href="/en-US/">front page of The Mozilla Developer Network</a>.</li>
- <li>View the page's source (Right/<kbd>Ctrl</kbd> + click on the page, choose <em>View Page Source</em> from the context menu.)</li>
+ <li>View the page's source (Right click on the page, choose <em>View Page Source</em> from the context menu.)</li>
  <li>Find the description meta tag. It will look something like this (although it may change over time):
   <pre class="brush: html">&lt;meta name="description" content="The MDN Web Docs site
   provides information about Open Web technologies

--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
@@ -138,7 +138,7 @@ started with developing web sites and applications."&gt;</pre>
 
 <ol>
  <li>Go to the <a href="/en-US/">front page of The Mozilla Developer Network</a>.</li>
- <li>View the page's source (Right click on the page, choose <em>View Page Source</em> from the context menu.)</li>
+ <li>View the page's source (Right click on the page, choose <em>View Page Source</em> from the context menu).</li>
  <li>Find the description meta tag. It will look something like this (although it may change over time):
   <pre class="brush: html">&lt;meta name="description" content="The MDN Web Docs site
   provides information about Open Web technologies
@@ -150,12 +150,12 @@ started with developing web sites and applications."&gt;</pre>
  </li>
 </ol>
 
-<div class="note">
-<p><strong>Note</strong>: In Google, you will see some relevant subpages of MDN Web Docs listed below the main homepage link — these are called sitelinks, and are configurable in <a href="https://www.google.com/webmasters/tools/">Google's webmaster tools</a> — a way to make your site's search results better in the Google search engine.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> In Google, you will see some relevant subpages of MDN Web Docs listed below the main homepage link — these are called sitelinks, and are configurable in <a href="https://www.google.com/webmasters/tools/">Google's webmaster tools</a> — a way to make your site's search results better in the Google search engine.</p>
 </div>
 
-<div class="note">
-<p><strong>Note</strong>: Many <code>&lt;meta&gt;</code> features just aren't used any more. For example, the keyword <code>&lt;meta&gt;</code> element (<code>&lt;meta name="keywords" content="fill, in, your, keywords, here"&gt;</code>) — which is supposed to provide keywords for search engines to determine relevance of that page for different search terms — is ignored by search engines, because spammers were just filling the keyword list with hundreds of keywords, biasing results.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> Many <code>&lt;meta&gt;</code> features just aren't used any more. For example, the keyword <code>&lt;meta&gt;</code> element (<code>&lt;meta name="keywords" content="fill, in, your, keywords, here"&gt;</code>) — which is supposed to provide keywords for search engines to determine relevance of that page for different search terms — is ignored by search engines, because spammers were just filling the keyword list with hundreds of keywords, biasing results.</p>
 </div>
 
 <h3 id="Other_types_of_metadata">Other types of metadata</h3>
@@ -214,7 +214,7 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."&gt;
 
 <p>Don't worry too much about implementing all these types of icon right now — this is a fairly advanced feature, and you won't be expected to have knowledge of this to progress through the course. The main purpose here is to let you know what such things are, in case you come across them while browsing other websites' source code.</p>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note:</strong> If your site uses a Content Security Policy (CSP) to enhance its security, the policy applies to the favicon. If you encounter problems with the favicon not loading, verify that the {{HTTPHeader("Content-Security-Policy")}} header's <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src"><code>img-src</code> directive</a> is not preventing access to it.</p>
 </div>
 
@@ -256,8 +256,8 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."&gt;
  <li>The CSS has caused the background to go green, and the text to become bigger. It has also styled some of the content that the JavaScript has added to the page (the red bar with the black border is the styling the CSS has added to the JS-generated list.)</li>
 </ul>
 
-<div class="note">
-<p><strong>Note</strong>: If you get stuck in this exercise and can't get the CSS/JS to apply, try checking out our <a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/the-html-head/css-and-js.html">css-and-js.html</a> example page.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> If you get stuck in this exercise and can't get the CSS/JS to apply, try checking out our <a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/the-html-head/css-and-js.html">css-and-js.html</a> example page.</p>
 </div>
 
 <h2 id="Setting_the_primary_language_of_the_document">Setting the primary language of the document</h2>


### PR DESCRIPTION
Removed the "<kbd>Ctrl</kbd>" tag as the instruction doesn't add meaning to opening a page source code

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The "<kbd>Ctrl</kbd>" that was added to the steps to follow when opening or viewing a page source code, doesn't perform the  task it was meant for, and removing it would stop the learner or reader from being confused.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
