### PR TITLE
Adds missing MIDIInput page

### DIFF
--- a/files/en-us/web/api/midiinput/index.html
+++ b/files/en-us/web/api/midiinput/index.html
@@ -11,20 +11,35 @@ tags:
   - Web MIDI API
 browser-compat: api.MIDIInput
 ---
-<div>{{APIRef("Web MIDI API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("Web MIDI API")}}{{securecontext_header}}</div>
 
-<p>Use the <strong><code>MIDIInput</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_MIDI_API">Web MIDI API</a> to access and pass messages to a MIDI input port.</p>
+<p>The <strong><code>MIDIInput</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_MIDI_API">Web MIDI API</a> receives messages from a MIDI input port.</p>
 
 <h2 id="Properties">Properties</h2>
 
-<p>None.</p>
+<p><em>This interface doesn't implement any specific properties, but inherits properties from {{domxref("MIDIPort")}}.</em></p>
 
 <h3 id="Event_handlers">Event handlers</h3>
 
 <dl>
- <dt>{{domxref("MIDIInput.onmidimessage")}}</dt>
- <dd>When the current port receives a {{domxref("MIDIMessage")}} it triggers a call to this event handler.</dd>
+  <dt>{{domxref("MIDIInput.onmidimessage")}}</dt>
+  <dd>When the current port receives a MIDI message it triggers a call to this event handler.</dd>
 </dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>This interface doesn't implement any specific methods, but inherits methods from {{domxref("MIDIPort")}}.</em></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example the name of each <code>MIDIInput</code> is printed to the console. Then, <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} is printed to the console.</p>
+
+<pre class="brush:js">inputs.forEach((input) => {
+  console.log(input.name); /* inherited property from MIDIPort */
+  input.onmidimessage = function(message) {
+    console.log(message.data);
+  }
+})</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/midiinput/index.html
+++ b/files/en-us/web/api/midiinput/index.html
@@ -32,7 +32,7 @@ browser-compat: api.MIDIInput
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following example the name of each <code>MIDIInput</code> is printed to the console. Then, <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} is printed to the console.</p>
+<p>In the following example the name of each <code>MIDIInput</code> is printed to the console. Then, <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} property is printed to the console.</p>
 
 <pre class="brush:js">inputs.forEach((input) => {
   console.log(input.name); /* inherited property from MIDIPort */

--- a/files/en-us/web/api/midiinput/onmidimessage/index.html
+++ b/files/en-us/web/api/midiinput/onmidimessage/index.html
@@ -1,0 +1,39 @@
+---
+title: MIDIInput.onmidimessage
+slug: Web/API/MIDIInput/onmidimessage
+tags:
+  - API
+  - Property
+  - Reference
+  - onmidimessage
+  - MIDIInput
+browser-compat: api.MIDIInput.onmidimessage
+---
+<div>{{APIRef("Web MIDI API")}}{{securecontext_header}}</div>
+
+<p class="summary">The <strong><code>onmidimessage</code></strong> EventHandler of the {{domxref("MIDIInput")}} interface is an {{event("Event_handlers", "event handler")}} that processes <code>midimessage</code> events.</p>
+
+<p> The event fires when the MIDI port corresponding to this {{domxref("MIDIInput")}} finishes receiving one or more MIDI messages. An instance of {{domxref("MIDIMessageEvent")}} containing the message that was received is passed to this event handler.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">MIDIInput.onmidimessage = function;
+MIDIInput.addEventListener('midimessage', function);</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} is printed to the console.</p>
+
+<pre class="brush:js">inputs.forEach((input) => {
+  input.onmidimessage = function(message) {
+    console.log(message.data);
+  }
+})</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midiinput/onmidimessage/index.html
+++ b/files/en-us/web/api/midiinput/onmidimessage/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIInput.onmidimessage
 ---
 <div>{{APIRef("Web MIDI API")}}{{securecontext_header}}</div>
 
-<p class="summary">The <strong><code>onmidimessage</code></strong> EventHandler of the {{domxref("MIDIInput")}} interface is an {{event("Event_handlers", "event handler")}} that processes <code>midimessage</code> events.</p>
+<p class="summary">The <strong><code>onmidimessage</code></strong> {{event("Event_handlers", "event handler")}} of the {{domxref("MIDIInput")}} interface processes <code>midimessage</code> events.</p>
 
 <p> The event fires when the MIDI port corresponding to this {{domxref("MIDIInput")}} finishes receiving one or more MIDI messages. An instance of {{domxref("MIDIMessageEvent")}} containing the message that was received is passed to this event handler.</p>
 
@@ -22,7 +22,7 @@ MIDIInput.addEventListener('midimessage', function);</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following example <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} is printed to the console.</p>
+<p>In the following example <code>onmidimessage</code> events are listened for on all input ports. When a message is received the {{domxref("MIDIMessageEvent.data")}} property is printed to the console.</p>
 
 <pre class="brush:js">inputs.forEach((input) => {
   input.onmidimessage = function(message) {


### PR DESCRIPTION
This PR adds the missing page to MIDIInput, and tidies up the main interface page.

Spec data was added in a previous BCD PR.

Reviewer: @jpmedley 
