### PR TITLE
Fix examples in window.btoa() doc that fail on long input

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
@@ -89,9 +89,12 @@ function toBinary(string) {
   for (let i = 0; i &lt; codeUnits.length; i++) {
     codeUnits[i] = string.charCodeAt(i);
   }
-  return new Uint8Array(codeUnits.buffer).reduce((acc, charCode) => {
-    return acc + String.fromCharCode(charCode);
-  }, "");
+  const charCodes = new Uint8Array(codeUnits.buffer);
+  let result = '';
+  for (let i = 0; i &lt; charCodes.byteLength; i++) {
+    result += String.fromCharCode(charCodes[i]);
+  }
+  return result;
 }
 
 // a string that contains characters occupying &gt; 1 byte
@@ -110,9 +113,12 @@ console.log(encoded);                 // OCY5JjomOyY8Jj4mPyY=
   for (let i = 0; i &lt; bytes.length; i++) {
     bytes[i] = binary.charCodeAt(i);
   }
-  return new Uint16Array(bytes.buffer).reduce((acc, charCode) => {
-    return acc + String.fromCharCode(charCode);
-  }, "");
+  const charCodes = new Uint16Array(bytes.buffer);
+  let result = '';
+  for (let i = 0; i &lt; charCodes.length; i++) {
+    result += String.fromCharCode(charCodes[i]);
+  }
+  return result;
 }
 
 const decoded = atob(encoded);

--- a/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/btoa/index.html
@@ -89,7 +89,9 @@ function toBinary(string) {
   for (let i = 0; i &lt; codeUnits.length; i++) {
     codeUnits[i] = string.charCodeAt(i);
   }
-  return String.fromCharCode(...new Uint8Array(codeUnits.buffer));
+  return new Uint8Array(codeUnits.buffer).reduce((acc, charCode) => {
+    return acc + String.fromCharCode(charCode);
+  }, "");
 }
 
 // a string that contains characters occupying &gt; 1 byte
@@ -108,7 +110,9 @@ console.log(encoded);                 // OCY5JjomOyY8Jj4mPyY=
   for (let i = 0; i &lt; bytes.length; i++) {
     bytes[i] = binary.charCodeAt(i);
   }
-  return String.fromCharCode(...new Uint16Array(bytes.buffer));
+  return new Uint16Array(bytes.buffer).reduce((acc, charCode) => {
+    return acc + String.fromCharCode(charCode);
+  }, "");
 }
 
 const decoded = atob(encoded);


### PR DESCRIPTION
…puts

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Functions `toBinary` and `fromBinary` are buggy - they fail with "RangeError: too many function arguments" if the input string is too long. The exact length when it starts to fail seems to depend on the browser.

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/7026

> Anything else that could help us review it

Testing ([fiddle](https://jsfiddle.net/75jvx1h9/)):

```javascript
// Before
function toBinary_before(string) {
  const codeUnits = new Uint16Array(string.length);
  for (let i = 0; i < codeUnits.length; i++) {
    codeUnits[i] = string.charCodeAt(i);
  }
  return String.fromCharCode(...new Uint8Array(codeUnits.buffer));
}

function fromBinary_before(binary) {
  const bytes = new Uint8Array(binary.length);
  for (let i = 0; i < bytes.length; i++) {
    bytes[i] = binary.charCodeAt(i);
  }
  return String.fromCharCode(...new Uint16Array(bytes.buffer));
}

// After
function toBinary_after(string) {
  const codeUnits = new Uint16Array(string.length);
  for (let i = 0; i < codeUnits.length; i++) {
    codeUnits[i] = string.charCodeAt(i);
  }
  const charCodes = new Uint8Array(codeUnits.buffer);
  let result = '';
  for (let i = 0; i < charCodes.byteLength; i++) {
    result += String.fromCharCode(charCodes[i]);
  }
  return result;
}

function fromBinary_after(binary) {
  const bytes = new Uint8Array(binary.length);
  for (let i = 0; i < bytes.length; i++) {
    bytes[i] = binary.charCodeAt(i);
  }
  const charCodes = new Uint16Array(bytes.buffer);
  let result = '';
  for (let i = 0; i < charCodes.length; i++) {
    result += String.fromCharCode(charCodes[i]);
  }
  return result;
}


// Test both versions on a short input.
// We expect them to be equivalent.

const shortString = 'hello - привет - 你好 - 😋';
// Check that the before and after versions return the same value.
console.log(toBinary_before(shortString) === toBinary_after(shortString));
const encodedShortString = toBinary_after(shortString);

// Check that the before and after versions return the same value.
console.log(fromBinary_before(encodedShortString) === fromBinary_after(encodedShortString));
// Sanity check
console.log(fromBinary_after(encodedShortString) === shortString);



// Test both versions on a long input.
// "After" works, "before" fails.

const longString = shortString.repeat(100000);
const encodedLongString = toBinary_after(longString);
// fails
// toBinary_before(longString);

console.log(fromBinary_after(encodedLongString) === longString);
// fails
// fromBinary_before(encodedLongString);
```