### PR TITLE
added clarity

### DIFF
--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.html
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.html
@@ -53,7 +53,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/writing-modes/block-inline.html", '100%', 1200)}}</p>
 
-<p>When we switch the writing mode, we are changing which direction is block and which is inline. In a <code>horizontal-tb</code> writing mode the block direction runs from top to bottom; in a <code>vertical-rl</code> writing mode the block direction runs right-to-left horizontally. So the <strong>block dimension</strong> is always the direction blocks are displayed on the page in the writing mode in use. The <strong>inline dimension</strong> is always the direction a sentence flows.</p>
+<p>When we switch the writing mode, we change the <strong>dimensions</strong> of block and inline elements as well as the <strong>direction</strong> their content flows. To speak of the direction of an inline element is to speak of the direction a sentence flows. In a <code>horizontal-tb</code> writing mode, a block's content flows in a downward direction, and an inline's content (sentences) flows in a rightward direction. By the same token, in a <code>vertical-rl</code> writing mode, a block's content flows in a leftward direction and an inline's content (sentences) flows in a downward direction.</p>
 
 <p>This figure shows the two dimensions when in a horizontal writing mode.<img alt="Showing the block and inline axis for a horizontal writing mode." src="horizontal-tb.png"></p>
 


### PR DESCRIPTION
The original equated **dimensions** with **directions**. But dimensions are not directions. For example, this clause is incoherent:

> "the block dimension is always the direction blocks are displayed"