### PR TITLE
Clarify when a button name/value is submitted

### DIFF
--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -101,7 +101,7 @@ browser-compat: html.elements.button
  </ul>
  </dd>
  <dt>{{htmlattrdef("name")}}</dt>
- <dd>The name of the button, submitted as a pair with the button’s <code>value</code> as part of the form data.</dd>
+ <dd>The name of the button, submitted as a pair with the button’s <code>value</code> as part of the form data, when that button is used to submit the form.</dd>
  <dt>{{htmlattrdef("type")}}</dt>
  <dd>The default behavior of the button. Possible values are:
  <ul>
@@ -111,7 +111,7 @@ browser-compat: html.elements.button
  </ul>
  </dd>
  <dt>{{htmlattrdef("value")}}</dt>
- <dd>Defines the value associated with the button’s <code>name</code> when it’s submitted with the form data. This value is passed to the server in params when the form is submitted.</dd>
+ <dd>Defines the value associated with the button’s <code>name</code> when it’s submitted with the form data. This value is passed to the server in params when the form is submitted uing this button.</dd>
 </dl>
 
 <h2 id="Notes">Notes</h2>


### PR DESCRIPTION
This clarifies that a button's name/value is submitted with a form only when that button is used to submit the form. Previously, the wording implied that any buttons ( eg. buttons with type="button") could be used to attach name/value pairs to the parameters. They can't.