### PR TITLE
Adds missing CSSRuleList property and method pages.

### DIFF
--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -12,6 +12,8 @@ browser-compat: api.CSSRuleList
 
 <p>A <code>CSSRuleList</code> represents an ordered collection of read-only {{domxref("CSSRule")}} objects.</p>
 
+<p>To edit the underlying rules returned by <code>CSSRule</code> objects, use {{domxref("CSSStyleSheet.insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule()")}}, which are methods of {{domxref("CSSStyleSheet")}}.</p>
+
 <p>The interface has no constructor. An instance of <code>CSSRuleList</code> is returned by {{domxref("CSSStyleSheet.cssRules")}} and {{domxref("CSSKeyframesRule.cssRules")}}.</p>
 
 <h2 id="Properties">Properties</h2>
@@ -27,11 +29,6 @@ browser-compat: api.CSSRuleList
   <dt>{{domxref("CSSRuleList.item()")}}</dt>
   <dd>Gets a single {{domxref("CSSRule")}}.</dd>
 </dl>
-
-<div class="notecard note">
-  <h4>Note:</h4>
-  <p>Note that being <em>indirect-modify</em> (<a href="https://www.w3.org/TR/cssom/#cssstylesheet">changeable</a> but <a href="https://www.w3.org/TR/cssom/#cssrulelist">only having</a> read-methods), rules are <strong>NOT</strong> added or removed from the list directly, but instead here, only via its parent stylesheet. In fact, {{domxref("CSSStyleSheet.insertRule",".insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule",".deleteRule()")}} are not even methods of CSSRuleList, but only of {{domxref("CSSStyleSheet")}}. If however, for some reason the list does need to be modified but has no parent stylesheet (perhaps being a <em><a href="https://www.w3.org/TR/cssom/#cssstylesheet">livecopy</a></em> of a list that does), it cannot just be assigned one (as it has <a href="https://www.w3.org/TR/cssom/#cssrulelist">no such property</a>), and neither can it be assigned to one (as stylesheet.css<code>Rules </code>is <a href="https://www.w3.org/TR/cssom/#cssstylesheet">read-only</a>), but it must unfortunately be <strong>inserted</strong> into one, rule by rule, and unless combining lists, after any existing list therein is deleted, rule by rule.</p>
-</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -12,6 +12,8 @@ browser-compat: api.CSSRuleList
 
 <p>A <code>CSSRuleList</code> represents an ordered collection of read-only {{domxref("CSSRule")}} objects.</p>
 
+<p>While the <code>CSSRuleList</code> object is read-only, and cannot be directly modified, it is considered a <code>live</code> object, as the content can change over time.</p>
+
 <p>To edit the underlying rules returned by <code>CSSRule</code> objects, use {{domxref("CSSStyleSheet.insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule()")}}, which are methods of {{domxref("CSSStyleSheet")}}.</p>
 
 <p>The interface has no constructor. An instance of <code>CSSRuleList</code> is returned by {{domxref("CSSStyleSheet.cssRules")}} and {{domxref("CSSKeyframesRule.cssRules")}}.</p>

--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -10,32 +10,57 @@ browser-compat: api.CSSRuleList
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p>A <code>CSSRuleList</code> is an (indirect-modify only) array-like object containing an ordered collection of <code><a href="/en-US/docs/Web/API/CSSRule">CSSRule</a></code> objects.</p>
+<p>A <code>CSSRuleList</code> represents an ordered collection of {{domxref("CSSRule")}} objects.</p>
 
-<h2 id="Syntax">Description</h2>
+<p>The interface has no constructor. An instance of <code>CSSRuleList</code> is returned by {{domxref("CSSStyleSheet.cssRules")}} and {{domxref("CSSKeyframesRule.cssRules")}}.</p>
 
-<p>Each <code>CSSRule</code> can be accessed as <code><var>rules</var>.item(<var>index</var>),</code> or <code><var>rules</var>[<var>index</var>]</code>, where <code><var>rules</var></code> is an object implementing the <code>CSSRuleList</code> interface (such as <code>{{domxref("CSSStylesheet","","",1)}}.cssRules</code>), and <code><var>index</var></code> is the 0-based index of the rule, in the order as it appears in the style sheet CSS. The number of rules in the list is <code><var>rules</var>.length</code>.</p>
+<h2 id="Properties">Properties</h2>
 
-<p>Note that being <em>indirect-modify</em> (<a href="https://www.w3.org/TR/cssom/#cssstylesheet">changeable</a> but <a href="https://www.w3.org/TR/cssom/#cssrulelist">only having</a> read-methods), rules are <strong>NOT</strong> added or removed from the list directly, but instead here, only via its parent stylesheet. In fact, {{domxref("CSSStyleSheet.insertRule",".insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule",".deleteRule()")}} are not even methods of CSSRuleList, but only of {{domxref("CSSStyleSheet")}}. If however, for some reason the list does need to be modified but has no parent stylesheet (perhaps being a <em><a href="https://www.w3.org/TR/cssom/#cssstylesheet">livecopy</a></em> of a list that does), it cannot just be assigned one (as it has <a href="https://www.w3.org/TR/cssom/#cssrulelist">no such property</a>), and neither can it be assigned to one (as stylesheet.css<code>Rules </code>is <a href="https://www.w3.org/TR/cssom/#cssstylesheet">read-only</a>), but it must unfortunately be <strong>inserted</strong> into one, rule by rule, and unless combining lists, after any existing list therein is deleted, rule by rule.</p>
+<dl>
+  <dt>{{domxref("CSSRuleList.length")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an integer representing the number of {{domxref("CSSRule")}} objects in the collection.</dd>
+</dl>
 
-<h2 id="Example">Examples</h2>
+<h2 id="Methods">Methods</h2>
 
-<h3 id="Simple_usage">Simple usage</h3>
+<dl>
+  <dt>{{domxref("CSSRuleList.item()")}}</dt>
+  <dd>Gets a single {{domxref("CSSRule")}}.</dd>
+</dl>
 
-<pre class="brush: js">// get the first style sheet’s first rule
-var first_rule = document.styleSheets[0].cssRules[0];
-</pre>
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>Note that being <em>indirect-modify</em> (<a href="https://www.w3.org/TR/cssom/#cssstylesheet">changeable</a> but <a href="https://www.w3.org/TR/cssom/#cssrulelist">only having</a> read-methods), rules are <strong>NOT</strong> added or removed from the list directly, but instead here, only via its parent stylesheet. In fact, {{domxref("CSSStyleSheet.insertRule",".insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule",".deleteRule()")}} are not even methods of CSSRuleList, but only of {{domxref("CSSStyleSheet")}}. If however, for some reason the list does need to be modified but has no parent stylesheet (perhaps being a <em><a href="https://www.w3.org/TR/cssom/#cssstylesheet">livecopy</a></em> of a list that does), it cannot just be assigned one (as it has <a href="https://www.w3.org/TR/cssom/#cssrulelist">no such property</a>), and neither can it be assigned to one (as stylesheet.css<code>Rules </code>is <a href="https://www.w3.org/TR/cssom/#cssstylesheet">read-only</a>), but it must unfortunately be <strong>inserted</strong> into one, rule by rule, and unless combining lists, after any existing list therein is deleted, rule by rule.</p>
+</div>
 
-<h3 id="CSSRuleList_implementations">CSSRuleList implementations</h3>
+<h2 id="Examples">Examples</h2>
 
-<p>There are multiple properties in the CSSOM that will return a <code>CSSRuleList</code>. They are:</p>
+<p>In the following example there is a stylesheet with three rules. Using {{domxref("CSSStyleSheet.cssRules")}} returns a <code>CSSRuleList</code>, which is printed to the console.</p>
 
-<ul>
- <li>{{ domxref("CSSStyleSheet") }} property {{ domxref("CSSStyleSheet/cssRules", "cssRules") }}</li>
- <li>{{ domxref("CSSMediaRule") }} property {{ domxref("CSSMediaRule/cssRules", "cssRules") }}</li>
- <li>{{ domxref("CSSKeyframesRule") }} property {{ domxref("CSSKeyframesRule/cssRules", "cssRules") }}</li>
- <li>{{ domxref("CSSMozDocumentRule") }} property {{ domxref("CSSMozDocumentRule/cssRules", "cssRules") }}</li>
-</ul>
+<p>The number of rules in the list is printed to the console using {{domxref("CSSRuleList.length")}}. The first {{domxref("CSSRule")}} can be returned by using <code>0</code> as the parameter for {{domxref("CSSRuleList.item")}}, in the example this will return the rules set for the <code>body</code> selector.</p>
+
+<h3>CSS</h3>
+<pre class="brush: css">body {
+  font-family: system-ui,-apple-system,sans-serif;
+  margin: 2em;
+}
+
+.container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 200px);
+}
+
+.container > * {
+  background-color: #3740ff;
+  color: #fff;
+}</pre>
+
+<h3>JavaScript</h3>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules);
+console.log(myRules.length);
+console.log(myRules[0]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CSSRuleList
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p>A <code>CSSRuleList</code> represents an ordered collection of {{domxref("CSSRule")}} objects.</p>
+<p>A <code>CSSRuleList</code> represents an ordered collection of read-only {{domxref("CSSRule")}} objects.</p>
 
 <p>The interface has no constructor. An instance of <code>CSSRuleList</code> is returned by {{domxref("CSSStyleSheet.cssRules")}} and {{domxref("CSSKeyframesRule.cssRules")}}.</p>
 

--- a/files/en-us/web/api/cssrulelist/item/index.html
+++ b/files/en-us/web/api/cssrulelist/item/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSRuleList.item
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the single {{domxref("CSSRule")}} which is at the position of the <code>index</code> parameter in the collection.</p>
+<p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the {{domxref("CSSRule")}} object at the specified <code>index</code> or <code>null</code> if the specified <code>index</code> doesn't exist.</p>
 
 <p>If no item exists at that index, the method will return <code>null</code>.</p>
 
@@ -44,5 +44,4 @@ console.log(myRules[0]);</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/cssrulelist/item/index.html
+++ b/files/en-us/web/api/cssrulelist/item/index.html
@@ -13,8 +13,6 @@ browser-compat: api.CSSRuleList.item
 
 <p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the {{domxref("CSSRule")}} object at the specified <code>index</code> or <code>null</code> if the specified <code>index</code> doesn't exist.</p>
 
-<p>If no item exists at that index, the method will return <code>null</code>.</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">CSSRuleList.item(index);</pre>
@@ -44,4 +42,3 @@ console.log(myRules[0]);</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-

--- a/files/en-us/web/api/cssrulelist/item/index.html
+++ b/files/en-us/web/api/cssrulelist/item/index.html
@@ -1,0 +1,48 @@
+---
+title: CSSRuleList.item()
+slug: Web/API/CSSRuleList/item
+tags:
+  - API
+  - Method
+  - Reference
+  - item
+  - CSSRuleList
+browser-compat: api.CSSRuleList.item
+---
+<p>{{ APIRef("CSSOM") }}</p>
+
+<p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the single {{domxref("CSSRule")}} which is at the position of the <code>index</code> parameter in the collection.</p>
+
+<p>If no item exists at that index, the method will return <code>null</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">CSSRuleList.item(index);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>An integer.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("CSSRule")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example the first item in the {{domxref("CSSRuleList")}} named <code>myRules</code> is printed to the console.</p>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0]);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/cssrulelist/length/index.html
+++ b/files/en-us/web/api/cssrulelist/length/index.html
@@ -1,0 +1,38 @@
+---
+title: CSSRuleList.length
+slug: Web/API/CSSRuleList/length
+tags:
+  - API
+  - Property
+  - Reference
+  - length
+  - CSSRuleList
+browser-compat: api.CSSRuleList.length
+---
+<p>{{ APIRef("CSSOM") }}</p>
+
+<p class="summary">The <strong><code>length</code></strong>  property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let length = CSSRuleList.length;</pre>
+
+<h3>Value</h3>
+<p>An integer.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example the number of items in the {{domxref("CSSRuleList")}} named <code>myRules</code> is printed to the console.</p>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules.length);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/cssrulelist/length/index.html
+++ b/files/en-us/web/api/cssrulelist/length/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSRuleList.length
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>length</code></strong>  property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.</p>
+<p class="summary">The <strong><code>length</code></strong> property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -34,5 +34,4 @@ console.log(myRules.length);</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 


### PR DESCRIPTION
Missing pages for `CSSRuleList`, also updated the interface page which was entirely different from other interface pages. Spec data PR has already been submitted.

Joe: there was a lengthy note on the interface page, I wasn't sure how necessary this was, though I guess a note that you can only get rules out of this object and not edit them is useful. I left the whole thing for now (just formatted it as a note) but let me know your thoughts.

Reviewer: @jpmedley 