### PR TITLE
improved mechanics

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.html
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.html
@@ -98,7 +98,7 @@ tags:
 
 <h2 id="What_is_the_CSS_box_model">What is the CSS box model?</h2>
 
-<p>The full CSS box model applies to block boxes, inline boxes only use some of the behavior defined in the box model. The model defines how the different parts of a box — margin, border, padding, and content — work together to create a box that you can see on the page. To add some additional complexity, there is a standard and an alternate box model.</p>
+<p>The CSS box model as a whole applies to block boxes. Inline boxes use just <em>some</em> of the behavior defined in the box model. The model defines how the different parts of a box — margin, border, padding, and content — work together to create a box that you can see on a page. To add some additional complexity, there is a standard and an alternate box model.</p>
 
 <h3 id="Parts_of_a_box">Parts of a box</h3>
 
@@ -108,7 +108,7 @@ tags:
  <li><strong>Content box</strong>: The area where your content is displayed, which can be sized using properties like {{cssxref("width")}} and {{cssxref("height")}}.</li>
  <li><strong>Padding box</strong>: The padding sits around the content as white space; its size can be controlled using {{cssxref("padding")}} and related properties.</li>
  <li><strong>Border box</strong>: The border box wraps the content and any padding. Its size and style can be controlled using {{cssxref("border")}} and related properties.</li>
- <li><strong>Margin box</strong>: The margin is the outermost layer, wrapping the content, padding and border as whitespace between this box and other elements. Its size can be controlled using {{cssxref("margin")}} and related properties.</li>
+ <li><strong>Margin box</strong>: The margin is the outermost layer, wrapping the content, padding, and border as whitespace between this box and other elements. Its size can be controlled using {{cssxref("margin")}} and related properties.</li>
 </ul>
 
 <p>The below diagram shows these layers:</p>


### PR DESCRIPTION
1) The MDN style guide calls for using the Oxford comma
2) The original opening consists of two independent clauses joined by a comma. This is a comma splice (or comma fault)
3) I tried to add some clarity, for example, by emphasizing the idea of SOME
