### PR TITLE
Replace (broken) {{event}} by {{DOMxRef}} in RTCPeerConnection.*

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addstream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addstream/index.html
@@ -21,7 +21,7 @@ browser-compat: api.RTCPeerConnection.addStream
 <p>If the {{domxref("RTCPeerConnection.signalingState", "signalingState")}} is set to
   <code>closed</code>, an <code>InvalidStateError</code> is raised. If the
   {{domxref("RTCPeerConnection.signalingState", "signalingState")}} is set to
-  <code>stable</code>, the event {{event("negotiationneeded")}} is sent on the
+  <code>stable</code>, the event {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} is sent on the
   {{domxref("RTCPeerConnection")}} to indicate that {{Glossary("ICE")}} negotiation must
   be repeated to consider the new stream.</p>
 
@@ -71,7 +71,7 @@ browser-compat: api.RTCPeerConnection.addStream
 
 <p>The exception is in Chrome, where <code>addStream()</code> <em>does</em> make the peer
   connection sensitive to later stream changes (though such changes do not fire the
-  {{event("negotiationneeded")}} event). If you are relying on the Chrome behavior, note
+  {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event). If you are relying on the Chrome behavior, note
   that other browsers do not have it. You can write web compatible code using feature
   detection instead:</p>
 

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
@@ -22,7 +22,7 @@ browser-compat: api.RTCPeerConnection.addTrack
 
 <div class="note">
   <p><strong>Note:</strong> Adding a track to a connection triggers renegotiation by
-    firing a {{event("negotiationneeded")}} event. See
+    firing a {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event. See
     {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling",
     "Starting negotiation")}} for details.</p>
 </div>
@@ -106,7 +106,7 @@ browser-compat: api.RTCPeerConnection.addTrack
 }</pre>
 
 <p>The result is a set of tracks being sent to the remote peer, with no stream
-  associations. The handler for the {{event("track")}} event on the remote peer will be
+  associations. The handler for the {{DOMxRef("RTCPeerConnection/track_event", "track")}} event on the remote peer will be
   responsible for determining what stream to add each track to, even if that means adding
   them all to the same stream. The {{domxref("RTCPeerConnection.ontrack", "ontrack")}}
   handler might look like this:</p>
@@ -162,7 +162,7 @@ pc.ontrack = ev =&gt; {
   }
 }</pre>
 
-<p>The remote peer might then use a {{event("track")}} event handler that looks like this:
+<p>The remote peer might then use a {{DOMxRef("RTCPeerConnection/track_event", "track")}} event handler that looks like this:
 </p>
 
 <pre
@@ -286,5 +286,5 @@ pc.setRemoteDescription(desc).then(function () {
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Intro_to_RTP">Introduction to the Real-time
       Transport Protocol (RTP)</a></li>
   <li>{{domxref("RTCPeerConnection.ontrack")}}</li>
-  <li>{{event("track")}}</li>
+  <li>{{DOMxRef("RTCPeerConnection/track_event", "track")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -22,7 +22,7 @@ browser-compat: api.RTCPeerConnection.createDataChannel
   packets, and so forth.</p>
 
 <p>If the new data channel is the first one added to the connection, renegotiation is
-  started by delivering a {{event("negotiationneeded")}} event.</p>
+  started by delivering a {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -121,7 +121,7 @@ browser-compat: api.RTCPeerConnection.createDataChannel
 <h2 id="Examples">Examples</h2>
 
 <p>This example shows how to create a data channel and set up handlers for the
-  {{event("open")}} and {{event("message")}} events to send and receive messages on it
+  {{DOMxRef("RTCDataChannel/open_event", "open")}} and {{DOMxRef("RTCDataChannel/message_event", "message")}} events to send and receive messages on it
   (For brievity, the example assumes onnegotiationneeded is set up).</p>
 
 <pre class="brush: js">// Offerer side

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
@@ -156,7 +156,7 @@ browser-compat: api.RTCPeerConnection.createOffer
 
 <h2 id="Example">Example</h2>
 
-<p>Here we see a handler for the {{event("negotiationneeded")}} event which creates the
+<p>Here we see a handler for the {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event which creates the
   offer and sends it to the remote system over a signaling channel.</p>
 
 <div class="note">
@@ -169,18 +169,18 @@ browser-compat: api.RTCPeerConnection.createOffer
     fulfillment handler, depend entirely on your design.</p>
 </div>
 
-<pre class="brush: js">  myPeerConnection.createOffer().then(function(offer) {
-    return myPeerConnection.setLocalDescription(offer);
-  })
-  .then(function() {
-    sendToServer({
-      name: myUsername,
-      target: targetUsername,
-      type: "video-offer",
-      sdp: myPeerConnection.localDescription
-    });
-  })
-  .catch(function(reason) {
+<pre class="brush: js">  myPeerConnection.createOffer().then(function(offer) {
+    return myPeerConnection.setLocalDescription(offer);
+  })
+  .then(function() {
+    sendToServer({
+      name: myUsername,
+      target: targetUsername,
+      type: "video-offer",
+      sdp: myPeerConnection.localDescription
+    });
+  })
+  .catch(function(reason) {
     // An error occurred, so handle the failure to connect
   });</pre>
 

--- a/files/en-us/web/api/rtcpeerconnection/onaddstream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onaddstream/index.html
@@ -18,7 +18,7 @@ browser-compat: api.RTCPeerConnection.onaddstream
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
 <p>The <code><strong>RTCPeerConnection.onaddstream</strong></code> event handler is a
-  property containing the code to execute when the {{event("addstream")}} event, of type
+  property containing the code to execute when the {{DOMxRef("RTCPeerConnection/addstream_event", "addstream")}} event, of type
   {{domxref("MediaStreamEvent")}}, is received by this {{domxref("RTCPeerConnection")}}.
   Such an event is sent when a {{domxref("MediaStream")}} is added to this connection by
   the remote peer. The event is sent immediately after the call
@@ -28,7 +28,7 @@ browser-compat: api.RTCPeerConnection.onaddstream
 <div class="warning">
   <p><strong>Important:</strong> This property has been <strong>removed</strong> from the
     specification; you should now use {{domxref("RTCPeerConnection.ontrack")}} to watch
-    for {{event("track")}} events instead. It is included here in order to help you adapt
+    for {{DOMxRef("RTCPeerConnection/track_event", "track")}} events instead. It is included here in order to help you adapt
     existing code and understand existing samples, which may not be up-to-date yet.</p>
 </div>
 
@@ -39,7 +39,7 @@ browser-compat: api.RTCPeerConnection.onaddstream
 
 <h3 id="Value">Value</h3>
 
-<p>A function which handles {{event("addstream")}} events. These events, of type
+<p>A function which handles {{DOMxRef("RTCPeerConnection/addstream_event", "addstream")}} events. These events, of type
   {{domxref("MediaStreamEvent")}}, are sent when streams are added to the connection by
   the remote peer. The first time an event occurs may be nearly immediately after the
   remote end of the connection is set using
@@ -50,7 +50,7 @@ browser-compat: api.RTCPeerConnection.onaddstream
 
 <p>This code, based on an older version of our <a
     href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video
-    calling</a> sample, responds to {{event("addstream")}} events by setting the video
+    calling</a> sample, responds to {{DOMxRef("RTCPeerConnection/addstream_event", "addstream")}} events by setting the video
   source for a {{HTMLElement("video")}} element to the stream specified in the event, and
   then enabling a "hang up" button in the app's user interface.</p>
 
@@ -69,7 +69,7 @@ browser-compat: api.RTCPeerConnection.onaddstream
 <div class="warning">
   <p><strong>Important:</strong> This property has been <strong>removed</strong> from the
     specification; you should now use {{domxref("RTCPeerConnection.ontrack")}} to watch
-    for {{event("track")}} events instead. It is included here in order to help you adapt
+    for {{DOMxRef("RTCPeerConnection/track_event", "track")}} events instead. It is included here in order to help you adapt
     existing code and understand existing samples, which may not be up-to-date yet.</p>
 </div>
 
@@ -78,8 +78,8 @@ browser-compat: api.RTCPeerConnection.onaddstream
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>Use the newer {{event("track")}} event, its type {{domxref("RTCTrackEvent")}}, and
+  <li>Use the newer {{DOMxRef("RTCPeerConnection/track_event", "track")}} event, its type {{domxref("RTCTrackEvent")}}, and
     the {{domxref("RTCPeerConnection.ontrack")}} event handler property instead of this.
   </li>
-  <li>The {{event("addstream")}} event and its type, {{domxref("MediaStreamEvent")}}.</li>
+  <li>The {{DOMxRef("RTCPeerConnection/addstream_event", "addstream")}} event and its type, {{domxref("MediaStreamEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
@@ -18,7 +18,7 @@ browser-compat: api.RTCPeerConnection.onconnectionstatechange
 <p>
   The <strong><code>RTCPeerConnection.onconnectionstatechange</code></strong> property
   specifies an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
-  which is called to handle the {{event("connectionstatechange")}} event
+  which is called to handle the {{DOMxRef("RTCPeerConnection/connectionstatechange_event", "connectionstatechange")}} event
   when it occurs on an instance of {{domxref("RTCPeerConnection")}}.
   This happens whenever the aggregate state of the connection changes.
   The aggregate state is a combination
@@ -32,7 +32,7 @@ browser-compat: api.RTCPeerConnection.onconnectionstatechange
 
 <h3 id="Value">Value</h3>
 
-<p>A function which is called by the browser when the {{event("connectionstatechange")}}
+<p>A function which is called by the browser when the {{DOMxRef("RTCPeerConnection/connectionstatechange_event", "connectionstatechange")}}
   event occurs on the {{domxref("RTCPeerConnection")}}. The function receives as input a
   single parameter, which is an object of type {{domxref("Event")}}. The event object
   contains no special information of note; you can look at the value of the peer
@@ -67,6 +67,6 @@ browser-compat: api.RTCPeerConnection.onconnectionstatechange
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("connectionstatechange")}} event and its type, {{domxref("Event")}}.
+  <li>The {{DOMxRef("RTCPeerConnection/connectionstatechange_event", "connectionstatechange")}} event and its type, {{domxref("Event")}}.
   </li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCPeerConnection.ondatachannel
 
 <p>The <code><strong>RTCPeerConnection.ondatachannel</strong></code> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function which is called when the
-  {{event("datachannel")}} event occurs on an {{domxref("RTCPeerConnection")}}. This
+  {{DOMxRef("RTCPeerConnection/datachannel_event", "datachannel")}} event occurs on an {{domxref("RTCPeerConnection")}}. This
   event, of type {{domxref("RTCDataChannelEvent")}}, is sent when an
   {{domxref("RTCDataChannel")}} is added to the connection by the remote peer calling
   {{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}}.</p>
@@ -56,7 +56,7 @@ browser-compat: api.RTCPeerConnection.ondatachannel
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("datachannel")}} event and its type, {{domxref("RTCDataChannelEvent")}}.
+  <li>The {{DOMxRef("RTCPeerConnection/datachannel_event", "datachannel")}} event and its type, {{domxref("RTCDataChannelEvent")}}.
   </li>
   <li>{{domxref("RTCPeerConnection.createDataChannel()")}}</li>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">A simple

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
@@ -21,7 +21,7 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 <p>The <code>RTCPeerConnection</code> property
     <strong>{{domxref("RTCPeerConnection.onicecandidate", "onicecandidate")}}</strong>
     property is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called
-    when the {{event("icecandidate")}} event occurs on an {{domxref("RTCPeerConnection")}}
+    when the {{DOMxRef("RTCPeerConnection/icecandidate_event", "icecandidate")}} event occurs on an {{domxref("RTCPeerConnection")}}
     instance. This happens whenever the local {{Glossary("ICE")}} agent needs to deliver a
     message to the other peer through the signaling server.This lets the ICE agent
   perform negotiation with the remote peer without the browser itself needing to know any
@@ -38,7 +38,7 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 
 <p>This should be set to a function which you provide that accepts as input an
   {{domxref("RTCPeerConnectionIceEvent")}} object representing the
-  {{event("icecandidate")}} event. The function should deliver the ICE candidate, whose
+  {{DOMxRef("RTCPeerConnection/icecandidate_event", "icecandidate")}} event. The function should deliver the ICE candidate, whose
   {{Glossary("SDP")}} can be found in the event's
   {{domxref("RTCPeerConnectionIceEvent.candidate", "candidate")}} property, to the remote
   peer through the signaling server.</p>
@@ -56,7 +56,7 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 
 <p>The example below, which is based on the code from the article <a
     href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video
-    calling</a>, sets up a handler for {{event("icecandidate")}} events to send the
+    calling</a>, sets up a handler for {{DOMxRef("RTCPeerConnection/icecandidate_event", "icecandidate")}} events to send the
   candidates to the remote peer.</p>
 
 <pre class="brush: js">pc.onicecandidate = function(event) {
@@ -82,6 +82,6 @@ browser-compat: api.RTCPeerConnection.onicecandidate
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("icecandidate")}} event and its type,
+  <li>The {{DOMxRef("RTCPeerConnection/icecandidate_event", "icecandidate")}} event and its type,
     {{domxref("RTCPeerConnectionIceEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
@@ -15,7 +15,7 @@ browser-compat: api.RTCPeerConnection.onicecandidateerror
 
 <p>The <code><strong>RTCPeerConnection.onicecandidateerror</strong></code> property is an
 	<a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function which is called to handle the
-	{{event("icecandidateerror")}} event when it occurs on an
+	{{DOMxRef("RTCPeerConnection/icecandidateerror_event", "icecandidateerror")}} event when it occurs on an
 	{{domxref("RTCPeerConnection")}} instance. This event is fired when an error occurs
 	during the {{Glossary("ICE")}} candidate gathering process.</p>
 
@@ -28,7 +28,7 @@ browser-compat: api.RTCPeerConnection.onicecandidateerror
 
 <p>This should be set to a function you provide which is passed a single parameter: an
 	{{domxref("RTCPeerConnectionIceErrorEvent")}} object describing the
-	{{event("icecandidateerror")}} event. The event offers properties describing the error
+	{{DOMxRef("RTCPeerConnection/icecandidateerror_event", "icecandidateerror")}} event. The event offers properties describing the error
 	to help you handle it appropriately.</p>
 
 <h2 id="Example">Example</h2>
@@ -55,6 +55,6 @@ browser-compat: api.RTCPeerConnection.onicecandidateerror
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li>The {{event("icecandidateerror")}} event and its type,
+	<li>The {{DOMxRef("RTCPeerConnection/icecandidateerror_event", "icecandidateerror")}} event and its type,
 		{{domxref("RTCPeerConnectionIceErrorEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCPeerConnection.oniceconnectionstatechange
 
 <p>The <code><strong>RTCPeerConnection.oniceconnectionstatechange</strong></code> property
   is an event handler which specifies a function to be called when the
-  {{event("iceconnectionstatechange")}} event is fired on an
+  {{DOMxRef("RTCPeerConnection/iceconnectionstatechange_event", "iceconnectionstatechange")}} event is fired on an
   {{domxref("RTCPeerConnection")}} instance. This happens when the state of the
   connection's ICE agent, as represented by the
   {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}} property,
@@ -28,7 +28,7 @@ browser-compat: api.RTCPeerConnection.oniceconnectionstatechange
 <h3 id="Value">Value</h3>
 
 <p>This event handler can be set to function which is passed a single input parameter: an
-  {{domxref("Event")}} object describing the {{event("iceconnectionstatechange")}} event
+  {{domxref("Event")}} object describing the {{DOMxRef("RTCPeerConnection/iceconnectionstatechange_event", "iceconnectionstatechange")}} event
   which occurred. Your code can look at the value of
   {{domxref("RTCPeerConnection.iceConnectionState")}} to determine what the new state is.
 </p>
@@ -63,6 +63,6 @@ browser-compat: api.RTCPeerConnection.oniceconnectionstatechange
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("iceconnectionstatechange")}} event and its type, {{domxref("Event")}}.
+  <li>The {{DOMxRef("RTCPeerConnection/iceconnectionstatechange_event", "iceconnectionstatechange")}} event and its type, {{domxref("Event")}}.
   </li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
@@ -15,7 +15,7 @@ browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 
 <p>The <code><strong>RTCPeerConnection.onicegatheringstatechange</strong></code> property
   is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
-  {{event("icegatheringstatechange")}} event is sent to an
+  {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}} event is sent to an
   {{domxref("RTCPeerConnection")}} instance. This happens when the ICE gathering
   state—that is, whether or not the ICE agent is actively gathering candidates—changes.
 </p>
@@ -31,7 +31,7 @@ browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 <h3 id="Value">Value</h3>
 
 <p>A function you provide which is passed a single parameter: an {{domxref("Event")}}
-  object containing the {{event("icegatheringstatechange")}} event. You can determine the
+  object containing the {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}} event. You can determine the
   new state of ICE gathering by looking at the value of the
   {{domxref("RTCPeerConnection.iceGatheringState")}} property.</p>
 
@@ -77,7 +77,6 @@ browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("icegatheringstatechange")}} event and its type, {{domxref("Event")}}.
-  </li>
+  <li>The {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}} event and its type, {{domxref("Event")}}.</li>
   <li>{{domxref("RTCPeerConnection.iceGatheringState")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
@@ -15,15 +15,15 @@ browser-compat: api.RTCPeerConnection.onnegotiationneeded
 <p>The {{domxref("RTCPeerConnection")}} interface's
   <strong><code>onnegotiationneeded</code></strong> property is an
   {{domxref("EventListener")}} which specifies a function which is called to handle the
-  {{event("negotiationneeded")}} event when it occurs on an
+  {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event when it occurs on an
   {{domxref("RTCPeerConnection")}} instance. This event is fired when a change has
   occurred which requires session negotiation. This negotiation should be carried out as
   the offerer, because some session changes cannot be negotiated as the answerer.</p>
 
-<p>Most commonly, the {{event("negotiationneeded")}} event is fired after a send track is
+<p>Most commonly, the {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event is fired after a send track is
   added to the {{domxref("RTCPeerConnection")}}. If the session is modified in a manner
   that requires negotiation while a negotiation is already in progress, no
-  {{event("negotiationneeded")}} event will fire until negotiation completes, and only
+  {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event will fire until negotiation completes, and only
   then if negotiation is still needed.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -34,7 +34,7 @@ browser-compat: api.RTCPeerConnection.onnegotiationneeded
 <h3 id="Value">Value</h3>
 
 <p>This should be set to a function you provide which is passed a single parameter: an
-  {{domxref("Event")}} object containing the {{event("negotiationneeded")}} event. There's
+  {{domxref("Event")}} object containing the {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event. There's
   no additional information provided in the event; anything you need, you can get by
   examining the <a href="/en-US/docs/Web/API/RTCPeerConnection#Properties">properties of
     the <code>RTCPeerConnection</code></a>.</p>
@@ -43,7 +43,7 @@ browser-compat: api.RTCPeerConnection.onnegotiationneeded
 
 <p>This example, derived from the example in <a
     href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video
-    calling</a>, establishes a handler for {{event("negotiationneeded")}} events to handle
+    calling</a>, establishes a handler for {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} events to handle
   creating an offer, configuring the local end of the connection, and sending the offer to
   the remote peer.</p>
 
@@ -75,5 +75,5 @@ browser-compat: api.RTCPeerConnection.onnegotiationneeded
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("negotiationneeded")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event and its type, {{domxref("Event")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onremovestream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onremovestream/index.html
@@ -13,10 +13,10 @@ browser-compat: api.RTCPeerConnection.onremovestream
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
 <div class="warning">
-<p>The {{event("removestream")}} event has been removed from the WebRTC specification in favor of the existing {{event("removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding {{domxref("MediaStream.onremovetrack")}} event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed and the old removestream event.</p>
+<p>The {{DOMxRef("RTCPeerConnection/removestream_event", "removestream")}} event has been removed from the WebRTC specification in favor of the existing {{DOMxRef("RTCPeerConnection/removetrack_event", "removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding {{domxref("MediaStream.onremovetrack")}} event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed and the old removestream event.</p>
 </div>
 
-<p>The <code><strong>RTCPeerConnection.onremovestream</strong></code> event handler is a property containing the code to execute when the {{event("removestream")}} event, of type {{domxref("MediaStreamEvent")}}, is received by this {{domxref("RTCPeerConnection")}}. Such an event is sent when a {{domxref("MediaStream")}} is removed from this connection.</p>
+<p>The <code><strong>RTCPeerConnection.onremovestream</strong></code> event handler is a property containing the code to execute when the {{DOMxRef("RTCPeerConnection/removestream_event", "removestream")}} event, of type {{domxref("MediaStreamEvent")}}, is received by this {{domxref("RTCPeerConnection")}}. Such an event is sent when a {{domxref("MediaStream")}} is removed from this connection.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -41,5 +41,5 @@ browser-compat: api.RTCPeerConnection.onremovestream
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>The {{event("removestream")}} event and its type, {{domxref("MediaStreamEvent")}}.</li>
+ <li>The {{DOMxRef("RTCPeerConnection/removestream_event", "removestream")}} event and its type, {{domxref("MediaStreamEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
@@ -22,7 +22,7 @@ browser-compat: api.RTCPeerConnection.onsignalingstatechange
 
 <p>The <code><strong>onsignalingstatechange</strong></code> event
     handler property of the <strong>{{domxref("RTCPeerConnection")}}</strong> interface
-    specifies a function to be called when the {{event("signalingstatechange")}} event
+    specifies a function to be called when the {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} event
     occurs on an {{domxref("RTCPeerConnection")}} interface. The function receives
   as input the event object of type {{domxref("Event")}}; this event is sent when the peer
   connection's {{domxref("RTCPeerConnection.signalingState", "signalingState")}} changes,
@@ -38,7 +38,7 @@ browser-compat: api.RTCPeerConnection.onsignalingstatechange
 <h3 id="Value">Value</h3>
 
 <p>Set this to a function which you provide that receives an {{domxref("Event")}} object
-  as input; this contains the {{event("signalingstatechange")}} event. This event object
+  as input; this contains the {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} event. This event object
   doesn't provide details about what changed, but you can examine the
   {{domxref("RTCPeerConnection.signalingState", "signalingState")}} property to determine
   what the new state is.</p>
@@ -58,7 +58,7 @@ browser-compat: api.RTCPeerConnection.onsignalingstatechange
 
 <h2 id="Example">Example</h2>
 
-<p>This snippet shows a handler for {{event("signalingstatechange")}} that looks for the
+<p>This snippet shows a handler for {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} that looks for the
   <code>"have-local-pranswer"</code> signaling state—indicating that a remote offer has
   been received and a local description of type <code>"pranswer"</code> has been applied
   in response.</p>
@@ -83,5 +83,5 @@ browser-compat: api.RTCPeerConnection.onsignalingstatechange
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and
       video calling</a>: A WebRTC example</li>
-  <li>The {{event("signalingstatechange")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} event and its type, {{domxref("Event")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCPeerConnection.ontrack
 
 <p>The {{domxref("RTCPeerConnection")}} property
     <strong><code>ontrack</code></strong> is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which
-    specifies a function to be called when the {{event("track")}} event occurs, indicating
+    specifies a function to be called when the {{DOMxRef("RTCPeerConnection/track_event", "track")}} event occurs, indicating
     that a track has been added to the {{domxref("RTCPeerConnection")}}. The
   function receives as input the event object, of type {{domxref("RTCTrackEvent")}}; this
   event is sent when a new incoming {{domxref("MediaStreamTrack")}} has been created and
@@ -65,5 +65,5 @@ browser-compat: api.RTCPeerConnection.ontrack
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{event("track")}} event and its type, {{domxref("RTCTrackEvent")}}.</li>
+  <li>The {{DOMxRef("RTCPeerConnection/track_event", "track")}} event and its type, {{domxref("RTCTrackEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/removestream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removestream/index.html
@@ -24,7 +24,7 @@ browser-compat: api.RTCPeerConnection.removeStream
 <p>If the {{domxref("RTCPeerConnection.signalingState", "signalingState")}} is set to
   <code>"closed"</code>, an <code>InvalidStateError</code> is raised. If the
   {{domxref("RTCPeerConnection.signalingState", "signalingState")}} is set to
-  <code>"stable"</code>, the event {{event("negotiationneeded")}} is sent on the
+  <code>"stable"</code>, the event {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} is sent on the
   {{domxref("RTCPeerConnection")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/rtcpeerconnection/removestream_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removestream_event/index.html
@@ -46,7 +46,7 @@ browser-compat: api.RTCPeerConnection.removestream_event
 </table>
 
 <div class="notecard warning">
-<p><strong>Important:</strong> This event has been removed from the WebRTC specification in favor of the existing {{event("removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding {{domxref("MediaStream.onremovetrack")}} event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed, which caused a <code>removestream</code> event.</p>
+<p><strong>Important:</strong> This event has been removed from the WebRTC specification in favor of the existing {{DOMxRef("RTCPeerConnection/removetrack_event", "removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding {{domxref("MediaStream.onremovetrack")}} event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed, which caused a <code>removestream</code> event.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
@@ -27,7 +27,7 @@ browser-compat: api.RTCPeerConnection.removeTrack
   ({{domxref("RTCPeerConnection.signalingState", "signalingState")}} is set to
   <code>"stable"</code>), it is marked as needing to be negotiated again; the remote peer
   won't experience the change until this negotiation occurs. A
-  {{event("negotiationneeded")}} event is sent to the {{domxref("RTCPeerConnection")}} to
+  {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event is sent to the {{domxref("RTCPeerConnection")}} to
   let the local end know this negotiation must occur.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
@@ -156,7 +156,7 @@ browser-compat: api.RTCPeerConnection.setLocalDescription
 <h3 id="Providing_your_own_offer_or_answer">Providing your own offer or answer</h3>
 
 <p>The example below shows the implementation of a handler for the
-  {{event("negotiationneeded")}} event that explicitly creates an offer, rather than
+  {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event that explicitly creates an offer, rather than
   letting <code>setLocalDescription()</code> do it.</p>
 
 <pre class="brush: js">async function handleNegotiationNeededEvent() {

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
@@ -39,7 +39,7 @@ browser-compat: api.RTCPeerConnection.signalingState
 <p>This value may also be useful during debugging, for example.</p>
 
 <p>In addition, when the value of this property changes, a
-  {{event("signalingstatechange")}} event is sent to the {{domxref("RTCPeerConnection")}}
+  {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} event is sent to the {{domxref("RTCPeerConnection")}}
   instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -121,6 +121,6 @@ var state = pc.signalingState;</pre>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime">Lifetime of a WebRTC
       session</a></li>
   <li>{{domxref("RTCPeerConnection")}}</li>
-  <li>{{event("signalingstatechange")}}</li>
+  <li>{{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}}</li>
   <li><a href="/en-US/docs/Web/Guide/API/WebRTC">WebRTC</a></li>
 </ul>


### PR DESCRIPTION
`{{event}}` works only if redirect in place, which is not always the case

This PR removes all occurences of that macro in `RTCPeerConnection.*` and replace it with `DOMxRef`.

_Note:_ With this PR I exit the rabit hole about improving `RTCPeerConnection` (I have other rabbit hole to fall in, like `RTCDataChannel`).