### PR TITLE
Make Author lifetime string robust

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
@@ -679,10 +679,16 @@ AuthorSchema
 });
 
 // Virtual for author's lifespan
-AuthorSchema
-</strong>.virtual('lifespan')
-.get(function () {
-  return (this.date_of_death.getYear() - this.date_of_birth.getYear()).toString();
+AuthorSchema.virtual('lifespan').get(function() {
+  var lifetime_string = '';
+  if (this.date_of_birth) {
+    lifetime_string = DateTime.fromJSDate(this.date_of_birth).toLocaleString(DateTime.DATE_MED);
+  }
+  lifetime_string += ' - ';
+  if (this.date_of_death) {
+    lifetime_string += DateTime.fromJSDate(this.date_of_death).toLocaleString(DateTime.DATE_MED)
+  }
+  return lifetime_string;
 });
 
 // Virtual for author's URL


### PR DESCRIPTION
This updates the virtual method for getting author lifetime with the method in the [demo tutorial](https://github.com/mdn/express-locallibrary-tutorial/blob/master/models/author.js#L23), which is more robust (i.e. copes with missing date of birth or death.

> Issue number (if there is an associated issue)

Fixes #6759
