### PR TITLE
Fix tags & flaws for XRRreferenceSpace.getOffsetReferenceSpace

### DIFF
--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
@@ -2,25 +2,26 @@
 title: XRReferenceSpace.getOffsetReferenceSpace()
 slug: Web/API/XRReferenceSpace/getOffsetReferenceSpace
 tags:
-- API
-- AR
-- Mixed
-- Orientation
-- Position
-- Reality
-- Reference
-- Rotate
-- VR
-- Virtual
-- WebXR
-- WebXR API
-- WebXR Device API
-- XR
-- XRReferenceSpace
-- augmented
-- getOffsetReferenceSpace
-- move
-- movement
+  - API
+  - AR
+  - Mixed
+  - Orientation
+  - Position
+  - Reality
+  - Reference
+  - Rotate
+  - VR
+  - Virtual
+  - WebXR
+  - WebXR API
+  - WebXR Device API
+  - XR
+  - XRReferenceSpace
+  - augmented
+  - getOffsetReferenceSpace
+  - move
+  - movement
+  - Method
 browser-compat: api.XRReferenceSpace.getOffsetReferenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
@@ -183,7 +184,7 @@ function rotateViewBy(dx, dy) {
 <p>You can see code similar to this in use in our broader WebXR tutorial article called <a
     href="/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion">Movement, orientation,
     and motion</a>. In particular, check out the section called <a
-    href="/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion#Starting_up_the_WebXR_session">Starting
+    href="/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion#starting_up_the_webxr_session">Starting
     up the WebXR session</a>.</p>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
getOffsetReferenceSpace wasn't showing up in the sidebar due to a missing "Method" tag. Also hit "fix flaws" button.