### PR TITLE
fixed grammar, improved readability

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -86,7 +86,7 @@ tags:
 
 <h5 id="Example_Too_long!">Example: Too long!</h5>
 
-<p>Here, we've updated the summary, but now it's far too long. Too much details are included, and the text gets far too much into describing other methods and properties.</p>
+<p>Here, we've updated the summary, but now it's far too long. Too much detail is included, and the text delves too deeply into describing other methods and properties.</p>
 
 <p>Instead, the summary should focus on the <code>strokeText()</code> method, and should refer to the appropriate guides where the other details are described.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

1) The phrase, "**Too much details**" is ungrammatical.
2) The sentence repeats the idea of excessiveness with the word "**much**" two times near each other. This can be halting for some readers.
