### PR TITLE
RTCDtlsTransport: Remove {{InterfaceOverview}} and fold RTCDtlsTransportState

### DIFF
--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.html
@@ -14,9 +14,10 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - events
+  - Event
 browser-compat: api.RTCDtlsTransport.error_event
 ---
-<p>{{WebRTCSidebar}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
 <p>An {{domxref("RTCDtlsTransport")}} receives an <code>error</code> event when a transport-level error occurs on the {{domxref("RTCPeerConnection")}}.</p>
 
@@ -49,7 +50,7 @@ browser-compat: api.RTCDtlsTransport.error_event
 
 <dl>
  <dt><code>dtls-failure</code></dt>
- <dd>The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error. The error's {{domxref("RTCError.message", "message")}} contains details about the nature of the error. If a fatal error is <em>received</em>, the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is set to the value of the DTLSL alert received. If, on the other hand, a fatal error was <em>sent</em>, the {{domxref("RTCError.sentAlert", "sentAlert")}} is set to the alert's value.</dd>
+ <dd>The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error. The error's {{domxref("DOMException.message", "message")}} contains details about the nature of the error. If a fatal error is <em>received</em>, the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is set to the value of the DTLSL alert received. If, on the other hand, a fatal error was <em>sent</em>, the {{domxref("RTCError.sentAlert", "sentAlert")}} is set to the alert's value.</dd>
  <dt><code>fingerprint-failure</code></dt>
  <dd>The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP. If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a <code>dtls-failure</code> error.</dd>
 </dl>
@@ -65,7 +66,7 @@ browser-compat: api.RTCDtlsTransport.error_event
 }</pre>
 
 <div class="notecard note">
-<p><strong>Note:</strong> Since <code>RTCError</code> is not one of the legacy errors, the value of {{domxref("DOMException.code", "RTCError.code")}} is always 0.</p>
+<p><strong>Note:</strong> Since <code>RTCError</code> is not one of the legacy errors, the value of {{domxref("DOMException.code", "code")}} is always 0.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
@@ -3,10 +3,6 @@ title: RTCDtlsTransport.iceTransport
 slug: Web/API/RTCDtlsTransport/iceTransport
 tags:
 - API
-- Draft
-- Experimental
-- NeedsCompatTable
-- NeedsExample
 - Property
 - RTCDtlsTransport
 - Read-only
@@ -14,11 +10,11 @@ tags:
 - iceTransport
 browser-compat: api.RTCDtlsTransport.iceTransport
 ---
-<p>{{DefaultAPISidebar("WebRTC")}}{{draft}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
 <p><span class="seoSummary">The read-only <strong>{{DOMxRef("RTCDtlsTransport")}}</strong>
-    property <code><strong>iceTransport</strong></code> contains a reference
-    to the underlying {{DOMxRef("RTCIceTransport")}}.</span></p>
+    property <code><strong>iceTransport</strong></code> contains areference
+    to the underlying {{DOMxRef("RTCIceTransport")}}.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/index.html
@@ -12,17 +12,78 @@ tags:
   - Reference
 browser-compat: api.RTCDtlsTransport
 ---
-<p>{{DefaultAPISidebar("WebRTC")}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
 <p>The <strong><code>RTCDtlsTransport</code></strong> interface provides access to information about the Datagram Transport Layer Security (<strong>{{Glossary("DTLS")}}</strong>) transport over which a {{domxref("RTCPeerConnection")}}'s {{Glossary("RTP")}} and {{Glossary("RTCP")}} packets are sent and received by its {{domxref("RTCRtpSender")}} and {{domxref("RTCRtpReceiver")}} objects.</p>
 
-<p>A DTLS transport is also used to provide information about {{Glossary("SCTP")}} packets transmitted and received by an connection's <a href="/en-US/docs/Web/API/RTCDataChannel">data channels</a>.</p>
+<p>A <code>RTCDtlsTransport</code> object is also used to provide information about {{Glossary("SCTP")}} packets transmitted and received by an connection's <a href="/en-US/docs/Web/API/RTCDataChannel">data channels</a>.</p>
 
 <p>Features of the DTLS transport include the addition of security to the underlying transport; the <code>RTCDtlsTransport</code> interface can be used to obtain information about the underlying transport and the security added to it by the DTLS layer.</p>
 
 <p>{{InheritanceDiagram}}</p>
 
-<div>{{InterfaceOverview("WebRTC")}}</div>
+<h2 id="Properties">Properties</h2>
+
+<p><em>Also inherits properties from {{DOMxRef("EventTarget")}}.</em></p>
+
+<dl>
+  <dt>{{DOMxRef("RTCDtlsTransport.iceTransport", "iceTransport")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns a reference to the underlying {{DOMxRef("RTCIceTransport")}} object.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDtlsTransport.state", "state")}} {{ReadOnlyInline}}</dt>
+  <dd>
+    Returns a string
+    which describes the underlying Datagram Transport Layer Security (<strong>{{Glossary("DTLS")}}</strong>) transport state.
+    It can be one of the following values:
+    <code>new</code>, <code>connecting</code>, <code>connected</code>, <code>closed</code>, or <code>failed</code>.
+  </dd>
+</dl>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<dl>
+  <dt>{{DOMxRef("RTCDtlsTransport.onerror", "onerror")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function the browser calls
+    when the{{DOMxRef("RTCDtlsTransport.error_event", "error")}} event is received.
+  </dd>
+
+  <dt>{{DOMxRef("RTCDtlsTransport.onstatechange", "onstatechange")}}</dt>
+  <dd>
+    Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a>
+    which specifies a function the browser calls
+    when the{{DOMxRef("RTCDtlsTransport.statechange_event", "statechange")}} event is received.
+  </dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>Also inherits properties from {{DOMxRef("EventTarget")}}.</em></p>
+<dl>
+  <dt>{{DOMxRef("RTCDtlsTransport.getRemoteCertificates", "getRemoteCertificates()")}}</dt>
+  <dd>
+    Returns an array of {{DOMxRef("ArrayBuffer")}} containing the certificates of the remote peer of the connectioin.
+  </dd>
+</dl>
+
+<h2 id="Events">Events</h2>
+
+<dl>
+  <dt>{{DOMxRef("RTCDtlsTransport.error_event", "error")}}</dt>
+  <dd>
+    Sent when a transport-level error occurs on the {{domxref("RTCPeerConnection")}}.</p>
+
+  </dd>
+
+  <dt>{{DOMxRef("RTCDtlsTransport.statechange_event", "statechange")}}</dt>
+  <dd>
+    Sent when the {{DOMxRef("RTCDtlsTransport.state", "state")}} of the DTLS transport changes.
+  </dd>
+
+</dl>
 
 <h2 id="Description">Description</h2>
 
@@ -53,7 +114,7 @@ const pc = new RTCPeerConnection(rtcConfig);
 
 <p>When the connection is using BUNDLE, each <code>RTCDtlsTransport</code> object represents a group of {{domxref("RTCRtpTransceiver")}} objects. If the connection was created using <code>max-compat</code> mode, each transport is responsible for handling all of the communications for a given type of media (audio, video, or data channel). Thus, a connection that has any number of audio and video channels will always have exactly one DTLS transport for audio and one for video communications.</p>
 
-<p>Because transports are established early in the negotiation process, it's likely that it won't be known until after they're created whether or not the remote peer supports bundling or not. For this reason, you'll sometimes see separate transports created at first, one for each track, then see them get bundled up once it's known that bundling is possible. If your code accesses  {{domxref("RTCRtpSender")}}s and/or {{domxref("RTCRtpReceiver")}}s directly, you may encounter situations where they're initially separate, then half or more of them get closed and the senders and receivers updated to refer to the appropriate remaining <code>RTCDtlsTransport</code> objects.</p>
+<p>Because transports are established early in the negotiation process, it's likely that it won't be known until after they're created whether or not the remote peer supports bundling or not. For this reason, you'll sometimes see separate transports created at first, one for each track, then see them get bundled up once it's known that bundling is possible. If your code accesses {{domxref("RTCRtpSender")}}s and/or {{domxref("RTCRtpReceiver")}}s directly, you may encounter situations where they're initially separate, then half or more of them get closed and the senders and receivers updated to refer to the appropriate remaining <code>RTCDtlsTransport</code> objects.</p>
 
 <h3 id="Data_channels">Data channels</h3>
 

--- a/files/en-us/web/api/rtcdtlstransport/state/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.html
@@ -5,14 +5,13 @@ tags:
 - API
 - Property
 - RTCDtlsTransport
-- RTCDtlsTransportState
 - Read-only
 - Reference
 - WebRTC
 - state
 browser-compat: api.RTCDtlsTransport.state
 ---
-<p>{{DefaultAPISidebar("WebRTC")}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
 <p>The <strong><code>state</code></strong> read-only property of the
   {{DOMxRef("RTCDtlsTransport")}} interface provides information which describes a
@@ -26,8 +25,7 @@ browser-compat: api.RTCDtlsTransport.state
 
 <h3 id="Value">Value</h3>
 
-<p>A string whose value is taken from the <code>RTCDtlsTransportState</code> enumerated
-  type. Its value is one of the following:</p>
+<p>A string. Its value is one of the following:</p>
 
 <dl>
   <dt><code>new</code></dt>


### PR DESCRIPTION
Replaced broken {{InterfaceOverview}} and removed mentions of the enum `RTCDtlsTransportState` (info still there, I removed the name that is not visible to web devs)