### PR TITLE
Add Web Components to index

### DIFF
--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -33,5 +33,7 @@ tags:
  <dd>Scalable Vector Graphics let you describe images as sets of vectors and shapes in order to allow them to scale smoothly regardless of the size at which they're drawn.</dd>
  <dt><a href="/en-US/docs/Web/MathML">MathML</a></dt>
  <dd>The Mathematical Markup Language makes it possible to display complex mathematical equations and syntax.</dd>
+ <dt><a href="/en-US/docs/Web/Web_Components">Web Components</a></dt>
+ <dd>Web Components are custom elements that you can define and reuse in your apps.</dd>
 </dl>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Web Components are an important web technology but it is not listed in the parent index

https://developer.mozilla.org/en-US/docs/Web
https://developer.mozilla.org/en-US/docs/Web/Web_Components

> Issue number (if there is an associated issue)

> Anything else that could help us review it

Also, shouldn't these urls use hyphens instead of underscores?