### PR TITLE
Document that <textarea> is display: inline-block

### DIFF
--- a/files/en-us/web/html/element/textarea/index.html
+++ b/files/en-us/web/html/element/textarea/index.html
@@ -108,7 +108,7 @@ browser-compat: html.elements.textarea
 
 <h2 id="Styling_with_CSS">Styling with CSS</h2>
 
-<p><code>&lt;textarea&gt;</code> is a <a href="/en-US/docs/Web/CSS/Replaced_element">replaced element</a> — it has intrinsic dimensions, like a raster image. By default, its {{cssxref("display")}} value is block. Compared to other form elements it is relatively easy to style, with its box model, fonts, color scheme, etc. being easily manipulable using regular CSS.</p>
+<p><code>&lt;textarea&gt;</code> is a <a href="/en-US/docs/Web/CSS/Replaced_element">replaced element</a> — it has intrinsic dimensions, like a raster image. By default, its {{cssxref("display")}} value is <code>inline-block</code>. Compared to other form elements it is relatively easy to style, with its box model, fonts, color scheme, etc. being easily manipulable using regular CSS.</p>
 
 <p><a href="/en-US/docs/Learn/Forms/Styling_web_forms">Styling HTML forms</a> provides some useful tips on styling <code>&lt;textarea&gt;</code>s.</p>
 


### PR DESCRIPTION
Per https://html.spec.whatwg.org/#the-textarea-element-2:

> The `textarea` element is expected to render as an 'inline-block' box depicting a multiline text control.

Fixes https://github.com/mdn/content/issues/6792