### PR TITLE
formatRangeParts: Fix to GMT values and add note

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
@@ -32,8 +32,12 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRangeToParts
 <h3 id="Basic_formatRangeToParts_usage">Basic formatRangeToParts usage</h3>
 
 <p>This method receives two {{jsxref("Date")}}s and returns an {{jsxref("Array")}} of
-	objects containing the locale-specific tokens representing each part of the formatted
-	date range.</p>
+	objects containing the <em>locale-specific</em> tokens representing each part of the formatted date range.</p>
+
+<div class="notecard note">
+	<p><strong>Note:</strong> The return values shown in your locale may differ from those listed below.</p>
+
+</div>
 
 <pre class="brush: js">let date1 = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));
 let date2 = new Date(Date.UTC(2007, 0, 10, 11, 0, 0));
@@ -51,15 +55,15 @@ console.log(fmt.formatRange(date1, date2));
 fmt.formatRangeToParts(date1, date2);
 // return value:
 // [
-//   { type: 'hour',      value: '9',  source: "startRange" },
+//   { type: 'hour',      value: '10',  source: "startRange" },
 //   { type: 'literal',   value: ':',   source: "startRange" },
 //   { type: 'minute',    value: '00',  source: "startRange" },
 //   { type: 'literal',   value: ' – ', source: "shared"     },
-//   { type: 'hour',      value: '10',  source: "endRange"   },
+//   { type: 'hour',      value: '11',  source: "endRange"   },
 //   { type: 'literal',   value: ':',   source: "endRange"   },
 //   { type: 'minute',    value: '00',  source: "endRange"   },
 //   { type: 'literal',   value: ' ',   source: "shared"     },
-//   { type: 'dayPeriod', value: 'PM',  source: "shared"     }
+//   { type: 'dayPeriod', value: 'AM',  source: "shared"     }
 // ]
 </pre>
 
@@ -74,6 +78,6 @@ fmt.formatRangeToParts(date1, date2);
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li>{{jsxref("Intl.DateTimeFormat.prototype.formatRange()")}}</li>
+	<li>{{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}}</li>
 	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
@@ -36,7 +36,6 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRangeToParts
 
 <div class="notecard note">
 	<p><strong>Note:</strong> The return values shown in your locale may differ from those listed below.</p>
-
 </div>
 
 <pre class="brush: js">let date1 = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));


### PR DESCRIPTION
Fixes https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRangeToParts as part of  #6710

Reverts change to return values added in #6841 , replacing them with a note that the values returned my differ by locale. Also fixed broken link to a related function.
