### PR TITLE
various typographical improvements

### DIFF
--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
@@ -31,9 +31,9 @@ tags:
 
 <h2 id="The_natural_or_intrinsic_size_of_things">The natural or intrinsic size of things</h2>
 
-<p>HTML Elements have a natural size, set before they are affected by any CSS. A straightforward example is an image. An image has a width and a height defined in the image file it is embedding into the page. This size is described as the <strong>intrinsic size</strong> — which comes from the image itself.</p>
+<p>HTML Elements have a natural size, set before they are affected by any CSS. A straightforward example is an image. The file that an image is stored in contains a definition about its size. This size is described as its <strong>intrinsic size</strong>. This size is determined by the image <em>itself</em>, not by any formatting we happen to apply.</p>
 
-<p>If you place an image on a page and do not change its height and width, either using attributes on the <code>&lt;img&gt;</code> tag or CSS, it will be displayed using that intrinsic size. We have given the image in the example below a border so that you can see the extent of the file.</p>
+<p>If you place an image on a page and do not change its height or width, either by using attributes on the <code>&lt;img&gt;</code> tag or else by CSS, it will be displayed using that intrinsic size. We have given the image in the example below a border so that you can see the extent of its size as defined in its file.</p>
 
 <p>{{EmbedGHLiveSample("css-examples/learn/sizing/intrinsic-image.html", '100%', 600)}}</p>
 

--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="The_natural_or_intrinsic_size_of_things">The natural or intrinsic size of things</h2>
 
-<p>HTML Elements have a natural size, set before they are affected by any CSS. A straightforward example is an image. The file that an image is stored in contains a definition about its size. This size is described as its <strong>intrinsic size</strong>. This size is determined by the image <em>itself</em>, not by any formatting we happen to apply.</p>
+<p>HTML Elements have a natural size, set before they are affected by any CSS. A straightforward example is an image. An image file contains sizing information, described as its <strong>intrinsic size</strong>. This size is determined by the image <em>itself</em>, not by any formatting we happen to apply.</p>
 
 <p>If you place an image on a page and do not change its height or width, either by using attributes on the <code>&lt;img&gt;</code> tag or else by CSS, it will be displayed using that intrinsic size. We have given the image in the example below a border so that you can see the extent of its size as defined in its file.</p>
 


### PR DESCRIPTION
1) The original said that an image can embed an image file. But images just are image files. They can't embed themselves.
2) The original said we can see the extent of a file. That's confusing terminology. 
3) Other small fixes