### PR TITLE
added clarity

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -338,7 +338,7 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 </table>
 
 <div class="note notecard">
-<p><strong>Note</strong>: Always consider whether it's truly beneficial to use a Latin abbreviation. Some of these are used so rarely that many readers won't understand the meaning, and others are often confused with one another.</p>
+<p><strong>Note</strong>: Always consider whether it's truly beneficial to use a Latin abbreviation. Some of these are used so rarely that many readers will either confuse or fail to understand their meanings.</p>
 
 <p>Also, be sure that <em>you</em> use them correctly, if you choose to do so. For example, be careful not to confuse "e.g." with "i.e.", which is a common error.</p>
 </div>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The phrase, "**and others are often confused with one another**" plays on an ambiguous usage of "**others**," which can refer to the readers or to the abbreviations. Besides, the phrase as a whole is somewhat clunky.

