### PR TITLE
Fix RegExp `\cX` character class explanation

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
@@ -110,7 +110,7 @@ tags:
   <tr>
    <td><code>\c<em>X</em></code></td>
    <td>
-    <p>Matches a control character using <a href="https://en.wikipedia.org/wiki/Caret_notation">caret notation</a>, where "X" is a letter from A–Z (corresponding to codepoints <code>U+0001</code><em>–</em><code>U+001F</code>). For example, <code>/\cM/</code> matches "\r" in "\r\n".</p>
+    <p>Matches a control character using <a href="https://en.wikipedia.org/wiki/Caret_notation">caret notation</a>, where "X" is a letter from A–Z (corresponding to codepoints <code>U+0001</code><em>–</em><code>U+001A</code>). For example, <code>/\cM\cJ/</code> matches "\r\n".</p>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

One cannot match codepoints `U+001B`-`U+001F` (27-31) with `\cX`, because only 26 letters are allowed.

> Anything else that could help us review it

Unrelated, I modified the example to showcase matching 100% more characters, while making it more concise.
