### PR TITLE
improved diction (and commas)

### DIFF
--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks")}}</div>
 
-<p>In the various lessons so far you have come across a number of ways to size items on a web page using CSS. Understanding how big the different features in your design will be is important, and in this lesson we will summarize the various ways elements get a size via CSS and define a few terms around sizing that will help you in the future.</p>
+<p>In the various lessons so far, you have come across a number of ways to size items on a web page using CSS. Understanding how big the different features in your design will be is important. So, in this lesson we will summarize the various ways elements get a size via CSS and define a few terms about sizing that will help you in the future.</p>
 
 <table class="learn-box standard-table">
 	<tbody>


### PR DESCRIPTION
The main problem was the original used "**around**" instead of "**about**".

Words are **about** things. They are not around **things**.