### PR TITLE
document.createElement returns an HTMLElement

### DIFF
--- a/files/en-us/web/api/document/createelement/index.html
+++ b/files/en-us/web/api/document/createelement/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Document.createElement
 
 <h3 id="Return_value">Return value</h3>
 
-<p>The new {{domxref("Element")}}.</p>
+<p>The new {{domxref("HTMLElement")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`document.createElement` more accurately returns an `HTMLElement` instances. `document.createElementNS` is needed (unfortunately) for non-`HTMLElement` types, like `SVGElement`.

The built-in type definition in TypeScript also returns `HTMLElement`.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
