### PR TITLE
omitted an anchor closing tag

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
@@ -46,7 +46,7 @@ tags:
 <pre class="brush: html">&lt;div role="navigation" aria-label="Customer service"&gt;
   &lt;ul&gt;
     &lt;li&gt;&lt;a href="#"&gt;Help&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href="#"&gt;Order tracking&lt;/li&gt;
+    &lt;li&gt;&lt;a href="#"&gt;Order tracking&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="#"&gt;Shipping &amp;amp; Delivery&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="#"&gt;Returns&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="#"&gt;Contact us&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In the example codebase, one of the anchor tags within the list that contains the text value "Order Tracking" is missing the closing tag, as I mentioned in the title. 
It is just a simple change to make sure all the codebases are coherent.


> Issue number (if there is an associated issue)



> Anything else that could help us review it
