### PR TITLE
removed redundancy

### DIFF
--- a/files/en-us/mdn/contribute/open_source_etiquette/index.html
+++ b/files/en-us/mdn/contribute/open_source_etiquette/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>If you've not worked on an open source project (OSP) before, it is a good idea to read this article before starting to contribute to MDN (or other open source projects). There are a few best practices to adopt that will help ensure that you and the other project contributors feel valued and safe, and stay productive.</p>
 
-<p>This article won't teach you everything about contributing to open source; the aim here is more to give you some good starting points to think about and learn more about as you get started with open source contributions.</p>
+<p>This article won't teach you everything about contributing to open source; the aim here is more to give you some good starting points to think about as you get started with open source contributions.</p>
 
 <h2 id="think_about_why_you_are_contributing_to_an_osp">Think about why you are contributing to an OSP</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The original was redundant. It's difficult to think without learning and it's impossible to learn without thinking. We gain nothing substantial by being told about both. English idiom favors the weaker concept of **thinking** over **learning** since it's at least conceivable to some that we can do the former without the latter.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
No