### PR TITLE
Fix 'type: ordinal' example in Intl.PluralRules() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.html
@@ -73,7 +73,7 @@ new Intl.PluralRules(locales, options)
 				to 20; the default for plain number and percent formatting is 0; the
 				default for currency formatting is the number of minor unit digits
 				provided by the <a
-					href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO
+					href="https://www.currency-iso.org/en/home/tables/table-a1.html">ISO
 					4217 currency code list</a> (2 if the list doesn't provide that
 				information).</dd>
 			<dt><code>maximumFractionDigits</code></dt>
@@ -82,7 +82,7 @@ new Intl.PluralRules(locales, options)
 				<code>minimumFractionDigits</code> and 3; the default for currency
 				formatting is the larger of <code>minimumFractionDigits</code> and the
 				number of minor unit digits provided by the <a
-					href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO
+					href="https://www.currency-iso.org/en/home/tables/table-a1.html">ISO
 					4217 currency code list</a> (2 if the list doesn't provide that
 				information); the default for percent formatting is the larger of
 				<code>minimumFractionDigits</code> and 0.</dd>
@@ -125,18 +125,27 @@ pr.select(2);
 
 <pre class="brush: js">var pr = new Intl.PluralRules('en-US', { type: 'ordinal' });
 
-pr.select(0);
-// → 'other'
-pr.select(1);
-// → 'one'
-pr.select(2);
-// → 'two'
-pr.select(3);
-// → 'few'
-pr.select(4);
-// → 'other'
-pr.select(42);
-// → 'two'
+const suffixes = new Map([
+  ['one',   'st'],
+  ['two',   'nd'],
+  ['few',   'rd'],
+  ['other', 'th'],
+]);
+const formatOrdinals = (n) =&gt; {
+  const rule = pr.select(n);
+  const suffix = suffixes.get(rule);
+  return `${n}${suffix}`;
+};
+
+formatOrdinals(0);   // '0th'
+formatOrdinals(1);   // '1st'
+formatOrdinals(2);   // '2nd'
+formatOrdinals(3);   // '3rd'
+formatOrdinals(4);   // '4th'
+formatOrdinals(11);  // '11th'
+formatOrdinals(21);  // '21st'
+formatOrdinals(42);  // '42nd'
+formatOrdinals(103); // '103rd'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/6877