### PR TITLE
Remove incorrect TypedArray.from() signatures

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.html
@@ -71,7 +71,7 @@ Array.from(arrayLike, function mapFn(element, index) { ... }, thisArg)
     <code>Array.from(<var>obj</var>, <var>mapFn</var>, <var>thisArg</var>)</code><br>
     has the same result
     as <code>Array.from(<var>obj</var>).map(<var>mapFn</var>, <var>thisArg</var>)</code>,<br>
-    except that it does not create an intermediate array, and <var>mapFn<var> only receives
+    except that it does not create an intermediate array, and <var>mapFn</var> only receives
     two arguments (<var>element</var>, <var>index</var>).</p>
 
 <div class="note"><p><strong>Note:</strong> This is especially important for certain array subclasses, like <a

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.html
@@ -25,19 +25,18 @@ browser-compat: javascript.builtins.TypedArray.from
 
 <pre class="brush: js">
 // Arrow function
-TypedArray.from(arrayLike, (currentValue) => { ... } )
-TypedArray.from(arrayLike, (currentValue, index) => { ... } )
-TypedArray.from(arrayLike, (currentValue, index, array) => { ... } )
+TypedArray.from(arrayLike, (element) => { ... } )
+TypedArray.from(arrayLike, (element, index) => { ... } )
 
 // Mapping function
 TypedArray.from(arrayLike, mapFn)
 TypedArray.from(arrayLike, mapFn, thisArg)
 
 // Inline mapping function
-TypedArray.from(arrayLike, function mapFn(currentValue) { ... })
-TypedArray.from(arrayLike, function mapFn(currentValue, index) { ... })
-TypedArray.from(arrayLike, function mapFn(currentValue, index, array){ ... })
-TypedArray.from(arrayLike, function mapFn(currentValue, index, array) { ... }, thisArg)
+TypedArray.from(arrayLike, function mapFn(element) { ... })
+TypedArray.from(arrayLike, function mapFn(element, index) { ... })
+TypedArray.from(arrayLike, function mapFn(element) { ... }, thisArg)
+TypedArray.from(arrayLike, function mapFn(element, index) { ... }, thisArg)
 </pre>
 
 <p>Where <code><var>TypedArray</var></code> is one of:</p>


### PR DESCRIPTION
Follow-up to #7038 

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Aligns `TypedArray.from()` function signatures with those of `Array.from()`.

> Anything else that could help us review it

https://tc39.es/ecma262/#sec-%typedarray%.from
