### PR TITLE
BCD and spec, tidy up for consistency

### DIFF
--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.html
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSGroupingRule
 - Property
 - Reference
+browser-compat: api.CSSGroupingRule.cssRules
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -16,8 +17,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <var>cssRules</var> = <var>cssGroupingRule</var>.cssRules;</pre>
+<pre class="brush: js">let cssRules = cssGroupingRule.cssRules;</pre>
 
 
 <h3>Value</h3>
@@ -31,23 +31,8 @@ console.log(myRules);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-cssrules', 'CSSRules') }}</td>
-      <td>{{ Spec2('CSSOM') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSGroupingRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSGroupingRule
 - Method
 - Reference
+browser-compat: api.CSSGroupingRule.deleteRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -18,7 +19,7 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><var>cssGroupingRule</var>.deleteRule(<var>index</var>);</pre>
+  class="brush: js">cssGroupingRule.deleteRule(index);</pre>
 
 
 <h3 id="Parameters">Parameters</h3>
@@ -54,23 +55,8 @@ myRules[0].deleteRule(2); /* deletes the rule at index 2 */
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-deleterule', 'deleteRule') }}</td>
-      <td>{{ Spec2('CSSOM') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSGroupingRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -12,36 +12,18 @@ browser-compat: api.CSSGroupingRule
 
 <p>The <strong><code>CSSGroupingRule</code></strong> interface of the {{domxref("CSS Object Model")}} represents any CSS {{CSSXref("at-rule")}} that contains other rules nested within it.</p>
 
-<p>Objects deriving from it:</p>
+<h2 id="Properties">Properties</h2>
 
-<ul>
- <li>{{domxref("CSSConditionRule")}} and its children: {{domxref("CSSMediaRule")}} and {{domxref("CSSSupportsRule")}}.</li>
- <li>{{domxref("CSSPageRule")}}</li>
-</ul>
-
-<h2 id="Syntax">Syntax</h2>
-
-<p>The syntax is described using the <a href="http://dev.w3.org/2006/webapi/WebIDL/">WebIDL</a> format.</p>
-
-<pre>interface CSSGroupingRule : CSSRule {
-    readonly attribute CSSRuleList cssRules;
-    unsigned long insertRule (DOMString rule, unsigned long index);
-    void deleteRule (unsigned long index);
-}
-</pre>
-
-<h2 id="Properties_common_to_all_CSSGroupingRule_instances">Properties common to all CSSGroupingRule instances</h2>
-
-<p>The <code>CSSGroupingRule</code> derives from {{domxref("CSSRule")}} and inherits all properties of this class. It has one specific property:</p>
+<p><em>This interface also inherits properties from {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="cssRules">{{domxref("CSSGroupingRule.cssRules")}} {{readonlyinline}}</dt>
+ <dt id="cssRules">{{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}</dt>
  <dd>Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
+<p><em>This interface also inherits methods from {{domxref("CSSRule")}}.</em></p>
 
 <dl>
  <dt id="deleteRule">{{domxref("CSSGroupingRule.deleteRule")}}</dt>

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSGroupingRule
 - Method
 - Reference
+browser-compat: api.CSSGroupingRule.insertRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -16,8 +17,8 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <var>index</var> = <var>cssGroupingRule</var>.insertRule(<var>rule</var>, <var>index</var>);</pre>
+<pre class="brush: js">cssGroupingRule.insertRule(rule);
+cssGroupingRule.insertRule(rule, index);</pre>
 
 
 <h3 id="Parameters">Parameters</h3>
@@ -58,23 +59,8 @@ myRules[0].insertRule('html {background-color: blue;}',0); /* inserts a rule for
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-insertrule', 'insertRule') }}</td>
-      <td>{{ Spec2('CSSOM') }}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSGroupingRule")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
Adds the spec and BCD to these pages. See BCD PR https://github.com/mdn/browser-compat-data/pull/11631

Reviewer: @jpmedley 

Joe, these came up as missing in the spreadsheet. They did exist but didn't have BCD (only the main interface did). While sorting that out I have also updated these pages for consistency as the main page was one with IDL info on it.