### PR TITLE
added conciseness, fixed grammar, improved clarity

### DIFF
--- a/files/en-us/mdn/contribute/open_source_etiquette/index.html
+++ b/files/en-us/mdn/contribute/open_source_etiquette/index.html
@@ -148,11 +148,11 @@ tags:
 
 <h2 id="be_patient_be_timely">Be patient, be timely</h2>
 
-<p>Bear in mind that many people working on OSPs are doing it in their own time, without payment, and all people working on OSPs are generally very busy. If you are waiting for something like a pull request review, or an answer to a question, be patient.</p>
+<p>Bear in mind that many people working on OSPs are doing it in their free time, without payment, and all people working on OSPs are generally very busy. If you are waiting for something like a pull request review, or an answer to a question, be patient.</p>
 
-<p>It is reasonable to wait a few days and then ping someone politely to ask if they've had time to look at it, and maybe follow up again after a week has passed to ask if they are too busy right now.</p>
+<p>It is reasonable to wait a few days and then ping someone politely to ask if they've had time to look at it. If they happen to be too busy, it may be best to wait a further week and try following up with them then.</p>
 
-<p>It is NOT reasonable to start demanding things, like you are owed a quick reply. You are not.</p>
+<p>It is NOT reasonable to start demanding things, like a quick reply. You are not.</p>
 
 <p>If someone is waiting for you to do something for them, you should be extended the same courtesy, but at the same time, try to respond as promptly as you can. If you really can't find the time, let them know, and ask the maintainers to help you find someone else to do the task.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

1) The phrase, "**to ask**" is a redundancy of "**follow up**". When we follow up with someone, we ask them something.
2) The conditional clause "**they are too busy right now**" refers to an obscure time. What is meant by "**right now**"?
3) The clause, "**you are owed a quick reply**" is a statement (or proposition). Statements are not really things we ordinarily demand. By contrast, "**a quick reply**" _is_ a thing we might ordinarily demand.
