### PR TITLE
Fix or simplify location and navigator syntax and examples

### DIFF
--- a/files/en-us/web/api/navigator/buildid/index.html
+++ b/files/en-us/web/api/navigator/buildid/index.html
@@ -24,7 +24,7 @@ browser-compat: api.Navigator.buildID
 
 <h2 id="Example">Example</h2>
 
-<pre class="eval">console.log(window.navigator.buildID);</pre>
+<pre class="eval">console.log(navigator.buildID);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/navigator/oscpu/index.html
+++ b/files/en-us/web/api/navigator/oscpu/index.html
@@ -73,7 +73,7 @@ browser-compat: api.Navigator.oscpu
 <h2 id="Example">Example</h2>
 
 <pre class="brush: js">function osInfo() {
-  alert(window.navigator.oscpu);
+  alert(navigator.oscpu);
 }
 
 osInfo(); // alerts "Windows NT 6.0" for example

--- a/files/en-us/web/api/navigator/productsub/index.html
+++ b/files/en-us/web/api/navigator/productsub/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Navigator.productSub
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>prodSub</em> = window.navigator.productSub</pre>
+<pre class="brush: js"><em>prodSub</em> = navigator.productSub</pre>
 
 <ul>
   <li><code>prodSub</code> is a string.</li>
@@ -28,7 +28,7 @@ browser-compat: api.Navigator.productSub
 <pre class="brush:js">&lt;script&gt;
 function prodsub() {
   var dt = document.getElementById("d").childNodes[0];
-  dt.data = window.navigator.productSub;
+  dt.data = navigator.productSub;
 }
 &lt;/script&gt;
 

--- a/files/en-us/web/api/navigator/vendor/index.html
+++ b/files/en-us/web/api/navigator/vendor/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Navigator.vendor
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="eval"><em>venString</em> = window.navigator.vendor
+<pre class="eval"><em>venString</em> = navigator.vendor
 </pre>
 
 <h3 id="Parameters">Value</h3>

--- a/files/en-us/web/api/navigator/vendorsub/index.html
+++ b/files/en-us/web/api/navigator/vendorsub/index.html
@@ -16,7 +16,7 @@ browser-compat: api.Navigator.vendorSub
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>venSub</var> = window.navigator.vendorSub
+<pre class="brush: js"><var>venSub</var> = navigator.vendorSub
 </pre>
 
 <h3 id="Value">Value</h3>

--- a/files/en-us/web/api/navigator/vibrate/index.html
+++ b/files/en-us/web/api/navigator/vibrate/index.html
@@ -23,7 +23,7 @@ browser-compat: api.Navigator.vibrate
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>successBool</em> = window.navigator.vibrate(<em><var>pattern</var></em>);
+<pre class="brush: js">var <em>successBool</em> = navigator.vibrate(<em><var>pattern</var></em>);
 </pre>
 
 <dl>
@@ -40,8 +40,8 @@ browser-compat: api.Navigator.vibrate
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">window.navigator.vibrate(200); // vibrate for 200ms
-window.navigator.vibrate([100,30,100,30,100,30,200,30,200,30,200,30,100,30,100,30,100]); // Vibrate 'SOS' in Morse.
+<pre class="brush: js">navigator.vibrate(200); // vibrate for 200ms
+navigator.vibrate([100,30,100,30,100,30,200,30,200,30,200,30,100,30,100,30,100]); // Vibrate 'SOS' in Morse.
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/hash/index.html
+++ b/files/en-us/web/api/workerlocation/hash/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.hash
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.hash;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.hash;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/WorkerLocation.hash#example
-var result = window.self.hash; // Returns:'#example'</pre>
+var result = location.hash; // Returns:'#example'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/workerlocation/hash/index.html
+++ b/files/en-us/web/api/workerlocation/hash/index.html
@@ -19,8 +19,8 @@ browser-compat: api.WorkerLocation.hash
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/WorkerLocation.hash#example
-var result = location.hash; // Returns:'#example'</pre>
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web/API/WorkerLocation/hash#examples
+var result = location.hash; // Returns '#examples'</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/workerlocation/host/index.html
+++ b/files/en-us/web/api/workerlocation/host/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.host
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.host;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.host;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.host
-var result = window.self.host; // Returns:'developer.mozilla.org:80'
+var result = location.host; // Returns:'developer.mozilla.org:80'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/host/index.html
+++ b/files/en-us/web/api/workerlocation/host/index.html
@@ -20,7 +20,7 @@ browser-compat: api.WorkerLocation.host
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.host
-var result = location.host; // Returns:'developer.mozilla.org:80'
+var result = location.host; // Returns 'developer.mozilla.org'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/host/index.html
+++ b/files/en-us/web/api/workerlocation/host/index.html
@@ -19,8 +19,8 @@ browser-compat: api.WorkerLocation.host
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.host
-var result = location.host; // Returns 'developer.mozilla.org'
+<pre class="brush: js">// In a Web worker, on the page http://localhost:8080/
+var result = location.host; // Returns 'localhost:8080'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/hostname/index.html
+++ b/files/en-us/web/api/workerlocation/hostname/index.html
@@ -16,12 +16,12 @@ browser-compat: api.WorkerLocation.hostname
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-	class="brush: js"><em>string</em> = <em>object</em>.hostname;</pre>
+	class="brush: js"><em>string</em> = <em>location</em>.hostname;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.hostname
-var result = window.self.hostname; // Returns:'developer.mozilla.org'
+var result = location.hostname; // Returns:'developer.mozilla.org'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/hostname/index.html
+++ b/files/en-us/web/api/workerlocation/hostname/index.html
@@ -20,8 +20,8 @@ browser-compat: api.WorkerLocation.hostname
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.hostname
-var result = location.hostname; // Returns:'developer.mozilla.org'
+<pre class="brush: js">// In a Web worker, on the page http://localhost:8080/
+var result = location.hostname; // Returns 'localhost'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/href/index.html
+++ b/files/en-us/web/api/workerlocation/href/index.html
@@ -19,8 +19,8 @@ browser-compat: api.WorkerLocation.href
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = location.href; // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
+var result = location.href; // Returns 'https://developer.mozilla.org/en-US/docs/Web'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/href/index.html
+++ b/files/en-us/web/api/workerlocation/href/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.href
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.href;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.href;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = window.self.href; // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
+var result = location.href; // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/pathname/index.html
+++ b/files/en-us/web/api/workerlocation/pathname/index.html
@@ -19,8 +19,8 @@ browser-compat: api.WorkerLocation.pathname
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.pathname
-var result = location.pathname; // Returns:'/en-US/WorkerLocation.pathname'
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
+var result = location.pathname; // Returns '/en-US/docs/Web'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/pathname/index.html
+++ b/files/en-us/web/api/workerlocation/pathname/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.pathname
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.pathname;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.pathname;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.pathname
-var result = window.self.pathname; // Returns:'/en-US/WorkerLocation.pathname'
+var result = location.pathname; // Returns:'/en-US/WorkerLocation.pathname'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/port/index.html
+++ b/files/en-us/web/api/workerlocation/port/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.port
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.port;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.port;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.port
-var result = window.self.port; // Returns:'80'
+var result = location.port; // Returns:'80'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/port/index.html
+++ b/files/en-us/web/api/workerlocation/port/index.html
@@ -19,8 +19,8 @@ browser-compat: api.WorkerLocation.port
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.port
-var result = location.port; // Returns:'80'
+<pre class="brush: js">// In a Web worker, on the page http://localhost:8080/
+var result = location.port; // Returns '8080'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/protocol/index.html
+++ b/files/en-us/web/api/workerlocation/protocol/index.html
@@ -16,12 +16,12 @@ browser-compat: api.WorkerLocation.protocol
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-	class="brush: js"><em>string</em> = <em>object</em>.protocol;</pre>
+	class="brush: js"><em>string</em> = <em>location</em>.protocol;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = window.self.protocol; // Returns:'https:'
+var result = location.protocol; // Returns:'https:'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/protocol/index.html
+++ b/files/en-us/web/api/workerlocation/protocol/index.html
@@ -20,8 +20,8 @@ browser-compat: api.WorkerLocation.protocol
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = location.protocol; // Returns:'https:'
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
+var result = location.protocol; // Returns 'https:'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/search/index.html
+++ b/files/en-us/web/api/workerlocation/search/index.html
@@ -19,7 +19,7 @@ browser-compat: api.WorkerLocation.search
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/WorkerLocation.href?t=67
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web?t=67
 var result = location.search; // Returns:'?t=67'
 </pre>
 

--- a/files/en-us/web/api/workerlocation/search/index.html
+++ b/files/en-us/web/api/workerlocation/search/index.html
@@ -15,12 +15,12 @@ browser-compat: api.WorkerLocation.search
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>string</em> = <em>object</em>.search;</pre>
+<pre class="brush: js"><em>string</em> = <em>location</em>.search;</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/WorkerLocation.href?t=67
-var result = window.self.search; // Returns:'?t=67'
+var result = location.search; // Returns:'?t=67'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/workerlocation/tostring/index.html
+++ b/files/en-us/web/api/workerlocation/tostring/index.html
@@ -16,12 +16,12 @@ browser-compat: api.WorkerLocation.toString
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>string</em> = <em>object</em>.toString();</pre>
+  class="brush: js"><em>string</em> = <em>location</em>.toString();</pre>
 
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = window.self.toString(); // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
+var result = location.toString(); // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
 </pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/workerlocation/tostring/index.html
+++ b/files/en-us/web/api/workerlocation/tostring/index.html
@@ -20,8 +20,8 @@ browser-compat: api.WorkerLocation.toString
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/WorkerLocation.href
-var result = location.toString(); // Returns:'https://developer.mozilla.org/en-US/WorkerLocation.href'
+<pre class="brush: js">// In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
+var result = location.toString(); // Returns 'https://developer.mozilla.org/en-US/docs/Web'
 </pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/workernavigator/connection/index.html
+++ b/files/en-us/web/api/workernavigator/connection/index.html
@@ -21,7 +21,7 @@ browser-compat: api.WorkerNavigator.connection
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>connectionInfo</em> = self.navigator.connection</pre>
+  class="brush: js"><em>connectionInfo</em> = navigator.connection</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/workernavigator/index.html
+++ b/files/en-us/web/api/workernavigator/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WorkerNavigator
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <code><strong>WorkerNavigator</strong></code> interface represents a subset of the {{DOMxRef("Navigator")}} interface allowed to be accessed from a {{DOMxRef("Worker")}}. Such an object is initialized for each worker and is available via the {{DOMxRef("WorkerGlobalScope.navigator")}} property obtained by calling <code>self.navigator</code>.</p>
+<p>The <code><strong>WorkerNavigator</strong></code> interface represents a subset of the {{DOMxRef("Navigator")}} interface allowed to be accessed from a {{DOMxRef("Worker")}}. Such an object is initialized for each worker and is available via the {{DOMxRef("WorkerGlobalScope.navigator", "self.navigator")}} property.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/workernavigator/permissions/index.html
+++ b/files/en-us/web/api/workernavigator/permissions/index.html
@@ -21,7 +21,7 @@ browser-compat: api.WorkerNavigator.permissions
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>permissionsObj</em> = self.permissions
+<pre class="brush: js"><em>permissionsObj</em> = navigator.permissions
 </pre>
 
 <h2 id="Value">Value</h2>
@@ -30,7 +30,7 @@ browser-compat: api.WorkerNavigator.permissions
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">self.navigator.permissions.query({name:'notifications'}).then(function(result) {
+<pre class="brush: js">navigator.permissions.query({name:'notifications'}).then(function(result) {
   if (result.state === 'granted') {
     showNotification();
   } else if (result.state === 'prompt') {

--- a/files/en-us/web/api/workernavigator/serial/index.html
+++ b/files/en-us/web/api/workernavigator/serial/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WorkerNavigator.serial
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">var <var>serialObj</var> = self.navigator.serial;</pre>
+<pre class="syntaxbox">var <var>serialObj</var> = navigator.serial;</pre>
 
 <h3>Value</h3>
 <p>A {{domxref("Serial")}} object.</p>
@@ -26,7 +26,7 @@ browser-compat: api.WorkerNavigator.serial
 
 <p>The following example uses the <code>getPorts()</code> method to initialize a list of available ports.</p>
 
-<pre class="brush: js notranslate">self.navigator.serial.getPorts()
+<pre class="brush: js notranslate">navigator.serial.getPorts()
 .then((ports) => {
   // Initialize the list of available ports.
 });</pre>


### PR DESCRIPTION
Many of the example were plainly wrong, with broken code like
self.permissions or window.self.hash suggested. Other examples just
unnecessarily included window instead of directly accessing the
navigator object, which isn't wrong but makes the code only work in
a window context where it would otherwise also work in workers.