### PR TITLE
Add `::-ms-browse` as an older syntax for `::file-selector-button`

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9906,6 +9906,7 @@
 /en-US/docs/Web/CSS/:-webkit-autofill	/en-US/docs/Web/CSS/:autofill
 /en-US/docs/Web/CSS/::-moz-placeholder	/en-US/docs/Web/CSS/::placeholder
 /en-US/docs/Web/CSS/::-moz-selection	/en-US/docs/Web/CSS/::selection
+/en-US/docs/Web/CSS/::-ms-browse	/en-US/docs/Web/CSS/::file-selector-button
 /en-US/docs/Web/CSS/::-webkit-file-upload-button	/en-US/docs/Web/CSS/::file-selector-button
 /en-US/docs/Web/CSS/::-webkit-input-placeholder	/en-US/docs/Web/CSS/::placeholder
 /en-US/docs/Web/CSS/::-webkit-resizer	/en-US/docs/Web/CSS/::-webkit-scrollbar

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.html
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.html
@@ -17,9 +17,9 @@ browser-compat: css.selectors.file-selector-button
 <div class="notecard note">
 <p>Older versions of WebKit/Blink compatible browsers like Chrome, Opera and Safari (indicated by the <code>-webkit</code> prefix) supported a non-standard pseudo-element <code>::-webkit-file-upload-button</code>.</p>
 
-<p>Legacy Edge and later versions of IE supported a non-standard pseudo-element <code>::-ms-browse</code></p>
+<p>Legacy Edge and later versions of IE supported a non-standard pseudo-element <code>::-ms-browse</code>.</p>
 
-<p>Both of these pseudo-elements serve the same purpose as <code>::file-selector-button</code></p>
+<p>Both of these pseudo-elements serve the same purpose as <code>::file-selector-button</code>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.html
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.html
@@ -15,7 +15,11 @@ browser-compat: css.selectors.file-selector-button
 <p>The <strong><code>::file-selector-button</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> represents the button of an {{HTMLElement("input") }} of  <code><a href="/en-US/docs/Web/HTML/Element/input/file">type="file"</a></code>.</p>
 
 <div class="notecard note">
-<p>Older versions of WebKit/Blink compatible browsers like Chrome, Opera and Safari (indicated by the <code>-webkit</code> prefix) supported a non-standard pseudo-class <code>::-webkit-file-upload-button</code> which serves the same purpose.</p>
+<p>Older versions of WebKit/Blink compatible browsers like Chrome, Opera and Safari (indicated by the <code>-webkit</code> prefix) supported a non-standard pseudo-element <code>::-webkit-file-upload-button</code>.</p>
+
+<p>Legacy Edge and later versions of IE supported a non-standard pseudo-element <code>::-ms-browse</code></p>
+
+<p>Both of these pseudo-elements serve the same purpose as <code>::file-selector-button</code></p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -63,7 +67,7 @@ input[type=file]::file-selector-button:hover {
 
 <p>{{EmbedLiveSample("basic_example", "100%", 150)}}</p>
 
-<p>Example with fallback for older browsers supporting the <code>-webkit</code> prefix. Note that as a selector you will need to write out the whole code block twice, as an unrecognized selector invalidates the whole list.</p>
+<p>Example with fallback for older browsers supporting the <code>-webkit</code> and <code>-ms</code> prefixes. Note that as a selector you will need to write out the whole code block twice, as an unrecognized selector invalidates the whole list.</p>
 
 <p>Note that <code>::file-selector-button</code> is a whole element, and as such matches the rules from the UA stylesheet. In particular, fonts and colors won't necessarily inherit from the <code>input</code> element.</p>
 
@@ -86,7 +90,14 @@ input[type=file]::file-selector-button:hover {
 </pre>
 </div>
 
-<pre class="brush: css">input[type=file]::-webkit-file-upload-button {
+<pre class="brush: css">input[type=file]::-ms-browse {
+  border: 2px solid #6c5ce7;
+  padding: .2em .4em;
+  border-radius: .2em;
+  background-color: #a29bfe;
+}
+
+input[type=file]::-webkit-file-upload-button {
   border: 2px solid #6c5ce7;
   padding: .2em .4em;
   border-radius: .2em;
@@ -100,6 +111,11 @@ input[type=file]::file-selector-button {
   border-radius: .2em;
   background-color: #a29bfe;
   transition: 1s;
+}
+
+input[type=file]::-ms-browse:hover {
+  background-color: #81ecec;
+  border: 2px solid #00cec9;
 }
 
 input[type=file]::-webkit-file-upload-button:hover {
@@ -129,6 +145,7 @@ input[type=file]::file-selector-button:hover {
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/WebKit_Extensions">WebKit CSS extensions</a></li>
+ <li><a href="/en-US/docs/Web/CSS/Microsoft_Extensions">Microsoft CSS extensions</a></li>
  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory Entries API</a></li>
  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Firefox_support">File and Directory Entries API support in Firefox</a></li>
  <li><code><a href="/en-US/docs/Web/HTML/Element/input/file">&lt;input type="file"&gt;</a></code></li>

--- a/files/en-us/web/css/microsoft_extensions/index.html
+++ b/files/en-us/web/css/microsoft_extensions/index.html
@@ -73,7 +73,7 @@ tags:
 
 <div class="index">
 <ul>
- <li>{{CSSxRef("::-ms-browse")}}</li>
+ <li>{{CSSxRef("::file-selector-button","::-ms-browse")}}*</li>
  <li>{{CSSxRef("::-ms-check")}}</li>
  <li>{{CSSxRef("::-ms-clear")}}</li>
  <li>{{CSSxRef("::-ms-expand")}}</li>
@@ -89,6 +89,8 @@ tags:
  <li>{{CSSxRef("::-ms-value")}}</li>
 </ul>
 </div>
+
+<p>* Now standard.</p>
 
 <h2 id="Media_features">Media features</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This PR adds a note and example of the `::-ms-browse` pseudo element as an older syntax for the standard `::file-selector-button`.

> Anything else that could help us review it

PR to browser-compat-data to add it as an alternative_name to IE and Edge: https://github.com/mdn/browser-compat-data/pull/11494
