### PR TITLE
add Object to the list of types supported by set()

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.storage.StorageArea.set
  <dd>
  <p>An object containing one or more key/value pairs to be stored in storage. If an item already exists, its value will be updated.</p>
 
- <p>Values may be <a href="/en-US/docs/Glossary/Primitive">primitive types</a> (such as numbers, booleans, and strings) or {{jsxref("Array")}} and {{jsxref("Object")}} types.</p>
+ <p>Values can be <a href="/en-US/docs/Glossary/Primitive">primitive</a> (such as a number, boolean, or string), {{jsxref("Array")}}, or {{jsxref("Object")}} types.</p>
 
  <p>It's generally not possible to store other types, such as <code>Function</code>, <code>Date</code>, <code>RegExp</code>, <code>Set</code>, <code>Map</code>, <code>ArrayBuffer</code>, and so on. Some of these unsupported types will restore as an empty object, and some cause <code>set()</code> to throw an error. The exact behavior here is browser-specific.</p>
  </dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.storage.StorageArea.set
  <dd>
  <p>An object containing one or more key/value pairs to be stored in storage. If an item already exists, its value will be updated.</p>
 
- <p>Values may be <a href="/en-US/docs/Glossary/Primitive">primitive types</a> (such as numbers, booleans, and strings) or {{jsxref("Array")}} types.</p>
+ <p>Values may be <a href="/en-US/docs/Glossary/Primitive">primitive types</a> (such as numbers, booleans, and strings) or {{jsxref("Array")}} and {{jsxref("Object")}} types.</p>
 
  <p>It's generally not possible to store other types, such as <code>Function</code>, <code>Date</code>, <code>RegExp</code>, <code>Set</code>, <code>Map</code>, <code>ArrayBuffer</code>, and so on. Some of these unsupported types will restore as an empty object, and some cause <code>set()</code> to throw an error. The exact behavior here is browser-specific.</p>
  </dd>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

[The page says that StorageArea.set method accepts Array types](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set), but does not mention Object types

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it

Quoting from the [storage documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage):

> The values stored can be any JSON-ifiable value, not just String. Among other things, this includes: Array and Object