### PR TITLE
Update Web/API/Request

### DIFF
--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Request
  <dt>{{domxref("Request.body")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("ReadableStream")}} of the body contents.</dd>
  <dt>{{domxref("Request.bodyUsed")}} {{readonlyInline}}</dt>
- <dd>Stores a {{domxref("Boolean")}} that declares whether the body has been used in a request yet.</dd>
+ <dd>Stores <code>true</code> or <code>false</code> that declares whether the body has been used in a request yet.</dd>
  <dt>{{domxref("Request.cache")}} {{readonlyInline}}</dt>
  <dd>Contains the cache mode of the request (e.g., <code>default</code>, <code>reload</code>, <code>no-cache</code>).</dd>
  <dt>{{domxref("Request.credentials")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Request
  <dt>{{domxref("Request.body")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("ReadableStream")}} of the body contents.</dd>
  <dt>{{domxref("Request.bodyUsed")}} {{readonlyInline}}</dt>
- <dd>Stores <code>true</code> or <code>false</code> that declares whether the body has been used in a request yet.</dd>
+ <dd>Stores <code>true</code> or <code>false</code> to indicate whether or not the body has been used in a request yet.</dd>
  <dt>{{domxref("Request.cache")}} {{readonlyInline}}</dt>
  <dd>Contains the cache mode of the request (e.g., <code>default</code>, <code>reload</code>, <code>no-cache</code>).</dd>
  <dt>{{domxref("Request.credentials")}} {{readonlyInline}}</dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Request.bodyUsed actually returns true or false primitive, not a Boolean wrapper object.

> Issue number (if there is an associated issue)

None.
