### PR TITLE
added clarity

### DIFF
--- a/files/en-us/mdn/contribute/github_beginners/index.html
+++ b/files/en-us/mdn/contribute/github_beginners/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{MDNSidebar}}</p>
 
-<p><a href="https://git-scm.com/">Git</a> and <a href="https://github.com/">GitHub</a> are challenging tools to learn and master, but with a few simple commands and some good advice, you should be able to do enough to start contributing to MDN without too much trouble. The aim of this article is not to help you master Git or GitHub, but to give you just enough to be productive with it at a basic level and contribute to MDN.</p>
+<p><a href="https://git-scm.com/">Git</a> and <a href="https://github.com/">GitHub</a> are challenging tools to learn and master, but with a few simple commands and some good advice, you should be able to do enough to start contributing to MDN without too much trouble. The aim of this article is not to help you master Git or GitHub, but to give you just enough to be productive at a basic level and contribute to MDN.</p>
 
 <p>If you are familiar with Git/GitHub basics already, you probably won't learn anything new here, but you may still find this article useful as a reference. There is a <a href="/en-US/docs/MDN/Contribute/GitHub_cheatsheet">GitHub cheatsheet</a> available too, with just the commands and none of the long explanations.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The original "**it**" is inappropriate since the intended referents are two (Git & GitHub). "**It**" is singular. Anyhow, we don't need it.

