### PR TITLE
adds content: none to experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -466,6 +466,46 @@ tags:
  </tbody>
 </table>
 
+<h3 id="Value_content_none">Value of the <code>content</code> property: none</h3>
+
+<p>The <code>none</code> value of the {{cssxref("content")}} property inhibits the children of the element from being rendered as children of this element, as if the element was empty. (See {{bug(1699964)}} for more details.)</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>91</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>91</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>91</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>91</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>layout.css.element-content-none.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
 <h3 id="Grid_Masonry_layout">Grid: Masonry layout</h3>
 
 <p>Adds support for a <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout">masonry-style layout</a> based on grid layout where one axis has a masonry layout and the other has a normal grid layout. This allows developers to easily create gallery style layouts like on Pinterest. See {{bug(1607954)}} for more details.</p>


### PR DESCRIPTION
Working on #6716 

This adds `content: none` to Experimental features.