### PR TITLE
Change all "Safe" glossary links to "Safe/HTTP"

### DIFF
--- a/files/en-us/glossary/idempotent/index.html
+++ b/files/en-us/glossary/idempotent/index.html
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - WebMechanics
 ---
-<p>An HTTP method is <strong>idempotent</strong> if an identical request can be made once or several times in a row with the same effect while leaving the server in the same state. In other words, an idempotent method should not have any side-effects (except for keeping statistics). Implemented correctly, the {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}, {{HTTPMethod("PUT")}}, and {{HTTPMethod("DELETE")}} methods are <strong>idempotent</strong>, but not the {{HTTPMethod("POST")}} method. All {{glossary("safe")}} methods are also idempotent.</p>
+<p>An HTTP method is <strong>idempotent</strong> if an identical request can be made once or several times in a row with the same effect while leaving the server in the same state. In other words, an idempotent method should not have any side-effects (except for keeping statistics). Implemented correctly, the {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}, {{HTTPMethod("PUT")}}, and {{HTTPMethod("DELETE")}} methods are <strong>idempotent</strong>, but not the {{HTTPMethod("POST")}} method. All {{glossary("Safe/HTTP", "safe")}} methods are also idempotent.</p>
 
 <p>To be idempotent, only the actual back-end state of the server is considered, the status code returned by each request may differ: the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a <em>delete last entry</em> functionality using the <code>DELETE</code> method.</p>
 

--- a/files/en-us/web/http/conditional_requests/index.html
+++ b/files/en-us/web/http/conditional_requests/index.html
@@ -17,8 +17,8 @@ tags:
 <p>The different behaviors are defined by the method of the request used, and by the set of headers used for a precondition:</p>
 
 <ul>
- <li>for {{glossary("safe")}} methods, like {{HTTPMethod("GET")}}, which usually tries to fetch a document, the conditional request can be used to send back the document, if relevant only. Therefore, this spares bandwidth.</li>
- <li>for {{glossary("safe", "unsafe")}} methods, like {{HTTPMethod("PUT")}}, which usually uploads a document, the conditional request can be used to upload the document, only if the original it is based on is the same as that stored on the server.</li>
+ <li>for {{glossary("Safe/HTTP", "safe")}} methods, like {{HTTPMethod("GET")}}, which usually tries to fetch a document, the conditional request can be used to send back the document, if relevant only. Therefore, this spares bandwidth.</li>
+ <li>for {{glossary("Safe/HTTP", "unsafe")}} methods, like {{HTTPMethod("PUT")}}, which usually uploads a document, the conditional request can be used to upload the document, only if the original it is based on is the same as that stored on the server.</li>
 </ul>
 
 <h2 id="Validators">Validators</h2>

--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -203,7 +203,7 @@ Keep-Alive: timeout=2, max=100
 Connection: Keep-Alive
 </pre>
 
-<p>Lines 1 - 10 above represent the preflight request with the {{HTTPMethod("OPTIONS")}} method. The browser determines that it needs to send this based on the request parameters that the JavaScript code snippet above was using, so that the server can respond whether it is acceptable to send the request with the actual request parameters. OPTIONS is an HTTP/1.1 method that is used to determine further information from servers, and is a {{Glossary("safe")}} method, meaning that it can't be used to change the resource. Note that along with the OPTIONS request, two other request headers are sent (lines 9 and 10 respectively):</p>
+<p>Lines 1 - 10 above represent the preflight request with the {{HTTPMethod("OPTIONS")}} method. The browser determines that it needs to send this based on the request parameters that the JavaScript code snippet above was using, so that the server can respond whether it is acceptable to send the request with the actual request parameters. OPTIONS is an HTTP/1.1 method that is used to determine further information from servers, and is a {{Glossary("Safe/HTTP", "safe")}} method, meaning that it can't be used to change the resource. Note that along with the OPTIONS request, two other request headers are sent (lines 9 and 10 respectively):</p>
 
 <pre class="brush: none">Access-Control-Request-Method: POST
 Access-Control-Request-Headers: X-PINGOTHER, Content-Type

--- a/files/en-us/web/http/headers/if-unmodified-since/index.html
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.html
@@ -12,7 +12,7 @@ browser-compat: http.headers.If-Unmodified-Since
 
 <p>The <strong><code>If-Unmodified-Since</code></strong> request HTTP header makes the
   request conditional: the server will send back the requested resource, or accept it in
-  the case of a {{HTTPMethod("POST")}} or another non-{{Glossary("safe")}} method, only if
+  the case of a {{HTTPMethod("POST")}} or another non-{{Glossary("Safe/HTTP", "safe")}} method, only if
   it has not been last modified after the given date. If the resource has been modified
   after the given date, the response will be a {{HTTPStatus("412")}} (Precondition Failed)
   error.</p>
@@ -20,7 +20,7 @@ browser-compat: http.headers.If-Unmodified-Since
 <p>There are two common use cases:</p>
 
 <ul>
-  <li>In conjunction with non-{{Glossary("safe")}} methods, like {{HTTPMethod("POST")}},
+  <li>In conjunction with non-{{Glossary("Safe/HTTP", "safe")}} methods, like {{HTTPMethod("POST")}},
     it can be used to implement an <a
       href="https://en.wikipedia.org/wiki/Optimistic_concurrency_control">optimistic
       concurrency control</a>, like done by some wikis: editions are rejected if the

--- a/files/en-us/web/http/methods/connect/index.html
+++ b/files/en-us/web/http/methods/connect/index.html
@@ -35,7 +35,7 @@ browser-compat: http.methods.CONNECT
       <td>Yes</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Safe")}}</th>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/methods/delete/index.html
+++ b/files/en-us/web/http/methods/delete/index.html
@@ -23,7 +23,7 @@ browser-compat: http.methods.DELETE
       <td>May</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Safe")}}</th>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/methods/get/index.html
+++ b/files/en-us/web/http/methods/get/index.html
@@ -12,36 +12,36 @@ browser-compat: http.methods.GET
 <p>The <strong>HTTP <code>GET</code> method</strong> requests a representation of the specified resource. Requests using <code>GET</code> should only be used to request data (they shouldn't include data).</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Sending body/payload in a <code>GET</code> request may cause some existing implementations to reject the request — while not prohibited by the specification, the semantics are undefined. It is better to just avoid sending payloads in <code>GET</code> requests.</p>
+  <p><strong>Note</strong>: Sending body/payload in a <code>GET</code> request may cause some existing implementations to reject the request — while not prohibited by the specification, the semantics are undefined. It is better to just avoid sending payloads in <code>GET</code> requests.</p>
 </div>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in HTML forms</th>
-   <td>Yes</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in HTML forms</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/head/index.html
+++ b/files/en-us/web/http/methods/head/index.html
@@ -19,32 +19,32 @@ browser-compat: http.methods.HEAD
 <p>If the response to a <code>HEAD</code> request shows that a cached URL response is now outdated, the cached copy is invalidated even if no <code>GET</code> request was made.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
-   <td>No</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
+      <td>No</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/index.html
+++ b/files/en-us/web/http/methods/index.html
@@ -9,7 +9,7 @@ browser-compat: http.methods
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>HTTP defines a set of <strong>request methods</strong> to indicate the desired action to be performed for a given resource. Although they can also be nouns, these request methods are sometimes referred to as <em>HTTP verbs</em>. Each of them implements a different semantic, but some common features are shared by a group of them: e.g. a request method can be {{glossary("safe")}}, {{glossary("idempotent")}}, or {{glossary("cacheable")}}.</p>
+<p>HTTP defines a set of <strong>request methods</strong> to indicate the desired action to be performed for a given resource. Although they can also be nouns, these request methods are sometimes referred to as <em>HTTP verbs</em>. Each of them implements a different semantic, but some common features are shared by a group of them: e.g. a request method can be {{glossary("Safe/HTTP", "safe")}}, {{glossary("idempotent")}}, or {{glossary("cacheable")}}.</p>
 
 <dl>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/GET">GET</a></code></dt>

--- a/files/en-us/web/http/methods/options/index.html
+++ b/files/en-us/web/http/methods/options/index.html
@@ -9,35 +9,35 @@ browser-compat: http.methods.OPTIONS
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p><span class="seoSummary">The <strong>HTTP <code>OPTIONS</code> method</strong> requests permitted communication options for a given URL or server. A client can specify a URL with this method, or an asterisk (<code>*</code>) to refer to the entire server.</span></p>
+<p>The <strong>HTTP <code>OPTIONS</code> method</strong> requests permitted communication options for a given URL or server. A client can specify a URL with this method, or an asterisk (<code>*</code>) to refer to the entire server.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in HTML forms</th>
-   <td>No</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in HTML forms</th>
+      <td>No</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/patch/index.html
+++ b/files/en-us/web/http/methods/patch/index.html
@@ -23,32 +23,32 @@ tags:
 <p>Another (implicit) indication that <code>PATCH</code> is allowed, is the presence of the {{HTTPHeader("Accept-Patch")}} header, which specifies the patch document formats accepted by the server.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
-   <td>No</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
+      <td>No</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/post/index.html
+++ b/files/en-us/web/http/methods/post/index.html
@@ -32,32 +32,32 @@ browser-compat: http.methods.POST
 </ul>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>Only if freshness information is included</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
-   <td>Yes</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>Only if freshness information is included</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/put/index.html
+++ b/files/en-us/web/http/methods/put/index.html
@@ -14,32 +14,32 @@ browser-compat: http.methods.PUT
 <p>The difference between <code>PUT</code> and {{HTTPMethod("POST")}} is that <code>PUT</code> is idempotent: calling it once or several times successively has the same effect (that is no <em>side</em> effect), whereas successive identical {{HTTPMethod("POST")}} requests may have additional effects, akin to placing an order several times.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
-   <td>No</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in <a href="/en-US/docs/Learn/Forms">HTML forms</a></th>
+      <td>No</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/methods/trace/index.html
+++ b/files/en-us/web/http/methods/trace/index.html
@@ -14,32 +14,32 @@ browser-compat: http.methods.TRACE
 <p>The final recipient of the request should reflect the message received, excluding some fields described below, back to the client as the message body of a {{HTTPStatus("200")}} (<code>OK</code>) response with a {{HTTPHeader("Content-Type")}} of <code>message/http</code>. The final recipient is either the origin server or the first server to receive a {{HTTPHeader("Max-Forwards")}} value of 0 in the request.</p>
 
 <table class="properties">
- <tbody>
-  <tr>
-   <th scope="row">Request has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Successful response has body</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Safe")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Idempotent")}}</th>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">{{Glossary("Cacheable")}}</th>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Allowed in HTML forms</th>
-   <td>No</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Allowed in HTML forms</th>
+      <td>No</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/http/redirections/index.html
+++ b/files/en-us/web/http/redirections/index.html
@@ -203,7 +203,7 @@ tags:
 
 <h3 id="Temporary_responses_to_unsafe_requests">Temporary responses to unsafe requests</h3>
 
-<p>{{Glossary("safe", "Unsafe")}} requests modify the state of the server and the user shouldn't resend them unintentionally.</p>
+<p>{{Glossary("Safe/HTTP", "Unsafe")}} requests modify the state of the server and the user shouldn't resend them unintentionally.</p>
 
 <p>Typically, you don't want your users to resend {{HTTPMethod("PUT")}}, {{HTTPMethod("POST")}} or {{HTTPMethod("DELETE")}} requests. If you serve the response as the result of this request, a simple press of the reload button will resend the request (possibly after a confirmation message).</p>
 
@@ -242,7 +242,7 @@ tags:
 Redirect 301 / https://www.example.com
 </pre>
 
-<p>The <code><a href="http://httpd.apache.org/docs/current/mod/mod_rewrite.html">mod_rewrite</a></code> module can also create redirects. It is more flexible, but a bit more complex.</p>
+<p>The <code><a href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html">mod_rewrite</a></code> module can also create redirects. It is more flexible, but a bit more complex.</p>
 
 <h3 id="Nginx">Nginx</h3>
 

--- a/files/en-us/web/http/status/304/index.html
+++ b/files/en-us/web/http/status/304/index.html
@@ -13,7 +13,7 @@ browser-compat: http.status.304
 <p>The HTTP <code><strong>304 Not Modified</strong></code> client redirection response
   code indicates that there is no need to retransmit the requested resources. It is an
   implicit redirection to a cached resource. This happens when the request method is
-  {{glossary("safe")}}, like a {{HTTPMethod("GET")}} or a {{HTTPMethod("HEAD")}} request,
+  {{glossary("Safe/HTTP", "safe")}}, like a {{HTTPMethod("GET")}} or a {{HTTPMethod("HEAD")}} request,
   or when the request is conditional and uses a {{HTTPHeader("If-None-Match")}} or a
   {{HTTPHeader("If-Modified-Since")}} header.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

#3649 didn't change macro usages. This PR covers them.


> Issue number (if there is an associated issue)

None.


> Anything else that could help us review it

None.