### PR TITLE
Document AggregateError: errors

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -24,6 +24,8 @@ The **`AggregateError`** object represents an error when several errors need to 
   - : Error message, defaults to `""`.
 - {{JSxRef("Error.prototype.name", "AggregateError.prototype.name")}}
   - : Error name, defaults to `AggregateError`.
+- `AggregateError`: `errors`
+  - : An array that essentially reflects the iterable with which the `AggregateError` was instantiated; for example, if the `AggregateError` was created using the {{JSxRef("AggregateError/AggregateError", "AggregateError()")}} constructor, an array produced from whatever iterable was passed to the constructor as its first argument.
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/7106

---

This one is exceptional in that the `errors` property is not a property of the prototype but is instead dynamically created on instantiation of the `AggregateError` object. See step 5 of the algorithm in the spec at https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error

A precedent here is `RegExp: lastIndex` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex, which we discussed in https://github.com/mdn/content/pull/2725.

Note also: this PR doesn’t add a separate new article for `AggregateError`: `errors` but intentionally just documents it in the `AggregateError` article itself. There’s really not a whole lot more which needs to be said that would justify a separate article.

(And the `AggregateError.prototype.message` and `AggregateError.prototype.name` links aren’t actually to separate articles specific to `AggregateError`, but instead just redirect to the `Error.prototype.message` and `Error.prototype.name` articles.)