### PR TITLE
Adds missing MIDIConnectionEvent pages

### DIFF
--- a/files/en-us/web/api/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/index.html
@@ -11,9 +11,9 @@ tags:
   - Web MIDI API
 browser-compat: api.MIDIConnectionEvent
 ---
-<p>{{APIRef("Web MIDI API")}}{{SeeCompatTable}}</p>
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p>The <strong><code>MIDIConnectionEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_MIDI_API">Web MIDI API</a> is the event passed to the {{domxref("MIDIAccess.onstatechange","onstatechange")}} event handler of the {{domxref("MIDIAccess")}} interface and the {{domxref("MIDIPorts.onstatechange","onstatechange")}} event of the {{domxref("MIDIPorts")}} interface. This occurs any time a new port becomes available, or when a previously available port becomes unavailable. For example, this event is fired whenever a MIDI device is either plugged in to or unplugged from a computer.  </p>
+<p>The <strong><code>MIDIConnectionEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_MIDI_API">Web MIDI API</a> is the event passed to the {{domxref("MIDIAccess.onstatechange","onstatechange")}} event handler of the {{domxref("MIDIAccess")}} interface and the {{domxref("MIDIPort.onstatechange","onstatechange")}} event of the {{domxref("MIDIPort")}} interface. This occurs any time a new port becomes available, or when a previously available port becomes unavailable. For example, this event is fired whenever a MIDI device is either plugged in to or unplugged from a computer.  </p>
 
 <h2 id="Constructor">Constructor</h2>
 
@@ -25,11 +25,21 @@ browser-compat: api.MIDIConnectionEvent
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("MIDIConnectionEvent.port")}}</dt>
+ <dt>{{domxref("MIDIConnectionEvent.port")}}{{readonlyinline}}</dt>
  <dd>Returns a reference to a {{domxref("MIDIPort")}} instance for a port that has been connected or disconnected."</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
+
+<p>The {{domxref("Navigator.requestMIDIAccess()")}} method returns a promise that resolves with a {{domxref("MIDIAccess")}} object. When a port changes state, a <code>MIDIConnectionEvent</code> is passed to {{domxref("MIDIAccess.onstatechange")}}, information about the port can then be printed to the console.</p>
+
+<pre class="brush: js">navigator.requestMIDIAccess()
+  .then(function(access) {
+
+     access.onstatechange = function(e) {
+       console.log(e.port.name, e.port.manufacturer, e.port.state);
+     };
+  });</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
@@ -14,14 +14,15 @@ browser-compat: api.MIDIConnectionEvent.MIDIConnectionEvent
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">new MIDIConnectionEvent(type, MIDIConnectionEventInit);</pre>
+<pre class="brush: js">new MIDIConnectionEvent(type);
+new MIDIConnectionEvent(type, MIDIConnectionEventInit);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
 	<dt><code>type</code></dt>
 	<dd>A {{domxref("DOMString")}} with one of <code>"connect"</code> or <code>"disconnect"</code>.</dd>
-	<dt><code>MIDIConnectionEventInit</code></dt>
+	<dt><code>MIDIConnectionEventInit</code>{{Optional_Inline}}</dt>
   <dd>A dictionary including the following fields:
     <dl>
       <dt><code>port</code></dt>

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
@@ -1,0 +1,49 @@
+---
+title: MIDIConnectionEvent.MIDIConnectionEvent()
+slug: Web/API/MIDIConnectionEvent/MIDIConnectionEvent
+tags:
+  - API
+  - Constructor
+  - Reference
+  - MIDIConnectionEvent
+browser-compat: api.MIDIConnectionEvent.MIDIConnectionEvent
+---
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
+
+<p class="summary">The <strong><code>MIDIConnectionEvent()</code></strong> constructor creates a new {{domxref("MIDIConnectionEvent")}} object. Typically this constructor is not used as events are created when a new port becomes available, and the object is passed to the {{domxref("MIDIAccess.onstagechange")}} event handler.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">new MIDIConnectionEvent(type, MIDIConnectionEventInit);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+	<dt><code>type</code></dt>
+	<dd>A {{domxref("DOMString")}} with one of <code>"connect"</code> or <code>"disconnect"</code>.</dd>
+	<dt><code>MIDIConnectionEventInit</code></dt>
+  <dd>A dictionary including the following fields:
+    <dl>
+      <dt><code>port</code></dt>
+      <dd>The {{domxref("MIDIPort")}} instance representing the port that has connected or disconnected.</dd>
+      <dt><code>bubbles</code> {{optional_inline}}</dt>
+      <dd>A {{jsxref("Boolean")}} indicating whether the event bubbles. The default is
+        <code>false</code>.</dd>
+      <dt><code>cancelable</code> {{optional_inline}}</dt>
+      <dd>A {{jsxref("Boolean")}} indicating whether the event can be cancelled. The
+        default is <code>false</code>.</dd>
+      <dt><code>composed</code> {{optional_inline}}</dt>
+      <dd>A {{jsxref("Boolean")}} indicating whether the event will trigger listeners
+        outside of a shadow root (see {{domxref("Event.composed")}} for more details). The
+        default is <code>false</code>.</dd>
+    </dl>
+  </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midiconnectionevent/port/index.html
+++ b/files/en-us/web/api/midiconnectionevent/port/index.html
@@ -22,7 +22,7 @@ browser-compat: api.MIDIConnectionEvent.port
 
 <h2 id="Examples">Examples</h2>
 
-<p>The {{domxref("Navigator.requestMIDIAccess()")}} method returns a promise that resolves with a {{domxref("MIDIAccess")}} object. When a port changes state, a <code>MIDIConnectionEvent</code> is passed to {{domxref("MIDIAccess.onstatechange")}}, information about the port can then be printed to the console.</p>
+<p>The {{domxref("Navigator.requestMIDIAccess()")}} method returns a promise that resolves with a {{domxref("MIDIAccess")}} object. When a port changes state, a <code>MIDIConnectionEvent</code> is passed to {{domxref("MIDIAccess.onstatechange")}}. Information about the port can then be printed to the console.</p>
 
 <pre class="brush: js">navigator.requestMIDIAccess()
   .then(function(access) {
@@ -39,5 +39,4 @@ browser-compat: api.MIDIConnectionEvent.port
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/midiconnectionevent/port/index.html
+++ b/files/en-us/web/api/midiconnectionevent/port/index.html
@@ -1,0 +1,43 @@
+---
+title: MIDIConnectionEvent.port
+slug: Web/API/MIDIConnectionEvent/port
+tags:
+  - API
+  - Property
+  - Reference
+  - port
+  - MIDIConnectionEvent
+browser-compat: api.MIDIConnectionEvent.port
+---
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
+
+<p class="summary">The <strong><code>port</code></strong> read-only property of the {{domxref("MIDIConnectionEvent")}} interface returns the port that has been disconnected or connected.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let port = MIDIConnectionEvent.port;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("MIDIPort")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The {{domxref("Navigator.requestMIDIAccess()")}} method returns a promise that resolves with a {{domxref("MIDIAccess")}} object. When a port changes state, a <code>MIDIConnectionEvent</code> is passed to {{domxref("MIDIAccess.onstatechange")}}, information about the port can then be printed to the console.</p>
+
+<pre class="brush: js">navigator.requestMIDIAccess()
+  .then(function(access) {
+
+     access.onstatechange = function(e) {
+       console.log(e.port.name, e.port.manufacturer, e.port.state);
+     };
+  });</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+


### PR DESCRIPTION
This PR adds the MIDIConnectionEvent subpages. The spec data was included in my PR today to add spec data for all these missing MIDI pages.

Reviewer @jpmedley 