### PR TITLE
Remove RTCRtcpMuxPolicy, RTCIceTransportPolicy and RTCBundlePolicy enums

### DIFF
--- a/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
@@ -42,9 +42,8 @@ rtcConfiguration.bundlePolicy = <em>policy</em>;
 <h3 id="Value">Value</h3>
 
 <p>A {{domxref("DOMString")}} identifying the SDP bundling policy to use for the RTP
-  streams used by the {{domxref("RTCPeerConnection")}}. This string, which must be a
-  member of the <code>RTCBundlePolicy</code> enumeration, has the following possible
-  values:</p>
+  streams used by the {{domxref("RTCPeerConnection")}}.
+  This string has the following possible values:</p>
 
 <dl>
   <dt><code>balanced</code></dt>

--- a/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
@@ -20,8 +20,7 @@ browser-compat: api.RTCConfiguration.iceTransportPolicy
 <p>The <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC Device API</a> dictionary
   {{domxref("RTCConfiguration")}}'s <code><strong>iceTransportPolicy</strong></code>
   property is a string indicating the transport selection policy the {{Glossary("ICE")}}
-  agent should use during negotiation of connections. Its value must come from the
-  {{domxref("RTCIceTransportPolicy")}} enumerated type.</p>
+  agent should use during negotiation of connections.</p>
 
 <p>If this property isn't included in the <code>RTCConfiguration</code>, the default
   value, <code>all</code>, is used.</p>

--- a/files/en-us/web/api/rtcconfiguration/index.html
+++ b/files/en-us/web/api/rtcconfiguration/index.html
@@ -13,42 +13,159 @@ tags:
   - rtc
 browser-compat: api.RTCConfiguration
 ---
-<p>{{DefaultAPISidebar("WebRTC")}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
-<p>The <strong><code>RTCConfiguration</code></strong> dictionary is used to provide configuration options for an {{domxref("RTCPeerConnection")}}. It may be passed into the constructor when instantiating a connection, or used with the {{domxref("RTCPeerConnection.getConfiguration()")}} and {{domxref("RTCPeerConnection.setConfiguration()")}} methods, which allow inspecting and changing the configuration while a connection is established.</p>
+<p>
+  The <strong><code>RTCConfiguration</code></strong> dictionary is used
+  to provide configuration options for an {{domxref("RTCPeerConnection")}}.
+  It may be passed into the constructor when instantiating a connection,
+  or used with the {{domxref("RTCPeerConnection.getConfiguration()")}}
+  and {{domxref("RTCPeerConnection.setConfiguration()")}} methods,
+  which allow inspecting and changing the configuration
+  while a connection is established.</p>
 
 <p>The options include ICE server and transport settings and identity information.</p>
 
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("RTCConfiguration.bundlePolicy", "bundlePolicy")}} {{optional_inline}}</dt>
- <dd>Specifies how to handle negotiation of candidates when the remote peer is not compatible with the <a href="https://webrtcstandards.info/sdp-bundle/">SDP BUNDLE standard</a>. This must be one of the values from the enum <code><a href="#rtcbundlepolicy_enum">RTCBundlePolicy</a></code>. If this value isn't included in the dictionary, <code>"balanced"</code> is assumed.</dd>
- <dt>{{domxref("RTCConfiguration.certificates", "certificates")}} {{optional_inline}}</dt>
- <dd>An {{jsxref("Array")}} of objects of type {{domxref("RTCCertificate")}} which are used by the connection for authentication. If this property isn't specified, a set of certificates is generated automatically for each {{domxref("RTCPeerConnection")}} instance. Although only one certificate is used by a given connection, providing certificates for multiple algorithms may improve the odds of successfully connecting in some circumstances. See <a href="/en-US/docs/Web/API/RTCConfiguration/certificates#using_certificates">Using certificates</a> for further information.
- <div class="note">This configuration option cannot be changed after it is first specified; once the certificates have been set, this property is ignored in future calls to {{domxref("RTCPeerConnection.setConfiguration()")}}.</div>
- </dd>
- <dt>{{domxref("RTCConfiguration.iceCandidatePoolSize", "iceCandidatePoolSize")}} {{optional_inline}}</dt>
- <dd>An unsigned 16-bit integer value which specifies the size of the prefetched ICE candidate pool. The default value is 0 (meaning no candidate prefetching will occur). You may find in some cases that connections can be established more quickly by allowing the ICE agent to start fetching ICE candidates before you start trying to connect, so that they're already available for inspection when {{domxref("RTCPeerConnection.setLocalDescription()")}} is called.
- <div class="note">Changing the size of the ICE candidate pool may trigger the beginning of ICE gathering.</div>
- </dd>
- <dt>{{domxref("RTCConfiguration.iceServers", "iceServers")}} {{optional_inline}}</dt>
- <dd>An array of {{domxref("RTCIceServer")}} objects, each describing one server which may be used by the ICE agent; these are typically STUN and/or TURN servers. If this isn't specified, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.</dd>
- <dt>{{domxref("RTCConfiguration.iceTransportPolicy", "iceTransportPolicy")}} {{optional_inline}}</dt>
- <dd>The current ICE transport policy; this must be one of the values from the {{domxref("RTCIceTransportPolicy")}} enumeration. If the policy isn't specified, <code>all</code> is assumed by default, allowing all candidates to be considered. A value of <code>relay</code> limits the candidates to those relayed through another server, such as a STUN or TURN server.</dd>
- <dt>{{domxref("RTCConfiguration.peerIdentity", "peerIdentity")}} {{optional_inline}}</dt>
- <dd>A {{domxref("DOMString")}} which specifies the target peer identity for the {{domxref("RTCPeerConnection")}}. If this value is set (it defaults to <code>null</code>), the <code>RTCPeerConnection</code> will not connect to a remote peer unless it can successfully authenticate with the given name.</dd>
- <dt>{{domxref("RTCConfiguration.rtcpMuxPolicy", "rtcpMuxPolicy")}} {{optional_inline}}</dt>
- <dd>The RTCP mux policy to use when gathering ICE candidates, in order to support non-multiplexed RTCP. The value must be one of those from the <a href="#rtcrtcpmuxpolicy_enum"><code>RTCRtcpMuxPolicy</code> enum</a>. The default is <code>"require"</code>.</dd>
+  <dt>{{domxref("RTCConfiguration.bundlePolicy", "bundlePolicy")}} {{optional_inline}}</dt>
+  <dd>
+    <p>
+      Specifies how to handle negotiation of candidates
+      when the remote peer is not compatible
+      with the <a href="https://webrtcstandards.info/sdp-bundle/">SDP BUNDLE standard</a>.
+      If the remote endpoint is BUNDLE-aware,
+      all media tracks and data channels are bundled onto a single transport at the completion of negotiation,
+      regardless of policy used,
+      and any superfluous transports that were created initially are closed at that point.
+    </p>
+    <p>
+      In technical terms,
+      a BUNDLE lets all media flow between two peers flow across a single <strong>5-tuple</strong>;
+      that is, from a single IP and port on one peer to a single IP and port on the other peer,
+      using the same transport protocol.
+    </p>
+    <p>
+      This must be one of the following string values,
+      if not <code>balanced</code> is assumed:
+    </p>
+    <dl>
+      <dt><code>balanced</code></dt>
+      <dd>
+        The ICE agent initially creates one {{domxref("RTCDtlsTransport")}}
+        for each type of content added: audio, video, and data channels.
+        If the remote endpoint is not BUNDLE-aware,
+        then each of these DTLS transports handles all the communication for one type of data.
+      </dd>
+
+      <dt><code>max-compat</code></dt>
+      <dd>
+        The ICE agent initially creates one {{domxref("RTCDtlsTransport")}} per media track
+        and a separate one for data channels.
+        If the remote endpoint is not BUNDLE-aware,
+        everything is negotiated on these separate DTLS transports.
+      </dd>
+
+      <dt><code>max-bundle</code></dt>
+      <dd>
+        The ICE agent initially creates only a single {{domxref("RTCDtlsTransport")}}
+        to carry all of the {{DOMxRef("RTCPeerConnection")}}'s data.
+        If the remote endpoint is not BUNDLE-aware,
+        then only a single track will be negotiated and the rest ignored.
+      </dd>
+    </dl>
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.certificates", "certificates")}} {{optional_inline}}</dt>
+  <dd>
+    An {{jsxref("Array")}} of objects of type {{domxref("RTCCertificate")}}
+    which are used by the connection for authentication.
+    If this property isn't specified,
+    a set of certificates is generated automatically for each {{domxref("RTCPeerConnection")}} instance.
+    Although only one certificate is used by a given connection,
+    providing certificates for multiple algorithms may improve the odds of successfully connecting in some circumstances.
+    See <a href="/en-US/docs/Web/API/RTCConfiguration/certificates#using_certificates">Using certificates</a> for further information.
+    <div class="note">This configuration option cannot be changed after it is first specified; once the certificates have been set, this property is ignored in future calls to {{domxref("RTCPeerConnection.setConfiguration()")}}.</div>
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.iceCandidatePoolSize", "iceCandidatePoolSize")}} {{optional_inline}}</dt>
+  <dd>
+    An unsigned 16-bit integer value which specifies the size of the prefetched ICE candidate pool.
+    The default value is 0 (meaning no candidate prefetching will occur).
+    You may find in some cases that connections can be established more quickly
+    by allowing the ICE agent to start fetching ICE candidates
+    before you start trying to connect,
+    so that they're already available for inspection
+    when {{domxref("RTCPeerConnection.setLocalDescription()")}} is called.
+    <div class="note">Changing the size of the ICE candidate pool may trigger the beginning of ICE gathering.</div>
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.iceServers", "iceServers")}} {{optional_inline}}</dt>
+  <dd>
+    An array of {{domxref("RTCIceServer")}} objects,
+    each describing one server which may be used by the ICE agent;
+    these are typically STUN and/or TURN servers.
+    If this isn't specified,
+    the connection attempt will be made with no STUN or TURN server available,
+    which limits the connection to local peers.
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.iceTransportPolicy", "iceTransportPolicy")}} {{optional_inline}}</dt>
+  <dd>
+    The current ICE transport policy;
+    if the policy isn't specified, <code>all</code> is assumed by default,
+    allowing all candidates to be considered.
+    Possible values are:
+    <dl>
+      <tr>
+        <td><code>"all"</code></td>
+        <td>All ICE candidates will be considered.</td>
+       </tr>
+       <tr>
+        <td><code>"public" </code>{{deprecated_inline}}</td>
+        <td>Only ICE candidates with public IP addresses will be considered. <em>Removed from the specification's May 13, 2016 working draft.</em></td>
+       </tr>
+       <tr>
+        <td><code>"relay"</code></td>
+        <td>Only ICE candidates whose IP addresses are being relayed, such as those being passed through a STUN or TURN server, will be considered.</td>
+       </tr>
+    </dl>
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.peerIdentity", "peerIdentity")}} {{optional_inline}}</dt>
+  <dd>
+    A {{domxref("DOMString")}}
+    which specifies the target peer identity for the {{domxref("RTCPeerConnection")}}.
+    If this value is set
+    (it defaults to <code>null</code>),
+    the <code>RTCPeerConnection</code> will not connect to a remote peer
+    unless it can successfully authenticate with the given name.
+  </dd>
+
+  <dt>{{domxref("RTCConfiguration.rtcpMuxPolicy", "rtcpMuxPolicy")}} {{optional_inline}}</dt>
+  <dd>
+    The RTCP mux policy to use when gathering ICE candidates, in order to support non-multiplexed RTCP. Possible values are:
+    <dl>
+      <dt><code>negotiate</code></dt>
+      <dd>
+        Instructs the ICE agent to gather both {{Glossary("RTP")}} and {{Glossary("RTCP")}} candidates.
+        If the remote peer can multiplex RTCP,
+        then RTCP candidates are multiplexed atop the corresponding RTP candidates.
+        Otherwise, both the RTP and RTCP candidates are returned, separately.
+      </dd>
+
+      <dt><code>require</code></td>
+      <dd>
+        Tells the ICE agent to gather ICE candidates for only RTP,
+        and to multiplex RTCP atop them.
+        If the remote peer doesn't support RTCP multiplexing,
+        then session negotiation fails.
+        This is the default value.
+      </dd>
+    </dl>
+   </dd>
 </dl>
-
-<h2 id="Constants">Constants</h2>
-
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCBundlePolicy enum", 0, 1)}}</p>
-
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCIceTransportPolicy enum", 0, 1)}}</p>
-
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCRtcpMuxPolicy enum", 0, 1)}}</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -567,38 +567,6 @@ browser-compat: api.RTCPeerConnection
 
 <h2 id="Constants">Constants</h2>
 
-<h3 id="RTCBundlePolicy_enum">RTCBundlePolicy enum</h3>
-
-<p>The <code>RTCBundlePolicy</code> enum defines string constants which are used to request a specific policy for gathering ICE candidates if the remote peer isn't "BUNDLE-aware" (compatible with the <a href="https://webrtcstandards.info/sdp-bundle/">SDP BUNDLE standard</a> for bundling multiple media streams on a single transport link). All browser implementations are BUNDLE-aware.</p>
-
-<p>If the remote endpoint is BUNDLE-aware, all media tracks and data channels are bundled onto a single transport at the completion of negotiation, regardless of policy used, and any superfluous transports that were created initially are closed at that point.</p>
-
-<div class="note">
-<p><strong>Note:</strong> In technical terms, a BUNDLE lets all media flow between two peers flow across a single <strong>5-tuple</strong>; that is, from a single IP and port on one peer to a single IP and port on the other peer, using the same transport protocol.</p>
-</div>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"balanced"</code></td>
-   <td>The ICE agent initially creates one {{domxref("RTCDtlsTransport")}} for each type of content added: audio, video, and data channels. If the remote endpoint is not BUNDLE-aware, then each of these DTLS transports then handles all the communication for one type of data.</td>
-  </tr>
-  <tr>
-   <td><code>"max-compat"</code></td>
-   <td>The ICE agent initially creates one {{domxref("RTCDtlsTransport")}} per media track and a separate one for data channels. If the remote endpoint is not BUNDLE-aware, everything is negotiated on these separate DTLS transports.</td>
-  </tr>
-  <tr>
-   <td><code>"max-bundle"</code></td>
-   <td>The ICE agent initially creates only a single {{domxref("RTCDtlsTransport")}} to carry all of the <code>RTCPeerConnection</code>'s data. If the remote endpoint is not BUNDLE-aware, then only a single track will be negotiated and the rest ignored.</td>
-  </tr>
- </tbody>
-</table>
 
 <h3 id="RTCIceGatheringState_enum">RTCIceGatheringState enum</h3>
 
@@ -623,56 +591,6 @@ browser-compat: api.RTCPeerConnection
   <tr>
    <td><code>"complete"</code></td>
    <td>The ICE agent has finished gathering candidates. If something happens that requires collecting new candidates, such as a new interface being added or the addition of a new ICE server, the state will revert to "gathering" to gather those candidates.</td>
-  </tr>
- </tbody>
-</table>
-
-<h3 id="RTCIceTransportPolicy_enum">RTCIceTransportPolicy enum</h3>
-
-<p>The <code>RTCIceTransportPolicy</code> enum defines string constants which can be used to limit the transport policies of the ICE candidates to be considered during the connection process.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"all"</code></td>
-   <td>All ICE candidates will be considered.</td>
-  </tr>
-  <tr>
-   <td><code>"public" </code>{{deprecated_inline}}</td>
-   <td>Only ICE candidates with public IP addresses will be considered. <em>Removed from the specification's May 13, 2016 working draft.</em></td>
-  </tr>
-  <tr>
-   <td><code>"relay"</code></td>
-   <td>Only ICE candidates whose IP addresses are being relayed, such as those being passed through a TURN server, will be considered.</td>
-  </tr>
- </tbody>
-</table>
-
-<h3 id="RTCRtcpMuxPolicy_enum">RTCRtcpMuxPolicy enum</h3>
-
-<p>The <code>RTCRtcpMuxPolicy</code> enum defines string constants which specify what ICE candidates are gathered to support non-multiplexed RTCP. <strong>&lt;&lt;&lt;add a link to info about multiplexed RTCP.</strong></p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"negotiate"</code></td>
-   <td>Instructs the ICE agent to gather both {{Glossary("RTP")}} and {{Glossary("RTCP")}} candidates. If the remote peer can multiplex RTCP, then RTCP candidates are multiplexed atop the corresponding RTP candidates. Otherwise, both the RTP and RTCP candidates are returned, separately.</td>
-  </tr>
-  <tr>
-   <td><code>"require"</code></td>
-   <td>Tells the ICE agent to gather ICE candidates for only RTP, and to multiplex RTCP atop them. If the remote peer doesn't support RTCP multiplexing, then session negotiation fails.</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
No need to document enums separately, even as a section of an (unrelated) page.
So I removed the section from RTCPeerConnection, put the values in the property `RTCConfiguration`, and got rid of `{{page}} `inclusions, too.

I wiped out all mentions of `RTCRtcpMuxPolicy`, `RTCIceTransportPolicy` and `RTCBundlePolicy` from MDN Web Docs.

**Note**: `RTCConfiguration` may be one of the rare dictionaries that will survive, at the end. But that's another story!