### PR TITLE
Test your skills: Loops - remove line about editors

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.html
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.html
@@ -69,8 +69,6 @@ tags:
 
 <h2 id="Assessment_or_further_help">Assessment or further help</h2>
 
-<p>You can practice these examples in the Interactive Editors above.</p>
-
 <p>If you would like your work assessed, or are stuck and want to ask for help:</p>
 
 <ol>


### PR DESCRIPTION
Fixes #7009

As suggested in #7009, remove line referring to interactive editors. Editors don't exist, and removal is good fix as section works fine without it. 