### PR TITLE
Clean RTCDataChannelEvent

### DIFF
--- a/files/en-us/web/api/rtcdatachannelevent/channel/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/channel/index.html
@@ -2,7 +2,6 @@
 title: RTCDataChannelEvent.channel
 slug: Web/API/RTCDataChannelEvent/channel
 tags:
-- Experimental
 - Property
 - RTCDataChannelEvent
 - Read-only
@@ -11,10 +10,9 @@ tags:
 - channel
 browser-compat: api.RTCDataChannelEvent.channel
 ---
-<p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
-<p>The read-only property
-  <code><strong>RTCDataChannelEvent</strong></code><strong><code>.channel</code></strong>
+<p>The read-only property <code><strong>RTCDataChannelEvent.channel</code></strong>
   returns the {{domxref("RTCDataChannel")}} associated with the event.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -29,15 +27,15 @@ browser-compat: api.RTCDataChannelEvent.channel
 
 <h2 id="Example">Example</h2>
 
-<p>The first line of code in the {{event("datachannel")}} event handler shown below takes
+<p>The first line of code in the {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} event handler shown below takes
   the channel from the event object and saves it locally for use by the code handling data
   traffic.</p>
 
 <pre class="brush: js">pc.ondatachannel = function(event) {
-  inboundDataChannel = event.channel;
-  inboundDataChannel.onmessage = handleIncomingMessage;
-  inboundDataChannel.onopen = handleChannelOpen;
-  inboundDataChannel.onclose = handleChannelClose;
+  inboundDataChannel = event.channel;
+  inboundDataChannel.onmessage = handleIncomingMessage;
+  inboundDataChannel.onopen = handleChannelOpen;
+  inboundDataChannel.onclose = handleChannelClose;
 }
 </pre>
 
@@ -52,7 +50,7 @@ browser-compat: api.RTCDataChannelEvent.channel
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{event("datachannel")}}</li>
+  <li>{{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}}</li>
   <li>{{domxref("RTCDataChannel")}}</li>
   <li>{{domxref("RTCPeerConnection.ondatachannel")}}</li>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">A simple

--- a/files/en-us/web/api/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/index.html
@@ -12,8 +12,8 @@ browser-compat: api.RTCDataChannelEvent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
-The <strong><code>RTCDataChannelEvent</code></strong> is an interface
-representing an event related to a specific {{DOMxRef("RTCDataChannel")}}.
+The <strong><code>RTCDataChannelEvent</code></strong> interface
+represents an event related to a specific {{DOMxRef("RTCDataChannel")}}.
 
 <p>{{InheritanceDiagram}}</p>
 

--- a/files/en-us/web/api/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/index.html
@@ -3,7 +3,6 @@ title: RTCDataChannelEvent
 slug: Web/API/RTCDataChannelEvent
 tags:
   - API
-  - Experimental
   - Interface
   - RTCDataChannelEvent
   - Reference
@@ -11,13 +10,27 @@ tags:
   - datachannel
 browser-compat: api.RTCDataChannelEvent
 ---
-<p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
-<p>The <strong><code>RTCDataChannelEvent()</code></strong> constructor returns a new {{domxref("RTCDataChannelEvent")}} object, which represents a {{domxref("datachannel")}} event. These events sent to an {{domxref("RTCPeerConnection")}} when its remote peer is asking to open an {{domxref("RTCDataChannel")}} between the two peers.</p>
+The <strong><code>RTCDataChannelEvent</code></strong> is an interface
+representing an event related to a specific {{DOMxRef("RTCDataChannel")}}.
 
-<p>You will rarely if ever construct an <code>RTCDataChannelEvent</code> by hand; instead, the WebRTC layer will generate and deliver them to you at the appropriate time. Just listen for the {{domxref("RTCPeerConnection.datachannel_event", "datachannel")}} event to be received by the <code>RTCPeerConnection</code> and when you receive it, use the {{domxref("RTCDataChannelEvent.channel")}} property to gain access to the data channel which has been opened.</p>
+<p>{{InheritanceDiagram}}</p>
 
-<div>{{InterfaceOverview("WebRTC")}}</div>
+<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt>{{DOMxRef("RTCDataChannelEvent.RTCDataChannelEvent", "RTCDataChannelEvent()")}}</dt>
+  <dd>Creates a new <code>RTCDataChannelEvent</code>.</dd>
+</dl>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>Also inherits properties from {{DOMxRef("Event")}}.</em></p>
+
+<dl>
+  <dt>{{DOMxRef("RTCDataChannelEvent.channel", "channel")}} {{ReadOnlyInline}}</dt>
+  <dd>Returns the {{domxref("RTCDataChannel")}} associated with the event.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 
@@ -46,7 +59,7 @@ browser-compat: api.RTCDataChannelEvent
 <ul>
  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
  <li>{{domxref("RTCDataChannel")}}</li>
- <li>{{domxref("RTCDataChannel.ondatachannel")}}</li>
+ <li>{{domxref("RTCPeerConnection.ondatachannel")}}</li>
  <li><a href="/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">A simple RTCDataChannel sample</a></li>
- <li>{{domxref("RTCPeerConnection")}} (the target interface for {{event("datachannel")}} events)</li>
+ <li>{{domxref("RTCPeerConnection")}} (the target interface for {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} events)</li>
 </ul>

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
@@ -31,7 +31,7 @@ browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
     type of <code>RTCDataChannelEvent</code>, so this will always be
     <code>"datachannel"</code>.</dd>
   <dt><code>rtcDataChannelEventInit</code></dt>
-  <dd>An object, which has following fields:
+  <dd>An object with the following fields:
     <ul>
       <li><code>channel</code> of type {{domxref("RTCDataChannel")}}, representing the
         data channel being concerned by the event.</li>

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
@@ -3,16 +3,15 @@ title: RTCDataChannelEvent()
 slug: Web/API/RTCDataChannelEvent/RTCDataChannelEvent
 tags:
   - Constructor
-  - Experimental
   - RTCDataChannelEvent
   - Reference
   - WebRTC
 browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 ---
-<p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebRTC")}}</p>
 
-<p>The <code><strong>RTCDataChannelEvent()</strong></code> constructor creates a new
-  {{domxref("RTCDataChannelEvent")}}.</p>
+<p>The <code><strong>RTCDataChannelEvent()</strong></code> constructor
+  creates a new {{domxref("RTCDataChannelEvent")}}.</p>
 
 <div class="note">
   <p>You will rarely if ever construct an <code>RTCDataChannelEvent</code> by hand; these
@@ -28,18 +27,18 @@ browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 
 <dl>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("DOMString")}} which specifies the name of the event. There is only one
+  <dd>A string which specifies the name of the event. There is only one
     type of <code>RTCDataChannelEvent</code>, so this will always be
     <code>"datachannel"</code>.</dd>
   <dt><code>rtcDataChannelEventInit</code></dt>
-  <dd>A <code>RTCDataChannelEventInit</code> dictionary, which has following fields:
+  <dd>An object, which has following fields:
     <ul>
-      <li><code>"channel"</code> of type {{domxref("RTCDataChannel")}}, representing the
+      <li><code>channel</code> of type {{domxref("RTCDataChannel")}}, representing the
         data channel being concerned by the event.</li>
-      <li><code>"bubbles"</code>, optional, inherited from <code>EventInit</code>.
+      <li><code>bubbles</code>, optional, inherited from <code>EventInit</code>.
         Indicates if the event must bubble or not. <strong>Default is
           <code>false</code></strong>.</li>
-      <li><code>"cancelable"</code>, optional, inherited from <code>EventInit</code>.
+      <li><code>cancelable</code>, optional, inherited from <code>EventInit</code>.
         Indicates if the event can be canceled or not. <strong>Default is false.</strong>
       </li>
     </ul>
@@ -52,7 +51,7 @@ browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 
 <h2 id="Example">Example</h2>
 
-<p>In this example, a new {{event("datachannel")}} event is created. <code>dc</code> is a
+<p>In this example, a new {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} event is created. <code>dc</code> is a
   data channel which already exists.</p>
 
 <pre


### PR DESCRIPTION
- Remove InterfaceOverview.
- Wrote interface description (it was wrong).
- Update experimental flags to match info in BCD.
- Removed {{event}}.
- A few non-breakable spaces removed.