### PR TITLE
improved phrasing

### DIFF
--- a/files/en-us/mdn/contribute/open_source_etiquette/index.html
+++ b/files/en-us/mdn/contribute/open_source_etiquette/index.html
@@ -91,7 +91,7 @@ tags:
   <li>Help to mentor people that are trying to make fixes.</li>
 </ul>
 
-<p>Every fix is useful, no matter how small, and we won't turn any fix away. Saying that however, try to make sure your fixes are productive. We'd like to advise against these kinds of contributions:</p>
+<p>Every fix is useful, no matter how small, and we won't turn any fix away. Nevertheless, try to make sure your fixes are productive. We'd like to advise against these kinds of contributions:</p>
 
 <ul>
   <li>Updating code styling just because "you like that style better".</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Modern usage dictates that the term **however**, when used as an **adverb**, be separated from the surrounding phrase/clause by commas.

In any case, the phrase "**saying that**" disposes a reader to _expect_ (future) information about what is said. And that's not what the phrase is doing here. For example, "Saying that roses are red is a common way to begin a doggerel."
