### PR TITLE
Move RTCIceGatheringState enum in property

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
@@ -12,26 +12,37 @@ browser-compat: api.RTCPeerConnection.iceGatheringState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
-<p>The read-only property
-  <code><strong>RTCPeerConnection.iceGatheringState</strong></code> returns an enum of
-  type <code>RTCIceGatheringState</code> that describes connection's ICE gathering state.
+<p>The read-only property<code><strong>RTCPeerConnection.iceGatheringState</strong></code> returns a string
+  that describes connection's ICE gathering state.
   This lets you detect, for example, when collection of ICE candidates has finished.</p>
 
 <p>You can detect when the value of this property changes by watching for an event of type
-  <code><a href="/en-US/docs/Web/API/RTCPeerConnection/icegatheringstatechange_event">icegatheringstatechange</a></code>.
+  {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}}.
 </p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"> var state = <em>RTCPeerConnection</em>.iceGatheringState;</pre>
+<pre class="brush: js"> var state = <em>RTCPeerConnection</em>.iceGatheringState;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>The possible values are those of an enum of type <code>RTCIceGatheringState</code>.</p>
+<p>The possible values are:</p>
 
-<p>{{page("/en-US/docs/Web/API/RTCPeerConnection", "RTCIceGatheringState enum", 0, 1)}}
-</p>
+<dl>
+  <dt><code>new</code></dt>
+  <dd>The peer connection was just created and hasn't done any networking yet.</dd>
+
+  <dt><code>gathering</code></dt>
+  <dd>The ICE agent is in the process of gathering candidates for the connection.</dd>
+
+  <dt><code>complete</code></dt>
+  <dd>
+    The ICE agent has finished gathering candidates.
+    If something happens that requires collecting new candidates,
+    such as a new interface being added or the addition of a new ICE server,
+    the state will revert to <code>gathering</code> to gather those candidates.
+  </dd>
+</dl>
 
 <h2 id="Example">Example</h2>
 
@@ -49,6 +60,6 @@ var state = pc.iceGatheringState;</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{event("icegatheringstatechange")}}</li>
-  <li><a href="/en-US/docs/Web/Guide/API/WebRTC">WebRTC</a></li>
+  <li>{{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}}</li>
+  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.RTCPeerConnection.iceGatheringState
 <p>{{APIRef("WebRTC")}}</p>
 
 <p>The read-only property<code><strong>RTCPeerConnection.iceGatheringState</strong></code> returns a string
-  that describes connection's ICE gathering state.
+  that describes the connection's ICE gathering state.
   This lets you detect, for example, when collection of ICE candidates has finished.</p>
 
 <p>You can detect when the value of this property changes by watching for an event of type

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -567,34 +567,6 @@ browser-compat: api.RTCPeerConnection
 
 <h2 id="Constants">Constants</h2>
 
-
-<h3 id="RTCIceGatheringState_enum">RTCIceGatheringState enum</h3>
-
-<p>The <code>RTCIceGatheringState</code> enum defines string constants which reflect the current status of ICE gathering, as returned using the {{domxref("RTCPeerConnection.iceGatheringState")}} property. You can detect when this value changes by watching for an event of type {{event("icegatheringstatechange")}}.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"new"</code></td>
-   <td>The peer connection was just created and hasn't done any networking yet.</td>
-  </tr>
-  <tr>
-   <td><code>"gathering"</code></td>
-   <td>The ICE agent is in the process of gathering candidates for the connection.</td>
-  </tr>
-  <tr>
-   <td><code>"complete"</code></td>
-   <td>The ICE agent has finished gathering candidates. If something happens that requires collecting new candidates, such as a new interface being added or the addition of a new ICE server, the state will revert to "gathering" to gather those candidates.</td>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="RTCSignalingState_enum">RTCSignalingState enum</h3>
 
 <p>The <code>RTCSignalingState</code> enum specifies the possible values of {{domxref("RTCPeerConnection.signalingState")}}, which indicates where in the process of signaling the exchange of offer and answer the connection currently is.</p>


### PR DESCRIPTION
No need to document enums separately, even as a section of an (unrelated) page.
So I removed the section from RTCPeerConnection, put the values in the property itself, and got rid of one `{{page}}` inclusion, too.

I wiped out all mentions of `RTCIceGatheringState` from MDN Web Docs.
