### PR TITLE
Fix typo in “MDN conventions and definitions”

### DIFF
--- a/files/en-us/mdn/guidelines/conventions_definitions/index.html
+++ b/files/en-us/mdn/guidelines/conventions_definitions/index.html
@@ -20,7 +20,7 @@ tags:
 
 <dl>
  <dt>Deprecated</dt>
- <dd>On MDN, the term <strong>deprecated</strong> used to mark an API or technology that is no longer recommended, but is still implemented and may still work. More recently, we've updated it to the definition used in our <a href="https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information">browser-compat-data project</a>, which is that "the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality."</dd>
+ <dd>On MDN, the term <strong>deprecated</strong> is used to mark an API or technology that is no longer recommended, but is still implemented and may still work. More recently, we've updated it to the definition used in our <a href="https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information">browser-compat-data project</a>, which is that "the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality."</dd>
  <dt>Obsolete</dt>
  <dd>On MDN, the term <strong>obsolete</strong> used to mark an API or technology that is not only no longer recommended, but also no longer implemented in browsers. This was however confusing — it is similar to deprecated, and the distinction is not very helpful (you still shouldn't use it in a production site). We are therefore not using it anymore, and any instances you come across should be removed/replaced by deprecated.</dd>
 </dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The word "**is**" was missing.
