### PR TITLE
Update scrollbar-color to match spec

### DIFF
--- a/files/en-us/web/css/scrollbar-color/index.html
+++ b/files/en-us/web/css/scrollbar-color/index.html
@@ -24,8 +24,6 @@ browser-compat: css.properties.scrollbar-color
 
 <pre class="brush: css">/* Keyword values */
 scrollbar-color: auto;
-scrollbar-color: dark;
-scrollbar-color: light;
 
 /* &lt;color&gt; values */
 scrollbar-color: rebeccapurple green;   /* Two valid colors.
@@ -48,14 +46,6 @@ scrollbar-color: unset;
    <tr>
     <td><code>auto</code></td>
     <td>Default platform rendering for the track portion of the scrollbar, in the absence of any other related scrollbar color properties.</td>
-   </tr>
-   <tr>
-    <td><code>dark</code></td>
-    <td>Show a dark scrollbar, which can be either a dark variant of scrollbar provided by the platform, or a custom scrollbar with dark colors.</td>
-   </tr>
-   <tr>
-    <td><code>light</code></td>
-    <td>Show a light scrollbar, which can be either a light variant of scrollbar provided by the platform, or a custom scrollbar with light colors.</td>
    </tr>
    <tr>
     <td><code>&lt;color&gt; &lt;color&gt;</code></td>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The spec for `scrollbar-color` has been updated to remove the `light` and `dark` keywords.

mdn/data PR: https://github.com/mdn/data/pull/492


> Anything else that could help us review it

https://github.com/w3c/csswg-drafts/issues/6438 - spec issue that removed them.
