### PR TITLE
Fix a link to John Resig's blog post

### DIFF
--- a/files/en-us/web/api/node/nodename/index.html
+++ b/files/en-us/web/api/node/nodename/index.html
@@ -90,7 +90,7 @@ text_field.value = div1.nodeName;
   <code>"div"</code>. However, in HTML, <code>text_field</code>'s value would read
   <code>"DIV"</code>, because <code>nodeName</code> and <code>tagName</code> return in
   upper case on HTML elements in DOMs flagged as HTML documents. Read more <a
-    href="http://ejohn.org/blog/nodename-case-sensitivity/">details on nodeName case
+    href="https://johnresig.com/blog/nodename-case-sensitivity/">details on nodeName case
     sensitivity in different browsers</a>.</p>
 
 <p>Note that the {{domxref("Element.tagName")}} property could have been used instead,


### PR DESCRIPTION
Also, make the link HTTPS.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The current link redirects to the one I propose. However, if you have HTTPS Everywhere installed with strict settings, redirecting everything to HTTPS, the extensions modifies the URL to `https://ejohn.org/blog/nodename-case-sensitivity/` which fails.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
