### PR TITLE
Add event inheritance in IDBOpenDBRequest

### DIFF
--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -18,6 +18,8 @@ browser-compat: api.IDBOpenDBRequest
 <p>The <strong><code>IDBOpenDBRequest</code></strong> interface of the IndexedDB API provides access to the results of requests to open or delete databases (performed using {{domxref("IDBFactory.open")}} and {{domxref("IDBFactory.deleteDatabase")}}), using specific event handler attributes.</p>
 </div>
 
+<p>The interface <code>IDBOpenDBRequest</code> is derived from {{domxref("IDBRequest")}}.</p>
+
 <p>{{AvailableInWorkers}}</p>
 
 <p>{{InheritanceDiagram}}</p>
@@ -32,7 +34,7 @@ browser-compat: api.IDBOpenDBRequest
 
 <h2 id="Events">Events</h2>
 
-<p>Listen to these events using <code>addEventListener()</code> or by assigning an event listener to the <code>on<em>eventname</em></code> property of this interface.</p>
+<p>Listen to these events using <code>addEventListener()</code> or by assigning an event listener to the <code>on<em>eventname</em></code> property of this interface. These events are unique to <code>IDBOpenDBRequest</code> and do not extend to {{domxref("IDBRequest")}}.</p>
 
 <dl>
  <dt><a href="/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event"><code>blocked</code></a></dt>

--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -18,8 +18,6 @@ browser-compat: api.IDBOpenDBRequest
 <p>The <strong><code>IDBOpenDBRequest</code></strong> interface of the IndexedDB API provides access to the results of requests to open or delete databases (performed using {{domxref("IDBFactory.open")}} and {{domxref("IDBFactory.deleteDatabase")}}), using specific event handler attributes.</p>
 </div>
 
-<p>The interface <code>IDBOpenDBRequest</code> is derived from {{domxref("IDBRequest")}}.</p>
-
 <p>{{AvailableInWorkers}}</p>
 
 <p>{{InheritanceDiagram}}</p>

--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -34,7 +34,9 @@ browser-compat: api.IDBOpenDBRequest
 
 <h2 id="Events">Events</h2>
 
-<p>Listen to these events using <code>addEventListener()</code> or by assigning an event listener to the <code>on<em>eventname</em></code> property of this interface. These events are unique to <code>IDBOpenDBRequest</code> and do not extend to {{domxref("IDBRequest")}}.</p>
+<p><em>Events defined on parent interfaces, {{DOMxRef("IDBRequest")}} and {{DOMxRef("EventTarget")}}, can also be dispatched on <code>IDBOpenDBRequest</code> objects.</p>
+<p>Listen to these generic and specific events using <code>addEventListener()</code> or by assigning an event listener to the <code>on<em>eventname</em></code> property of this interface. </p>
+<p>Events specific to this interface are:</p>
 
 <dl>
  <dt><a href="/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event"><code>blocked</code></a></dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
A clarification seemed necessary on the fact that the IDBOpenDBRequest was derived from IDBRequest, and as a result the events of the child IDBOpenDBRequest were not available in the parent IDBRequest


> Issue number (if there is an associated issue)
#3356


> Anything else that could help us review it
