### PR TITLE
Update on let and const variable on hoisting.

### DIFF
--- a/files/en-us/glossary/hoisting/index.html
+++ b/files/en-us/glossary/hoisting/index.html
@@ -56,7 +56,8 @@ num = 6; // Initialization</pre>
 <pre class="brush: js">console.log(num); // Throws ReferenceError exception
 num = 6; // Initialization</pre>
 
-<p>Initializations using <code>let</code> and <code>const</code> are also not hoisted. </p>
+<p>Initializations using <code>let</code> and <code>const</code> are also hoisted but they are in Temporal Dead Zone so whenever we try to access any variable in Temporal Dead Zone it gives us Reference error and after assiging value to let and const variables the temporal dead zone will vanish.</p>
+
 
 <pre class="brush: js">// Example with let:
 a = 1; // initialization.


### PR DESCRIPTION
I update on let and const variable on hoisting behavior. As your page said that let and const are not hoisted but they hoisted in a temporal dead zone so whenever we try to access the let and const variable in a temporal dead zone it gives us a Reference Error and after assigning the values to variables the temporal dead zone will vanish.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
We can't say that let and const are not hoisted. It gives the wrong understanding to viewers.



> Issue number (if there is an associated issue)



> Anything else that could help us review it
