### PR TITLE
HTMLDialogElement: Add the 'cancel` event to the event list

### DIFF
--- a/files/en-us/web/api/htmldialogelement/index.html
+++ b/files/en-us/web/api/htmldialogelement/index.html
@@ -43,6 +43,9 @@ browser-compat: api.HTMLDialogElement
 <h2 id="Events">Events</h2>
 
 <dl>
+ <dt>{{domxref("HTMLDialogElement/cancel_event", "cancel")}}</dt>
+ <dd>Fired when the user instructs the browser that they wish to dismiss the current open dialog.<br>
+ Also available via the {{domxref("GlobalEventHandlers/oncancel", "oncancel")}} property.</dd>
  <dt>{{domxref("HTMLDialogElement/close_event", "close")}}</dt>
  <dd>Fired when the dialog is closed.<br>
  Also available via the {{domxref("GlobalEventHandlers/onclose", "onclose")}} property.</dd>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Missing `cancel` event to go alongside `close`

