### PR TITLE
remove duplicate h3 ID

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -323,7 +323,7 @@ console.log(new Intl.DateTimeFormat('fr', { hour: 'numeric', hourCycle: 'h12',
     dayPeriod: 'long', timeZone: 'UTC' }).format(date));
 // > "4 du matin"</pre>
 
-<h3 id="using_dayperiod">Using timeZoneName</h3>
+<h3 id="using_timezonename">Using timeZoneName</h3>
 
 <p>Use the <code>timeZoneName</code> option to output a string for the timezone ("GMT", "Pacific Time", etc.).</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The page reused the same `id="using_dayperiod"`.
This can lead to really weird bugs because we use those IDs to React render the page. 
See https://github.com/mdn/yari/issues/4227#issuecomment-881674861

> Anything else that could help us review it

Once https://github.com/mdn/yari/pull/4233 lands, these problems will sorta go away. 
What's going to happen, if you have...:
```html
<h2 id="foo">Hi</h2>
<h2 id="foo">World</h2>
```
...is that it forcibly produces...:
```html
<h2 id="foo">Hi</h2>
<h2 id="foo_2">World</h2>
```
and it'll also spit out a `sectioning` flaw on that page. 
