### PR TITLE
Update “Web video codec guide” to recommend VP9 (not VP8)

### DIFF
--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -1547,7 +1547,7 @@ tags:
 
 <ol>
  <li>
-  <p>A <strong><a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></strong> container using the <strong><a href="#vp8">VP8</a></strong> codec for video and the <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a></strong> codec for audio. These are all open, royalty-free formats which are generally well-supported, although only in quite recent browsers, which is why a fallback is a good idea.</p>
+  <p>A <strong><a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></strong> container using the <strong><a href="#vp9">VP9</a></strong> codec for video and the <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a></strong> codec for audio. These are all open, royalty-free formats which are generally well-supported, although only in quite recent browsers, which is why a fallback is a good idea.</p>
 
   <pre class="brush: js">&lt;video controls src="filename.webm"&gt;&lt;/video&gt;
 </pre>

--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -334,7 +334,7 @@ tags:
 
 <h3 id="AV1">AV1</h3>
 
-<p>The <strong>AOMedia Video 1</strong> (<strong>AV1</strong>) codec is an open format designed by the <a href="https://aomedia.org/">Alliance for Open Media</a> specifically for internet video. It achieves higher data compression rates than <a href="#VP9">VP9</a> and <a href="#hevc_h.265">H.265/HEVC</a>, and as much as 50% higher rates than <a href="#avc_h.264">AVC</a>. AV1 is fully royalty-free and is designed for use by both the {{HTMLElement("video")}} element and by <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a>.</p>
+<p>The <strong>AOMedia Video 1</strong> (<strong>AV1</strong>) codec is an open format designed by the <a href="https://aomedia.org/">Alliance for Open Media</a> specifically for internet video. It achieves higher data compression rates than <a href="#vp9">VP9</a> and <a href="#hevc_h.265">H.265/HEVC</a>, and as much as 50% higher rates than <a href="#avc_h.264">AVC</a>. AV1 is fully royalty-free and is designed for use by both the {{HTMLElement("video")}} element and by <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a>.</p>
 
 <p>AV1 currently offers three profiles: <strong>main</strong>, <strong>high</strong>, and <strong>professional</strong> with increasing support for color depths and chroma subsampling. In addition, a series of <strong>levels</strong> are specified, each defining limits on a range of attributes of the video. These attributes include frame dimensions, image area in pixels, display and decode rates, average and maximum bit rates, and limits on the number of tiles and tile columns used in the encoding/decoding process.</p>
 
@@ -847,7 +847,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Specifications</th>
-   <td><a href="http://www.itu.int/rec/T-REC-H.265">http://www.itu.int/rec/T-REC-H.265</a><br>
+   <td><a href="https://www.itu.int/rec/T-REC-H.265">http://www.itu.int/rec/T-REC-H.265</a><br>
     <a href="https://www.iso.org/standard/69668.html">https://www.iso.org/standard/69668.html</a></td>
   </tr>
   <tr>
@@ -1202,7 +1202,7 @@ tags:
 
 <p>One drawback to Theora is that it only supports 8 bits per color component, with no option to use 10 or more in order to avoid color banding. That said, 8 bits per component is still the most commonly-used color format in use today, so this is only a minor inconvenience in most cases. Also, Theora can only be used in an Ogg container. The biggest drawback of all, however, is that it is not supported by Safari, leaving Theora unavailable not only on macOS but on all those millions and millions of iPhones and iPads.</p>
 
-<p>The <a href="http://en.flossmanuals.net/ogg-theora/">Theora Cookbook</a> offers additional details about Theora as well as the Ogg container format it is used within.</p>
+<p>The <a href="https://en.flossmanuals.net/ogg-theora/">Theora Cookbook</a> offers additional details about Theora as well as the Ogg container format it is used within.</p>
 
 <table class="standard-table">
  <tbody>
@@ -1690,7 +1690,7 @@ let recorder = new MediaRecorder(sourceStream, options);</pre>
  <li>{{RFC(3839)}}: MIME Type Registrations for 3GPP Multimedia Files</li>
  <li>{{RFC(4381)}}: MIME Type Registrations for 3GPP2 Multimedia Files</li>
  <li>{{RFC(4337)}}: MIME Type Registrations for MPEG-4</li>
- <li><a href="http://dev.opera.com/articles/view/introduction-html5-video/#codecs">Video codecs in Opera</a></li>
+ <li><a href="https://dev.opera.com/articles/view/introduction-html5-video/#codecs">Video codecs in Opera</a></li>
  <li><a href="https://msdn.microsoft.com/en-us/library/ff975073%28v=VS.85%29.aspx">Video</a> and <a href="https://msdn.microsoft.com/en-us/library/ff975061%28v=vs.85%29.aspx">audio</a> codecs in Internet Explorer</li>
- <li><a href="http://www.chromium.org/audio-video">Video and audio codecs in Chrome</a></li>
+ <li><a href="https://www.chromium.org/audio-video">Video and audio codecs in Chrome</a></li>
 </ul>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/7064