### PR TITLE
Remove RTCPeerConnectionState enum

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
@@ -11,26 +11,81 @@ browser-compat: api.RTCPeerConnection.connectionState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
-<p>The read-only <strong><code>connectionState</code></strong> property of the
-  {{domxref("RTCPeerConnection")}} interface indicates the current state of the peer
-  connection by returning one of the string values specified by the enum
-  <code><a href="#rtcpeerconnectionstate_enum">RTCPeerConnectionState</a></code>.</p>
+<p>
+  The read-only <strong><code>connectionState</code></strong> property
+  of the {{domxref("RTCPeerConnection")}} interface
+  indicates the current state of the peer connection
+  by returning one of the following string values:
+  <code>new</code>, <code>connecting</code>, <code>connected</code>, <code>disconnected</code>,
+  <code>failed</code>, or <code>closed</code>.
+</p>
 
-<p>When this property's value changes, a {{event("connectionstatechange")}} event is sent
-  to the {{domxref("RTCPeerConnection")}} instance.</p>
+<p>This state essentially represents the aggregate state of all ICE transports
+  (which are of type {{domxref("RTCIceTransport")}} or {{domxref("RTCDtlsTransport")}})
+  being used by the connection.</p>
+</p>
+
+<p>
+  When this property's value changes,
+  a {{domxref("RTCPeerconnection.connectionstatechange_event", "connectionstatechange")}} event
+  is sent to the {{domxref("RTCPeerConnection")}} instance.
+</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>connectionState</em> = <em>RTCPeerConnection</em>.connectionState;</pre>
+<pre class="brush: js">var <em>connectionState</em> = <em>RTCPeerConnection</em>.connectionState;</pre>
 
-<h3 id="Value">Value</h3>
+<h2 id="Value">Value</h2>
 
-<p>The current state of the connection, as a value from the enum
-  <code><a href="#rtcpeerconnectionstate_enum">RTCPeerConnectionState</a></code>.</p>
+<p>A string representing the current state of the connection, that is one of the following litterals:</p>
 
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCPeerConnectionState enum", 0, 1)}}
-</p>
+  <dl>
+    <dt><code>new</code></dt>
+    <dd>
+      At least one of the connection's {{Glossary("ICE")}} transports
+      ({{domxref("RTCIceTransport")}} or {{domxref("RTCDtlsTransport")}} objects)
+      is in the <code>new</code> state,
+      and none of them are in one of the following states:
+      <code>connecting</code>, <code>checking</code>, <code>failed</code>, <code>disconnected</code>,
+       or all of the connection's transports are in the <code>closed</code> state.
+    </d>
+
+    <dt><code>connecting</code></dt>
+    <dd>
+      One or more of the {{Glossary("ICE")}} transports are currently in the process of establishing a connection;
+      that is, their {{DOMxRef("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} is
+      either <code>checking</code> or <code>connected</code>,
+      and no transports are in the <code>failed</code> state.
+    </dd>
+
+    <dt><code>connected</code></dt>
+    <dd>
+      Every {{Glossary("ICE")}} transport used by the connection
+      is either in use
+      (state <code>connected</code> or <code>completed</code>)
+      or is closed (state <code>closed</code>);
+      in addition, at least one transport is either <code>connected</code> or <code>completed</code>.
+    </dd>
+
+    <dt><code>disconnected</code></dt>
+    <dd>
+      At least one of the {{Glossary("ICE")}} transports for the connection
+      is in the <code>disconnected</code> state
+      and none of the other transports are in the state
+      <code>failed</code>, <code>connecting</code>, or <code>checking</code>.
+    </dd>
+
+    <dt><code>failed</code></dt>
+    <dd>
+      One or more of the {{Glossary("ICE")}} transports on the connection
+      is in the <code>failed</code> state.
+    </dd>
+
+    <dt><code>closed</code></dt>
+    <dd>
+      The {{DOMxRef("RTCPeerConnection")}} is closed.
+    </dd>
+  </dl>
 
 <h2 id="Example">Example</h2>
 
@@ -54,6 +109,6 @@ var connectionState = pc.connectionState;</pre>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime">Lifetime of a WebRTC
       session</a></li>
   <li>{{domxref("RTCPeerConnection")}}</li>
-  <li>{{event("connectionstatechange")}}</li>
-  <li><a href="/en-US/docs/Web/Guide/API/WebRTC">WebRTC</a></li>
+  <li>{{domxref("RTCPeerconnection.connectionstatechange_event", "connectionstatechange")}}</li>
+  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
@@ -12,7 +12,11 @@ browser-compat: api.RTCPeerConnection.connectionstatechange_event
 <div>{{APIRef("WebRTC")}}</div>
 
 <p>The <strong><code>connectionstatechange</code></strong> event is sent to the {{domxref("RTCPeerConnection.onconnectionstatechange", "onconnectionstatechange")}} event handler on an {{domxref("RTCPeerConnection")}} object after a new track has been added to an {{domxref("RTCRtpReceiver")}} which is part of the connection.
-  The new connection state can be found in {{domxref("RTCPeerConnection.connectionState", "connectionState")}}, and is one of the strings in the {{domxref("RTCPeerConnectionState")}} enumerated type.</p>
+  The new connection state can be found in {{domxref("RTCPeerConnection.connectionState", "connectionState")}},
+  and is one of the string values:
+  <code>new</code>, <code>connecting</code>, <code>connected</code>, <code>disconnected</code>,
+  <code>failed</code>, or <code>closed</code>.
+</p>
 
 <table class="properties">
  <tbody>
@@ -87,5 +91,5 @@ browser-compat: api.RTCPeerConnection.connectionstatechange_event
  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a></li>
  <li><a href="/en-US/docs/Web/API/WebRTC_API/Connectivity">WebRTC connectivity</a></li>
  <li><a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime">Lifetime of a WebRTC session</a></li>
- <li>{{domxref("RTCPeerConnectionState")}}</li>
+ <li>{{domxref("RTCPeerConnection.connectionState")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -697,49 +697,6 @@ browser-compat: api.RTCPeerConnection
  </tbody>
 </table>
 
-<h3 id="RTCPeerConnectionState_enum">RTCPeerConnectionState enum</h3>
-
-<p>The <code>RTCPeerConnectionState</code> enum defines string constants which describe states in which the <code>RTCPeerConnection</code> may be. These values are returned by the {{domxref("RTCPeerConnection.connectionState", "connectionState")}} property. This state essentially represents the aggregate state of all ICE transports (which are of type {{domxref("RTCIceTransport")}} or {{domxref("RTCDtlsTransport")}}) being used by the connection.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"new"</code></td>
-   <td>At least one of the connection's ICE transports ({{domxref("RTCIceTransport")}}s or {{domxref("RTCDtlsTransport")}}s) are in the <code>"new"</code> state, and none of them are in one of the following states: <code>"connecting"</code>, <code>"checking"</code>, <code>"failed"</code>, or <code>"disconnected"</code>, <em>or</em> all of the connection's transports are in the <code>"closed"</code> state.</td>
-  </tr>
-  <tr>
-   <td><code>"connecting"</code></td>
-   <td>One or more of the ICE transports are currently in the process of establishing a connection; that is, their <code>RTCIceConnectionState</code> is either <code>"checking"</code> or <code>"connected"</code>, and no transports are in the <code>"failed"</code> state. <strong>&lt;&lt;&lt; Make this a link once I know where that will be documented</strong></td>
-  </tr>
-  <tr>
-   <td><code>"connected"</code></td>
-   <td>Every ICE transport used by the connection is either in use (state <code>"connected"</code> or <code>"completed"</code>) or is closed (state <code>"closed"</code>); in addition, at least one transport is either <code>"connected"</code> or <code>"completed"</code>.</td>
-  </tr>
-  <tr>
-   <td><code>"disconnected"</code></td>
-   <td>At least one of the ICE transports for the connection is in the <code>"disconnected"</code> state and none of the other transports are in the state <code>"failed"</code>, <code>"connecting"</code>, or <code>"checking"</code>.</td>
-  </tr>
-  <tr>
-   <td><code>"failed"</code></td>
-   <td>One or more of the ICE transports on the connection is in the <code>"failed"</code> state.</td>
-  </tr>
-  <tr>
-   <td><code>"closed"</code></td>
-   <td>
-    <p>The <code>RTCPeerConnection</code> is closed.</p>
-
-    <p>This value was in the <a href="#rtcsignalingstate_enum"><code>RTCSignalingState</code> enum</a> (and therefore found by reading the value of the {{domxref("RTCPeerConnection.signalingState", "signalingState")}}) property until the May 13, 2016 draft of the specification.</p>
-   </td>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="RTCRtcpMuxPolicy_enum">RTCRtcpMuxPolicy enum</h3>
 
 <p>The <code>RTCRtcpMuxPolicy</code> enum defines string constants which specify what ICE candidates are gathered to support non-multiplexed RTCP. <strong>&lt;&lt;&lt;add a link to info about multiplexed RTCP.</strong></p>
@@ -794,16 +751,6 @@ browser-compat: api.RTCPeerConnection
   <tr>
    <td><code>"have-remote-pranswer"</code></td>
    <td>A provisional answer has been received and successfully applied in response to an offer previously sent and established by calling <code>setLocalDescription()</code>.</td>
-  </tr>
-  <tr>
-   <td><code>"closed"</code> {{deprecated_inline}}</td>
-   <td>
-    <p>The connection is closed.</p>
-
-    <div class="note">
-    <p><strong>Note:</strong> This value moved into the <a href="#rtcpeerconnectionstate_enum"><code>RTCPeerConnectionState</code> enum</a> in the May 13, 2016 draft of the specification, as it reflects the state of the <code>RTCPeerConnection</code>, not the signaling connection. You now detect a closed connection by checking for {{domxref("RTCPeerConnection.connectionState", "connectionState")}} to be <code>"closed"</code> instead.</p>
-    </div>
-   </td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
No need to document enums separately, even as a section of an (unrelated) page.
So I removed the section from `RTCPeerConnection`, put the values in the property `RCTPeerCOnnection.connectionState`, and got rid of a {{page}} inclusion, too.

I wiped out all mentions of RTCPeerConnectionState from MDN Web Docs.