### PR TITLE
added clarity

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -72,9 +72,9 @@ tags:
 
 <h4 id="Provide_a_useful_summary">Provide a useful summary</h4>
 
-<p>Make sure the article's summary—that is, the opening paragraph or paragraphs before the first heading—provides enough information for the readers to understand if the article is likely to be covering what they're interested in reading about.</p>
+<p>Make sure the article's summary—that is, the opening paragraph or paragraphs before the first heading—provides enough information to adequately inform readers of the article's contents. This way a reader can determine quickly whether the article is relevant to their concerns.</p>
 
-<p>In a guide or tutorial content, the summary should let the reader know what topics will be covered and what they're already expected to know, if anything. It should mention the technologies and/or APIs that are being documented or discussed, with links to related information, and it should offer hints to situations in which the article's contents might be useful.</p>
+<p>In a guide or tutorial, the summary should inform the reader of the topics that are covered as well as of what requisite knowledge the reader is expected to have, if any. It should mention the technologies and/or APIs that are being documented or discussed, with links to related information, and it should offer hints to situations in which the article's contents might be useful.</p>
 
 <h5 id="Example_Too_short!">Example: Too short!</h5>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

1) The phrase, "**...provides enough information for the readers to understand if the article is likely to be covering what they're interested in reading about**" is pleonastic. No need to use so many words to convey the idea.
2) The phrase, "**In a guide or tutorial content**" is either ungrammatical or clunky, depending on its interpretation.
3) The term "**they're**" in, "**what they're already expected to know**", is ambiguous. It could refer to the topics or to the readers.
