### PR TITLE
Move Element.attachShadow() to HTMLElement.attachShadow()

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7384,6 +7384,7 @@
 /en-US/docs/Web/API/Element/animationend_event	/en-US/docs/Web/API/HTMLElement/animationend_event
 /en-US/docs/Web/API/Element/animationiteration_event	/en-US/docs/Web/API/HTMLElement/animationiteration_event
 /en-US/docs/Web/API/Element/animationstart_event	/en-US/docs/Web/API/HTMLElement/animationstart_event
+/en-US/docs/Web/API/Element/attachInternals	/en-US/docs/Web/API/HTMLElement/attachInternals
 /en-US/docs/Web/API/Element/cancel_event	/en-US/docs/Web/API/HTMLDialogElement/cancel_event
 /en-US/docs/Web/API/Element/fullscreenchange	/en-US/docs/Web/API/Element/fullscreenchange_event
 /en-US/docs/Web/API/Element/gotpointercapture_event	/en-US/docs/Web/API/HTMLElement/gotpointercapture_event

--- a/files/en-us/web/api/element/index.html
+++ b/files/en-us/web/api/element/index.html
@@ -197,8 +197,6 @@ browser-compat: api.Element
  <dd>Registers an event handler to a specific event type on the element.</dd>
  <dt>{{DOMxRef("Element.after()")}}</dt>
  <dd>Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the <code>Element</code>'s parent, just after the <code>Element</code>.</dd>
- <dt>{{DOMxRef("Element.attachInternals()")}}</dt>
- <dd>Returns an {{DOMxRef("ElementInternals")}} object, and enables a custom element to participate in HTML forms.</dd>
  <dt>{{DOMxRef("Element.attachShadow()")}}</dt>
  <dd>Attaches a shadow DOM tree to the specified element and returns a reference to its {{DOMxRef("ShadowRoot")}}.</dd>
  <dt>{{DOMxRef("Element.animate()")}} {{Experimental_Inline}}</dt>

--- a/files/en-us/web/api/elementinternals/index.html
+++ b/files/en-us/web/api/elementinternals/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ElementInternals
 
 <h2 id="Constructor">Constructor</h2>
 
-<p>This interface has no constructor. An <code>ElementInternals</code> object is returned when calling {{domxref("Element.attachInternals()")}}.</p>
+<p>This interface has no constructor. An <code>ElementInternals</code> object is returned when calling {{domxref("HTMLElement.attachInternals()")}}.</p>
 
 <h2 id="Properties">Properties</h2>
 
@@ -141,7 +141,7 @@ browser-compat: api.ElementInternals
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example demonstrates how to create a custom form-associated element with {{domxref("Element.attachInternals")}}.</p>
+<p>The following example demonstrates how to create a custom form-associated element with {{domxref("HTMLElement.attachInternals")}}.</p>
 
 <pre class="brush: js">class CustomCheckbox extends HTMLElement {
   static formAssociated = true;

--- a/files/en-us/web/api/elementinternals/shadowroot/index.html
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.html
@@ -23,7 +23,7 @@ browser-compat: api.ElementInternals.shadowRoot
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example prints the value of <code>shadowRoot</code> to the console, immediately after calling {{domxref("Element.attachInternals()")}}. At this point the value is <code>null</code>. After calling {{domxref("Element.attachShadow()")}} the element has a Shadow Root, and <code>shadowRoot</code> returns the object representing it.</p>
+<p>The following example prints the value of <code>shadowRoot</code> to the console, immediately after calling {{domxref("HTMLElement.attachInternals()")}}. At this point the value is <code>null</code>. After calling {{domxref("Element.attachShadow()")}} the element has a Shadow Root, and <code>shadowRoot</code> returns the object representing it.</p>
 
 <pre class="brush: js">constructor() {
   super();

--- a/files/en-us/web/api/htmlelement/attachinternals/index.html
+++ b/files/en-us/web/api/htmlelement/attachinternals/index.html
@@ -1,21 +1,21 @@
 ---
-title: Element.attachInternals()
-slug: Web/API/Element/attachInternals
+title: HTMLElement.attachInternals()
+slug: Web/API/HTMLElement/attachInternals
 tags:
 - API
 - Element
 - Method
 - Reference
 - attachInternals
-browser-compat: api.Element.attachInternals
+browser-compat: api.HTMLElement.attachInternals
 ---
 <div>{{APIRef('DOM')}}</div>
 
-<p>The <strong><code>Element.attachInternals()</code></strong> method returns a {{domxref("ElementInternals")}} object. This method allows a <a href="/en-US/docs/Web/Web_Components/Using_custom_elements">custom element</a> to participate in HTML forms. The <code>ElementInternals</code> interface provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the <a href="https://wicg.github.io/aom/explainer.html">Accessibility Object Model</a> to the element.</p>
+<p>The <strong><code>HTMLElement.attachInternals()</code></strong> method returns a {{domxref("ElementInternals")}} object. This method allows a <a href="/en-US/docs/Web/Web_Components/Using_custom_elements">custom element</a> to participate in HTML forms. The <code>ElementInternals</code> interface provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the <a href="https://wicg.github.io/aom/explainer.html">Accessibility Object Model</a> to the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">Element.attachInternals();</pre>
+<pre class="brush: js">var <var>internals</var> = <var>element</var>.attachInternals();</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -38,7 +38,7 @@ browser-compat: api.Element.attachInternals
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example demonstrates how to create a custom form-associated element with {{domxref("Element.attachInternals")}}. The {{domxref("ElementInternals.form")}} property is then printed to the console to demonstrate that we have an {{domxref("ElementInternals")}} object.</p>
+<p>The following example demonstrates how to create a custom form-associated element with {{domxref("HTMLElement.attachInternals")}}. The {{domxref("ElementInternals.form")}} property is then printed to the console to demonstrate that we have an {{domxref("ElementInternals")}} object.</p>
 
 <pre class="brush: js">class CustomCheckbox extends HTMLElement {
   static formAssociated = true;

--- a/files/en-us/web/api/htmlelement/index.html
+++ b/files/en-us/web/api/htmlelement/index.html
@@ -120,7 +120,7 @@ browser-compat: api.HTMLElement
 
 <dl>
  <dt>{{DOMxRef("HTMLElement.attachInternals()")}} {{Experimental_Inline}}</dt>
- <dd>Attaches an {{DOMxRef("ElementInternals")}} instance to the custom element.</dd>
+ <dd>Returns an {{DOMxRef("ElementInternals")}} object, and enables a custom element to participate in HTML forms.</dd>
  <dt>{{DOMxRef("HTMLElement.blur()")}}</dt>
  <dd>Removes keyboard focus from the currently focused element.</dd>
  <dt>{{DOMxRef("HTMLElement.click()")}}</dt>


### PR DESCRIPTION
Goes with https://github.com/mdn/browser-compat-data/pull/11556.