### PR TITLE
Drop duplicated note from “JavaScript guidelines” doc

### DIFF
--- a/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
+++ b/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
@@ -352,11 +352,6 @@ function notVeryObviousName() {
 };
 </pre>
 
-<div class="notecard note">
-  <h4>Note</h4>
-  <p>The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using <code>i</code>, <code>j</code>, etc. for loop iterators.</p>
-</div>
-
 <h3 id="Defining_functions">Defining functions</h3>
 
 <p>Where possible, use the <code>function</code> declaration to define functions over function expressions:</p>


### PR DESCRIPTION
This note is a non sequitur in this context, since the context here is named functions, and the note cites examples of variable names — and also because unlike the case of i, j, etc. for loop iterators, there is no analogous case for named functions; that is, there is no common practice of ever using non-“human-readable” names for named functions.

Fixes https://github.com/mdn/content/issues/6847