### PR TITLE
Object.entries() order does depend on how an object is defined

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.html
@@ -13,13 +13,14 @@ browser-compat: javascript.builtins.Object.entries
 
 <p>The <code><strong>Object.entries()</strong></code> method returns an array of a given
   object's own enumerable string-keyed property
-  <code>[<var>key</var>, <var>value</var>]</code> pairs, in the same order as that
-  provided by a {{jsxref("Statements/for...in", "for...in")}} loop. (The only important
-  difference is that a <code>for...in</code> loop enumerates properties in the prototype
+  <code>[<var>key</var>, <var>value</var>]</code> pairs. This is the same as iterating
+  with a {{jsxref("Statements/for...in", "for...in")}} loop, except that a
+  <code>for...in</code> loop enumerates properties in the prototype
   chain as well). </p>
 
-<p>The order of the array returned by <code><strong>Object.entries()</strong></code> does
-  not depend on how an object is defined. If there is a need for certain ordering, then
+<p>The order of the array returned by <code><strong>Object.entries()</strong></code> is
+  the same as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop. If
+  there is a need for different ordering, then
   the array should be sorted first, like
   <code>Object.entries(obj).sort((a, b) =&gt; b[0].localeCompare(a[0]));</code>.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`Object.entries()` internally uses the object's `[[OwnPropertyKeys]]` internal method, which [(for non-exotic objects)](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys), orders string properties "in ascending chronological order of property creation". That is, the order does depend on how the object is defined.

> Issue number (if there is an associated issue)

N/A


> Anything else that could help us review it

﻿See also mdn/interactive-examples#1868 for the comment in the code example.
