### PR TITLE
Remove window. and similar from WindowOrWorkerGlobalScope docs

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/atob/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/atob/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.atob
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">var <var>decodedData</var> = scope.atob(<var>encodedData</var>);</pre>
+  class="brush: js">var <var>decodedData</var> = atob(<var>encodedData</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -48,8 +48,8 @@ browser-compat: api.WindowOrWorkerGlobalScope.atob
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush:js">const encodedData = window.btoa('Hello, world'); // encode a string
-const decodedData = window.atob(encodedData); // decode the string</pre>
+<pre class="brush:js">const encodedData = btoa('Hello, world'); // encode a string
+const decodedData = atob(encodedData); // decode the string</pre>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.btoa
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">var <var>encodedData</var> = <var>scope</var>.btoa(<var>stringToEncode</var>);</pre>
+  class="brush: js">var <var>encodedData</var> = btoa(<var>stringToEncode</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -53,8 +53,8 @@ browser-compat: api.WindowOrWorkerGlobalScope.btoa
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">const encodedData = window.btoa('Hello, world'); // encode a string
-const decodedData = window.atob(encodedData); // decode the string
+<pre class="brush: js">const encodedData = btoa('Hello, world'); // encode a string
+const decodedData = atob(encodedData); // decode the string
 </pre>
 
 <h2 id="Unicode_strings">Unicode strings</h2>

--- a/files/en-us/web/api/windoworworkerglobalscope/clearinterval/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/clearinterval/index.html
@@ -22,7 +22,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.clearInterval
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>scope</em>.clearInterval(<var>intervalID</var>)
+<pre class="brush: js">clearInterval(<var>intervalID</var>)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/api/windoworworkerglobalscope/cleartimeout/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/cleartimeout/index.html
@@ -18,7 +18,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.clearTimeout
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>scope</em>.clearTimeout(<em>timeoutID</em>)
+<pre class="brush: js">clearTimeout(<em>timeoutID</em>)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -53,13 +53,13 @@ browser-compat: api.WindowOrWorkerGlobalScope.clearTimeout
       this.cancel();
     }
 
-    this.timeoutID = window.setTimeout(function(msg) {
+    this.timeoutID = setTimeout(function(msg) {
       this.remind(msg);
     }.bind(this), 1000, 'Wake up!');
   },
 
   cancel: function() {
-    window.clearTimeout(this.timeoutID);
+    clearTimeout(this.timeoutID);
   }
 };
 window.onclick = function() { alarm.setup(); };

--- a/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
@@ -52,7 +52,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.queueMicrotask
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>scope</em>.queueMicrotask(<em>function</em>);
+<pre class="brush: js">queueMicrotask(<em>function</em>);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -70,7 +70,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.queueMicrotask
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">self.queueMicrotask(() =&gt; {
+<pre class="brush: js">queueMicrotask(() =&gt; {
   // function contents here
 })</pre>
 
@@ -98,8 +98,8 @@ browser-compat: api.WindowOrWorkerGlobalScope.queueMicrotask
 <p>The code below is basically a monkey-patch for <code>queueMicrotask()</code> for modern
   engines. It creates a microtask by using a promise that resolves immediately.</p>
 
-<pre class="brush: js">if (typeof window.queueMicrotask !== "function") {
-  window.queueMicrotask = function (callback) {
+<pre class="brush: js">if (typeof self.queueMicrotask !== "function") {
+  self.queueMicrotask = function (callback) {
     Promise.resolve()
       .then(callback)
       .catch(e =&gt; setTimeout(() =&gt; { throw e; })); // report exceptions

--- a/files/en-us/web/api/windoworworkerglobalscope/setinterval/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/setinterval/index.html
@@ -28,9 +28,9 @@ browser-compat: api.WindowOrWorkerGlobalScope.setInterval
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>var intervalID</em> = <em>scope</em>.setInterval(<em>func</em>, [<em>delay</em>, <em>arg1</em>, <em>arg2</em>, ...]);
-var <em>intervalID</em> = <em>scope</em>.setInterval(function[, delay]);
-<em>var intervalID</em> = <em>scope</em>.setInterval(<em>code</em>, [<em>delay]</em>);
+<pre class="brush: js"><em>var intervalID</em> = setInterval(<em>func</em>, [<em>delay</em>, <em>arg1</em>, <em>arg2</em>, ...]);
+var <em>intervalID</em> = setInterval(function[, delay]);
+<em>var intervalID</em> = setInterval(<em>code</em>, [<em>delay]</em>);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -82,7 +82,7 @@ var <em>intervalID</em> = <em>scope</em>.setInterval(function[, delay]);
 
 <p>The following example demonstrates <code>setInterval()</code>'s basic syntax.</p>
 
-<pre class="brush:js">var intervalID = window.setInterval(myCallback, 500, 'Parameter 1', 'Parameter 2');
+<pre class="brush:js">var intervalID = setInterval(myCallback, 500, 'Parameter 1', 'Parameter 2');
 
 function myCallback(a, b)
 {

--- a/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
@@ -24,9 +24,9 @@ browser-compat: api.WindowOrWorkerGlobalScope.setTimeout
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <var>timeoutID</var> = <var>scope</var>.setTimeout(<var>function</var>[, <var>delay</var>, <var>arg1</var>, <var>arg2</var>, ...]);
-var <var>timeoutID</var> = <var>scope</var>.setTimeout(<var>function</var>[, <var>delay</var>]);
-var <var>timeoutID</var> = <var>scope</var>.setTimeout(<var>code</var>[, <var>delay</var>]);
+<pre class="brush: js">var <var>timeoutID</var> = setTimeout(<var>function</var>[, <var>delay</var>, <var>arg1</var>, <var>arg2</var>, ...]);
+var <var>timeoutID</var> = setTimeout(<var>function</var>[, <var>delay</var>]);
+var <var>timeoutID</var> = setTimeout(<var>code</var>[, <var>delay</var>]);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -153,11 +153,11 @@ setTimeout(myBoundMethod, 1.5*1000, "1"); // prints "one" after 1.5 seconds
 </p>
 
 <pre class="brush: js example-bad">// Don't do this
-window.setTimeout("alert('Hello World!');", 500);
+setTimeout("alert('Hello World!');", 500);
 </pre>
 
 <pre class="brush: js example-good">// Do this instead
-window.setTimeout(function() {
+setTimeout(function() {
   alert('Hello World!');
 }, 500);
 </pre>
@@ -319,11 +319,11 @@ foo has been called</pre>
 <pre class="brush: js">let timeoutID;
 
 function delayedAlert() {
-  timeoutID = window.setTimeout(window.alert, 2*1000, 'That was really slow!');
+  timeoutID = setTimeout(window.alert, 2*1000, 'That was really slow!');
 }
 
 function clearAlert() {
-  window.clearTimeout(timeoutID);
+  clearTimeout(timeoutID);
 }
 </pre>
 


### PR DESCRIPTION
In particular for methods there's no reason to promote
window.setTimeout() over just setTimeout(), which will also work in
workers.

For properties, it's already consistently documented as self.prop with a
useful "or just prop" comment, like here:
https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/isSecureContext#syntax