### PR TITLE
Fix audioworklet example to use GitHub page instead of Glitch

### DIFF
--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
@@ -38,14 +38,11 @@ tags:
 
 <p>Throughout the remainder of this article, we'll look at these steps in more detail, with examples (including working examples you can try out on your own).</p>
 
-<p>The example code found on this page is derived from <a href="https://glitch.com/~audioworkletnode-sample">this working example</a> which is available on <a href="https://glitch.me/">Glitch</a>. The example creates an oscillator node and adds white noise to it using an {{domxref("AudioWorkletNode")}} before playing the resulting sound out. Slider controls are available to allow controlling the gain of both the oscillator and the audio worklet's output.</p>
+<p>The example code found on this page is derived from <a href="https://mdn.github.io/webaudio-examples/audioworklet/">this working example</a> which is part of MDN's <a href="https://github.com/mdn/webaudio-examples/">GitHub repository of Web Audio examples</a>. The example creates an oscillator node and adds white noise to it using an {{domxref("AudioWorkletNode")}} before playing the resulting sound out. Slider controls are available to allow controlling the gain of both the oscillator and the audio worklet's output.</p>
 
+<p><a href="https://github.com/mdn/webaudio-examples/tree/master/audioworklet"><strong>See the code</strong></a></p>
 
-<p><a href="https://glitch.com/~audioworkletnode-sample"><strong>Glitch Project Page</strong></a></p>
-
-<p><a href="https://glitch.com/edit/#!/audioworkletnode-sample"><strong>See the Code</strong></a></p>
-
-<p><a href="https://audioworkletnode-sample.glitch.me/"><strong>Try it Live</strong></a></p>
+<p><a href="https://mdn.github.io/webaudio-examples/audioworklet/"><strong>Try it live</strong></a></p>
 
 <h2 id="Creating_an_audio_worklet_processor">Creating an audio worklet processor</h2>
 


### PR DESCRIPTION
Fix for https://github.com/mdn/content/issues/6426.

Now we have the example running in a GitHub page (https://github.com/mdn/webaudio-examples/pull/50) we can update the MDN to to refer to that instead of the broken Glitch example.
