### PR TITLE
fixed typo/grammar

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -419,7 +419,7 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 
 <h3 id="Hyphenation">Hyphenation</h3>
 
-<p>Hyphenate compounds should be used when the last letter of the prefix is a vowel and is the same as the first letter of the root.</p>
+<p>Hyphenated compounds should be used when the last letter of the prefix is a vowel and is the same as the first letter of the root.</p>
 
 <ul>
  <li><span class="correct"><strong>Correct</strong></span>: email, re-elect, co-op</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The term "**hyphenate**" is a verb, not an adjective.
