### PR TITLE
Mark PaymentRequestEvent.p.instrumentKey deprecated and non-standard

### DIFF
--- a/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
+++ b/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
@@ -3,11 +3,11 @@ title: PaymentRequestEvent.instrumentKey
 slug: Web/API/PaymentRequestEvent/instrumentKey
 browser-compat: api.PaymentRequestEvent.instrumentKey
 ---
-<p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{deprecated_header}}{{non-standard_header}}</p>
 
 <p>The <strong><code>instrumentKey</code></strong> read-only property of the
     {{domxref("PaymentRequestEvent")}} interface returns a
-    {{domxref("PaymentInstrument")}} object reflecting the payment instrument selected by
+    <code>PaymentInstrument</code> object reflecting the payment instrument selected by
     the user or an empty string if the user has not registered or chosen a payment
     instrument.</p>
 
@@ -18,11 +18,11 @@ browser-compat: api.PaymentRequestEvent.instrumentKey
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("PaymentInstrument")}} object.</p>
+<p>A <code>PaymentInstrument</code> object.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
https://github.com/w3c/payment-handler/commit/20a0ca9 (https://github.com/w3c/payment-handler/pull/393) dropped `PaymentRequestEvent.prototype.instrumentKey` from the Payment Handler spec. Related BCD change: https://github.com/mdn/browser-compat-data/pull/11549.