### PR TITLE
Navigator.getUserMedia - fix fixable flaws

### DIFF
--- a/files/en-us/web/api/navigator/getusermedia/index.html
+++ b/files/en-us/web/api/navigator/getusermedia/index.html
@@ -2,16 +2,16 @@
 title: Navigator.getUserMedia()
 slug: Web/API/Navigator/getUserMedia
 tags:
-- API
-- Deprecated
-- Media
-- Media Capture and Streams API
-- Media Streams API
-- Method
-- Navigator
-- Reference
-- WebRTC
-- getusermedia
+  - API
+  - Deprecated
+  - Media
+  - Media Capture and Streams API
+  - Media Streams API
+  - Method
+  - Navigator
+  - Reference
+  - WebRTC
+  - getusermedia
 browser-compat: api.Navigator.getUserMedia
 ---
 <div>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</div>
@@ -46,7 +46,7 @@ browser-compat: api.Navigator.getUserMedia
    <dt><code><var>constraints</var></code></dt>
    <dd>A {{domxref("MediaStreamConstraints")}} object specifying the types of media to
       request, along with any requirements for each type. For details, see the <a
-         href="/en-US/docs/Web/API/MediaDevices/getUserMedia#Parameters">constraints</a>
+         href="/en-US/docs/Web/API/MediaDevices/getUserMedia#parameters">constraints</a>
       section under the modern {{domxref("MediaDevices.getUserMedia()")}} method, as well
       as the article <a
          href="/en-US/docs/Web/API/Media_Streams_API/Constraints">Capabilities,
@@ -82,7 +82,7 @@ browser-compat: api.Navigator.getUserMedia
 
 <p>Here's an example of using <code>getUserMedia()</code>, including code to cope with
    various browsers' prefixes. Note that this is the deprecated way of doing it: See the
-   <a href="/en-US/docs/Web/API/MediaDevices/getUserMedia#Frame_rate">Examples</a> section
+   <a href="/en-US/docs/Web/API/MediaDevices/getUserMedia#frame_rate">Examples</a> section
    under the {{domxref("MediaDevices.getUserMedia()")}} for modern examples.</p>
 
 <pre class="brush: js">navigator.getUserMedia = navigator.getUserMedia ||
@@ -110,7 +110,7 @@ if (navigator.getUserMedia) {
 <h2 id="Permissions">Permissions</h2>
 
 <p>To use <code>getUserMedia()</code> in an installable app (for example, a <a
-      href="/en-US/Apps/Build/Building_apps_for_Firefox_OS/Firefox_OS_app_beginners_tutorial">Firefox
+      href="/en-US/docs/Web/Apps/Build/Building_apps_for_Firefox_OS/Firefox_OS_app_beginners_tutorial">Firefox
       OS app</a>), you need to specify one or both of the following fields inside your
    manifest file:</p>
 
@@ -123,15 +123,15 @@ if (navigator.getUserMedia) {
   }
 }</pre>
 
-<p>See <a href="/en-US/Apps/Developing/App_permissions#audio-capture">permission:
+<p>See <a href="/en-US/docs/Web/Apps/Developing/App_permissions#audio-capture">permission:
       audio-capture</a> and <a
-      href="/en-US/Apps/Developing/App_permissions#video-capture">permission:
+      href="/en-US/docs/Web/Apps/Developing/App_permissions#video-capture">permission:
       video-capture</a> for more information.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="warning">
-   <p>New code should use {{domxref("Navigator.mediaDevices.getUserMedia()")}} instead.
+   <p>New code should use {{domxref("MediaDevices.getUserMedia")}} instead.
    </p>
 </div>
 
@@ -142,10 +142,10 @@ if (navigator.getUserMedia) {
 <ul>
    <li>{{domxref("MediaDevices.getUserMedia()")}} that replaces this deprecated method.
    </li>
-   <li><a href="/en-US/docs/WebRTC">WebRTC</a> - the introductory page to the API</li>
-   <li><a href="/en-US/docs/WebRTC/MediaStream_API">MediaStream API</a> - the API for the
+   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> - the introductory page to the API</li>
+   <li><a href="/en-US/docs/Web/API/Media_Streams_API">MediaStream API</a> - the API for the
       media stream objects</li>
-   <li><a href="/en-US/docs/WebRTC/taking_webcam_photos">Taking webcam photos</a> - a
+   <li><a href="/en-US/docs/Web/API/WebRTC_API/Taking_still_photos">Taking webcam photos</a> - a
       tutorial on using <code>getUserMedia() for taking photos rather than video.</code>
    </li>
 </ul>


### PR DESCRIPTION
This just fixes the fixable flaws in `Navigator.getUserMedia()`. I'm playing with PeterB's new global flaw finder.