### PR TITLE
Remove mentions of RTCDataChannelInit dictionary

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -12,15 +12,15 @@ browser-compat: api.RTCDataChannel.ordered
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
-<p>The read-only <code>RTCDataChannel</code> property
-    <code><strong>ordered</strong></code> indicates whether or not the data channel
-    guarantees in-order delivery of messages; the default is <code>true</code>, which
-    indicates that the data channel is indeed ordered. This is set when the
-  {{domxref("RTCDataChannel")}} is created, by setting the <code>ordered</code> property
-  on the
-  <code><a href="/en-US/docs/Web/API/RTCPeerConnection/createDataChannel#rtcdatachannelinit_dictionary">RTCDataChannelInit</a></code>
-  object passed as {{domxref("RTCPeerConnection.createDataChannel()")}}'s
-  <code>options</code> parameter.</p>
+<p>
+  The read-only <code>RTCDataChannel</code> property <code><strong>ordered</strong></code> indicates
+  whether or not the data channel guarantees in-order delivery of messages;
+  the default is <code>true</code>,
+  which indicates that the data channel is indeed ordered.
+  This is set when the {{domxref("RTCDataChannel")}} is created,
+  by setting the <code>ordered</code> property
+  on the object passed as {{domxref("RTCPeerConnection.createDataChannel()")}}'s <code>options</code> parameter.
+</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -91,7 +91,7 @@ browser-compat: api.RTCPeerConnection.createDataChannel
         Alternatively (<code>true</code>),
         they can be negotiated out of-band,
         where both sides call <code>createDataChannel</code>
-        with an agreed-upon id.
+        with an agreed-upon ID.
         <strong>Default: <code>false</code>.</strong>
       </dd>
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -98,7 +98,7 @@ browser-compat: api.RTCPeerConnection.createDataChannel
       <dt><code>id</code> {{optional_inline}}</dt>
       <dd>
         A 16-bit numeric ID for the channel;
-        permitted values are 0-65534.
+        permitted values are 0 to 65534.
         If you don't include this option,
         the user agent will select an ID for you.
       </dd>

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -85,8 +85,8 @@ browser-compat: api.RTCPeerConnection.createDataChannel
       <dd>
         By default (<code>false</code>),
         data channels are negotiated in-band,
-        where one side calls <code>createDataChannel</code>, a
-        nd the other side listens to the {{domxref("RTCDataChannelEvent")}} event
+        where one side calls <code>createDataChannel</code>, and
+        the other side listens to the {{domxref("RTCDataChannelEvent")}} event
         using the {{DOMxRef("RTCPeerConnection.ondatachannel", "ondatachannel")}} event handler.
         Alternatively (<code>true</code>),
         they can be negotiated out of-band,

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -33,55 +33,80 @@ browser-compat: api.RTCPeerConnection.createDataChannel
 
 <dl>
   <dt><code>label</code></dt>
-  <dd>A human-readable name for the channel. This string may not be longer than 65,535
-    <em>bytes</em>.</dd>
+  <dd>
+    A human-readable name for the channel.
+    This string may not be longer than 65,535 bytes.</dd>
   <dt><code>options</code> {{optional_inline}}</dt>
-  <dd>An <a href="#rtcdatachannelinit_dictionary"><code>RTCDataChannelInit</code>
-      dictionary</a> providing configuration options for the data channel</dd>
-</dl>
+  <dd>
+    An object providing configuration options for the data channel.
+    It can contain the following fields:
+    <dl>
+      <dt><code>ordered</code> {{optional_inline}}</dt>
+      <dd>
+        Indicates whether or not
+        messages sent on the {{domxref("RTCDataChannel")}}
+        are required to arrive at their destination in the same order
+        in which they were sent (<code>true</code>),
+        or if they're allowed to arrive out-of-order (<code>false</code>).
+        <strong>Default: <code>true</code>.</strong>
+      </dd>
 
-<h3 id="RTCDataChannelInit_dictionary">RTCDataChannelInit dictionary</h3>
+      <dt><code>maxPacketLifeTime</code> {{optional_inline}}</dt>
+      <dd>
+        The maximum number of milliseconds
+        that attempts to transfer a message may take in unreliable mode.
+        While this value is a 16-bit unsigned number,
+        each user agent may clamp it
+        to whatever maximum it deems appropriate.
+        <strong>Default: <code>null</code>.</strong>
+      </dd>
 
-<p>The <code>RTCDataChannelInit</code> dictionary provides the following fields, any of
-  which may be included in the object passed as the options parameter in order to
-  configure the data channel to suit your needs:</p>
+      <dt><code>maxRetransmits</code> {{optional_inline}}</dt>
+      <dd>
+        The maximum number of times
+        the user agent should attempt to retransmit a message
+        which fails the first time in unreliable mode.
+        While this value is a 16-bit unsigned number,
+        each user agent may clamp it to whatever maximum it deems appropriate.
+        <strong>Default: <code>null</code>.</strong>
+      </dd>
 
-<dl>
-  <dt><code>ordered</code> {{optional_inline}}</dt>
-  <dd>Indicates whether or not messages sent on the {{domxref("RTCDataChannel")}} are
-    required to arrive at their destination in the same order in which they were sent
-    (<code>true</code>), or if they're allowed to arrive out-of-order
-    (<code>false</code>). <strong>Default: <code>true</code>.</strong></dd>
-  <dt><strong><code>maxPacketLifeTime</code> {{optional_inline}}</strong></dt>
-  <dd>The maximum number of milliseconds that attempts to transfer a message may take in
-    unreliable mode. While this value is a 16-bit unsigned number, each user agent may
-    clamp it to whatever maximum it deems appropriate. <strong>Default:
-      <code>null</code>.</strong></dd>
-  <dt><code>maxRetransmits</code> {{optional_inline}}</dt>
-  <dd>The maximum number of times the user agent should attempt to retransmit a message
-    which fails the first time in unreliable mode. While this value is a16-bit unsigned
-    number, each user agent may clamp it to whatever maximum it deems appropriate.
-    <strong>Default: <code>null</code>.</strong></dd>
-  <dt><code>protocol</code> {{optional_inline}}</dt>
-  <dd>The name of the sub-protocol being used on the {{domxref("RTCDataChannel")}}, if
-    any; otherwise, the empty string (""). <strong>Default: empty string,
-      <code>""</code>.</strong> This string may not be longer than 65,535 <em>bytes</em>.
+      <dt><code>protocol</code> {{optional_inline}}</dt>
+      <dd>
+        The name of the sub-protocol
+        being used on the {{domxref("RTCDataChannel")}},
+        if any;
+        otherwise, the empty string (<code>""</code>).
+        <strong>Default: empty string (<code>""</code>).</strong>
+        This string may not be longer than 65,535 <em>bytes</em>.
+      </dd>
+
+      <dt><code>negotiated</code> {{optional_inline}}</dt>
+      <dd>
+        By default (<code>false</code>),
+        data channels are negotiated in-band,
+        where one side calls <code>createDataChannel</code>, a
+        nd the other side listens to the {{domxref("RTCDataChannelEvent")}} event
+        using the {{DOMxRef("RTCPeerConnection.ondatachannel", "ondatachannel")}} event handler.
+        Alternatively (<code>true</code>),
+        they can be negotiated out of-band,
+        where both sides call <code>createDataChannel</code>
+        with an agreed-upon id.
+        <strong>Default: <code>false</code>.</strong>
+      </dd>
+
+      <dt><code>id</code> {{optional_inline}}</dt>
+      <dd>
+        A 16-bit numeric ID for the channel;
+        permitted values are 0-65534.
+        If you don't include this option,
+        the user agent will select an ID for you.
+      </dd>
+    </dl>
   </dd>
-  <dt><code>negotiated</code> {{optional_inline}}</dt>
-  <dd>By default (<code>false</code>), data channels are negotiated in-band, where one
-    side calls <code>createDataChannel</code>, and the other side listens to the
-    {{domxref("RTCDataChannelEvent")}} event using the <code>ondatachannel</code>
-    <code>EventHandler</code> . Alternatively (<code>true</code>), they can be negotiated
-    out of-band, where both sides call <code>createDataChannel </code>with an agreed-upon
-    id. <strong>Default: <code>false</code>.</strong></dd>
-  <dt><code>id</code> {{optional_inline}}</dt>
-  <dd>An 16-bit numeric ID for the channel; permitted values are 0-65534. If you don't
-    include this option, the user agent will select an ID for you.</dd>
 </dl>
-
 <div class="note">
-  <p>The options which can be configured using the <code>RTCDataChannelInit</code>
-    dictionary represent the script-settable subset of the properties on the
+  <p>These options represent the script-settable subset of the properties on the
     {{domxref("RTCDataChannel")}} interface.</p>
 </div>
 

--- a/files/en-us/web/api/webrtc_api/using_data_channels/index.html
+++ b/files/en-us/web/api/webrtc_api/using_data_channels/index.html
@@ -13,7 +13,7 @@ tags:
   - WebRTC API
   - buffering
 ---
-<p>{{WebRTCSidebar}}{{draft}}</p>
+<p>{{WebRTCSidebar}}</p>
 
 <p>Once you've established a WebRTC peer connection using the {{domxref("RTCPeerConnection")}} interface, you're able to send and receive media data between the two peers on the connection. But there's a lot more you can do with WebRTC. <span class="seoSummary">In this guide, we'll examine how to add a data channel to a peer connection, which can then be used to securely exchange arbitrary data; that is, any kind of data we wish, in any format we choose.</span></p>
 

--- a/files/en-us/web/api/webrtc_api/using_data_channels/index.html
+++ b/files/en-us/web/api/webrtc_api/using_data_channels/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>Often, you can allow the peer connection to handle negotiating the {{domxref("RTCDataChannel")}} connection for you. To do this, call</p>
 
-<p>{{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}} without specifying a value for the {{domxref("RTCDataChannelInit.negotiated", "negotiated")}} property, or specifying the property with a value of <code>false</code>. This will automatically trigger the <code>RTCPeerConnection</code> to handle the negotiations for you, causing the remote peer to create a data channel and linking the two together across the network.</p>
+<p>{{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}} without specifying a value for the <code>negotiated</code> property, or specifying the property with a value of <code>false</code>. This will automatically trigger the <code>RTCPeerConnection</code> to handle the negotiations for you, causing the remote peer to create a data channel and linking the two together across the network.</p>
 
 <p>The <code>RTCDataChannel</code> object is returned immediately by <code>createDataChannel()</code>; you can tell when the connection has been made successfully by watching for the {{domxref("RTCDataChannel.open_event", "open")}} event to be sent to the <code>RTCDataChannel</code>.</p>
 
@@ -49,7 +49,7 @@ dataChannel.addEventListener("open", (event) =&gt; {
 
 <h3 id="Manual_negotiation">Manual negotiation</h3>
 
-<p>To manually negotiate the data channel connection, you need to first create a new {{domxref("RTCDataChannel")}} object using the {{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}} method on the {{domxref("RTCPeerConnection")}}, specifying in the options a {{domxref("RTCDataChannelInit.negotiated", "negotiated")}} property set to <code>true</code>. This signals to the peer connection to not attempt to negotiate the channel on your behalf.</p>
+<p>To manually negotiate the data channel connection, you need to first create a new {{domxref("RTCDataChannel")}} object using the {{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}} method on the {{domxref("RTCPeerConnection")}}, specifying in the options a <code>negotiated</code> property set to <code>true</code>. This signals to the peer connection to not attempt to negotiate the channel on your behalf.</p>
 
 <p>Then negotiate the connection out-of-band, using a web server or other means. This process should signal to the remote peer that it should create its own <code>RTCDataChannel</code> with the <code>negotiated</code> property also set to <code>true</code>, using the same {{domxref("RTCDataChannel.id", "id")}}. This will link the two objects across the <code>RTCPeerConnection</code>.</p>
 


### PR DESCRIPTION
`RTCDataChannelInit` is a dictionary used only in `createDataChannel`. I anonymize it. (=== remove it).

With this, I'm finishing the `RTCDataChannel` rabbit hole.