### PR TITLE
Object.hasOwn() docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -53,34 +53,46 @@ external object, `Object.hasOwn()` is more intuitive.
 
 ## Examples
 
-### Using hasOwn to test for a property's existence
+### Using hasOwn to test for a property's existence 
 
-The following example shows how to test whether an object directly defines
-('owns') a particular property:
+The following code hows how to determine whether the `example` object contains a property named `prop`.
+ 
+```js
+let example = {};
+Object.hasOwn(example, 'prop');   // false = 'prop' has not been defined
+
+example.prop = 'exists';
+Object.hasOwn(example, 'prop');   // true - 'prop' has been defined
+
+example.prop = null;
+Object.hasOwn(example, 'prop');   // true - own property exists wtih value of null
+
+example.prop = undefined;
+Object.hasOwn(example, 'prop');   // true - own property exists with value of undefined
+```
+
+### Direct vs. inherited properties
+
+The following example differentiates between direct properties and properties inherited through the prototype chain:
 
 ```js
-let object1 = {};
-object1.prop = 'exists';
+let example = {}
+example.prop = 'exists';
 
-// Normal way to use the method
-if (Object.hasOwn(object1, 'prop')) {
-  // true - 'prop' is defined
-}
-  
-// Own property values can be null or undefined
-object1.prop_value_null = null;
-Object.hasOwn(object1, 'prop_value_null');  // true
-object1.prop_value_undefined = undefined;
-Object.hasOwn(object1, 'prop_value_undefined');  // true
-  
-// Inherited and undeclared properties return false
-Object.hasOwn(object1,'toString');  // false
-Object.hasOwn(object1,'prop_not_defined');  // false
+// `hasOwn` will only return true for direct properties:
+Object.hasOwn(example, 'prop');             // returns true
+Object.hasOwn(example, 'toString');         // returns false
+Object.hasOwn(example, 'hasOwnProperty');   // returns false
+
+// The `in` operator will return true for direct or inherited properties:
+'prop' in example;                          // returns true
+'toString' in example;                      // returns true
+'hasOwnProperty' in example;                // returns true
 ```
 
 ### Iterating over the properties of an object
 
-To iterate over the enumerable properties of an object, you should use:
+To iterate over the enumerable properties of an object, you _should_ use:
 
 ```js
 let example = { foo: true, bar: true };
@@ -89,7 +101,7 @@ for (let name of Object.keys(example)) {
 }
 ```
 
-But if you need to use `for..in` you can use `Object.hasOwn()` to skip the inherited properties:
+But if you need to use `for..in`, you can use `Object.hasOwn()` to skip the inherited properties:
 
 ```js
 let example = { foo: true, bar: true };

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -1,0 +1,166 @@
+---
+title: Object.hasOwn()
+slug: Web/JavaScript/Reference/Global_Objects/Object/hasOwn
+tags:
+  - JavaScript
+  - Method
+  - Object
+  - hasOwn
+browser-compat: javascript.builtins.Object.hasOwn
+---
+{{JSRef}}
+
+The **`Object.hasOwn()`** static method returns `true` if the specified object
+has the indicated property as its _own_ property. If the property is inherited,
+or does not exist, the method returns `false`.
+
+> **Note:** `Object.hasOwn()` is intended as a replacement for
+> {{jsxref("Object.hasOwnProperty()")}}.
+
+{{EmbedInteractiveExample("pages/js/object-hasown.html")}}
+
+## Syntax
+
+```js
+Object.hasOwn(instance,prop)
+```
+
+### Parameters
+
+- _instance_
+  - : The JavaScript object instance to test.
+- _prop_
+  - : The {{jsxref("String")}} name or {{Glossary("Symbol")}} of
+    the property to test.
+
+### Return value
+
+`true` if the specified object has directly defined the specified property.
+Otherwise `false`
+
+## Description
+
+The **`Object.hasOwn()`** method returns `true` if the specified property is a
+direct property of the object — even if the property value is `null` or
+`undefined`. The method returns `false` if the property is inherited, or has not
+been declared at all.
+
+It is recommended over {{jsxref("Object.hasOwnProperty()")}} because
+it works for objects created using `Object.create(null)` and with objects that
+have overridden the inherited `hasOwnProperty()` method. While it is possible to
+workaround these problems by calling `Object.prototype.hasOwnProperty()` on an
+external object, `Object.hasOwn()` is more intuitive.
+
+## Examples
+
+### Using hasOwn to test for a property's existence
+
+The following example shows how to test whether an object directly defines
+('owns') a particular property:
+
+```js
+let object1 = {};
+object1.prop = 'exists';
+
+// Normal way to use the method
+if (Object.hasOwn(object1, 'prop')) {
+  // true - 'prop' is defined
+}
+  
+// Own property values can be null or undefined
+object1.prop_value_null = null;
+Object.hasOwn(object1, 'prop_value_null');  // true
+object1.prop_value_undefined = undefined;
+Object.hasOwn(object1, 'prop_value_undefined');  // true
+  
+// Inherited and undeclared properties return false
+Object.hasOwn(object1,'toString');  // false
+Object.hasOwn(object1,'prop_not_defined');  // false
+```
+
+### Iterating over the properties of an object
+
+The following example shows how to iterate over the enumerable properties of an
+object without executing on inherited properties.
+
+```js
+let buz = {
+  fog: 'stack'
+};
+
+for (let name in buz) {
+  if (Object.hasOwn(buz, name)) {
+    console.log('this is fog (' +
+      name + ') for sure. Value: ' + buz[name]);
+  }
+  else {
+    console.log(name); // toString or something else
+  }
+}
+```
+
+Note that the {{jsxref("Statements/for...in", "for...in")}} loop
+only iterates enumerable items: the absence of non-enumerable properties emitted
+from the loop does not imply that `hasOwn` itself is confined strictly to
+enumerable items (as with
+{{jsxref("Object.getOwnPropertyNames()")}}).
+
+### Checking if an Array index exists
+
+The elements of an {{jsxref("Array")}} are defined as direct properties, so
+you can use `hasOwn()` method to check whether a particular index exists:
+
+```js
+let fruits = ['Apple', 'Banana','Watermelon', 'Orange'];
+Object.hasOwn(fruits, 3);   // true ('Orange')
+Object.hasOwn(fruits, 4);   // false - not defined
+    
+```
+
+### Problematic cases for hasOwnProperty
+
+This section demonstrate that `hasOwn()` is immune to the problems that affect
+`hasOwnProperty`. Firstly, it can be used with objects that have reimplemented
+`hasOwnProperty()`:
+
+```js
+let foo = {
+  hasOwnProperty: function() {
+    return false;
+  },
+  bar: 'The dragons be out of office'
+};
+
+if (Object.hasOwn(foo, 'bar')) {
+  console.log(foo.bar); //true - remplementation of hasOwnProperty() does not affect Object
+}
+```
+
+It can also be used to test objects created using
+{{jsxref("Object.create()","Object.create(null)")}}. These do
+not inherit from `Object.prototype`, and so `hasOwnProperty()` is inaccessible.
+
+```js
+let foo = Object.create(null);
+foo.prop = 'exists';
+if (Object.hasOwn(foo, 'prop')) {
+  console.log(foo.prop); //true - works irrespective of how the object is created.
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Object.hasOwnProperty()")}}
+- [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
+- {{jsxref("Object.getOwnPropertyNames()")}}
+- {{jsxref("Statements/for...in", "for...in")}}
+- {{jsxref("Operators/in", "in")}}
+- [JavaScript Guide: Inheritance revisited](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -10,12 +10,11 @@ browser-compat: javascript.builtins.Object.hasOwn
 ---
 {{JSRef}}
 
-The **`Object.hasOwn()`** static method returns `true` if the specified object
-has the indicated property as its _own_ property. If the property is inherited,
-or does not exist, the method returns `false`.
+The **`Object.hasOwn()`** static method returns `true` if the specified object has the indicated property as its _own_ property.
+If the property is inherited, or does not exist, the method returns `false`.
 
-> **Note:** `Object.hasOwn()` is intended as a replacement for
-> {{jsxref("Object.hasOwnProperty()")}}.
+
+> **Note:** `Object.hasOwn()` is intended as a replacement for {{jsxref("Object.hasOwnProperty()")}}.
 
 {{EmbedInteractiveExample("pages/js/object-hasown.html")}}
 
@@ -41,9 +40,10 @@ Otherwise `false`
 ## Description
 
 The **`Object.hasOwn()`** method returns `true` if the specified property is a
-direct property of the object — even if the property value is `null` or
-`undefined`. The method returns `false` if the property is inherited, or has not
-been declared at all.
+direct property of the object — even if the property value is `null` or `undefined`.
+The method returns `false` if the property is inherited, or has not been declared at all.
+Unlike the {{jsxref("Operators/in", "in")}} operator, this
+method does not check for the specified property in the object's prototype chain.
 
 It is recommended over {{jsxref("Object.hasOwnProperty()")}} because
 it works for objects created using `Object.create(null)` and with objects that

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -80,30 +80,25 @@ Object.hasOwn(object1,'prop_not_defined');  // false
 
 ### Iterating over the properties of an object
 
-The following example shows how to iterate over the enumerable properties of an
-object without executing on inherited properties.
+To iterate over the enumerable properties of an object, you should use:
 
 ```js
-let buz = {
-  fog: 'stack'
-};
-
-for (let name in buz) {
-  if (Object.hasOwn(buz, name)) {
-    console.log('this is fog (' +
-      name + ') for sure. Value: ' + buz[name]);
-  }
-  else {
-    console.log(name); // toString or something else
-  }
+let example = { foo: true, bar: true };
+for (let name of Object.keys(example)) {
+  // ...
 }
 ```
 
-Note that the {{jsxref("Statements/for...in", "for...in")}} loop
-only iterates enumerable items: the absence of non-enumerable properties emitted
-from the loop does not imply that `hasOwn` itself is confined strictly to
-enumerable items (as with
-{{jsxref("Object.getOwnPropertyNames()")}}).
+But if you need to use `for..in` you can use `Object.hasOwn()` to skip the inherited properties:
+
+```js
+let example = { foo: true, bar: true };
+for (let name in example) {
+  if (Object.hasOwn(example, name)) {
+    // ...
+  }
+}
+```
 
 ### Checking if an Array index exists
 

--- a/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -65,31 +65,39 @@ objects created using `Object.create(null)` (as these don't inherit from
 
 ### Using hasOwnProperty to test for an own property's existence
 
-The following example hows how to determine whether the `o` object contains a
-property named `prop`.
+The following code hows how to determine whether the `example` object contains a property named `prop`.
 
 ```js
-o = new Object();
-o.hasOwnProperty('prop');   // false
-o.prop = 'exists';
-o.hasOwnProperty('prop');   // true - 'prop' has been defined
-o.prop = null;
-o.hasOwnProperty('prop');   // true - own property exists wtih value of null
-o.prop = undefined;
-o.hasOwnProperty('prop');   // true - own property exists with value of undefined
+let example = {};
+example.hasOwnProperty('prop');   // false
+
+example.prop = 'exists';
+example.hasOwnProperty('prop');   // true - 'prop' has been defined
+
+example.prop = null;
+example.hasOwnProperty('prop');   // true - own property exists wtih value of null
+
+example.prop = undefined;
+example.hasOwnProperty('prop');   // true - own property exists with value of undefined
 ```
 
 ### Direct vs. inherited properties
 
-The following example differentiates between direct properties and properties
-inherited through the prototype chain:
+The following example differentiates between direct properties and properties inherited through the prototype chain:
 
 ```js
-o = new Object();
-o.prop = 'exists';
-o.hasOwnProperty('prop');             // returns true
-o.hasOwnProperty('toString');         // returns false
-o.hasOwnProperty('hasOwnProperty');   // returns false
+let example = {};
+example.prop = 'exists';
+
+// `hasOwnProperty` will only return true for direct properties:
+example.hasOwnProperty('prop');             // returns true
+example.hasOwnProperty('toString');         // returns false
+example.hasOwnProperty('hasOwnProperty');   // returns false
+
+// The `in` operator will return true for direct or inherited properties:
+'prop' in example;                          // returns true
+'toString' in example;                      // returns true
+'hasOwnProperty' in example;                // returns true
 ```
 
 ### Iterating over the properties of an object

--- a/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -11,11 +11,14 @@ browser-compat: javascript.builtins.Object.hasOwnProperty
 ---
 {{JSRef}}
 
-The **`hasOwnProperty()`** method returns a boolean indicating
-whether the object has the specified property as its own property (as opposed to
-inheriting it).
+The **`hasOwnProperty()`** method returns a boolean indicating whether the
+object has the specified property as its own property (as opposed to inheriting
+it).
 
 {{EmbedInteractiveExample("pages/js/object-prototype-hasownproperty.html")}}
+
+> **Note:** {{jsxref("Object.hasOwn()")}} is recommended over
+> `hasOwnProperty()`, in browsers where it is supported.
 
 ## Syntax
 
@@ -26,53 +29,60 @@ hasOwnProperty(prop)
 ### Parameters
 
 - _prop_
-  - : The {{jsxref("String")}} name or {{Glossary("Symbol")}} of the property to test.
+  - : The {{jsxref("String")}} name or {{Glossary("Symbol")}} of
+    the property to test.
 
 ### Return value
 
-A {{jsxref("Boolean")}} indicating whether or not the object has the specified property
-as own property.
+Returns `true` if the object has the specified property as own property; `false`
+otherwise.
 
 ## Description
 
-All descendants of {{jsxref("Object")}} inherit the `hasOwnProperty` method.
-This method can be used to determine whether an object has the specified property as a
-direct property of that object; unlike the {{jsxref("Operators/in", "in")}} operator,
-this method does not check for a property in the object's prototype chain. If an
-{{jsxref("Object")}} is an {{jsxref("Array")}}, `hasOwnProperty` method can
-check whether an index exists.
+The **`hasOwnProperty()`** method returns `true` if the specified property is a
+direct property of the object — even if the value is `null` or `undefined`. The
+method returns `false` if the property is inherited, or has not been declared at
+all. Unlike the {{jsxref("Operators/in", "in")}} operator, this
+method does not check for the specified property in the object's prototype
+chain.
 
-## Note
-
-`hasOwnProperty` returns true even if the value of the property is
-`null` or `undefined`.
+The method can be called on _most_ JavaScript objects, because most objects
+descend from {{jsxref("Object")}}, and hence inherit its methods. For
+example {{jsxref("Array")}} is an {{jsxref("Object")}}, so you can
+use `hasOwnProperty()` method to check whether an index exists:
 
 ```js
-o = new Object();
-o.propOne = null;
-o.hasOwnProperty('propOne');   // returns true
-o.propTwo = undefined;
-o.hasOwnProperty('propTwo');   // returns true
+let fruits = ['Apple', 'Banana','Watermelon', 'Orange'];
+fruits.hasOwnProperty(3);   // true ('Orange')
+fruits.hasOwnProperty(4);   // false - not defined
 ```
+
+The method will not be available in objects where it is reimplemented, or on
+objects created using `Object.create(null)` (as these don't inherit from
+`Object.prototype`). Examples for these cases are given below.
 
 ## Examples
 
-### Using hasOwnProperty to test for a property's existence
+### Using hasOwnProperty to test for an own property's existence
 
-The following example determines whether the `o` object contains a property
-named `prop`:
+The following example hows how to determine whether the `o` object contains a
+property named `prop`.
 
 ```js
 o = new Object();
-o.hasOwnProperty('prop');   // returns false
+o.hasOwnProperty('prop');   // false
 o.prop = 'exists';
-o.hasOwnProperty('prop');   // returns true
+o.hasOwnProperty('prop');   // true - 'prop' has been defined
+o.prop = null;
+o.hasOwnProperty('prop');   // true - own property exists wtih value of null
+o.prop = undefined;
+o.hasOwnProperty('prop');   // true - own property exists with value of undefined
 ```
 
 ### Direct vs. inherited properties
 
-The following example differentiates between direct properties and properties inherited
-through the prototype chain:
+The following example differentiates between direct properties and properties
+inherited through the prototype chain:
 
 ```js
 o = new Object();
@@ -84,19 +94,15 @@ o.hasOwnProperty('hasOwnProperty');   // returns false
 
 ### Iterating over the properties of an object
 
-The following example shows how to iterate over the properties of an object without
-executing on inherited properties. Note that the {{jsxref("Statements/for...in",
-  "for...in")}} loop is already only iterating enumerable items, so one should not assume
-based on the lack of non-enumerable properties shown in the loop that
-`hasOwnProperty` itself is confined strictly to enumerable items (as with
-{{jsxref("Object.getOwnPropertyNames()")}}).
+The following example shows how to iterate over the enumerable properties of an
+object without executing on inherited properties.
 
 ```js
-var buz = {
+let buz = {
   fog: 'stack'
 };
 
-for (var name in buz) {
+for (let name in buz) {
   if (buz.hasOwnProperty(name)) {
     console.log('this is fog (' +
       name + ') for sure. Value: ' + buz[name]);
@@ -107,32 +113,63 @@ for (var name in buz) {
 }
 ```
 
+Note that the {{jsxref("Statements/for...in", "for...in")}} loop
+only iterates enumerable items: the absence of non-enumerable properties emitted
+from the loop does not imply that `hasOwnProperty` itself is confined strictly
+to enumerable items (as with
+{{jsxref("Object.getOwnPropertyNames()")}}).
+
 ### Using hasOwnProperty as a property name
 
-JavaScript does not protect the property name `hasOwnProperty`; thus, if the
-possibility exists that an object might have a property with this name, it is necessary
-to use an _external_ `hasOwnProperty` to get correct results:
+JavaScript does not protect the property name `hasOwnProperty`; an object that
+has a property with this name may return incorrect results:
 
 ```js
-var foo = {
+let foo = {
   hasOwnProperty: function() {
     return false;
   },
   bar: 'Here be dragons'
 };
 
-foo.hasOwnProperty('bar'); // always returns false
+foo.hasOwnProperty('bar'); // reimplementation always returns false
+```
+
+The recommended way to overcome this problem is to instead use
+{{jsxref("Object.hasOwn()")}} (in browsers that support it). Other
+alternatives include using an _external_ `hasOwnProperty`:
+
+```js
+let foo = { bar: 'Here be dragons' };
+
+// Use Object.hasOwn() method - recommended
+Object.hasOwn(foo, "bar");  // true
+  
+// Use the hasOwnProperty property from the Object prototype
+Object.prototype.hasOwnProperty.call(foo, 'bar'); // true
 
 // Use another Object's hasOwnProperty
 // and call it with 'this' set to foo
 ({}).hasOwnProperty.call(foo, 'bar'); // true
-
-// It's also possible to use the hasOwnProperty property
-// from the Object prototype for this purpose
-Object.prototype.hasOwnProperty.call(foo, 'bar'); // true
 ```
 
-Note that in the last case there are no newly created objects.
+Note that in the first two cases there are no newly created objects.
+
+### Objects created with Object.create(null)
+
+Objects created using
+{{jsxref("Object.create()","Object.create(null)")}} do not
+inherit from `Object.prototype`, making `hasOwnProperty()` inaccessible.
+
+```js
+let foo = Object.create(null);
+foo.prop = 'exists';
+foo.hasOwnProperty("prop");  // Uncaught TypeError: foo.hasOwnProperty is not a function
+```
+
+The solutions in this case are the same as for the previous section: use
+{{jsxref("Object.hasOwn()")}} by preference, otherwise use an
+external object's `hasOwnProperty()`.
 
 ## Specifications
 
@@ -144,10 +181,9 @@ Note that in the last case there are no newly created objects.
 
 ## See also
 
-- [Enumerability and
-  ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
+- {{jsxref("Object.hasOwn()")}}
+- [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.getOwnPropertyNames()")}}
 - {{jsxref("Statements/for...in", "for...in")}}
 - {{jsxref("Operators/in", "in")}}
-- [JavaScript
-  Guide: Inheritance revisited](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)
+- [JavaScript Guide: Inheritance revisited](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)


### PR DESCRIPTION
This adds docs for the new `Object.hasOwn()` static method. This is going to be implemented in FF92. See #6717 for more information and docs tracking.

Depends on:
- BCD is pending FF92 : https://github.com/mdn/browser-compat-data/pull/11548
- Interactive example: https://github.com/mdn/interactive-examples/pull/1872

I am hoping this can drop without the BCD info, once the interactive example goes in.

@jamiebuilds This is draft for your new feature. It includes both new doc and some tidying of `hasOwnProperty`. Would appreciate your comments.

Further, there is a doc https://developer.mozilla.org//en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties which I think may also need an update. I THINK this just should have `hasOwn` mentioned alongside the other method. Does that make sense?