### PR TITLE
Update XRSystem docs; fold in enums/dictionaries

### DIFF
--- a/files/en-us/web/api/xrsystem/index.html
+++ b/files/en-us/web/api/xrsystem/index.html
@@ -30,9 +30,10 @@ browser-compat: api.XRSystem
 
 <dl>
  <dt>{{DOMxRef("XRSystem.isSessionSupported", "isSessionSupported()")}} {{Experimental_Inline}}</dt>
- <dd>Returns a promise which resolves to <code>true</code> if the browser supports the given {{domxref("XRSessionMode")}}. Resolves to <code>false</code> if the specified mode isn't supported.</dd>
+ <dd>Returns a promise which resolves to <code>true</code> if the browser supports the given session mode.
+  Resolves to <code>false</code> if the specified mode isn't supported.</dd>
  <dt>{{DOMxRef("XRSystem.requestSession", "requestSession()")}} {{Experimental_Inline}}</dt>
- <dd>Returns a promise that resolves to a new {{DOMxRef("XRSession")}} with the specified {{DOMxRef("XRSessionMode")}}.</dd>
+ <dd>Returns a promise that resolves to a new {{DOMxRef("XRSession")}} with the specified session mode.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.html
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.html
@@ -23,23 +23,26 @@ browser-compat: api.XRSystem.isSessionSupported
     <code>true</code> if the specified WebXR session mode is supported by the user's WebXR
     device. Otherwise, the promise resolves with <code>false</code>.</span></p>
 
-<p class="summary">If the no devices are available or the browser doesn't have permission
+<p class="summary">If no devices are available or the browser doesn't have permission
   to use the XR device, the promise is rejected with an appropriate
   {{domxref("DOMException")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>isSupportedPromise = xr</em>.isSessionSupported(<em>xrSessionMode</em>)</pre>
+<pre class="brush: js">xr.isSessionSupported(mode)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>xrSessionMode</code></dt>
-  <dd>A {{domxref("DOMString")}} specifying the WebXR session mode for which support is to
-    be checked. This string must be one of <code>inline</code> (to present the WebXR
-    content inline within the context of an HTML document) or <code>immersive-vr</code>
-    for a fully-immersive virtual experience.</dd>
+  <dt><code>mode</code></dt>
+  <dd>A {{jsxref("String")}} specifying the WebXR session mode for which support is to
+    be checked. Possible modes to check for:
+    <ul>
+      <li><code>immersive-ar</code> {{experimental_inline}}</li>
+      <li><code>immersive-vr</code></li>
+      <li><code>inline</code></li>
+     </ul>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/xrsystem/requestsession/index.html
+++ b/files/en-us/web/api/xrsystem/requestsession/index.html
@@ -217,7 +217,7 @@ function onButtonClicked() {
 
 <h3>Requesting a session with required features</h3>
 
-<p>Require an unbounded experience in which the user is able to freely move around their physical environment.</p>
+<p>Require an unbounded experience in which the user is able to freely move around their physical environment:</p>
 
 <pre class="brush: js">
 navigator.xr.requestSession('immersive-vr', { requiredFeatures: ['unbounded'] })

--- a/files/en-us/web/api/xrsystem/requestsession/index.html
+++ b/files/en-us/web/api/xrsystem/requestsession/index.html
@@ -2,19 +2,19 @@
 title: 'XRSystem: requestSession()'
 slug: Web/API/XRSystem/requestSession
 tags:
-- API
-- AR
-- Augmented Reality
-- Experimental
-- Method
-- Reference
-- VR
-- Virtual Reality
-- WebXR
-- WebXR Device API
-- XR
-- XRSystem
-- requestSession
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Method
+  - Reference
+  - VR
+  - Virtual Reality
+  - WebXR
+  - WebXR Device API
+  - XR
+  - XRSystem
+  - requestSession
 browser-compat: api.XRSystem.requestSession
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
@@ -29,22 +29,46 @@ browser-compat: api.XRSystem.requestSession
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>sessionPromise = xr</em>.requestSession(<em>sessionMode</em>, <em>sessionInit</em>)
+<pre class="brush: js">navigator.xr</em>.requestSession(<em>mode</em>, <em>options</em>)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>sessionMode</code></dt>
+  <dt><code>mode</code></dt>
   <dd>
-    <p>A {{domxref("DOMString")}} whose value is one of those included in the
-      {{domxref("XRSessionMode")}} <code>enum</code>. The supported modes are:</p>
-    {{page("/en-US/docs/Web/API/XRSessionMode", "Values")}}
+    <p>A {{jsxref("String")}} defining the XR session mode. The supported modes are:</p>
+      <ul>
+        <li>{{experimental_inline}} <code>immersive-ar</code>: The session's output will be given exclusive access to the immersive device,
+         but the rendered content will be blended with the real-world environment.
+         The session's {{DOMxRef("XRSession.environmentBlendMode", "environmentBlendMode")}} indicates the method
+         to be used to blend the content together.
+        </li>
+        <li><code>immersive-vr</code>: Indicates that the rendered session will be displayed using an immersive XR device
+         in VR mode; it is not intended to be overlaid or integrated into the surrounding environment.
+         The {{DOMxRef("XRSession.environmentBlendMode", "environmentBlendMode")}} is expected to be
+         <code>opaque</code> if possible, but might be <code>additive</code> if the hardware requires it.
+        </li>
+        <li><code>inline</code>: The output is presented inline within the context of an element in a standard HTML document,
+         rather than occupying the full visual space. Inline sessions can be presented in either mono or stereo mode,
+         and may or may not have viewer tracking available. Inline sessions don't require special hardware and should be
+         available on any {{Glossary("user agent")}} offering WebXR API support.
+        </li>
+       </ul>
   </dd>
-  <dt><code>sessionInit</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("XRSessionInit")}} object providing options to configure the new
-    {{domxref("XRSession")}}. See {{anch("Specifying session options")}} for details on
-    how to configure a WebXR session.</dd>
+  <dt><code>options</code> {{optional_inline}}</dt>
+  <dd>An object that can contain two properties (<code>requiredFeatures</code> and <code>optionalFeatures</code>)
+  to configure the new {{domxref("XRSession")}}. If none are included, the device will use a default feature
+  configuration for all options. For more information, see <a href="#session_features">Session features</a> below.
+  <ul>
+    <li><code>requiredFeatures</code> {{optional_inline}}: An array of values which the returned {{domxref("XRSession")}}
+      <em>must</em> support.</li>
+    <li><code>optionalFeatures</code> {{optional_inline}}: An array of values identifying features which the returned
+     {{domxref("XRSession")}} may optionally support.</li>
+    </ul>
+  </dd>
+</dl>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -75,6 +99,61 @@ browser-compat: api.XRSystem.requestSession
       security")}}.</p>
   </dd>
 </dl>
+
+<h2 id="Session_features">Session features</h2>
+
+<h3 id="Immersive_sessions">Immersive sessions</h3>
+
+<p>All immersive (both <code>immersive-vr</code> and <code>immersive-ar</code>)  
+sessions support both the <code>viewer</code> and <code>local</code> reference spaces.</p>
+
+<p>Because immersive sessions are required to support the <code>local</code> reference space,
+any request to open an immersive {{domxref("XRSession")}} is required to obtain explicit or implicit user consent.</p>
+
+<h3 id="Inline_sessions">Inline sessions</h3>
+
+<p>All <code>inline</code> WebXR sessions support the <code>viewer</code> reference space.</p>
+
+<h3 id="Security_requirements">Security requirements</h3>
+
+<p>Each reference space or feature type has minimum safety requirements. By session type, those are:</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Reference space type</th>
+   <th scope="col">User consent rquirement</th>
+   <th scope="col">Feature policy requirement</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><code>bounded-floor</code></td>
+   <td>Always required</td>
+   <td><code>xr-spatial-tracking</code></td>
+  </tr>
+  <tr>
+   <td><code>local</code></td>
+   <td>Always required for inline sessions</td>
+   <td><code>xr-spatial-tracking</code></td>
+  </tr>
+  <tr>
+   <td><code>local-floor</code></td>
+   <td>Always required</td>
+   <td><code>xr-spatial-tracking</code></td>
+  </tr>
+  <tr>
+   <td><code>unbounded</code></td>
+   <td>Always required</td>
+   <td><code>xr-spatial-tracking</code></td>
+  </tr>
+  <tr>
+   <td><code>viewer</code></td>
+   <td>Always required</td>
+   <td>—</td>
+  </tr>
+ </tbody>
+</table>
 
 <h2 id="Examples">Examples</h2>
 
@@ -135,6 +214,14 @@ function onButtonClicked() {
     xrSession.end().then(() =&gt; xrSession = null);
   }
 }</pre>
+
+<h3>Requesting a session with required features</h3>
+
+<p>Require an unbounded experience in which the user is able to freely move around their physical environment.</p>
+
+<pre class="brush: js">
+navigator.xr.requestSession('immersive-vr', { requiredFeatures: ['unbounded'] })
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This updates 
http://localhost:3000/en-US/docs/Web/API/XRSystem
http://localhost:3000/en-US/docs/Web/API/XRSystem/isSessionSupported
http://localhost:3000/en-US/docs/Web/API/XRSystem/requestSession

and inlines the content from
http://localhost:3000/en-US/docs/Web/API/XRSessionMode
http://localhost:3000/en-US/docs/Web/API/XRSessionInit

(next step is to remove these separate enums/dictionary pages plus BCD)