### PR TITLE
Intl.Locale: Unify code examples across the various getter properties

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
@@ -135,8 +135,8 @@ The `calendar` property returns the part of the `Locale` that indicates the `Loc
 Calendar eras fall under the category of locale key "extension keys". These keys add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the calendar era type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor. To add the calendar type, first add the `-u` extension to the string. Next, add the `-ca` extension to indicate that you are adding a calendar type. Finally, add the calendar era to the string.
 
 ```js
-let frBuddhist = new Intl.Locale("fr-FR-u-ca-buddhist");
-console.log(frBuddhist.calendar); // Prints "buddhist"
+let locale = new Intl.Locale("fr-FR-u-ca-buddhist");
+console.log(locale.calendar); // Prints "buddhist"
 ```
 
 ### Adding a calendar with a configuration object
@@ -144,8 +144,8 @@ console.log(frBuddhist.calendar); // Prints "buddhist"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including calendars. Set the `calendar` property of the configuration object to your desired calendar era, and then pass it into the constructor.
 
 ```js
-let frBuddhist = new Intl.Locale("fr-FR", {calendar: "buddhist"});
-console.log(frBuddhist.calendar); // Prints "buddhist"
+let locale = new Intl.Locale("fr-FR", { calendar: "buddhist" });
+console.log(locale.calendar); // Prints "buddhist"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
@@ -37,8 +37,8 @@ There are 3 values that the `caseFirst` property can have, outlined in the table
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `caseFirst` represents correspond to the key `kf`. `kf` is treated as a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `caseFirst` value can be added to the initial locale identifier string that is passed into the `Locale` constructor. To add the `caseFirst` value, first add the `-u` extension key to the string. Next, add the `-kf` extension key to indicate that you are adding a value for `caseFirst`. Finally, add the `caseFirst` value to the string.
 
 ```js
-let caseFirstStr = new Intl.Locale("fr-Latn-FR-u-kf-upper");
-console.log(caseFirstStr.caseFirst); // Prints "upper"
+let locale = new Intl.Locale("fr-Latn-FR-u-kf-upper");
+console.log(locale.caseFirst); // Prints "upper"
 ```
 
 ### Setting the caseFirst value via the configuration object argument
@@ -46,8 +46,8 @@ console.log(caseFirstStr.caseFirst); // Prints "upper"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `caseFirst` property of the configuration object to your desired `caseFirst` value, and then pass it into the constructor.
 
 ```js
-let caseFirstObj= new Intl.Locale("en-Latn-US", {caseFirst: "lower"});
-console.log(us12hour.caseFirst); // Prints "lower"
+let locale = new Intl.Locale("en-Latn-US", { caseFirst: "lower" });
+console.log(locale.caseFirst); // Prints "lower"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -147,8 +147,8 @@ Like other locale subtags, the collation type can be added to the {{jsxref("Intl
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), collation types are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the collation type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To add the collation type, first add the `-u` extension to the string. Next, add the `-co` extension to indicate that you are adding a collation type. Finally, add the collation to the string.
 
 ```js
-let stringColl = new Intl.Locale("en-Latn-US-u-co-emoji");
-console.log(stringColl.collation); // Prints "emoji"
+let locale = new Intl.Locale("en-Latn-US-u-co-emoji");
+console.log(locale.collation); // Prints "emoji"
 ```
 
 ### Adding a collation type via the configuration object argument
@@ -156,8 +156,8 @@ console.log(stringColl.collation); // Prints "emoji"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including collation types. Set the `collation` property of the configuration object to your desired collation type, and then pass it into the constructor.
 
 ```js
-let configColl = new Intl.Locale("en-Latn-US", {collation: "emoji"});
-console.log(configColl.collation); // Prints "emoji"
+let locale = new Intl.Locale("en-Latn-US", { collation: "emoji" });
+console.log(locale.collation); // Prints "emoji"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
@@ -38,8 +38,8 @@ These examples will show you how to add hour cycle data to your {{jsxref("Intl/L
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the hour cycle is a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the hour cycle type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To add the hour cycle type, first add the `-u` extension key to the string. Next, add the `-hc` extension key to indicate that you are adding an hour cycle. Finally, add the hour cycle type to the string.
 
 ```js
-let fr24hour = new Intl.Locale("fr-FR-u-hc-h23");
-console.log(fr24hour.hourCycle); // Prints "h23"
+let locale = new Intl.Locale("fr-FR-u-hc-h23");
+console.log(locale.hourCycle); // Prints "h23"
 ```
 
 ### Adding an hour cycle via the configuration object argument
@@ -47,8 +47,8 @@ console.log(fr24hour.hourCycle); // Prints "h23"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including hour cycle types. Set the `hourCycle` property of the configuration object to your desired hour cycle type, and then pass it into the constructor.
 
 ```js
-let us12hour = new Intl.Locale("en-US", {hourCycle: "h12"});
-console.log(us12hour.hourCycle); // Prints "h12"
+let locale = new Intl.Locale("en-US", { hourCycle: "h12" });
+console.log(locale.hourCycle); // Prints "h12"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
@@ -27,9 +27,8 @@ Language is one of the core features of a locale. The Unicode specification trea
 In order to be a valid Unicode locale identifier, a string must start with the language subtag. The main argument to the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor must be a valid Unicode locale identifier, so whenever the constructor is used, it must be passed an identifier with a language subtag.
 
 ```js
-let langStr = new Intl.Locale("en-Latn-US");
-
-console.log(langStr.language); // Prints "en"
+let locale = new Intl.Locale("en-Latn-US");
+console.log(locale.language); // Prints "en"
 ```
 
 ### Overriding language via the configuration object
@@ -37,9 +36,8 @@ console.log(langStr.language); // Prints "en"
 While the language subtag must be specified, the {{jsxref("Intl/Locale", "Locale")}} constructor takes a configuration object, which can override the language subtag.
 
 ```js
-let langObj = new Intl.Locale("en-Latn-US", {language: "es"});
-
-console.log(langObj.language); // Prints "es"
+let locale = new Intl.Locale("en-Latn-US", { language: "es" });
+console.log(locale.language); // Prints "es"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -55,7 +55,7 @@ property of the configuration object to your desired hour cycle type, and then p
 into the constructor:
 
 ```js
-let us12hour = new Intl.Locale("en-US", {hourCycle: "h12"});
+let us12hour = new Intl.Locale("en-US", { hourCycle: "h12" });
 console.log(us12hour.hourCycle); // Prints "h12"
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -55,8 +55,8 @@ property of the configuration object to your desired hour cycle type, and then p
 into the constructor:
 
 ```js
-let us12hour = new Intl.Locale("en-US", { hourCycle: "h12" });
-console.log(us12hour.hourCycle); // Prints "h12"
+let locale = new Intl.Locale("en-US", { hourCycle: "h12" });
+console.log(locale.hourCycle); // Prints "h12"
 ```
 
 ## Polyfill

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
@@ -116,8 +116,8 @@ A numeral system is a system for expressing numbers. The `numberingSystem` prope
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numberingSystem` represents correspond to the key `nu`. `nu` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by first adding the `-u` key. To set the `numberingSystem` value via the string argument to the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor, first add the `-u` extension key. Next, add the `-nu` extension key to indicate that you are adding a value for `numberingSystem`. Finally, add the `numberingSystem` value to the string.
 
 ```js
-let numberingSystemViaStr = new Intl.Locale("fr-Latn-FR-u-nu-mong");
-console.log(numberingSystemStr.numberingSystem); // Prints "mong"
+let locale = new Intl.Locale("fr-Latn-FR-u-nu-mong");
+console.log(locale.numberingSystem); // Prints "mong"
 ```
 
 ### Setting the `numberingSystem` value via the configuration object argument
@@ -125,8 +125,8 @@ console.log(numberingSystemStr.numberingSystem); // Prints "mong"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numberingSystem` property of the configuration object to your desired `numberingSystem` value and pass it into the constructor.
 
 ```js
-let numberingSystemViaObj= new Intl.Locale("en-Latn-US", {numberingSystem: "latn"});
-console.log(us12hour.numberingSystem); // Prints "latn"
+let locale = new Intl.Locale("en-Latn-US", { numberingSystem: "latn" });
+console.log(locale.numberingSystem); // Prints "latn"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
@@ -27,8 +27,8 @@ Like {{jsxref("Intl/Locale/caseFirst", "Intl.Locale.caseFirst")}}, `numeric` rep
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numeric` represents correspond to the key `kn`. `kn` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `numeric` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To set the `numeric` value, first add the `-u` extension key to the string. Next, add the `-kn` extension key to indicate that you are adding a value for `numeric`. Finally, add the `numeric` value to the string. If you want to set `numeric` to `true`, adding the `kn` key will suffice. To set the value to `false`, you must specify in by adding "`false`" after the `kn` key.
 
 ```js
-let numericViaStr = new Intl.Locale("fr-Latn-FR-u-kn-false");
-console.log(numericStr.numeric); // Prints "false"
+let locale = new Intl.Locale("fr-Latn-FR-u-kn-false");
+console.log(locale.numeric); // Prints "false"
 ```
 
 ### Setting the `numeric` value via the configuration object argument
@@ -36,8 +36,8 @@ console.log(numericStr.numeric); // Prints "false"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numeric` property of the configuration object to your desired `numeric` value and pass it into the constructor.
 
 ```js
-let numericViaObj= new Intl.Locale("en-Latn-US", {numeric: true});
-console.log(us12hour.numeric); // Prints "true"
+let locale = new Intl.Locale("en-Latn-US", { numeric: true });
+console.log(locale.numeric); // Prints "true"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -27,9 +27,8 @@ The region is an essential part of the locale identifier, as it places the local
 The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. The region is a mandatory part of a
 
 ```js
-let regionStr = new Intl.Locale("en-Latn-US");
-
-console.log(regionStr.region); // Prints "US"
+let locale = new Intl.Locale("en-Latn-US");
+console.log(locale.region); // Prints "US"
 ```
 
 ### Setting the region via the configuration object
@@ -37,9 +36,8 @@ console.log(regionStr.region); // Prints "US"
 The {{jsxref("Intl/Locale/Locale", "Locale")}} constructor takes a configuration object, which can be used to set the region subtag and property.
 
 ```js
-let regionObj = new Intl.Locale("fr-Latn", {region: "FR"});
-
-console.log(regionObj.region); // Prints "FR"
+let locale = new Intl.Locale("fr-Latn", { region: "FR" });
+console.log(locale.region); // Prints "FR"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -27,9 +27,8 @@ A script, sometimes called writing system, is one of the core attributes of a lo
 The script is the second part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
-let scriptStr = new Intl.Locale("en-Latn-US");
-
-console.log(scriptStr.script); // Prints "Latn"
+let locale = new Intl.Locale("en-Latn-US");
+console.log(locale.script); // Prints "Latn"
 ```
 
 ### Setting the script via the configuration object
@@ -37,9 +36,8 @@ console.log(scriptStr.script); // Prints "Latn"
 The {{jsxref("Intl/Locale/Locale", "Locale")}} constructor takes a configuration object, which can be used to set the script subtag and property.
 
 ```js
-let scriptObj = new Intl.Locale("fr-FR", {script: "Latn"});
-
-console.log(scriptObj.script); // Prints "Latn"
+let locale = new Intl.Locale("fr-FR", { script: "Latn" });
+console.log(locale.script); // Prints "Latn"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Most of these examples had either incorrect variable names or inconsistent formatting (spacing, newlines, etc). 

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

I've chosen to give all of these variable names the generic name of `locale` for consistency. The examples are all extremely short (~2 lines), so there isn't really anything being lost compared to a more descriptive name (like `frBuddhistStr`). If the specific variable names are still desired, I can update this PR to include that change. 