### PR TITLE
Fix code error in example in “constructor” doc

### DIFF
--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -140,7 +140,7 @@ class Square extends Polygon {
   constructor(length) {
     // Here, it calls the parent class' constructor with lengths
     // provided for the Polygon's width and height
-    super(height, width);
+    super(length, length);
     // NOTE: In derived classes, `super()` must be called before you
     // can use `this`. Leaving this out will cause a ReferenceError.
     this.name = 'Square';


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

width and height are not defined up until this point. Square is polygon whose width and height are equal.