### PR TITLE
Correct adjacent sibling combinator grammar

### DIFF
--- a/files/en-us/web/css/css_selectors/index.html
+++ b/files/en-us/web/css/css_selectors/index.html
@@ -66,7 +66,7 @@ tags:
  <strong>Syntax:</strong> <code><var>A</var> ~ <var>B</var></code><br>
  <strong>Example:</strong> <code>p ~ span</code> will match all {{HTMLElement("span")}} elements that follow a {{HTMLElement("p")}}, immediately or not.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">Adjacent sibling combinator</a></dt>
- <dd>The <code>+</code> combinator selects a single, immediately succeeding/following, sibling element. An element can only be adjacent to sibling (same parent) elements where no siblings exist between the two.<br>
+ <dd>The <code>+</code> combinator matches the second element only if it <em>immediately</em> follows the first element.<br>
  <strong>Syntax:</strong> <code><var>A</var> + <var>B</var></code><br>
  <strong>Example:</strong> <code>h2 + p</code> will match all {{HTMLElement("p")}} elements which have an immediately preceeding {{HTMLElement("h2")}} element.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Column_combinator">Column combinator</a> {{Experimental_Inline}}</dt>

--- a/files/en-us/web/css/css_selectors/index.html
+++ b/files/en-us/web/css/css_selectors/index.html
@@ -68,7 +68,7 @@ tags:
  <dt><a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">Adjacent sibling combinator</a></dt>
  <dd>The <code>+</code> combinator matches the second element only if it <em>immediately</em> follows the first element.<br>
  <strong>Syntax:</strong> <code><var>A</var> + <var>B</var></code><br>
- <strong>Example:</strong> <code>h2 + p</code> will match all {{HTMLElement("p")}} elements which have an immediately preceeding {{HTMLElement("h2")}} element.</dd>
+ <strong>Example:</strong> <code>h2 + p</code> will match all {{HTMLElement("p")}} elements that <em>immediately</em> follows {{HTMLElement("h2")}} element.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Column_combinator">Column combinator</a> {{Experimental_Inline}}</dt>
  <dd>The <code>||</code> combinator selects nodes which belong to a column.<br>
  <strong>Syntax:</strong> <code><var>A</var> || <var>B</var></code><br>

--- a/files/en-us/web/css/css_selectors/index.html
+++ b/files/en-us/web/css/css_selectors/index.html
@@ -66,9 +66,9 @@ tags:
  <strong>Syntax:</strong> <code><var>A</var> ~ <var>B</var></code><br>
  <strong>Example:</strong> <code>p ~ span</code> will match all {{HTMLElement("span")}} elements that follow a {{HTMLElement("p")}}, immediately or not.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">Adjacent sibling combinator</a></dt>
- <dd>The <code>+</code> combinator selects adjacent siblings. This means that the second element directly follows the first, and both share the same parent.<br>
+ <dd>The <code>+</code> combinator selects a single, immediately succeeding/following, sibling element. An element can only be adjacent to sibling (same parent) elements where no siblings exist between the two.<br>
  <strong>Syntax:</strong> <code><var>A</var> + <var>B</var></code><br>
- <strong>Example:</strong> <code>h2 + p</code> will match all {{HTMLElement("p")}} elements that directly follow an {{HTMLElement("h2")}}.</dd>
+ <strong>Example:</strong> <code>h2 + p</code> will match all {{HTMLElement("p")}} elements which have an immediately preceeding {{HTMLElement("h2")}} element.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Column_combinator">Column combinator</a> {{Experimental_Inline}}</dt>
  <dd>The <code>||</code> combinator selects nodes which belong to a column.<br>
  <strong>Syntax:</strong> <code><var>A</var> || <var>B</var></code><br>


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The grammar and plurality of the adjacent sibling combinator's description implied that a selector of `h2 + p` would return multiple `p`'s per `h2`. This change should resolve any confusion.


> Issue number (if there is an associated issue)
None that I know of.


> Anything else that could help us review it
N/A
