### PR TITLE
Replace {{event} with {{DOMxRef}} in RTCDataChannel.*

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/binarytype/index.html
+++ b/files/en-us/web/api/rtcdatachannel/binarytype/index.html
@@ -21,7 +21,7 @@ browser-compat: api.RTCDataChannel.binaryType
     default is <code>blob</code>.</p>
 
 <p>When a binary message is received on the data channel, the resulting
-  {{event("message")}} event's {{domxref("MessageEvent.data")}} property is an object of
+  {{DOMxRef("RTCDataChannel.message_event", "message")}} event's {{domxref("MessageEvent.data")}} property is an object of
   the type specified by the <code>binaryType</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -47,7 +47,7 @@ browser-compat: api.RTCDataChannel.binaryType
 <h2 id="Example">Example</h2>
 
 <p>This code configures a data channel to receive binary data in
-  {{jsxref("ArrayBuffer")}} objects, and establishes a listener for {{event("message")}}
+  {{jsxref("ArrayBuffer")}} objects, and establishes a listener for {{DOMxRef("RTCDataChannel.message_event", "message")}}
   events which constructs a string representing the received data as a list of hexadecimal
   byte values.</p>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
@@ -32,7 +32,7 @@ browser-compat: api.RTCDataChannel.bufferedAmount
 
 <p>Whenever this value decreases to fall to or below the value specified in the
   {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}
-  property, the user agent fires the {{event("bufferedamountlow")}} event. This event may
+  property, the user agent fires the {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event. This event may
   be used, for example, to implement code which queues more messages to be sent whenever
   there's room to buffer them.</p>
 
@@ -79,6 +79,6 @@ function showBufferedAmount(channel) {
       channels</a></li>
   <li>{{domxref("RTCDataChannel")}}</li>
   <li>{{domxref("RTCDataChannel.bufferedAmountLowThreshold")}}</li>
-  <li>{{event("bufferedamountlow")}} event</li>
+  <li>{{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event</li>
   <li>{{domxref("RTCDataChannel.onbufferedamountlow")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
@@ -20,7 +20,7 @@ browser-compat: api.RTCDataChannel.bufferedamountlow_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p><span class="seoSummary">A <strong><code>bufferedamountlow</code></strong> event is sent to an {{domxref("RTCDataChannel")}} when the number of bytes currently in the outbound data transfer buffer falls below the threshold specified in {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}.</span> <code>bufferedamountlow</code> events aren't sent if <code>bufferedAmountLowThreshold</code> is 0.</p>
+<p>A <strong><code>bufferedamountlow</code></strong> event is sent to an {{domxref("RTCDataChannel")}} when the number of bytes currently in the outbound data transfer buffer falls below the threshold specified in {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}. <code>bufferedamountlow</code> events aren't sent if <code>bufferedAmountLowThreshold</code> is 0.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
@@ -16,7 +16,7 @@ browser-compat: api.RTCDataChannel.bufferedAmountLowThreshold
     of bytes of buffered outgoing data that is considered "low." The default value is
     0. hen the number of buffered outgoing bytes, as indicated by the
   {{domxref("RTCDataChannel.bufferedAmount", "bufferedAmount")}} property, falls to or
-  below this value, a {{event("bufferedamountlow")}} event is fired. This event may be
+  below this value, a {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event is fired. This event may be
   used, for example, to implement code which queues more messages to be sent whenever
   there's room to buffer them. Listeners may be added with
   {{domxref("RTCDataChannel.onbufferedamountlow", "onbufferedamountlow")}} or
@@ -46,7 +46,7 @@ browser-compat: api.RTCDataChannel.bufferedAmountLowThreshold
 <h2 id="Example">Example</h2>
 
 <p>In this snippet of code, <code>bufferedAmountLowThreshold</code> is set to 64kB, and a
-  handler for the {{event("bufferedamountlow")}} event is established by setting the
+  handler for the {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event is established by setting the
   {{domxref("RTCDataChannel.onbufferedamountlow")}} property to a function which should
   send more data into the buffer by calling {{domxref("RTCDataChannel.send", "send()")}}.
 </p>
@@ -75,6 +75,6 @@ dc.onbufferedamountlow = function() {
       channels</a></li>
   <li>{{domxref("RTCDataChannel")}}</li>
   <li>{{domxref("RTCDataChannel.bufferedAmount")}}</li>
-  <li>{{event("bufferedamountlow")}} event</li>
+  <li>{{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event</li>
   <li>{{domxref("RTCDataChannel.onbufferedamountlow")}}</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/close/index.html
+++ b/files/en-us/web/api/rtcdatachannel/close/index.html
@@ -22,7 +22,7 @@ browser-compat: api.RTCDataChannel.close
 
 <p>Closure of the data channel is not instantaneous. Most of the process of closing the
   connection is handled asynchronously; you can detect when the channel has finished
-  closing by watching for a {{event("close")}} event on the data channel.</p>
+  closing by watching for a {{DOMxRef("RTCDataChannel.close_event", "close")}} event on the data channel.</p>
 
 <p>The sequence of events which occurs in response to this method being called:</p>
 
@@ -35,9 +35,13 @@ browser-compat: api.RTCDataChannel.close
   <li>The underlying data transport is closed.</li>
   <li>The {{domxref("RTCDataChannel.readyState")}} property is set to
     <code>closed</code>.</li>
-  <li>If the transport was closed with an error, the <code>RTCDataChannel</code> is sent a
-    {{event("NetworkError")}} event.</li>
-  <li>A {{domxref("close")}} event is sent to the channel.</li>
+  <li>
+    If the transport was closed with an error,
+    the <code>RTCDataChannel</code> is sent
+    an {{DOMxRef("RTCDataChannel.error_event", "error")}} event
+    with its {{DOMxRef("DOMException.name", "name")}} set to <code>NetworkError</code>.
+  </li>
+  <li>A {{domxref("RTCDataChannel.close_event", "close")}} event is sent to the channel.</li>
 </ol>
 
 <h2 id="Syntax">Syntax</h2>
@@ -88,5 +92,5 @@ dc.onclose = function (
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
   <li>{{domxref("RTCDataChannel")}}</li>
   <li>{{domxref("RTCDataChannel.readyState")}}</li>
-  <li>{{event("close")}} event</li>
+  <li>{{DOMxRef("RTCDataChannel.close_event", "close")}} event</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
@@ -16,7 +16,7 @@ browser-compat: api.RTCDataChannel.onbufferedamountlow
 
 <p>The <strong><code>RTCDataChannel.onbufferedamountlow</code></strong> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function the browser calls when the
-  {{event("bufferedamountlow")}} event is sent to the {{domxref("RTCDataChannel")}}. This
+  {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event is sent to the {{domxref("RTCDataChannel")}}. This
   event, which is represented by a simple {{domxref("Event")}} object, is sent when the
   amount of data buffered to be sent falls to or below the threshold specified by the
   channel's {{domxref("RTCDataChannel.bufferedAmountLowThreshold",
@@ -32,13 +32,13 @@ browser-compat: api.RTCDataChannel.onbufferedamountlow
 
 <h3 id="Value">Value</h3>
 
-<p>A function which the browser will call to handle the {{event("bufferedamountlow")}}
+<p>A function which the browser will call to handle the {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}}
   event. This function receives as its only input parameter a simple {{domxref("Event")}}
   object representing the event which has occurred.</p>
 
 <h2 id="Example">Example</h2>
 
-<p>This example responds to the {{event("bufferedamountlow")}} event by fetching up to
+<p>This example responds to the {{DOMxRef("RTCDataChannel.bufferedamountlow_event", "bufferedamountlow")}} event by fetching up to
   64kB of a file represented by an object <code>source</code> and calling
   {{domxref("RTCDataChannel.send()")}} to queue up the retrieved data for sending on the
   data channel.</p>

--- a/files/en-us/web/api/rtcdatachannel/onclose/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclose/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onclose
 
 <p>The <code><strong>RTCDataChannel.onclose</strong></code> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called by the browser when
-  the {{event("close")}} event is received by the {{domxref("RTCDataChannel")}}. This is a
+  the {{DOMxRef("RTCDataChannel.close_event", "close")}} event is received by the {{domxref("RTCDataChannel")}}. This is a
   simple {{domxref("Event")}} which indicates that the data channel has closed down.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -24,14 +24,14 @@ browser-compat: api.RTCDataChannel.onclose
 
 <h3 id="Value">Value</h3>
 
-<p>A function which the browser will call to handle the {{event("close")}} event. The
+<p>A function which the browser will call to handle the {{DOMxRef("RTCDataChannel.close_event", "close")}} event. The
   function receives as its sole input parameter the event itself, as an object of type
   {{domxref("Event")}}.</p>
 
 <h2 id="Example">Example</h2>
 
 <p>In this sample from a hypothetical instant messaging client, a data channel is created,
-  then handlers for the {{event("open")}} and {{event("close")}} events are set up to
+  then handlers for the {{DOMxRef("RTCDataChannel.open_event", "open")}} and {{DOMxRef("RTCDataChannel.close_event", "close")}} events are set up to
   enable and disable user interface objects based on the state of the channel. This way,
   the message entry field and the send button are only enabled for use when the connection
   is actually open.</p>
@@ -63,7 +63,7 @@ dc.onclose = function(event) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
-  <li>The {{event("close")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.close_event", "close")}} event and its type, {{domxref("Event")}}.</li>
   <li>{{domxref("RTCDataChannel.onopen")}}</li>
-  <li>The {{event("open")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.open_event", "open")}} event and its type, {{domxref("Event")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/onclosing/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclosing/index.html
@@ -15,7 +15,7 @@ browser-compat: api.RTCDataChannel.onclosing
 
 <p>The <code><strong>RTCDataChannel.onclosing</strong></code> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called by the browser when
-  the {{Event("closing")}} event is received by the {{DOMxRef("RTCDataChannel")}}. This is
+  the {{DOMxRef("RTCDataChannel.closing_event", "closing")}} event is received by the {{DOMxRef("RTCDataChannel")}}. This is
   a simple {{DOMxRef("Event")}} which indicates that the data channel is being closed,
   that is, {{DOMxRef("RTCDataChannel")}} transitions to "closing" state. For example,
   after {{DOMxRef("RTCDataChannel.close", "RTCDataChannel.close()")}} was called but the
@@ -44,8 +44,8 @@ browser-compat: api.RTCDataChannel.onclosing
 
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
-  <li>{{DOMxRef("RTCDataChannel.onclose")}} event handler and its {{Event("close")}}
+  <li>{{DOMxRef("RTCDataChannel.onclose")}} event handler and its {{DOMxRef("RTCDataChannel.close_event", "close")}}
     event.</li>
   <li>{{DOMxRef("RTCDataChannel.onopen")}}</li>
-  <li>The {{Event("open")}} event and its type, {{DOMxRef("Event")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.open_event", "open")}} event and its type, {{DOMxRef("Event")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/onerror/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onerror/index.html
@@ -14,8 +14,8 @@ browser-compat: api.RTCDataChannel.onerror
 
 <p>The <code><strong>RTCDataChannel.onerror</strong></code> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
-  {{event("error")}} event is received. When an error occurs on the data channel, the
-  function receives as input an {{domxref("ErrorEvent")}} object describing the error
+  {{DOMxRef("RTCDataChannel.error_event", "error")}} event is received. When an error occurs on the data channel, the
+  function receives as input an {{domxref("RTCErrorEvent")}} object describing the error
   which occurred.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -25,7 +25,7 @@ browser-compat: api.RTCDataChannel.onerror
 
 <h3 id="Value">Value</h3>
 
-<p>A function which the browser will call to handle the {{event("error")}} event when it
+<p>A function which the browser will call to handle the {{DOMxRef("RTCDataChannel.error_event", "error")}} event when it
   occurs on the data channel. This function receives as its only input an
   {{domxref("ErrorEvent")}} object describing the event which was received. That event
   object, in turn, describes the error that took place.</p>
@@ -65,5 +65,5 @@ dc.onerror = function(event) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
-  <li>The {{event("error")}} event and its type, {{domxref("ErrorEvent")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.error_event", "error")}} event and its type, {{domxref("ErrorEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/onmessage/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onmessage/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onmessage
 
 <p>The <code><strong>RTCDataChannel.onmessage</strong></code> property stores an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
-  {{event("message")}} event is fired on the channel. This event is represented by the
+  {{DOMxRef("RTCDataChannel.message_event", "message")}} event is fired on the channel. This event is represented by the
   {{domxref("MessageEvent")}} interface. This event is sent to the channel when a message
   is received from the other peer.</p>
 
@@ -25,7 +25,7 @@ browser-compat: api.RTCDataChannel.onmessage
 
 <h3 id="Value">Value</h3>
 
-<p>A function which the browser will call to handle the {{event("message")}} event. The
+<p>A function which the browser will call to handle the {{DOMxRef("RTCDataChannel.message_event", "message")}} event. The
   function receives as its sole input parameter a {{domxref("MessageEvent")}} object
   describing the event.</p>
 
@@ -62,5 +62,5 @@ dc.onmessage = function(event) {
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
   <li>{{domxref("RTCPeerConnection")}}</li>
   <li>{{domxref("RTCDataChannel")}}</li>
-  <li>The {{event("message")}} event and its type, {{domxref("MessageEvent")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.message_event", "message")}} event and its type, {{domxref("MessageEvent")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/onopen/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onopen/index.html
@@ -14,7 +14,7 @@ browser-compat: api.RTCDataChannel.onopen
 
 <p>The <code><strong>RTCDataChannel.onopen</strong></code> property is an
   <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> which specifies a function to be called when the
-  {{event("open")}} event is fired; this is a simple {{domxref("Event")}} which is sent
+  {{DOMxRef("RTCDataChannel.open_event", "open")}} event is fired; this is a simple {{domxref("Event")}} which is sent
   when the data channel's underlying data transport—the link over which the
   {{domxref("RTCDataChannel")}}'s messages flow—is established or re-established.</p>
 
@@ -25,14 +25,14 @@ browser-compat: api.RTCDataChannel.onopen
 
 <h3 id="Value">Value</h3>
 
-<p>A function which the browser will call to handle the {{event("open")}} event. The
+<p>A function which the browser will call to handle the {{DOMxRef("RTCDataChannel.open_event", "open")}} event. The
   function receives as its only input parameter the event itself, of type
   {{domxref("Event")}}.</p>
 
 <h2 id="Example">Example</h2>
 
 <p>This example adds a new data channel to an existing {{domxref("RTCPeerConnection")}},
-  <code>myPeerConnection</code>. It then establishes an {{event("open")}} event handler
+  <code>myPeerConnection</code>. It then establishes an {{DOMxRef("RTCDataChannel.open_event", "open")}} event handler
   which updates some user interface elements to prepare them for being used to send
   messages over the data channel.</p>
 
@@ -60,7 +60,7 @@ dc.onopen = function(event) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
-  <li>The {{event("open")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.open_event", "open")}} event and its type, {{domxref("Event")}}.</li>
   <li>{{domxref("RTCDataChannel.onclose")}}</li>
-  <li>The {{event("close")}} event and its type, {{domxref("Event")}}.</li>
+  <li>The {{DOMxRef("RTCDataChannel.close_event", "close")}} event and its type, {{domxref("Event")}}.</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannel/readystate/index.html
+++ b/files/en-us/web/api/rtcdatachannel/readystate/index.html
@@ -38,7 +38,7 @@ browser-compat: api.RTCDataChannel.readyState
     This is the default state of a new {{domxref("RTCDataChannel")}} created by the WebRTC layer
     when the remote peer created the channel
     and delivered it to the site or app
-    in a {{event("datachannel")}} event.
+    in a {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} event.
   </dd>
 
   <dt><code>closing</code></dt>

--- a/files/en-us/web/api/rtcdatachannel/send/index.html
+++ b/files/en-us/web/api/rtcdatachannel/send/index.html
@@ -109,5 +109,5 @@ function sendMessage(msg) {
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
   <li>{{domxref("RTCDataChannel")}}</li>
   <li>{{domxref("RTCDataChannel.readyState")}}</li>
-  <li>{{event("close")}} event</li>
+  <li>{{DOMxRef("RTCDataChannel.close_event", "close")}} event</li>
 </ul>


### PR DESCRIPTION
Some of the links generated by {{event}} were broken or linked to the event on the wrong object.