### PR TITLE
Fix taller interactive examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Array.slice
   (<code>end</code> not included) where <code>start</code> and <code>end</code> represent
   the index of items in that array. The original array will not be modified.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/array-slice.html")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/array-slice.html", "taller")}}</div>
 
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.html
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.ListFormat
   {{jsxref("Intl/ListFormat", "Intl.ListFormat")}} objects that enable language-sensitive list
   formatting.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/intl-listformat.html")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}</div>
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
I noticed that a couple of pages include interactive examples that are longer, but don't give the "taller" argument in the `EmbedInteractiveExample` macro, which means the iframe they get isn't big enough.

https://developer.mozilla.org/en-us/docs/web/javascript/reference/global_objects/intl/listformat/listformat
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice

This PR fixes that for those two pages. 