### PR TITLE
added clarity

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.html
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.html
@@ -144,7 +144,7 @@ tags:
 
 <p><img alt="Showing the size of the box when the alternate box model is being used." src="alternate-box-model.png"></p>
 
-<p>By default, browsers use the standard box model. If you want to turn on the alternative model for an element you do so by setting <code>box-sizing: border-box</code> on it. By doing this you are telling the browser to take the border box as the area defined by any size you set.</p>
+<p>By default, browsers use the standard box model. If you want to turn on the alternative model for an element, you do so by setting <code>box-sizing: border-box</code> on it. By doing this, you are telling the browser to use the border box, as shown above, as your defined area.</p>
 
 <pre class="brush: css">.box {
   box-sizing: border-box;


### PR DESCRIPTION
The concept of a "**border box**" is a novel one. I have at least some understanding of what "**border box**" is as a **value** of "**box-sizing**" because I already understand the concepts of **properties** and **values**. But in the last sentence, "**By doing this you are telling the browser to take the border box as the area defined by any size you set.**" The concept of **border box** is reinvoked, this time _not_ as a value. So the meaning seems to have changed. If so, its meaning should be clarified. For example, does "**border box**" in the sentence equate to "**alternative CSS box**"? In any case, it's clear the idea is illustrated in the image above.
