### PR TITLE
Fix typo for CSS font shorthand

### DIFF
--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -138,7 +138,7 @@ p { font: status-bar }
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;p&gt;
-    Change the radio buttons below to see the generated shorthand and it's effect.
+    Change the radio buttons below to see the generated shorthand and its effect.
 &lt;/p&gt;
 &lt;form action="createShortHand()"&gt;
     &lt;div class="cf"&gt;


### PR DESCRIPTION
"...shorthand and it's effect." does not need an apostrophe. Should read, "...shorthand and its effect."

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

No apostrophe grammatically necessary for this instance of "its".

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
N/A