### PR TITLE
FF91: DateTimeFormat timeZoneName options

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -252,8 +252,8 @@ new Intl.DateTimeFormat(locales, options)
 			<dt><code>timeZoneName</code></dt>
 			<dd>The localized representation of the time zone name. Possible values are:
 				<ul>
-					<li>"<code>long</code>" Long localised form (e.g., <code>Pacific Standard Time</code>, <code>Nordamerikanische Westküsten-Normalzeit</code>)</li>
-					<li>"<code>short</code>" Short localised form (e.g.: <code>PST</code>, <code>GMT-8</code>)</li>
+					<li>"<code>long</code>" Long localized form (e.g., <code>Pacific Standard Time</code>, <code>Nordamerikanische Westküsten-Normalzeit</code>)</li>
+					<li>"<code>short</code>" Short localized form (e.g.: <code>PST</code>, <code>GMT-8</code>)</li>
 					<li>"<code>shortOffset</code>" Short localized GMT format (e.g., <code>GMT-8</code>)</li>
 					<li>"<code>longOffset</code>" Long localized GMT format (e.g., <code>GMT-0800</code>)</li>
 					<li>"<code>shortGeneric</code>" Short generic non-location format (e.g.: <code>PT</code>, <code>Los Angeles Zeit</code>)</li>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -250,7 +250,7 @@ new Intl.DateTimeFormat(locales, options)
 				</ul>
 			</dd>
 			<dt><code>timeZoneName</code></dt>
-			<dd>The localised representation of the time zone name. Possible values are:
+			<dd>The localized representation of the time zone name. Possible values are:
 				<ul>
 					<li>"<code>long</code>" Long localised form (e.g., <code>Pacific Standard Time</code>, <code>Nordamerikanische Westküsten-Normalzeit</code>)</li>
 					<li>"<code>short</code>" Short localised form (e.g.: <code>PST</code>, <code>GMT-8</code>)</li>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -250,10 +250,14 @@ new Intl.DateTimeFormat(locales, options)
 				</ul>
 			</dd>
 			<dt><code>timeZoneName</code></dt>
-			<dd>The representation of the time zone name. Possible values are:
+			<dd>The localised representation of the time zone name. Possible values are:
 				<ul>
-					<li>"<code>long</code>" (e.g., <code>British Summer Time</code>)</li>
-					<li>"<code>short</code>" (e.g., <code>GMT+1</code>)</li>
+					<li>"<code>long</code>" Long localised form (e.g., <code>Pacific Standard Time</code>, <code>Nordamerikanische Westküsten-Normalzeit</code>)</li>
+					<li>"<code>short</code>" Short localised form (e.g.: <code>PST</code>, <code>GMT-8</code>)</li>
+					<li>"<code>shortOffset</code>" Short localized GMT format (e.g., <code>GMT-8</code>)</li>
+					<li>"<code>longOffset</code>" Long localized GMT format (e.g., <code>GMT-0800</code>)</li>
+					<li>"<code>shortGeneric</code>" Short generic non-location format (e.g.: <code>PT</code>, <code>Los Angeles Zeit</code>)</li>
+					<li>"<code>longGeneric</code>" Long generic non-location format (e.g.: <code>Pacific Time</code>, <code>Nordamerikanische Westküstenzeit</code>)</li>
 				</ul>
 			</dd>
 		</dl>
@@ -314,6 +318,30 @@ console.log(new Intl.DateTimeFormat('fr', { hour: 'numeric', hourCycle: 'h12',
 console.log(new Intl.DateTimeFormat('fr', { hour: 'numeric', hourCycle: 'h12', 
     dayPeriod: 'long', timeZone: 'UTC' }).format(date));
 // > "4 du matin"</pre>
+
+<h3 id="using_dayperiod">Using timeZoneName</h3>
+
+<p>Use the <code>timeZoneName</code> option to output a string for the timezone ("GMT", "Pacific Time", etc.).</p>
+
+<pre class="brush: js">var date = Date.UTC(2021, 11, 17, 3, 0, 42);
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric']
+	
+for (const zoneName of timezoneNames) {
+  // Do something with currentValue
+  var formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    timeZoneName: zoneName,
+  });
+  console.log(zoneName + ": " + formatter.format(date) );
+}
+	
+// expected output: 
+// > "short: 12/16/2021, PST"
+// > "long: 12/16/2021, Pacific Standard Time"
+// > "shortOffset: 12/16/2021, GMT-8"
+// > "longOffset: 12/16/2021, GMT-08:00"
+// > "shortGeneric: 12/16/2021, PT"
+// > "longGeneric: 12/16/2021, Pacific Time"</pre>
 
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -256,9 +256,13 @@ new Intl.DateTimeFormat(locales, options)
 					<li>"<code>short</code>" Short localized form (e.g.: <code>PST</code>, <code>GMT-8</code>)</li>
 					<li>"<code>shortOffset</code>" Short localized GMT format (e.g., <code>GMT-8</code>)</li>
 					<li>"<code>longOffset</code>" Long localized GMT format (e.g., <code>GMT-0800</code>)</li>
-					<li>"<code>shortGeneric</code>" Short generic non-location format (e.g.: <code>PT</code>, <code>Los Angeles Zeit</code>)</li>
+					<li>"<code>shortGeneric</code>" Short generic non-location format (e.g.: <code>PT</code>, <code>Los Angeles Zeit</code>).</li>
 					<li>"<code>longGeneric</code>" Long generic non-location format (e.g.: <code>Pacific Time</code>, <code>Nordamerikanische Westküstenzeit</code>)</li>
 				</ul>
+				<div class="notecard note">
+					<p><strong>Note:</strong> Timezone display may fall back to another format if a required string is unavailable. For example, the non-location formats should display the timezone without a specific country/city location like "Pacific Time", but may fall back to a timezone like "Los Angeles Time".</p>
+
+				</div>
 			</dd>
 		</dl>
 


### PR DESCRIPTION
[Intl.DateTimeFormat() constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) has a number of new options for timeZoneName which were added in  https://bugzilla.mozilla.org/show_bug.cgi?id=1710429.
Info about the addition also in https://github.com/tc39/proposal-intl-extend-timezonename/

This add docs for the option and an example.

This is part of #6710
