### PR TITLE
Move RTCSignalingState enum in property

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -565,43 +565,6 @@ browser-compat: api.RTCPeerConnection
   </dd>
 </dl>
 
-<h2 id="Constants">Constants</h2>
-
-<h3 id="RTCSignalingState_enum">RTCSignalingState enum</h3>
-
-<p>The <code>RTCSignalingState</code> enum specifies the possible values of {{domxref("RTCPeerConnection.signalingState")}}, which indicates where in the process of signaling the exchange of offer and answer the connection currently is.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Constant</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>"stable"</code></td>
-   <td>There is no ongoing exchange of offer and answer underway. This may mean that the {{domxref("RTCPeerConnection")}} object is new, in which case both the {{domxref("RTCPeerConnection.localDescription", "localDescription")}} and {{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} are <code>null</code>; it may also mean that negotiation is complete and a connection has been established.</td>
-  </tr>
-  <tr>
-   <td><code>"have-local-offer"</code></td>
-   <td>The local peer has called {{domxref("RTCPeerConnection.setLocalDescription()")}}, passing in SDP representing an offer (usually created by calling {{domxref("RTCPeerConnection.createOffer()")}}), and the offer has been applied successfully.</td>
-  </tr>
-  <tr>
-   <td><code>"have-remote-offer"</code></td>
-   <td>The remote peer has created an offer and used the signaling server to deliver it to the local peer, which has set the offer as the remote description by calling {{domxref("RTCPeerConnection.setRemoteDescription()")}}.</td>
-  </tr>
-  <tr>
-   <td><code>"have-local-pranswer"</code></td>
-   <td>The offer sent by the remote peer has been applied and an answer has been created (usually by calling {{domxref("RTCPeerConnection.createAnswer()")}}) and applied by calling {{domxref("RTCPeerConnection.setLocalDescription()")}}. This provisional answer describes the supported media formats and so forth, but may not have a complete set of ICE candidates included. Further candidates will be delivered separately later.</td>
-  </tr>
-  <tr>
-   <td><code>"have-remote-pranswer"</code></td>
-   <td>A provisional answer has been received and successfully applied in response to an offer previously sent and established by calling <code>setLocalDescription()</code>.</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
@@ -20,10 +20,11 @@ browser-compat: api.RTCPeerConnection.signalingState
 <p>{{APIRef("WebRTC")}}</p>
 
 <p>The read-only <strong><code>signalingState</code></strong> property on the
-  {{domxref("RTCPeerConnection")}} interface returns one of the string values specified by
-  the <code>RTCSignalingState</code> enum; these values describe the state of the
-  signaling process on the local end of the connection while connecting or reconnecting to
-  another peer. See {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Session_lifetime",
+  {{domxref("RTCPeerConnection")}} interface returns a string value
+  describing the state of the signaling process
+  on the local end of the connection
+  while connecting or reconnecting to another peer.
+  See {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Session_lifetime",
   "Signaling")}} for more details about the signaling process.</p>
 
 <p>Because the signaling process is a state machine, being able to verify that your code
@@ -48,11 +49,58 @@ browser-compat: api.RTCPeerConnection.signalingState
 
 <h3 id="Value">Value</h3>
 
-<p>The allowed values are those included in the enum
-  <code><a href="#rtcsignalingstate_enum">RTCSignalingState</a></code>.</p>
+<p>The allowed string values are:</p>
 
-<p id="RTCSignalingState_enum">{{page("/en-US/docs/Web/API/RTCPeerConnection",
-  "RTCSignalingState enum", 0, 1)}}</p>
+<dl>
+  <dt><code>stable</code></dt>
+  <dd>
+    There is no ongoing exchange of offer and answer underway.
+    This may mean that the {{domxref("RTCPeerConnection")}} object is new,
+    in which case
+    both the {{domxref("RTCPeerConnection.localDescription", "localDescription")}}
+    and {{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}}
+    are <code>null</code>;
+    it may also mean that negotiation is complete
+    and a connection has been established.
+  </dd>
+
+  <dt><code>have-local-offer</code></dt>
+  <dd>
+    The local peer has called {{domxref("RTCPeerConnection.setLocalDescription()")}},
+    passing in SDP representing an offer
+    (usually created by calling {{domxref("RTCPeerConnection.createOffer()")}}),
+    and the offer has been applied successfully.
+  </dd>
+
+  <dt><code>have-remote-offer</code></dt>
+  <dd>
+    The remote peer has created an offer
+    and used the signaling server
+    to deliver it to the local peer,
+    which has set the offer
+    as the remote description
+    by calling {{domxref("RTCPeerConnection.setRemoteDescription()")}}.
+  </dd>
+
+  <dt><code>have-local-pranswer</code></dt>
+  <dd>
+    The offer sent by the remote peer has been applied
+    and an answer has been created
+    (usually by calling {{domxref("RTCPeerConnection.createAnswer()")}})
+    and applied by calling {{domxref("RTCPeerConnection.setLocalDescription()")}}.
+    This provisional answer describes the supported media formats and so forth,
+    but may not have a complete set of ICE candidates included.
+    Further candidates will be delivered separately later.
+  </dd>
+
+  <dt><code>have-remote-pranswer</code></dt>
+  <dd>
+    A provisional answer has been received
+    and successfully applied
+    in response to an offer previously sent
+    and established by calling <code>setLocalDescription()</code>.
+  </dd>
+</dl>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
No need to document enums separately, even as a section of an (unrelated) page.
So I removed the section from RTCPeerConnection, put the values in the property, and got rid of the `{{page}} `inclusion, too.

I wiped out all mentions of `RTCSignalingState` from MDN Web Docs.
