### PR TITLE
Remove secure context warnings from XR member pages

### DIFF
--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
@@ -23,7 +23,7 @@ tags:
 - space
 browser-compat: api.XRBoundedReferenceSpace.boundsGeometry
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRBoundedReferenceSpace")}}
     property <code><strong>boundsGeometry</strong></code> is an array of

--- a/files/en-us/web/api/xrframe/getpose/index.html
+++ b/files/en-us/web/api/xrframe/getpose/index.html
@@ -16,7 +16,7 @@ tags:
 - getPose
 browser-compat: api.XRFrame.getPose
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p class="summary"><span class="seoSummary">The {{domxref("XRFrame")}}
     method <code><strong>getPose()</strong></code> returns the relative position and

--- a/files/en-us/web/api/xrframe/getviewerpose/index.html
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.html
@@ -17,7 +17,7 @@ tags:
 - pose
 browser-compat: api.XRFrame.getViewerPose
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p class="summary"><span
     class="seoSummary">The <code><strong>getViewerPose()</strong></code> method, a member

--- a/files/en-us/web/api/xrinputsource/gripspace/index.html
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.html
@@ -16,7 +16,7 @@ tags:
   - gripSpace
 browser-compat: api.XRInputSource.gripSpace
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p class="summary"><span class="seoSummary">The read-only {{domxref("XRInputSource")}}
     property <code><strong>gripSpace</strong></code> returns an {{domxref("XRSpace")}}

--- a/files/en-us/web/api/xrinputsource/handedness/index.html
+++ b/files/en-us/web/api/xrinputsource/handedness/index.html
@@ -21,7 +21,7 @@ tags:
 - right
 browser-compat: api.XRInputSource.handedness
 ---
-<p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
+<p>{{APIRef("WebXR")}}</p>
 
 <p>The read-only {{domxref("XRInputSource")}} property
   <code><strong>handedness</strong></code> indicates which of the user's hands the WebXR

--- a/files/en-us/web/api/xrinputsource/profiles/index.html
+++ b/files/en-us/web/api/xrinputsource/profiles/index.html
@@ -20,7 +20,7 @@ tags:
 - profile
 browser-compat: api.XRInputSource.profiles
 ---
-<p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
+<p>{{APIRef("WebXR")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRInputSource")}} property
     <code><strong>profiles</strong></code> returns an array of strings, each describing a

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.html
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.html
@@ -21,7 +21,7 @@ tags:
 - targetRayMode
 browser-compat: api.XRInputSource.targetRayMode
 ---
-<p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
+<p>{{APIRef("WebXR")}}</p>
 
 <p>The read-only {{domxref("XRInputSource")}}
   property <strong><code>targetRayMode</code></strong> indicates the method by which the

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -27,7 +27,7 @@ tags:
 - target
 browser-compat: api.XRInputSource.targetRaySpace
 ---
-<p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
+<p>{{APIRef("WebXR")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRInputSource")}} property
     <code><strong>targetRaySpace</strong></code> returns an {{domxref("XRSpace")}}

--- a/files/en-us/web/api/xrinputsourcearray/entries/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/entries/index.html
@@ -18,7 +18,7 @@ tags:
 - XRInputSourceArray
 browser-compat: api.XRInputSourceArray.entries
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRInputSourceArray")}} interface's
     <code><strong>entries()</strong></code> method returns a JavaScript

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.html
@@ -21,7 +21,7 @@ tags:
 - forEach
 browser-compat: api.XRInputSourceArray.forEach
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The {{domxref("XRInputSourceArray")}}
   method <code><strong>forEach()</strong></code> executes the specified callback once for

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.html
@@ -24,7 +24,7 @@ tags:
 - keys
 browser-compat: api.XRInputSourceArray.keys
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The <code><strong>keys()</strong></code> method in the
   {{domxref("XRInputSourceArray")}} interface returns a {{Glossary("JavaScript")}}

--- a/files/en-us/web/api/xrinputsourcearray/length/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.html
@@ -22,7 +22,7 @@ tags:
 - count
 browser-compat: api.XRInputSourceArray.length
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The read-only <code><strong>length</strong></code> property returns an integer value
   indicating the number of items in the input source list represented by

--- a/files/en-us/web/api/xrinputsourcearray/values/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.html
@@ -23,7 +23,7 @@ tags:
 - values
 browser-compat: api.XRInputSourceArray.values
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The {{domxref("XRInputSourceArray")}}
   method  <code><strong>values()</strong></code> returns a {{Glossary("JavaScript")}}

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.html
@@ -22,7 +22,7 @@ tags:
 - events
 browser-compat: api.XRInputSourceEvent.frame
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRInputSourceEvent")}} property
     <code><strong>frame</strong></code> specifies an {{domxref("XRFrame")}} object

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
@@ -23,7 +23,7 @@ tags:
 - source
 browser-compat: api.XRInputSourceEvent.inputSource
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRInputSourceEvent")}} interface's read-only
     <code><strong>inputSource</strong></code> property specifies the

--- a/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
@@ -22,7 +22,7 @@ tags:
 - events
 browser-compat: api.XRInputSourceEvent.XRInputSourceEvent
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <code><strong>XRInputSourceEvent()</strong></code>
     constructor creates and returns a new {{domxref("XRInputSourceEvent")}} object

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
@@ -19,7 +19,7 @@ tags:
 - augmented
 browser-compat: api.XRInputSourcesChangeEvent.added
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRInputSourcesChangeEvent")}}
     property {{domxref("XRInputSourcesChangeEvent.added", "added")}} is a list of zero or

--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
@@ -23,7 +23,7 @@ tags:
 - removed
 browser-compat: api.XRInputSourcesChangeEvent.removed
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRInputSourcesChangeEvent")}}
     property {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} is an array of

--- a/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
@@ -22,7 +22,7 @@ tags:
 - augmented
 browser-compat: api.XRInputSourcesChangeEvent.session
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRInputSourcesChangeEvent")}} property
     {{domxref("XRInputSourcesChangeEvent.session", "session")}} specifies the

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
@@ -21,7 +21,7 @@ tags:
 - augmented
 browser-compat: api.XRInputSourcesChangeEvent.XRInputSourcesChangeEvent
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <code><strong>XRInputSourcesChangeEvent()</strong></code>
     constructor creates and returns a new {{domxref("XRInputSourcesChangeEvent")}} object,

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
@@ -22,7 +22,7 @@ tags:
 - augmented
 browser-compat: api.XRInputSourcesChangeEventInit.added
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRInputSourcesChangeEventInit")}} property
     {{domxref("XRInputSourcesChangeEventInit.added", "added")}} specifies a list of input

--- a/files/en-us/web/api/xrpermissionstatus/granted/index.html
+++ b/files/en-us/web/api/xrpermissionstatus/granted/index.html
@@ -20,7 +20,7 @@ tags:
 - granted
 browser-compat: api.XRPermissionStatus.granted
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The WebXR Device API's {{domxref("XRPermissionStatus")}}
   interface's <code><strong>granted</strong></code> property is an array of strings, each

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
@@ -23,7 +23,7 @@ tags:
 - movement
 browser-compat: api.XRReferenceSpace.getOffsetReferenceSpace
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRReferenceSpace")}}
     interface's <code><strong>getOffsetReferenceSpace()</strong></code> method returns a

--- a/files/en-us/web/api/xrreferencespace/onreset/index.html
+++ b/files/en-us/web/api/xrreferencespace/onreset/index.html
@@ -22,7 +22,7 @@ tags:
 - tracking
 browser-compat: api.XRReferenceSpace.onreset
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The {{domxref("XRReferenceSpace")}}
   interface's <code><strong>onreset</strong></code> event handler property can be set to a

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.html
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.html
@@ -19,7 +19,7 @@ tags:
   - reset
 browser-compat: api.XRReferenceSpace.reset_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <code><strong>reset</strong></code> event is sent to an {{domxref("XRReferenceSpace")}} object when a discontinuity is detected in either the native origin or the effective origin, causing a jump in the position or orientation of objects oriented using the reference space.</span> This is common when the user calibrates or recalibrates an XR device, or if the device automatically changes its origin after losing tracking of the user, then re-gaining it.</p>
 

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
@@ -21,7 +21,7 @@ tags:
 - source
 browser-compat: api.XRReferenceSpaceEvent.referenceSpace
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The read-only {{domxref("XRReferenceSpaceEvent")}} property
   <code><strong>referenceSpace</strong></code> specifies the reference space which is the

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.html
@@ -26,7 +26,7 @@ tags:
 - transform
 browser-compat: api.XRReferenceSpaceEvent.transform
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRReferenceSpaceEvent")}} property
     <code><strong>transform</strong></code> indicates the position and orientation of the

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
@@ -21,7 +21,7 @@ tags:
 - events
 browser-compat: api.XRReferenceSpaceEvent.XRReferenceSpaceEvent
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <code><strong>XRReferenceSpaceEvent()</strong></code>
     constructor is used to create a new {{domxref("XRReferenceSpaceEvent")}} object, which

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.html
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.html
@@ -16,7 +16,7 @@ tags:
 - baseLayer
 browser-compat: api.XRRenderState.baseLayer
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p class="summary">The read-only <strong><code>baseLayer</code></strong> property of the
   {{domxref("XRRenderState")}} interface returns the {{domxref("XRWebGLLayer")}} instance

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.html
@@ -16,7 +16,7 @@ tags:
 - depthFar
 browser-compat: api.XRRenderState.depthFar
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p class="summary">The <strong><code>depthFar</code></strong> read-only property of the
   {{domxref("XRRenderState")}} interface returns the distance in meters of the far clip

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.html
@@ -16,7 +16,7 @@ tags:
 - depthNear
 browser-compat: api.XRRenderState.depthNear
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p class="summary">The <strong><code>depthNear</code></strong> read-only property of the
   {{domxref("XRRenderState")}} interface returns the distance in meters of the near clip

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
@@ -9,7 +9,7 @@ tags:
 - WebXR Device API
 browser-compat: api.XRRenderState.inlineVerticalFieldOfView
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p class="summary">The read-only <strong><code>inlineVerticalFieldOfView</code></strong>
   property of the {{DOMxRef("XRRenderState")}} interface returns the default vertical

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.html
@@ -16,7 +16,7 @@ tags:
 - cancelAnimationFrame()
 browser-compat: api.XRSession.cancelAnimationFrame
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span
     class="seoSummary">The <strong><code>cancelAnimationFrame()</code></strong> method of

--- a/files/en-us/web/api/xrsession/end/index.html
+++ b/files/en-us/web/api/xrsession/end/index.html
@@ -16,7 +16,7 @@ tags:
 - end()
 browser-compat: api.XRSession.end
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>end()</strong></code> method shuts down the
     {{domxref("XRSession")}} on which it's called, returning a promise which resolves once

--- a/files/en-us/web/api/xrsession/inputsources/index.html
+++ b/files/en-us/web/api/xrsession/inputsources/index.html
@@ -16,7 +16,7 @@ tags:
 - inputSources
 browser-compat: api.XRSession.inputSources
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The
     <em>read-only</em> <strong><code>inputSources</code></strong> property of the

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
@@ -22,7 +22,7 @@ tags:
   - inputsourceschange
 browser-compat: api.XRSession.inputsourceschange_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <strong><code>inputsourceschange</code></strong> event is sent to an {{domxref("XRSession")}} when the set of available WebXR input devices changes.</span> The received event, of type {{domxref("XRInputSourcesChangeEvent")}}, contains a list of any newly {{domxref("XRInputSourcesChangeEvent.added", "added")}} and/or {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} input devices.</p>
 

--- a/files/en-us/web/api/xrsession/onend/index.html
+++ b/files/en-us/web/api/xrsession/onend/index.html
@@ -16,7 +16,7 @@ tags:
 - onend
 browser-compat: api.XRSession.onend
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>onend</strong></code> attribute of the
     {{DOMxRef("XRSession")}} object is the event handler for the

--- a/files/en-us/web/api/xrsession/oninputsourceschange/index.html
+++ b/files/en-us/web/api/xrsession/oninputsourceschange/index.html
@@ -16,7 +16,7 @@ tags:
   - oninputsourceschange
 browser-compat: api.XRSession.oninputsourceschange
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>oninputsourcechange</strong></code> attribute of the {{DOMxRef("XRSession")}} object is the event handler for the {{DOMxRef("XRSession.inputsourcechange_event", "inputsourcechange")}} event, which is dispatched when session's list of active XR input sources has changed. The list itself is accessible via {{DOMxRef("XRSession.inputSources")}}.</span></p>
 

--- a/files/en-us/web/api/xrsession/onselect/index.html
+++ b/files/en-us/web/api/xrsession/onselect/index.html
@@ -17,7 +17,7 @@ tags:
 - onselect
 browser-compat: api.XRSession.onselect
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>onselect</strong></code> property of the
     {{DOMxRef("XRSession")}} object is the event handler for the

--- a/files/en-us/web/api/xrsession/onselectend/index.html
+++ b/files/en-us/web/api/xrsession/onselectend/index.html
@@ -14,7 +14,7 @@ tags:
 - onselectend
 browser-compat: api.XRSession.onselectend
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>onselectend</strong></code> attribute of the
     {{DOMxRef("XRSession")}} object is the event handler for the

--- a/files/en-us/web/api/xrsession/onselectstart/index.html
+++ b/files/en-us/web/api/xrsession/onselectstart/index.html
@@ -16,7 +16,7 @@ tags:
 - onselectstart
 browser-compat: api.XRSession.onselectstart
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>onselectstart</strong></code> attribute of
     the {{DOMxRef("XRSession")}} object is the event handler for the

--- a/files/en-us/web/api/xrsession/onsqueeze/index.html
+++ b/files/en-us/web/api/xrsession/onsqueeze/index.html
@@ -21,7 +21,7 @@ tags:
 - squeeze
 browser-compat: api.XRSession.onsqueeze
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRSession")}} interface's
     <code><strong>onsqueeze</strong></code> event handler property can be set to a

--- a/files/en-us/web/api/xrsession/onsqueezeend/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezeend/index.html
@@ -21,7 +21,7 @@ tags:
 - squeeze
 browser-compat: api.XRSession.onsqueezeend
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRSession")}} interface's
     <code><strong>onsqueezeend</strong></code> event handler property is a function to be

--- a/files/en-us/web/api/xrsession/onsqueezestart/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezestart/index.html
@@ -22,7 +22,7 @@ tags:
 - onsqueezestart
 browser-compat: api.XRSession.onsqueezestart
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRSession")}} interface's
     <code><strong>onsqueezestart</strong></code> event handler property can be set to a

--- a/files/en-us/web/api/xrsession/onvisibilitychange/index.html
+++ b/files/en-us/web/api/xrsession/onvisibilitychange/index.html
@@ -14,7 +14,7 @@ tags:
 - onvisibilitychange
 browser-compat: api.XRSession.onvisibilitychange
 ---
-<div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The <code><strong>onvisibilitychange</strong></code>
     attribute of the {{DOMxRef("XRSession")}} object is the event handler for the

--- a/files/en-us/web/api/xrsession/renderstate/index.html
+++ b/files/en-us/web/api/xrsession/renderstate/index.html
@@ -16,7 +16,7 @@ tags:
 - renderState
 browser-compat: api.XRSession.renderState
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p><span class="seoSummary">The
     <em>read-only</em> <strong><code>renderState</code></strong> property of an

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.html
@@ -16,7 +16,7 @@ tags:
 - requestAnimationFrame()
 browser-compat: api.XRSession.requestAnimationFrame
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR")}}</div>
 
 <p><span class="seoSummary">The {{domxref("XRSession")}}
     method <code><strong>requestAnimationFrame()</strong></code>, much like the

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.html
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.html
@@ -19,7 +19,7 @@ tags:
 - tracking
 browser-compat: api.XRSession.requestReferenceSpace
 ---
-<p>{{APIRef("WebXR")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR")}}</p>
 
 <p class="summary"><span class="seoSummary">The
     <strong><code>requestReferenceSpace()</code></strong> method of the

--- a/files/en-us/web/api/xrsession/select_event/index.html
+++ b/files/en-us/web/api/xrsession/select_event/index.html
@@ -23,7 +23,7 @@ tags:
   - target
 browser-compat: api.XRSession.select_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR event <code><strong>select</strong></code> is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_actions">primary action</a>.</span> Examples of comon kinds of primary action are users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.html
+++ b/files/en-us/web/api/xrsession/selectend_event/index.html
@@ -22,7 +22,7 @@ tags:
   - selectend
 browser-compat: api.XRSession.selectend_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR event <code><strong>selectend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</span> Primary actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 

--- a/files/en-us/web/api/xrsession/selectstart_event/index.html
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.html
@@ -22,7 +22,7 @@ tags:
   - selectstart
 browser-compat: api.XRSession.selectstart_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a> event <code><strong>selectstart</strong></code> is sent to an {{domxref("XRSession")}} when the user begins a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_actions">primary action</a> on one of its input sources.</span> Primary actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 

--- a/files/en-us/web/api/xrsession/squeeze_event/index.html
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.html
@@ -24,7 +24,7 @@ tags:
   - squeeze
 browser-compat: api.XRSession.squeeze_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR event <code><strong>squeeze</strong></code> is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_squeeze_actions">primary squeeze action</a>.</span> Examples of comon kinds of primary action are users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.html
@@ -23,7 +23,7 @@ tags:
   - squeezeend
 browser-compat: api.XRSession.squeezeend_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR event <code><strong>squeezeend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_squeeze_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</span> Primary squeeze actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.html
@@ -24,7 +24,7 @@ tags:
   - squeezestart
 browser-compat: api.XRSession.squeezestart_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a> event <code><strong>squeezestart</strong></code> is sent to an {{domxref("XRSession")}} when the user begins a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_squeeze_actions">primary squeeze action</a> on one of its input sources.</span> Primary squeeze actions are actions which are meant to represent gripping or squeezing using your hands, and may be simulated using triggers on hand controllers.</p>
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.html
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.html
@@ -20,7 +20,7 @@ tags:
   - updateRenderState()
 browser-compat: api.XRSession.updateRenderState
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p><span class="seoSummary">The <code>updateRenderState()</code> method of the
     {{DOMxRef("XRSession")}} interface of <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.html
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.html
@@ -25,7 +25,7 @@ tags:
   - visibilitychange
 browser-compat: api.XRSession.visibilitychange_event
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <code><strong>visibilitychange</strong></code> event is sent to an {{domxref("XRSession")}} to inform it when it becomes visible or hidden, or when it becomes visible but not currently focused.</span> Upon receiving the event, you can check the value of the session's {{domxref("XRSession.visibilityState", "visibilityState")}} property to determine the new visibility state.</p>
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.html
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.html
@@ -16,7 +16,7 @@ tags:
 - visibilityState
 browser-compat: api.XRSession.visibilityState
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p><span class="seoSummary">The
     <em>read-only</em> <strong><code>visibilityState</code></strong> property of the

--- a/files/en-us/web/api/xrsessionevent/session/index.html
+++ b/files/en-us/web/api/xrsessionevent/session/index.html
@@ -22,7 +22,7 @@ tags:
 - sessions
 browser-compat: api.XRSessionEvent.session
 ---
-<p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRSessionEvent")}} interface's
     <code><strong>session</strong></code> property indicates which

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
@@ -18,7 +18,7 @@ tags:
 - events
 browser-compat: api.XRSessionEvent.XRSessionEvent
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR Device API's
     <code><strong>XRSessionEvent()</strong></code> constructor creates and returns a new

--- a/files/en-us/web/api/xrspace/index.html
+++ b/files/en-us/web/api/xrspace/index.html
@@ -15,7 +15,7 @@ tags:
   - XRSpace
 browser-compat: api.XRSpace
 ---
-<div>{{draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
+<div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
 <p class="summary"><span class="seoSummary">The <strong><code>XRSpace</code></strong> interface of the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> is an abstract interface providing a common basis for every class which represents a virtual coordinate system within the virtual world, in which its origin corresponds to a physical location.</span> Spatial data in WebXR is always expressed relative to an object based upon one of the descendant interfaces of <code>XRSpace</code>, at the time at which a given {{domxref("XRFrame")}} takes place.</p>
 

--- a/files/en-us/web/api/xrsystem/ondevicechange/index.html
+++ b/files/en-us/web/api/xrsystem/ondevicechange/index.html
@@ -15,7 +15,7 @@ tags:
 - ondevicechange
 browser-compat: api.XRSystem.ondevicechange
 ---
-<div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
+<div>{{APIRef("WebXR Device API")}}</div>
 
 <p class="summary">The <strong><code>ondevicechange</code></strong> property of the
   {{domxref("XRSystem")}} interface is passed a {{Event("devicechange")}} event whenever

--- a/files/en-us/web/api/xrview/eye/index.html
+++ b/files/en-us/web/api/xrview/eye/index.html
@@ -19,7 +19,7 @@ tags:
 - augmented
 browser-compat: api.XRView.eye
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The {{domxref("XRView")}} interface's read-only <code><strong>eye</strong></code>
   property is a string taken from the {{domxref("XREye")}} enumerated type, indicating

--- a/files/en-us/web/api/xrview/projectionmatrix/index.html
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.html
@@ -20,7 +20,7 @@ tags:
 - projectionMatrix
 browser-compat: api.XRView.projectionMatrix
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The {{domxref("XRView")}} interface's read-only
   <code><strong>projectionMatrix</strong></code> property specifies the projection matrix

--- a/files/en-us/web/api/xrview/transform/index.html
+++ b/files/en-us/web/api/xrview/transform/index.html
@@ -24,7 +24,7 @@ tags:
 - transform
 browser-compat: api.XRView.transform
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The read-only <code><strong>transform</strong></code> property of the
   {{domxref("XRView")}} interface is an {{domxref("XRRigidTransform")}} object which

--- a/files/en-us/web/api/xrviewerpose/index.html
+++ b/files/en-us/web/api/xrviewerpose/index.html
@@ -19,7 +19,7 @@ tags:
   - augmented
 browser-compat: api.XRViewerPose
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The WebXR Device API interface <code><strong>XRViewerPose</strong></code> represents the pose (the position and orientation) of a viewer's point of view on the scene. Each <code>XRViewerPose</code> can have multiple views to represent, for example, the slight separation between the left and right eye.</span> This view can represent anything from the point-of-view of a user's XR headset to the viewpoint represented by a player's movement of an avatar using mouse and keyboard, presented on the screen, to a virtual camera capturing the scene for a spectator.</p>
 

--- a/files/en-us/web/api/xrviewerpose/views/index.html
+++ b/files/en-us/web/api/xrviewerpose/views/index.html
@@ -19,7 +19,7 @@ tags:
 - views
 browser-compat: api.XRViewerPose.views
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p>The read-only {{domxref("XRViewerPose")}} property <strong><code>views</code></strong>
   returns an array which contains every {{domxref("XRView")}} which must be rendered in

--- a/files/en-us/web/api/xrviewport/height/index.html
+++ b/files/en-us/web/api/xrviewport/height/index.html
@@ -21,7 +21,7 @@ tags:
 - viewport
 browser-compat: api.XRViewport.height
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRViewport")}} property
     <code><strong>height</strong></code> specifies the height, in pixels, of the viewport

--- a/files/en-us/web/api/xrviewport/width/index.html
+++ b/files/en-us/web/api/xrviewport/width/index.html
@@ -21,7 +21,7 @@ tags:
 - width
 browser-compat: api.XRViewport.width
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRViewport")}} property
     <strong><code>width</code></strong> specifies the width of the viewport, in pixels,

--- a/files/en-us/web/api/xrviewport/x/index.html
+++ b/files/en-us/web/api/xrviewport/x/index.html
@@ -24,7 +24,7 @@ tags:
 - x
 browser-compat: api.XRViewport.x
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRViewport")}} interface's
     <code><strong>x</strong></code> property indicates the offset from the left edge of

--- a/files/en-us/web/api/xrviewport/y/index.html
+++ b/files/en-us/web/api/xrviewport/y/index.html
@@ -23,7 +23,7 @@ tags:
 - 'y'
 browser-compat: api.XRViewport.y
 ---
-<p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRViewport")}} interface's
     <code><strong>y</strong></code> property indicates the offset from the bottom edge of

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.html
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.html
@@ -23,7 +23,7 @@ tags:
 - rendering
 browser-compat: api.XRWebGLLayer.antialias
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRWebGLLayer")}} property
     <code><strong>antialias</strong></code> is a Boolean value which is <code>true</code>

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
@@ -20,7 +20,7 @@ tags:
 - framebuffer
 browser-compat: api.XRWebGLLayer.framebuffer
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRWebGLLayer")}} property
     <code><strong>framebuffer</strong></code> is an opaque {{domxref("WebGLFramebuffer")}}

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
@@ -23,7 +23,7 @@ tags:
 - size
 browser-compat: api.XRWebGLLayer.framebufferHeight
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRWebGLLayer")}} property
     <strong><code>framebufferHeight</code></strong> indicates the height of the

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
@@ -22,7 +22,7 @@ tags:
 - width
 browser-compat: api.XRWebGLLayer.framebufferWidth
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRWebGLLayer")}} property
     <strong><code>framebufferWidth</code></strong> specifies the width of the framebuffer,

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
@@ -25,7 +25,7 @@ tags:
   - resolution
 browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The static method
     <code><strong>XRWebGLLayer.getNativeFramebufferScaleFactor()</strong></code> returns a

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.html
@@ -21,7 +21,7 @@ tags:
 - viewport
 browser-compat: api.XRWebGLLayer.getViewport
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The {{domxref("XRWebGLLayer")}} interface's
     <code><strong>getViewport()</strong></code> method returns the

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
@@ -21,7 +21,7 @@ tags:
 - ignoreDepthValues
 browser-compat: api.XRWebGLLayer.ignoreDepthValues
 ---
-<p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The read-only {{domxref("XRWebGLLayer")}} property
     <strong><code>ignoreDepthValues</code></strong> is a Boolean value which is

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
@@ -22,7 +22,7 @@ tags:
 - new
 browser-compat: api.XRWebGLLayer.XRWebGLLayer
 ---
-<p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
+<p>{{APIRef("WebXR Device API")}}</p>
 
 <p><span class="seoSummary">The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR
       Device API</a> <code><strong>XRWebGLLayer()</strong></code> constructor creates and


### PR DESCRIPTION
Not sure if we have guidelines about this but to me it makes no sense to have this (loud) banner on every member page. On an interface level it makes sense to warn about availability of the whole API. However, at a stage when you are concerned with the API members already, I don't think secure context is a thing you need to worry about.