### PR TITLE
Window.clientInformation - add alias entry and release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -54,6 +54,11 @@ tags:
 
 <h4 id="DOM">DOM</h4>
 
+<ul>
+  <li><code>Window.clientInformation</code> can now be used as an alias for {{domxref("Window.navigator")}} ({{bug(1717072)}}).</li>
+</ul>
+
+
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
 
 <h4 id="removals_media">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -55,7 +55,7 @@ tags:
 <h4 id="DOM">DOM</h4>
 
 <ul>
-  <li><code>Window.clientInformation</code> can now be used as an alias for {{domxref("Window.navigator")}} ({{bug(1717072)}}).</li>
+  <li><code>Window.clientInformation</code> has been added as an alias for {{domxref("Window.navigator")}}, in order to match recent specification updates and improve compatibility with other major browsers ({{bug(1717072)}}).</li>
 </ul>
 
 

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -52,6 +52,8 @@ browser-compat: api.Window
 <p>Note that properties which are objects (e.g.,. for overriding the prototype of built-in elements) are listed in a separate section below.</p>
 
 <dl>
+ <dt>{{domxref("Window.navigator", "Window.clientInformation")}} {{readOnlyInline}}</dt>
+ <dd>An alias for {{domxref("Window.navigator")}}.</dd>
  <dt>{{domxref("Window.closed")}} {{readOnlyInline}}</dt>
  <dd>This property indicates whether the current window is closed or not.</dd>
  <dt>{{domxref("Window.console")}} {{ReadOnlyInline}}</dt>


### PR DESCRIPTION
`Window.clientInformation` was added as an alias of `Window.navigator` in FF91. This adds
- Entry for the alias in top level [Window](https://developer.mozilla.org/en-US/docs/Web/API/Window), which links to `Window.navigator`. This appears to be the model used for other alias cases - we don't duplicate all the docs at a lower level. I think this is all that is needed.
- Release note entry. 

Other work for this tracked in https://github.com/mdn/content/issues/6721