### PR TITLE
Remove RTCIceConnectionState enum

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
@@ -20,27 +20,91 @@ browser-compat: api.RTCPeerConnection.iceConnectionState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
-<p>The read-only property
-  <code><strong>RTCPeerConnection.iceConnectionState</strong></code> returns an enum of
-  type <code>RTCIceConnectionState</code> which state of the ICE agent associated with the
-  {{domxref("RTCPeerConnection")}}.</p>
+<p>
+  The read-only property <code><strong>RTCPeerConnection.iceConnectionState</strong></code> returns
+  a string which state of the {{Glossary("ICE")}} agent associated with the {{domxref("RTCPeerConnection")}}:
+  <code>new</code>, <code>checking</code>, <code>connected</code>, <code>completed</code>,
+  <code>failed</code>, <code>disconnected</code>, and <code>closed</code>.
+</p>
+
+<p>
+  It describes the current state of the ICE agent
+  and its connection to the ICE server;
+  that is, the {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
+</p>
 
 <p>You can detect when this value has changed by watching for the
-  {{event("iceconnectionstatechange")}} event.</p>
+  {{DOMxRef("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}} event.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"> var <em>state</em> = <em>RTCPeerConnection</em>.iceConnectionState;</pre>
+<pre class="brush: js"> var <em>state</em> = <em>RTCPeerConnection</em>.iceConnectionState;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>The current state of the ICE agent and its connection. The value is one of the strings
-  in the <a href="#rtciceconnectionstate_enum"><code>RTCIceConnectionState</code>
-    enum</a>.</p>
+<p>The current state of the ICE agent and its connection. The value is one of the following strings:</p>
 
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCIceConnectionState enum", 0, 1)}}
-</p>
+<dl>
+  <dt><code>new</code></dt>
+  <dd>
+    The ICE agent is gathering addresses
+    or is waiting to be given remote candidates
+    through calls to {{domxref("RTCPeerConnection.addIceCandidate()")}} (or both).
+  </dd>
+
+  <dt><code>checking</code></dt>
+  <dd>
+    The ICE agent has been given one or more remote candidates
+    and is checking pairs of local and remote candidates against one another
+    to try to find a compatible match,
+    but has not yet found a pair which will allow the peer connection to be made.
+    It is possible that gathering of candidates is also still underway.
+  </dd>
+
+  <dt><code>connected</code></dt>
+  <dd>
+    A usable pairing of local and remote candidates has been found for all components of the connection,
+    and the connection has been established.
+    It is possible that gathering is still underway,
+    and it is also possible that the ICE agent is still checking candidates
+    against one another
+    looking for a better connection to use.
+  </dd>
+
+  <dt><code>completed</code></dt>
+  <dd>
+    The ICE agent has finished gathering candidates,
+    has checked all pairs against one another,
+    and has found a connection for all components.
+  </dd>
+
+  <dt><code>failed</code></dt>
+  <dd>
+    The ICE candidate has checked all candidates pairs against one another
+    and has failed to find compatible matches for all components of the connection.
+    It is, however, possible that the ICE agent did find compatible connections for some components.
+  </dd>
+
+  <dt><code>disconnected</code></dt>
+  <dd>
+    Checks to ensure
+    that components are still connected failed
+    for at least one component of the {{domxref("RTCPeerConnection")}}.
+    This is a less stringent test than <code>failed</code>
+    and may trigger intermittently
+    and resolve just as spontaneously on less reliable networks,
+    or during temporary disconnections.
+    When the problem resolves,
+    the connection may return to the <code>connected</code> state.
+  </dd>
+
+  <dt><code>closed</code></dt>
+  <dd>
+    The ICE agent for this {{domxref("RTCPeerConnection")}} has shut down
+    and is no longer handling requests.
+  </dd>
+
+</dl>
 
 <h2 id="Example">Example</h2>
 
@@ -59,6 +123,6 @@ var state = pc.iceConnectionState;</pre>
 
 <ul>
   <li><a href="/en-US/docs/Web/Guide/API/WebRTC">WebRTC API</a></li>
-  <li>{{event("iceconnectionstatechange")}}</li>
+  <li>{{DOMxRef("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}}</li>
   <li>{{domxref("RTCPeerConnection")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
@@ -20,7 +20,10 @@ browser-compat: api.RTCPeerConnection.iceconnectionstatechange_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p><span class="seoSummary">An <strong><code>iceconnectionstatechange</code></strong> event is sent to an {{domxref("RTCPeerConnection")}} object each time the {{Glossary("ICE")}} connection state changes during the negotiation process.</span> The new ICE connection state is available in the object's {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} property.</p>
+<p>
+  An <strong><code>iceconnectionstatechange</code></strong> event is sent to an {{domxref("RTCPeerConnection")}} object each time the {{Glossary("ICE")}} connection state changes during the negotiation process.
+  The new ICE connection state is available in the object's {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} property.
+</p>
 
 <table class="properties">
  <tbody>
@@ -47,33 +50,33 @@ browser-compat: api.RTCPeerConnection.iceconnectionstatechange_event
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<p>A successful connection attempt will typically involve the state starting at <code>new</code>, then transitioning through <code>checking</code>, then <code>connected</code>, and finally <code>completed</code>. However, under certain circumstances, the <code>connected</code> state can be skipped, causing a connection to transition directly from the <code>checking</code> state to <code>completed</code>. This can happen when only the last checked candidate is successful, and the gathering and end-of-candidates signals both occur before the successful negotiation is completed.</p>
+<p>A successful connection attempt will typically involve the state starting at <code>new</code>, then transitioning through <code>checking</code>, then <code>connected</code>, and finally <code>completed</code>. However, under certain circumstances, the <code>connected</code> state can be skipped, causing a connection to transition directly from the <code>checking</code> state to <code>completed</code>. This can happen when only the last checked candidate is successful, and the gathering and end-of-candidates signals both occur before the successful negotiation is completed.</p>
 
 <h3 id="ICE_connection_state_during_ICE_restarts">ICE connection state during ICE restarts</h3>
 
-<p>When an ICE restart is processed, the gathering and connectivity checking process is started over from the beginning, which will cause the <code>iceConnectionState</code> to transition to <code>connected</code> if the ICE restart was triggered while in the <code>completed</code> state. If ICE restart is initiated while in the transient <code>disconnected</code> state, the state transitions instead to <code>checking</code>, essentially indicating that the negotiation is ignoring the fact that the connection had been temporarily lost.</p>
+<p>When an ICE restart is processed, the gathering and connectivity checking process is started over from the beginning, which will cause the <code>iceConnectionState</code> to transition to <code>connected</code> if the ICE restart was triggered while in the <code>completed</code> state. If ICE restart is initiated while in the transient <code>disconnected</code> state, the state transitions instead to <code>checking</code>, essentially indicating that the negotiation is ignoring the fact that the connection had been temporarily lost.</p>
 
 <h3 id="State_transitions_as_negotiation_ends">State transitions as negotiation ends</h3>
 
-<p>When the negotiation process runs out of candidates to check, the ICE connection transitions to one of two states. If no suitable candidates were found, the state transitions to <code>failed</code>. If at least one suitable candidate was successfully identified, the state transitions to <code>completed</code>. The ICE layer makes this determination upon receiving the end-of-candidates signal, which is provided by caling {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}} with a candidate whose {{domxref("RTCIceCandidate.candidate", "candidate")}} property is an empty string (""), or by setting the {{domxref("RTCPeerConnection")}} property {{domxref("RTCPeerConnection.canTrickleIceCandidates", "canTrickleIceCandidates")}} to <code>false</code>.</p>
+<p>When the negotiation process runs out of candidates to check, the ICE connection transitions to one of two states. If no suitable candidates were found, the state transitions to <code>failed</code>. If at least one suitable candidate was successfully identified, the state transitions to <code>completed</code>. The ICE layer makes this determination upon receiving the end-of-candidates signal, which is provided by caling {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}} with a candidate whose {{domxref("RTCIceCandidate.candidate", "candidate")}} property is an empty string (""), or by setting the {{domxref("RTCPeerConnection")}} property {{domxref("RTCPeerConnection.canTrickleIceCandidates", "canTrickleIceCandidates")}} to <code>false</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 
 <p>An event handler for this event can be added using the {{domxref("RTCPeerConnection.oniceconnectionstatechange")}} property or by using {{domxref("EventTarget.addEventListener", "addEventListener()")}} on the <code>RTCPeerConnection</code>.</p>
 
-<p>In this example, a handler for <code>iceconnectionstatechange</code> is set up to update a call state indicator by using the value of {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} to create a string which corresponds to the name of a CSS class that we can assign to the status indicator to cause it to reflect the current state of the connection.</p>
+<p>In this example, a handler for <code>iceconnectionstatechange</code> is set up to update a call state indicator by using the value of {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} to create a string which corresponds to the name of a CSS class that we can assign to the status indicator to cause it to reflect the current state of the connection.</p>
 
 <pre class="brush: js">pc.addEventListener("iceconnectionstatechange", ev =&gt; {
-  let stateElem = document.querySelector("#call-state");
-  stateElem.className = `${pc.iceConnectionState}-state`;
+  let stateElem = document.querySelector("#call-state");
+  stateElem.className = `${pc.iceConnectionState}-state`;
 }, false);
 </pre>
 
 <p>This can also be written as:</p>
 
 <pre class="brush: js">pc.oniceconnectionstatechange = ev =&gt; {
-  let stateElem = document.querySelector("#call-state");
-  stateElem.className = `${pc.iceConnectionState}-state`;
+  let stateElem = document.querySelector("#call-state");
+  stateElem.className = `${pc.iceConnectionState}-state`;
 }
 </pre>
 

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -600,49 +600,6 @@ browser-compat: api.RTCPeerConnection
  </tbody>
 </table>
 
-<h3 id="RTCIceConnectionState_enum">RTCIceConnectionState enum</h3>
-
-<p>The <code>RTCIceConnectionState</code> enum defines the string constants used to describe the current state of the ICE agent and its connection to the ICE server (that is, the {{Glossary("STUN")}} or {{Glossary("TURN")}} server).</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"new"</code></td>
-   <td>The ICE agent is gathering addresses or is waiting to be given remote candidates through calls to {{domxref("RTCPeerConnection.addIceCandidate()")}} (or both).</td>
-  </tr>
-  <tr>
-   <td><code>"checking"</code></td>
-   <td>The ICE agent has been given one or more remote candidates and is checking pairs of local and remote candidates against one another to try to find a compatible match, but has not yet found a pair which will allow the peer connection to be made. It's possible that gathering of candidates is also still underway.</td>
-  </tr>
-  <tr>
-   <td><code>"connected"</code></td>
-   <td>A usable pairing of local and remote candidates has been found for all components of the connection, and the connection has been established. It's possible that gathering is still underway, and it's also possible that the ICE agent is still checking candidates against one another looking for a better connection to use.</td>
-  </tr>
-  <tr>
-   <td><code>"completed"</code></td>
-   <td>The ICE agent has finished gathering candidates, has checked all pairs against one another, and has found a connection for all components.</td>
-  </tr>
-  <tr>
-   <td><code>"failed"</code></td>
-   <td>The ICE candidate has checked all candidates pairs against one another and has failed to find compatible matches for all components of the connection. It is, however, possible that the ICE agent did find compatible connections for some components.</td>
-  </tr>
-  <tr>
-   <td><code>"disconnected"</code></td>
-   <td>Checks to ensure that components are still connected failed for at least one component of the {{domxref("RTCPeerConnection")}}. This is a less stringent test than <code>"failed"</code> and may trigger intermittently and resolve just as spontaneously on less reliable networks, or during temporary disconnections. When the problem resolves, the connection may return to the <code>"connected"</code> state.</td>
-  </tr>
-  <tr>
-   <td><code>"closed"</code></td>
-   <td>The ICE agent for this {{domxref("RTCPeerConnection")}} has shut down and is no longer handling requests.</td>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="RTCIceGatheringState_enum">RTCIceGatheringState enum</h3>
 
 <p>The <code>RTCIceGatheringState</code> enum defines string constants which reflect the current status of ICE gathering, as returned using the {{domxref("RTCPeerConnection.iceGatheringState")}} property. You can detect when this value changes by watching for an event of type {{event("icegatheringstatechange")}}.</p>


### PR DESCRIPTION
No need to document enums separately, even as a section of an (unrelated) page.
So I removed the section from RTCPeerConnection, put the values in the property RCTPeerConnection.iceConnectionState, and got rid of a {{page}} inclusion, too.

I wiped out all mentions of RTCIceConnectionState from MDN Web Docs.