### PR TITLE
[Markdown] Fix markdown inconvertibles in JS

### DIFF
--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.html
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.html
@@ -12,7 +12,7 @@ tags:
   {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling",
   "Web/JavaScript/Guide/Functions")}}</div>
 
-<p class="summary">Loops offer a quick and easy way to do something repeatedly. This
+<p>Loops offer a quick and easy way to do something repeatedly. This
   chapter of the <a href="/en-US/docs/Web/JavaScript/Guide">JavaScript Guide</a>
   introduces the different iteration statements available to JavaScript.</p>
 

--- a/files/en-us/web/javascript/guide/using_promises/index.html
+++ b/files/en-us/web/javascript/guide/using_promises/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Details_of_the_Object_Model", "Web/JavaScript/Guide/Iterators_and_Generators")}}</div>
 
-<p class="summary"><span class="seoSummary">A {{jsxref("Promise")}} is an object representing the eventual completion or failure of an asynchronous operation. Since most people are consumers of already-created promises, this guide will explain consumption of returned promises before explaining how to create them.</span></p>
+<p>A {{jsxref("Promise")}} is an object representing the eventual completion or failure of an asynchronous operation. Since most people are consumers of already-created promises, this guide will explain consumption of returned promises before explaining how to create them.</p>
 
 <p>Essentially, a promise is a returned object to which you attach callbacks, instead of passing callbacks into a function.</p>
 

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.html
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.html
@@ -54,7 +54,7 @@ SyntaxError: expected '=&gt;' after argument list, got "x"
 
 <p>Sometimes, you leave out brackets around <code>if</code> statements:</p>
 
-<pre class="brush: js example-bad line-numbers  language-js">function round(n, upperBound, lowerBound){
+<pre class="brush: js example-bad">function round(n, upperBound, lowerBound){
   if(n &gt; upperBound) || (n &lt; lowerBound){
     throw 'Number ' + String(n) + ' is more than ' + String(upperBound) + ' or less than ' + String(lowerBound);
   }else if(n &lt; ((upperBound + lowerBound)/2)){

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.html
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.html
@@ -10,9 +10,9 @@ browser-compat: javascript.functions.default_parameters
 ---
 <div>{{jsSidebar("Functions")}}</div>
 
-<p><span class="seoSummary"><strong>Default function parameters</strong> allow named
+<p><strong>Default function parameters</strong> allow named
     parameters to be initialized with default values if no value or <code>undefined</code>
-    is passed.</span></p>
+    is passed.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/functions-default.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/arguments/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/arguments/index.html
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Function.arguments
 ---
 <div>{{JSRef}} {{deprecated_header}}</div>
 
-<p>The <code><strong><em>function</em>.arguments</strong></code> property refers to an array-like object corresponding to the arguments passed to a function. Use the simple variable {{jsxref("Functions/arguments", "arguments")}} instead. This property is restricted to non-strict functions.</p>
+<p>The <code><strong>function.arguments</strong></code> property refers to an array-like object corresponding to the arguments passed to a function. Use the simple variable {{jsxref("Functions/arguments", "arguments")}} instead. This property is restricted to non-strict functions.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/displayname/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/displayname/index.html
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Function.displayName
 ---
 <div>{{JSRef}} {{non-standard_header}}</div>
 
-<p>The <code><strong><em>function</em>.displayName</strong></code> property returns the display name of the function.</p>
+<p>The <code><strong>function.displayName</strong></code> property returns the display name of the function.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/function/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/function/index.html
@@ -10,12 +10,12 @@ browser-compat: javascript.builtins.Function.Function
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>Function</code> constructor</strong> creates
+<p>The <strong><code>Function</code> constructor</strong> creates
     a new <code>Function</code> <strong>object</strong>. Calling the constructor directly
     can create functions dynamically, but suffers from security and similar (but far less
     significant) performance issues to {{jsxref("Global_Objects/eval")}}. However, unlike eval, the
     <code>Function</code> constructor creates functions which execute in the global scope
-    only.</span></p>
+    only.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/function-constructor.html","shorter")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -258,7 +258,7 @@ new Intl.DateTimeFormat(locales, options)
 			</dd>
 		</dl>
 
-		<p class="noinclude">The default value for each date-time component property is
+		<p>The default value for each date-time component property is
 			{{jsxref("undefined")}}, but if all component properties are
 			{{jsxref("undefined")}}, then <code>year</code>, <code>month</code>, and
 			<code>day</code> are assumed to be "<code>numeric</code>".</p>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.html
@@ -13,10 +13,10 @@ browser-compat: javascript.builtins.Intl.Locale.maximize
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The
+<p>The
 		<strong><code>Intl.Locale.prototype.maximize()</code></strong> method gets the
 		most likely values for the language, script, and region of the locale based on
-		existing values.</span></p>
+		existing values.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-maximize.html")}}</div>
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.html
@@ -12,10 +12,10 @@ browser-compat: javascript.builtins.Intl.Locale.minimize
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The
+<p>The
 		<strong><code>Intl.Locale.prototype.minimize()</code></strong> method attempts to
 		remove information about the locale that would be added by calling
-		{{jsxref("Intl/Locale/maximize", "Locale.maximize()")}}.</span></p>
+		{{jsxref("Intl/Locale/maximize", "Locale.maximize()")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html", "taller")}}
 </div>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.html
@@ -13,11 +13,11 @@ browser-compat: javascript.builtins.Intl.Locale.toString
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The
+<p>The
 		<strong><code>Intl.Locale.prototype.toString()</code></strong> returns the
 		Locale's full <a
 			href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">locale
-			identifier string</a>.</span></p>
+			identifier string</a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html")}}</div>
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->

--- a/files/en-us/web/javascript/reference/global_objects/math/min/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/min/index.html
@@ -17,9 +17,9 @@ browser-compat: javascript.builtins.Math.min
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The static function <strong><code>Math.min()</code></strong>
+<p>The static function <strong><code>Math.min()</code></strong>
     returns the lowest-valued number passed into it, or {{jsxref("NaN")}} if any parameter
-    isn't a number and can't be converted into one.</span></p>
+    isn't a number and can't be converted into one.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/math-min.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.html
@@ -12,11 +12,11 @@ browser-compat: javascript.builtins.Object.assign
 ---
 <p>{{JSRef}}</p>
 
-<p><span class="seoSummary">The <strong><code>Object.assign()</code></strong> method
+<p>The <strong><code>Object.assign()</code></strong> method
     copies all {{jsxref("Object/propertyIsEnumerable", "enumerable", "", 1)}}
     {{jsxref("Object/hasOwnProperty", "own properties", "", 1)}} from one or more
     <em>source objects</em> to a <em>target object</em>. It returns the modified target
-    object.</span></p>
+    object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/object-assign.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.html
@@ -12,11 +12,11 @@ browser-compat: javascript.builtins.Reflect.getOwnPropertyDescriptor
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The static
+<p>The static
     <strong><code>Reflect.getOwnPropertyDescriptor()</code></strong> method is similar to
     {{jsxref("Object.getOwnPropertyDescriptor()")}}. It returns a property descriptor of
     the given property if it exists on the object, {{jsxref("undefined")}}
-    otherwise.</span></p>
+    otherwise.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-getownpropertydescriptor.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.html
@@ -12,11 +12,11 @@ browser-compat: javascript.builtins.Reflect.isExtensible
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The static
+<p>The static
     <strong><code>Reflect.isExtensible()</code></strong> method determines if an object is
     extensible (whether it can have new properties added to it). It is similar to
     {{jsxref("Object.isExtensible()")}}, but with some <a
-      href="#Difference_to_Object.isExtensible">differences</a>.</span></p>
+      href="#Difference_to_Object.isExtensible">differences</a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-isextensible.html", "taller")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -259,7 +259,7 @@ new Set("firefox")  // Set(6) { "f", "i", "r", "e", "o", "x" }
 
 <h3 id="Use_Set_to_ensure_the_uniqueness_of_a_list_of_values">Use Set to ensure the uniqueness of a list of values</h3>
 
-<pre class="brush: js" dir="ltr">const array = Array
+<pre class="brush: js">const array = Array
   .from(document.querySelectorAll('[id]'))
   .map(function(e) {
       return e.id

--- a/files/en-us/web/javascript/reference/global_objects/string/charat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/charat/index.html
@@ -11,9 +11,9 @@ browser-compat: javascript.builtins.String.charAt
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The {{jsxref("String")}} object's
+<p>The {{jsxref("String")}} object's
     <strong><code>charAt()</code></strong> method returns a new string consisting of the
-    single UTF-16 code unit located at the specified offset into the string.</span></p>
+    single UTF-16 code unit located at the specified offset into the string.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/string-charat.html", "shorter")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.html
@@ -12,9 +12,9 @@ browser-compat: javascript.builtins.String.endsWith
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>endsWith()</code></strong> method determines
+<p>The <strong><code>endsWith()</code></strong> method determines
     whether a string ends with the characters of a specified string, returning
-    <code>true</code> or <code>false</code> as appropriate.</span></p>
+    <code>true</code> or <code>false</code> as appropriate.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/string-endswith.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
@@ -11,10 +11,10 @@ browser-compat: javascript.builtins.String.indexOf
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>indexOf()</code></strong> method returns the
+<p>The <strong><code>indexOf()</code></strong> method returns the
     index within the calling {{jsxref("String")}} object of the first occurrence of the
     specified value, starting the search at <code>fromIndex</code>. Returns
-    <code>-1</code> if the value is not found.</span></p>
+    <code>-1</code> if the value is not found.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/string-indexof.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.html
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.TypedArray.name
 ---
 <div>{{JSRef}}</div>
 
-<p>The <code><strong><em>TypedArray</em>.name</strong></code> property represents a string value of the typed array constructor name.</p>
+<p>The <code><strong>TypedArray.name</strong></code> property represents a string value of the typed array constructor name.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-name.html","shorter")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/clear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/clear/index.html
@@ -23,7 +23,7 @@ browser-compat: javascript.builtins.WeakMap.clear
 
 <h3 id="Using_the_clear_method">Using the <code>clear</code> method</h3>
 
-<pre class="brush: js;highlight:[10] example-bad">var wm = new WeakMap();
+<pre class="brush: js; example-bad">var wm = new WeakMap();
 var obj = {};
 
 wm.set(obj, 'foo');

--- a/files/en-us/web/javascript/reference/operators/delete/index.html
+++ b/files/en-us/web/javascript/reference/operators/delete/index.html
@@ -15,9 +15,9 @@ browser-compat: javascript.operators.delete
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p><span class="seoSummary">The JavaScript <strong><code>delete</code> operator</strong>
+<p>The JavaScript <strong><code>delete</code> operator</strong>
 		removes a property from an object; if no more references to the same property are
-		held, it is eventually released automatically.</span></p>
+		held, it is eventually released automatically.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-deleteoperator.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/operators/function/index.html
+++ b/files/en-us/web/javascript/reference/operators/function/index.html
@@ -76,8 +76,8 @@ var notHoisted = function() {
 <h3 id="Named_function_expression">Named function expression</h3>
 
 <p>If you want to refer to the current function inside the function body, you need to
-  create a named function expression. <u><strong>This name is then local only to the
-      function body (scope)</strong></u>. This also avoids using the non-standard
+  create a named function expression. <strong>This name is then local only to the
+      function body (scope)</strong>. This also avoids using the non-standard
   {{jsxref("Functions/arguments/callee", "arguments.callee")}} property.</p>
 
 <pre class="brush: js">let math = {

--- a/files/en-us/web/javascript/reference/operators/in/index.html
+++ b/files/en-us/web/javascript/reference/operators/in/index.html
@@ -27,8 +27,7 @@ browser-compat: javascript.operators.in
   <dd>A string or symbol representing a property name or array index (non-symbols will be
     coerced to strings).</dd>
   <dt><code><var>object</var></code></dt>
-  <dd>Object to check if it (or its prototype chain) <span class="short_text"
-      lang="en">contains</span> the property with specified name
+  <dd>Object to check if it (or its prototype chain) contains the property with specified name
     (<code><var>prop</var></code>).</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/operators/in/index.html
+++ b/files/en-us/web/javascript/reference/operators/in/index.html
@@ -10,9 +10,9 @@ browser-compat: javascript.operators.in
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p><span class="seoSummary">The <strong><code>in</code> operator</strong> returns
+<p>The <strong><code>in</code> operator</strong> returns
     <code>true</code> if the specified property is in the specified object or its
-    prototype chain.</span></p>
+    prototype chain.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-inoperator.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/operators/new.target/index.html
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.html
@@ -85,7 +85,7 @@ class D extends C { constructor() { super()  } }
 let c = new C()  // logs class C{constructor(){console.log(new.target);}}
 let d = new D()  // logs class D extends C{constructor(){super();}}</pre>
 
-<p class="summary">Thus from the above example of class <code>C</code> and <code>D</code>,
+<p>Thus from the above example of class <code>C</code> and <code>D</code>,
   it seems that <code>new.target</code> points to the class definition of class which is
   initialized. For example, when <code>d</code> was initialized using
   <code>new D()</code>, the class definition of <code>D</code> was printed; and similarly,

--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -79,8 +79,8 @@ browser-compat: javascript.statements.async_function
 </pre>
 
 <div class="notecard note">
-    <h4 id="checking_equality_with_promise_resolve_vs_async_return">Checking equality with <code>Promise.resolve</code> vs <code>async</code> return</h4>
-    <p>Even though the return value of an async function behaves as if it's wrapped in a <code>Promise.resolve</code>, they are not equivalent.</p>
+  <p><strong>Note:</strong></p>
+  <p>Even though the return value of an async function behaves as if it's wrapped in a <code>Promise.resolve</code>, they are not equivalent.</p>
     <p>An async function will return a different <em>reference</em>, whereas <code>Promise.resolve</code> returns the same reference if the given value is a promise.</p>
     <p>It can be a problem when you want to check the equality of a promise and a return value of an async function.</p>
     <pre class="brush: js">const p = new Promise((res, rej) => {


### PR DESCRIPTION
This gist: https://gist.github.com/fiji-flo/b110637c7a1a3ce0b7289f98a311b386 contains the report from running the converter on the current JS docs.

Apart from tables, many of which we expect to be unconvertible, many of the unconvertible elements can be easily fixed in content, and that's what this PR docs:

* remove a few `.seoSummary` and `.summary` classes
* remove cases where `<code>` tags contain markup, but the contained markup is a subset of the contents of the `<code>`
* remove a few random redundant classes

