### PR TITLE
Copy-edit fixes for Date.toLocaleString doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.html
@@ -37,16 +37,16 @@ toLocaleString(locales, options)
 
 <p>The <code><var>locales</var></code> and <code><var>options</var></code> arguments
   customize the behavior of the function and let applications specify the language whose
-  formatting conventions should be used. In implementations, which ignore the
+  formatting conventions should be used. In implementations which ignore the
   <code><var>locales</var></code> and <code><var>options</var></code> arguments, the
-  locale used and the form of the string returned are entirely implementation dependent.
+  locale used and the form of the string returned are entirely implementation-dependent.
 </p>
 
 <p>See the {{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}
   constructor for details on these parameters and how to use them.</p>
 
 <p>The default value for each date-time component property is {{jsxref("undefined")}}.
-  But, if the <code>weekday</code>, <code>year</code>, <code>month</code>, and
+  But if the <code>weekday</code>, <code>year</code>, <code>month</code>, and
   <code>day</code> properties are all {{jsxref("undefined")}}, then <code>year</code>,
   <code>month</code>, and <code>day</code> are assumed to be <code>"numeric"</code>.</p>
 
@@ -96,7 +96,7 @@ console.log(date.toLocaleString());
 
 <pre class="brush: js">let date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
-// formats below assume the local time zone of the locale;
+// Formats below assume the local time zone of the locale;
 // America/Los_Angeles for the US
 
 // US English uses month-day-year order and 12-hour time with AM/PM
@@ -111,11 +111,11 @@ console.log(date.toLocaleString('en-GB'));
 console.log(date.toLocaleString('ko-KR'));
 // → "2012. 12. 20. 오후 12:00:00"
 
-// Arabic in most Arabic speaking countries uses real Arabic digits
+// Arabic in most Arabic-speaking countries uses Eastern Arabic numerals
 console.log(date.toLocaleString('ar-EG'));
 // → "<span dir="rtl">٢٠‏/١٢‏/٢٠١٢ ٥:٠٠:٠٠ ص</span>"
 
-// for Japanese, applications may want to use the Japanese calendar,
+// For Japanese, applications may want to use the Japanese calendar,
 // where 2012 was the year 24 of the Heisei era
 console.log(date.toLocaleString('ja-JP-u-ca-japanese'));
 // → "24/12/20 12:00:00"
@@ -133,20 +133,20 @@ console.log(date.toLocaleString(['ban', 'id']));
 
 <pre class="brush: js">let date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
-// request a weekday along with a long date
+// Request a weekday along with a long date
 let options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
 
 console.log(date.toLocaleString('de-DE', options));
 // → "Donnerstag, 20. Dezember 2012"
 
-// an application may want to use UTC and make that visible
+// An application may want to use UTC and make that visible
 options.timeZone = 'UTC';
 options.timeZoneName = 'short';
 
 console.log(date.toLocaleString('en-US', options));
 // → "Thursday, December 20, 2012, GMT"
 
-// sometimes even the US needs 24-hour time
+// Sometimes even the US needs 24-hour time
 console.log(date.toLocaleString('en-US', { hour12: false }));
 // → "12/19/2012, 19:00:00"
 </pre>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This commit fixes some grammatical and terminology errors on the Date.toLocaleString documentation page.


> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Nothing.