### PR TITLE
Add missing tags

### DIFF
--- a/files/en-us/web/api/htmlcollection/length/index.html
+++ b/files/en-us/web/api/htmlcollection/length/index.html
@@ -2,6 +2,12 @@
 title: HTMLCollection.length
 slug: Web/API/HTMLCollection/length
 browser-compat: api.HTMLCollection.length
+tags:
+  - API
+  - HTML DOM
+  - HTMLCollection
+  - Reference
+  - Property
 ---
 <div>{{APIRef("DOM")}}</div>
 


### PR DESCRIPTION
This will allow the `length` link to appear in the sidebar, requested in #7161
