### PR TITLE
fix: Math.max reducer example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -71,7 +71,7 @@ element in a numeric array, by comparing each value:
 var arr = [1,2,3];
 var max = arr.reduce(function(a, b) {
     return Math.max(a, b);
-});
+}, 0);
 ```
 
 The following function uses {{jsxref("Function.prototype.apply()")}} to get the maximum


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Without the 0 as the initial accumulator value, the reduce would always return NaN, due to the initial "undefined" value passing into Math.max.

Math.max(undefined, 2) for example, returns NaN.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
