### PR TITLE
ReadableStreamDefaultReader example: drop redundant forward decl

### DIFF
--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.html
@@ -109,7 +109,6 @@ browser-compat: api.ReadableStreamDefaultReader.read
 
   let re = /\r\n|\n|\r/gm;
   let startIndex = 0;
-  let result;
 
   for (;;) {
     let result = re.exec(chunk);


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The forward declaration is not used since the variable is not used outside its scope and it's immediately initialized unconditionally on each iteration.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
