### PR TITLE
Handling text_direction - fixing heights

### DIFF
--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.html
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.html
@@ -83,7 +83,7 @@ tags:
 
 <p>The property mapped to <code>width</code> when in a horizontal writing mode is called {{cssxref("inline-size")}} — it refers to the size in the inline dimension. The property for <code>height</code> is named {{cssxref("block-size")}} and is the size in the block dimension. You can see how this works in the example below where we have replaced <code>width</code> with <code>inline-size</code>.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/writing-modes/inline-size.html", '100%', 1200)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/learn/writing-modes/inline-size.html", '100%', 950)}}</p>
 
 <h3 id="Logical_margin_border_and_padding_properties">Logical margin, border, and padding properties</h3>
 
@@ -111,7 +111,7 @@ tags:
 
 <p><strong>Change the writing mode on this example to <code>vertical-rl</code> to see what happens to the image. Change <code>inline-start</code> to <code>inline-end</code> to change the float.</strong></p>
 
-<p>{{EmbedGHLiveSample("css-examples/learn/writing-modes/float.html", '100%', 1200)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/learn/writing-modes/float.html", '100%', 850)}}</p>
 
 <p>Here we are also using logical margin values to ensure the margin is in the correct place no matter what the writing mode is.</p>
 


### PR DESCRIPTION
Fixes #7004

Heights on some EmbedGHLiveSample macros were much bigger than content. This reduces the whitespace.

