### PR TITLE
BroadcastChannel(): rename parameter

### DIFF
--- a/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
@@ -21,12 +21,12 @@ browser-compat: api.BroadcastChannel.BroadcastChannel
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"> <em>channel</em> = new BroadcastChannel(<em>channel</em>);</pre>
+  class="brush: js"> <em>channel</em> = new BroadcastChannel(<em>channelName</em>);</pre>
 
 <h3 id="Values">Values</h3>
 
 <dl>
-  <dt><em>channel</em></dt>
+  <dt><em>channelName</em></dt>
   <dd>Is a {{domxref("DOMString")}} representing the name of the channel; there is one
     single channel with this name for all {{glossary("browsing context", "browsing
     contexts")}} with the same {{glossary("origin")}}.</dd>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I think it can be confusing that the parameter and the result variable have the same name, especially when referenced by name afterwards.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
