### PR TITLE
removed unnecessary wording, improved phrasing

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">One of HTML's main jobs is to give text structure and meaning (also known as {{glossary("semantics")}}) so that a browser can display it correctly. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
+<p class="summary">One of HTML's main jobs is to give text structure so that a browser can display a webpage the way its developer envisions it. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
 
 <table class="learn-box standard-table">
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">One of HTML's main jobs is to give text structure so that a browser can display a webpage the way its developer envisions it. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
+<p class="summary">One of HTML's main jobs is to give text structure so that a browser can display an HTML document the way its developer intends. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
 
 <table class="learn-box standard-table">
  <tbody>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

1) The notion of **semantics** isn't used in this lesson, which is concerned solely with **structure**. Besides, the preliminary gloss of semantics being about structure isn't true.
2) We can improve the phrasing a bit, as I hope I've done.

> Issue number (if there is an associated issue)

Fixes #6753
