### PR TITLE
Remove {{InterfaceOverview}} from RTCDataChannel

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/index.html
+++ b/files/en-us/web/api/rtcdatachannel/index.html
@@ -19,23 +19,220 @@ browser-compat: api.RTCDataChannel
 
 <p>The <strong><code>RTCDataChannel</code></strong> interface represents a network channel which can be used for bidirectional peer-to-peer transfers of arbitrary data. Every data channel is associated with an {{DOMxRef("RTCPeerConnection")}}, and each peer connection can have up to a theoretical maximum of 65,534 data channels (the actual limit may vary from browser to browser).</p>
 
-<p>To create a data channel and ask a remote peer to join you, call the {{DOMxRef("RTCPeerConnection")}}'s {{DOMxRef("RTCPeerConnection.createDataChannel", "createDataChannel()")}} method. The peer being invited to exchange data receives a {{event("datachannel")}} event (which has type {{DOMxRef("RTCDataChannelEvent")}}) to let it know the data channel has been added to the connection.</p>
+<p>To create a data channel and ask a remote peer to join you, call the {{DOMxRef("RTCPeerConnection")}}'s {{DOMxRef("RTCPeerConnection.createDataChannel", "createDataChannel()")}} method. The peer being invited to exchange data receives a {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} event (which has type {{DOMxRef("RTCDataChannelEvent")}}) to let it know the data channel has been added to the connection.</p>
 
-<div>{{InterfaceOverview("WebRTC")}}</div>
+<p>{{InheritanceDiagram}}</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>Also inherits properties from {{DOMxRef("EventTarget")}}.</em></p>
+
+<dl>
+  <dt>{{DOMxRef("RTCDataChannel.binaryType", "binaryType")}}</dt>
+  <dd>
+    Is a string specifying the type of object
+    that should be used to represent binary data received on the <code>RTCDataChannel</code>.
+    Values are the same as allowed on the {{DOMxRef("WebSocket.binaryType")}} property:
+    <code>blob</code> if {{DOMxRef("Blob")}} objects are being used,
+    or <code>arraybuffer</code> if {{jsxref("ArrayBuffer")}} objects are being used.
+    The default is <code>blob</code>.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.bufferedAmount", "bufferedAmount")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns the number of bytes of data
+    currently queued to be sent over the data channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}</dt>
+  <dd>
+    Specifies the number of bytes of buffered outgoing data that is considered "low".
+    The default value is 0.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.id", "id")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns an ID number (between 0 and 65,534)
+    which uniquely identifies the <code>RTCDataChannel</code>.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.label", "label")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns a string that contains a name describing the data channel.
+    These labels are not required to be unique.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.maxPacketLifeTime", "maxPacketLifeTime")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns the amount of time,
+    in milliseconds,
+    the browser is allowed to take to attempt to transmit a message,
+    as set when the data channel was created,
+    or <code>null</code>.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.maxRetransmits", "maxRetransmits")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns the maximum number of times
+    the browser should try to retransmit a message before giving up,
+    as set when the data channel was created,
+    or <code>null</code>, which indicates that there is no maximum.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.negotiated", "negotiated")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Indicates
+    whether the <code>RTCDataChannel</code>'s connection was negotiated by the Web app
+    (<code>true</code>)
+    or by the WebRTC layer (<code>false</code>).
+    The default is <code>false</code>.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.ordered", "ordered")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Indicates whether or not the data channel guarantees in-order delivery of messages;
+    the default is <code>true</code>, which indicates that the data channel is indeed ordered.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.protocol", "protocol")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns a string containing the name of the subprotocol in use.
+    If no protocol was specified
+    when the data channel was created,
+    then this property's value is the empty string (<code>""</code>).
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.readyState", "readyState")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns a string
+    which indicates the state of the data channel's underlying data connection.
+    It can have on of the following values:
+    <code>connecting</code>, <code>open</code>, <code>closing</code>, or <code>closed</code>.
+  </dd>
+</dl>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<p><em>Also inherits event handlers from {{DOMxRef("EventTarget")}}.</em></p>
+
+<dl>
+  <dt>{{DOMxRef("RTCDataChannel.onbufferedamountlow", "onbufferedamountlow")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function the browser calls
+    when the{{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event is sent to the data channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.onclose", "onclose")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function to be called by the browser
+    when the {{DOMxRef("RTCDataChannel.close_event", "close")}} event is received by the data channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.onclosing", "onclose")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function to be called by the browser
+    when the {{DOMxRef("RTCDataChannel.closing_event", "closing")}} event is received by the data channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.onerror", "onerror")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function to be called
+    when the {{DOMxRef("RTCDataChannel.error_event", "error")}} event is received.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.onmessage", "onmessage")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function to be called
+    when the {{DOMxRef("RTCDataChannel.message_event", "message")}} event is fired on the channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.onopen", "onopen")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function to be called when the {{DOMxRef("RTCDataChannel.open_event", "open")}} event is fired on the
+  </dd>
+</dl>
+
+<h3 id="Obsolete_properties">Obsolete properties</h3>
+<dl>
+  <dt>{{DOMxRef("RTCDataChannel.reliable", "reliable")}} {{ReadOnlyInline}} {{Obsolete_Inline}}</dt>
+  <dd>
+    Indicates whether or not the data channel is <em>reliable</em>.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.stream", "stream")}} {{ReadOnlyInline}} {{Obsolete_Inline}}</dt>
+  <dd>
+    Returns an ID number (between 0 and 65,535)
+    which uniquely identifies the data channel.
+  </dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>Also inherits methods from {{DOMxRef("EventTarget")}}.</em></p>
+
+<dl>
+  <dt>{{DOMxRef("RTCDataChannel.close", "close()")}}</dt>
+  <dd>
+    Closes the{{domxref("RTCDataChannel")}}.
+    Either peer is permitted to call this method
+    to initiate closure of the channel.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDataChannel.send", "send()")}}</dt>
+  <dd>
+    Sends data across the data channel to the remote peer.
+  </dd>
+</dl>
 
 <h2 id="Events">Events</h2>
 
 <dl>
- <dt>{{domxref("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}}</dt>
- <dd>Sent to the channel's {{domxref("RTCDataChannel.onbufferedamountlow", "onbufferedamountlow")}} event handler when the number of bytes of data in the outgoing data buffer falls below the value specified by {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}.</dd>
- <dt>{{domxref("RTCDataChannel.close_event", "close")}}</dt>
- <dd>Sent to the {{domxref("RTCDataChannel.onclose", "onclose")}} event handler when the underlying data transport closes.</dd>
- <dt>{{domxref("RTCDataChannel.error_event", "error")}}</dt>
- <dd>Sent to the {{domxref("RTCDataChannel.onerror", "onerror")}} event handler when an error occurs on the data channel.</dd>
- <dt>{{domxref("RTCDataChannel.message_event", "message")}}</dt>
- <dd>Sent to the {{domxref("RTCDataChannel.onmessage", "onmessage")}} event handler when a message has been received from the remote peer. The message contents can be found in the event's {{domxref("MessageEvent.data", "data")}} property.</dd>
- <dt>{{domxref("RTCDataChannel.open_event", "open")}}</dt>
- <dd>Sent to the {{domxref("RTCDataChannel.onopen", "onopen")}} event handler when the data channel is first opened, or when an existing data channel's underlying connection re-opens.</dd>
+  <dt>{{domxref("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}}</dt>
+  <dd>
+    Sent
+    when the number of bytes of data in the outgoing data buffer
+    falls below the value specified by {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}.<br/>
+    Also available as the {{domxref("RTCDataChannel.onbufferedamountlow", "onbufferedamountlow")}} event handler property.
+  </dd>
+
+  <dt>{{domxref("RTCDataChannel.close_event", "close")}}</dt>
+  <dd>
+    Sent when the underlying data transport closes.<br/>
+    Also available as the {{domxref("RTCDataChannel.onclose", "onclose")}} event handler property.
+  </dd>
+
+  <dt>{{domxref("RTCDataChannel.closing_event", "closing")}}</dt>
+  <dd>
+    Sent when the underlying data transport is about to start closing.<br/>
+    Also available as the {{domxref("RTCDataChannel.onclosing", "onclosing")}} event handler property.
+  </dd>
+
+  <dt>{{domxref("RTCDataChannel.error_event", "error")}}</dt>
+  <dd>
+    Sent when an error occurs on the data channel.<br/>
+    Also available as the {{domxref("RTCDataChannel.onerror", "onerror")}} event handler property.
+  </dd>
+
+  <dt>{{domxref("RTCDataChannel.message_event", "message")}}</dt>
+  <dd>
+    Sent when a message has been received from the remote peer.
+    The message contents can be found
+    in the event's {{domxref("MessageEvent.data", "data")}} property.<br/>
+    Also available as the {{domxref("RTCDataChannel.onmessage", "onmessage")}} event handler property.
+  </dd>
+
+  <dt>{{domxref("RTCDataChannel.open_event", "open")}}</dt>
+  <dd>
+    Sent when the data channel is first opened,
+    or when an existing data channel's underlying connection re-opens.<br/>
+    Also available as the {{domxref("RTCDataChannel.onopen", "onopen")}} event handler property.
+  </dd>
 </dl>
 
 <h2 id="Data_format">Data format</h2>
@@ -71,5 +268,5 @@ dc.onclose = function () {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Guide/API/WebRTC_API">WebRTC API</a></li>
+ <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a></li>
 </ul>


### PR DESCRIPTION
`{{InterfaceOverview}}` is broken.

This replace it, and make the structure of this interface page follow our template.