### PR TITLE
Remove broken links

### DIFF
--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
@@ -50,6 +50,3 @@ tags:
 
 <p>In Internet Explorer, press <em>F12</em>, and look for <em>Document Mode</em>.</p>
 
-<h2 id="What_are_the_differences_between_the_modes">What are the differences between the modes?</h2>
-
-<p>See the <a href="/en-US/docs/Mozilla_Quirks_Mode_Behavior">list of quirks</a> and <a href="/en-US/docs/Mozilla/Gecko_Almost_Standards_Mode">almost standards mode</a> for the differences between the modes.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Links in the last section of the page ["Quirks Mode and Standards Mode"](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) points to broken URLs.


> Issue number (if there is an associated issue)

#7190

> Anything else that could help us review it
