### PR TITLE
Fix typo in “Evolution of HTTP” doc

### DIFF
--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.html
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.html
@@ -38,7 +38,7 @@ tags:
 A very simple HTML page
 &lt;/HTML&gt;</pre>
 
-<p>Unlike subsequent evolutions, there were no HTTP headers, meaning that only HTML files could be transmitted, but no other type of documents. There were no status or error codes: in case of a problem, a specific HTML file was send back with the description of the problem contained in it, for human consumption.</p>
+<p>Unlike subsequent evolutions, there were no HTTP headers, meaning that only HTML files could be transmitted, but no other type of documents. There were no status or error codes: in case of a problem, a specific HTML file was sent back with the description of the problem contained in it, for human consumption.</p>
 
 <h2 id="HTTP1.0_–_Building_extensibility">HTTP/1.0 – Building extensibility</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Past tense of "send" is given as "send", but would be correctly spelt "sent".

> Issue number (if there is an associated issue)

> Anything else that could help us review it

https://grammar.collinsdictionary.com/english-usage/what-is-the-difference-between-send-and-sent