### PR TITLE
<code> should enclose right operand too

### DIFF
--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.html
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.html
@@ -720,9 +720,9 @@ var n3 = !'Cat'; // !t returns false
   "short-circuit" evaluation using the following rules:</p>
 
 <ul>
-  <li><code>false</code> &amp;&amp; <em>anything</em> is short-circuit evaluated to false.
+  <li><code>false &amp;&amp; <em>anything</em></code> is short-circuit evaluated to false.
   </li>
-  <li><code>true</code> || <em>anything</em> is short-circuit evaluated to true.</li>
+  <li><code>true || <em>anything</em></code> is short-circuit evaluated to true.</li>
 </ul>
 
 <p>The rules of logic guarantee that these evaluations are always correct. Note that the


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Under the Expressions and Operators guide's [Short-circuit evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#short-circuit_evaluation) section, there's this:

- `false` && *anything* is short-circuit evaluated to false.
- `true` || *anything* is short-circuit evaluated to true.

As the operators and right operands are both a part of each expression, they should be within the `<code>` as well.


> Issue number (if there is an associated issue)

None.


> Anything else that could help us review it

None.

(cc. mdn/translated-content#1393)