### PR TITLE
Remove obsolete note

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -100,13 +100,6 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
         rather than the capturing and bubbling phases.
         Event listeners in the “capturing” phase are called before event listeners in any non-capturing phases.</p>
     </div>
-
-    <div class="notecard note">
-      <h4>Note</h4>
-      <p><code><var>useCapture</var></code> has not
-      always been optional. Ideally, you should include it for the widest possible browser
-      compatibility.</p>
-    </div>
   </dd>
   <dt><code><var>wantsUntrusted</var></code> {{optional_inline}} {{Non-standard_inline}}</dt>
   <dd>A Firefox (Gecko)-specific parameter. If <code>true</code>, the listener receives


### PR DESCRIPTION
This came out of https://github.com/mdn/content/discussions/6845 :

> For example, "useCapture (of the addEventListener method) has not always been optional", which is false after IE9. These kinds of information are just the source of the confusion to most of the new comers, which only maintain for current browsers.

I agree with this, and this PR removes the note.