### PR TITLE
made concise

### DIFF
--- a/files/en-us/mdn/contribute/open_source_etiquette/index.html
+++ b/files/en-us/mdn/contribute/open_source_etiquette/index.html
@@ -78,7 +78,7 @@ tags:
 
 <h2 id="choose_impactful_contributions">Choose impactful contributions</h2>
 
-<p>Think about what you want to do on the project. For example, we have a large list of issues filed at <a href="https://github.com/mdn/content/issues">https://github.com/mdn/content/issues</a>, broken up by various GitHub labels into estimated time to fix, technology categories, and more. Another good label to look for is "good first issue", which is generally given to issues that are quite simple and good for beginners to the project to get started with. We are also soon going to start triaging our issues more extensively, by adding other labels such as priority indicators. Try picking some issues that you think you can manage OK with the time you have available, and ask to be assigned to them.</p>
+<p>Think about what you want to do on the project. For example, we have a large list of issues filed at <a href="https://github.com/mdn/content/issues">https://github.com/mdn/content/issues</a>, broken up by various GitHub labels into estimated time to fix, technology categories, and more. Another good label to look for is "good first issue", which is generally given to issues that are quite simple and good for beginners to get started with. We are also soon going to start triaging our issues more extensively, by adding other labels such as priority indicators. Try picking some issues that you think you can manage with the time you have available, and ask to be assigned to them.</p>
 
 <p>You could also contribute by opening pull requests to fix problems that you come across while reading MDN articles.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
1) The phrase, "**to the project**" is superfluous. It also adds clunkiness to the sentence because of all the "**to**"s.
2) The term "**OK**" is redundant. It adds nothing to the meaning of "**manage**" and instead disrupts the flow of words.