### PR TITLE
Remove useless div that was creating a sectioning flaw

### DIFF
--- a/files/en-us/web/css/css_lists_and_counters/consistent_list_indentation/index.html
+++ b/files/en-us/web/css/css_lists_and_counters/consistent_list_indentation/index.html
@@ -90,7 +90,6 @@ tags:
  <li>When altering the indentation of lists, make sure to set both the padding and margin.</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
@@ -99,4 +98,3 @@ tags:
  <li>Copyright Information: Copyright © 2001-2003 Netscape. All rights reserved.</li>
  <li>Note: This reprinted article was originally part of the DevEdge site.</li>
 </ul>
-</div>


### PR DESCRIPTION
The `<div>` was preventing the `<h2>` to be at the top level and was creating a flaw, and partially breaking the Table of content.