### PR TITLE
Revise Element»ariaHasPopup example & add note

### DIFF
--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -41,12 +41,12 @@ browser-compat: api.Element.ariaHasPopup
 </dl>
 
 <div class="warning">
-  Be aware that support for the different <code>aria-haspopup</code> values can vary depending on the element to which the attribute is specified. Ensure that when using `aria-haspopup` it is done in accordance to the ARIA specification, and that it behaves as expected when testing with necessary browsers and assistive technologies.
+  Be aware that support for the different <code>aria-haspopup</code> values can vary depending on the element to which the attribute is specified. Ensure that when using <code>aria-haspopup</code>, it is done in accordance to the ARIA specification, and that it behaves as expected when testing with necessary browsers and assistive technologies.
 </div>
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example the <code>aria-haspopup</code> attribute on the element with an ID of <code>animal</code> is set to "true". Using <code>ariaHasPopup</code> we update the value to "listbox", which is the expected value for a combobox that invokes a <code>listbox</code> popup.</p>
+<p>In this example, the <code>aria-haspopup</code> attribute on the element with an ID of <code>animal</code> is set to "<code>true</code>". Using <code>ariaHasPopup</code>, we update the value to "<code>listbox</code>", which is the expected value for a combobox that invokes a <code>listbox</code> popup.</p>
 
 <pre class="brush: html">&lt;div class="animals-combobox"&gt;
   &lt;label for="animal"&gt;Animal&lt;/label&gt;

--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -42,12 +42,11 @@ browser-compat: api.Element.ariaHasPopup
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example the <code>aria-haspopup</code> attribute on the element with an ID of <code>animal</code> is set to "true". Using <code>ariaHasPopup</code> we update the value to "false".</p>
+<p>In this example the <code>aria-haspopup</code> attribute on the element with an ID of <code>animal</code> is set to "true". Using <code>ariaHasPopup</code> we update the value to "listbox", which is the expected value for a combobox that invokes a <code>listbox</code> popup.</p>
 
 <pre class="brush: html">&lt;div class="animals-combobox"&gt;
   &lt;label for="animal"&gt;Animal&lt;/label&gt;
-  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true"&gt;
-  &lt;button id="animals-button" tabindex="-1" aria-label="Open"&gt;&#9661;&lt;/button&gt;
+  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="list" aria-controls="animals-listbox" aria-activedescendant="" aria-expanded="false" aria-haspopup="true"&gt;
   &lt;ul id="animals-listbox" role="listbox" aria-label="Animals"&gt;
     &lt;li id="animal-cat" role="option">Cat&lt;/li&gt;
     &lt;li id="animal-dog" role="option">Dog&lt;/li&gt;
@@ -56,8 +55,8 @@ browser-compat: api.Element.ariaHasPopup
 
 <pre class="brush: js">let el = document.getElementById('animal');
 console.log(el.ariaHasPopup); // true
-el.ariaHasPopup = "false";
-console.log(el.ariaHasPopup); // false</pre>
+el.ariaHasPopup = "listbox";
+console.log(el.ariaHasPopup); // listbox</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -40,6 +40,10 @@ browser-compat: api.Element.ariaHasPopup
   <dd>The element has a popup that is a dialog.</dd>
 </dl>
 
+<div class="warning">
+  Be aware that support for the different <code>aria-haspopup</code> values can vary depending on the element to which the attribute is specified. Ensure that when using `aria-haspopup` it is done in accordance to the ARIA specification, and that it behaves as expected when testing with necessary browsers and assistive technologies.
+</div>
+
 <h2 id="Examples">Examples</h2>
 
 <p>In this example the <code>aria-haspopup</code> attribute on the element with an ID of <code>animal</code> is set to "true". Using <code>ariaHasPopup</code> we update the value to "listbox", which is the expected value for a combobox that invokes a <code>listbox</code> popup.</p>


### PR DESCRIPTION
Closes #7102.  Adds note about `aria-haspopup` support, and corrects [oddities/errors I outlined with the example](https://github.com/mdn/content/issues/7102#issuecomment-884158533) on this page.  Specifically:

* update demo JS to change the `aria-haspopup` value from `true` (incorrect for this pattern) to `listbox` (correct).  Understanding this is just an example, it would be inappropriate to provide a `false` value here, so this correction is done to not confuse developers that this would ever be appropriate.
* Markup pattern for the combobox has been updated to include additional attributes that make this now conforming to the [ARIA 1.2 combobox pattern](https://www.w3.org/TR/wai-aria-1.2/#combobox)
  * specifically added `aria-controls` and `aria-activedescendant`
  * `aria-activedescendant` is purposefully without a value because the combobox is indicated to be in the `aria-expanded=false` state.
  * the "open" button was removed from this example as it is arguably unnecessary, but also irrelevant to the purpose of this example.

