### PR TITLE
Fix type on “accent” glossary entry

### DIFF
--- a/files/en-us/glossary/accent/index.html
+++ b/files/en-us/glossary/accent/index.html
@@ -11,7 +11,7 @@ tags:
 <p>On the web, an accent is sometimes used in {{HTMLElement("input")}} elements for the active portion of the control, for instance the background of a checked <a href="/en-US/docs/Web/HTML/Element/input/checkbox">checkbox</a>.</p>
 
 <h2 id="Learn_more">Learn more</h2>
-s
+
 <h3 id="CSS_related_to_the_accent">CSS related to the accent</h3>
 
 <p>You can set the color of the accent for a given element by setting the element's CSS {{cssxref("accent-color")}} property to the appropriate {{cssxref("&lt;color&gt;")}} value.</p>


### PR DESCRIPTION
The s between "Learn more" and "CSS related to the accent" looks unnecessary, so I propose removing this s.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
