### PR TITLE
Fix typo in MediaDevices.getDisplayMedia()

### DIFF
--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
@@ -55,7 +55,7 @@ browser-compat: api.MediaDevices.getDisplayMedia
 <div class="notecard note">
   <p><strong>Note:</strong> Browser support for audio tracks varies, both in terms of
     whether or not they're supported at all by the media recorder and in terms of the
-    which audio source or sourcoes are supported. Check the {{anch("Browser
+    which audio source or sources are supported. Check the {{anch("Browser
     compatibility", "compatibility table")}} for details for each browser.</p>
 </div>
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
@@ -55,7 +55,7 @@ browser-compat: api.MediaDevices.getDisplayMedia
 <div class="notecard note">
   <p><strong>Note:</strong> Browser support for audio tracks varies, both in terms of
     whether or not they're supported at all by the media recorder and in terms of the
-    which audio source or sources are supported. Check the {{anch("Browser
+    audio sources supported. Check the {{anch("Browser
     compatibility", "compatibility table")}} for details for each browser.</p>
 </div>
 


### PR DESCRIPTION
Small typo fix in `MediaDevices.getDisplayMedia()`.
