### PR TITLE
Document that FinalizationRegistry's callback is not optional

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.html
@@ -16,9 +16,6 @@ browser-compat: javascript.builtins.FinalizationRegistry.FinalizationRegistry
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">
-// No callback
-new FinalizationRegistry();
-
 // Arrow callback function
 new FinalizationRegistry(heldValue => { ... } )
 
@@ -32,8 +29,8 @@ new FinalizationRegistry(function callbackFn(heldValue) { ... })
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>callback</var></code> {{optional_inline}}</dt>
- <dd>The callback function this registry should use. If provided, this must be a function.</dd>
+ <dt><code><var>callback</var></code></dt>
+ <dd>The callback function this registry should use.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-cleanup-callback says:

> If IsCallable(cleanupCallback) is false, throw a TypeError exception.

Chrome, Firefox and Safari all throw an exception for `new FinalizationRegistry()`.