### PR TITLE
Remove InterfaceOverview from HTMLMenuElement

### DIFF
--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -38,8 +38,8 @@ browser-compat: api.HTMLMenuElement
   </dd>
   <dt>{{DOMxRef("HTMLMenuElement.label", "label")}} {{Non-Standard_Inline}}</dt>
   <dd>
-    Is a string associating the menu with a name,
-    displayed when the menu is a used as a context menu.
+    A string associating the menu with a name,
+    displayed when the menu is used as a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
     and is now obsolete.
   </dd>

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -32,7 +32,7 @@ browser-compat: api.HTMLMenuElement
   </dd>
   <dt>{{DOMxRef("HTMLMenuElement.type", "type")}} {{Non-Standard_Inline}}</dt>
   <dd>
-    Returns <code>context</code> is the menu is a context menu.
+    Returns <code>context</code> if the menu is a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
     and is now obsolete.
   </dd>

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -26,17 +26,17 @@ browser-compat: api.HTMLMenuElement
 
 <p><em>Inherits properties from its parent, {{domxref("HTMLElement")}}, and its ancestors.</em></p>
 <dl>
-  <dt>{{DOMxRef("HTMLMenuElement.compact", "compact")}} {{deprecated_inline}}</dt>
+  <dt><code>compact</code> {{deprecated_inline}}</dt>
   <dd>
     A Boolean value determining if the menu displays in a compact way.
   </dd>
-  <dt>{{DOMxRef("HTMLMenuElement.type", "type")}} {{Non-Standard_Inline}}</dt>
+  <dt><code>type</code> {{Non-Standard_Inline}}</dt>
   <dd>
     Returns <code>context</code> if the menu is a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
     and is now obsolete.
   </dd>
-  <dt>{{DOMxRef("HTMLMenuElement.label", "label")}} {{Non-Standard_Inline}}</dt>
+  <dt><code>label</code> {{Non-Standard_Inline}}</dt>
   <dd>
     A string associating the menu with a name,
     displayed when the menu is used as a context menu.

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -3,20 +3,54 @@ title: HTMLMenuElement
 slug: Web/API/HTMLMenuElement
 tags:
   - API
-  - Draft
   - Experimental
+  - Draft
   - HTMLMenuElement
   - Interface
   - Reference
 browser-compat: api.HTMLMenuElement
 ---
-<p>{{APIRef("HTML DOM")}}{{Draft}}{{SeeCompatTable}}</p>
+<p>{{APIRef("HTML DOM")}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>HTMLMenuElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menu")}} elements.</p>
+<p>The <strong><code>HTMLMenuElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menu")}} elements.</p>
 
 <p>{{InheritanceDiagram(600, 120)}}</p>
 
-<div>{{InterfaceOverview("HTML DOM")}}</div>
+<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt>{{DOMxRef("HTMLMenuElement.HTMLMenuElement", "HTMLMenuElement()")}}</dt>
+  <dd>Returns a newly constructed <code>HTMLMenuElement</code>.</dd>
+</dl>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>Inherits properties from its parent, {{domxref("HTMLElement")}}, and its ancestors.</em></p>
+<dl>
+  <dt>{{DOMxRef("HTMLMenuElement.compact", "compact")}} {{deprecated_inline}}</dt>
+  <dd>
+    Is a Boolean value determining if the menu displays in a compact way.
+  </dd>
+  <dt>{{DOMxRef("HTMLMenuElement.type", "type")}} {{Non-Standard_Inline}}</dt>
+  <dd>
+    Returns <code>context</code> is the menu is a context menu.
+    This use of the {{HTMLElement("menu")}} element has never been implemented widely
+    and is now obsolete.
+  </dd>
+  <dt>{{DOMxRef("HTMLMenuElement.label", "label")}} {{Non-Standard_Inline}}</dt>
+  <dd>
+    Is a string associating the menu with a name,
+    displayed when the menu is a used as a context menu.
+    This use of the {{HTMLElement("menu")}} element has never been implemented widely
+    and is now obsolete.
+  </dd>
+
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>Inherits methods from its parent, {{domxref("HTMLElement")}}, and its ancestors.</em></p>
+
+<p><em><code>HTMLMenuItem</code> doesn't implement specific methods.</em></p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -50,7 +50,7 @@ browser-compat: api.HTMLMenuElement
 
 <p><em>Inherits methods from its parent, {{domxref("HTMLElement")}}, and its ancestors.</em></p>
 
-<p><em><code>HTMLMenuItem</code> doesn't implement specific methods.</em></p>
+<p><em><code>HTMLMenuElement</code> doesn't implement specific methods.</em></p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -30,18 +30,18 @@ browser-compat: api.HTMLMenuElement
   <dd>
     A Boolean value determining if the menu displays in a compact way.
   </dd>
-  <dt><code>type</code> {{Non-Standard_Inline}}</dt>
+  <dt><code>type</code> {{deprecated_inline}}</dt>
   <dd>
     Returns <code>context</code> if the menu is a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
-    and is now obsolete.
+    and is now deprecated.
   </dd>
-  <dt><code>label</code> {{Non-Standard_Inline}}</dt>
+  <dt><code>label</code> {{deprecated_inline}}</dt>
   <dd>
     A string associating the menu with a name,
     displayed when the menu is used as a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
-    and is now obsolete.
+    and is now deprecated.
   </dd>
 
 </dl>

--- a/files/en-us/web/api/htmlmenuelement/index.html
+++ b/files/en-us/web/api/htmlmenuelement/index.html
@@ -28,7 +28,7 @@ browser-compat: api.HTMLMenuElement
 <dl>
   <dt>{{DOMxRef("HTMLMenuElement.compact", "compact")}} {{deprecated_inline}}</dt>
   <dd>
-    Is a Boolean value determining if the menu displays in a compact way.
+    A Boolean value determining if the menu displays in a compact way.
   </dd>
   <dt>{{DOMxRef("HTMLMenuElement.type", "type")}} {{Non-Standard_Inline}}</dt>
   <dd>


### PR DESCRIPTION
This lead to write this page (as InterfaceOverview was 1) broken and 2) only trying to copy stuff from non-written pages

(With this PR, and a couple of already opened PRs, `{{InterfaceOverview}}` is no more used on en-US/, yeah!)