### PR TITLE
Add missing 'Property' tag to XRReferenceSpaceEvent.referenceSpace

### DIFF
--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
@@ -19,6 +19,7 @@ tags:
 - events
 - referenceSpace
 - source
+- Property
 browser-compat: api.XRReferenceSpaceEvent.referenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}</p>


### PR DESCRIPTION
Without this tag, the sidebar doesn't show this page