### PR TITLE
Fix syntax error in first example at end of “constructor” doc

### DIFF
--- a/files/en-us/web/javascript/reference/classes/constructor/index.html
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.html
@@ -134,7 +134,7 @@ try {
   constructor(length) {
     // Here, it calls the parent class' constructor with lengths
     // provided for the Polygon's width and height
-    super(length, length);
+    super(height, width);
     // NOTE: In derived classes, `super()` must be called before you
     // can use `this`. Leaving this out will cause a ReferenceError.
     this.name = 'Square';


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
These are errors that make it difficult to understand the examples.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
