### PR TITLE
Add missing quotes to XMLHttpRequest.responseType

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.html
@@ -38,7 +38,7 @@ It can take the following values:
     <dd>An empty <code>responseType</code> string is the same as <code>"text"</code>, the default type.</dd>
     <dt><code>"arraybuffer"</code></dt>
     <dd>The {{domxref("XMLHttpRequest.response", "response")}} is a JavaScript {{jsxref("ArrayBuffer")}} containing binary data.</dd>
-    <dt><code>"blob</code></dt>
+    <dt><code>"blob"</code></dt>
     <dd>The <code>response</code> is a {{domxref("Blob")}} object containing the binary data.</dd>
     <dt><code>"document"</code></dt>
     <dd>The <code>response</code> is an {{Glossary("HTML")}} {{domxref("Document")}} or {{Glossary("XML")}} {{domxref("XMLDocument")}}, as appropriate based on the MIME type of the received data. See <a href="/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest">HTML in XMLHttpRequest</a> to learn more about using XHR to fetch HTML content.</dd>


### PR DESCRIPTION
This PR adds a missing quote around the `blob` value in the documentation for `XMLHttpRequest.responseType`.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A quotation mark was missing from the documentation. A tiny change, but hopefully improves the reading experience! 