### PR TITLE
Fix broken github page link

### DIFF
--- a/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.html
+++ b/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.html
@@ -23,7 +23,7 @@ tags:
 <h2 id="Resources">Resources</h2>
 
 <ul>
- <li>A good tutorial on basic features in WebRTC is at <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/">HTML5 Rocks</a>.   A collection of basic test pages to support development are at <a href="https://mozilla.github.com/webrtc-landing">webrtc-landing</a>.</li>
+ <li>A good tutorial on basic features in WebRTC is at <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/">HTML5 Rocks</a>.   A collection of basic test pages to support development are at <a href="https://mozilla.github.io/webrtc-landing">webrtc-landing</a>.</li>
  <li>You can make simple person-to-person calls (including to people using Chrome) at <a href="https://apprtc.appspot.com/">apprtc.appspot.com</a>.</li>
  <li>A high-level description of what happens in an <code>RTCPeerConnection</code> was shown in the <a href="https://hacks.mozilla.org/category/webrtc/">Mozilla Hacks</a> blog article <a href="https://hacks.mozilla.org/2013/05/embedding-webrtc-video-chat-right-into-your-website/">Embedding WebRTC video chat</a>.</li>
 </ul>


### PR DESCRIPTION
the github link is pointing to non exists page. change domain from `github.com` to `github.io`