### PR TITLE
Element.ariaAutoComplete: revise example

### DIFF
--- a/files/en-us/web/api/element/ariaautocomplete/index.html
+++ b/files/en-us/web/api/element/ariaautocomplete/index.html
@@ -35,12 +35,11 @@ browser-compat: api.Element.ariaAutoComplete
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example the <code>aria-autocomplete</code> attribute on the element with an ID of <code>animal</code> is set to "list". Using <code>ariaAutoComplete</code> we update the value to "inline".</p>
+<p>In this example, the <code>aria-autocomplete</code> attribute on the element with an ID of <code>animal</code> is set to "<code>inline</code>". Using <code>ariaAutoComplete</code> we update the value to "<code>list</code>", which is the expected value for a combobox that invokes a <code>listbox</code> popup.</p>
 
 <pre class="brush: html">&lt;div class="animals-combobox"&gt;
   &lt;label for="animal"&gt;Animal&lt;/label&gt;
-  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true"&gt;
-  &lt;button id="animals-button" tabindex="-1" aria-label="Open"&gt;&#9661;&lt;/button&gt;
+  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="inline" aria-controls="animals-listbox" aria-expanded="false" aria-haspopup="listbox"&gt;
   &lt;ul id="animals-listbox" role="listbox" aria-label="Animals"&gt;
     &lt;li id="animal-cat" role="option">Cat&lt;/li&gt;
     &lt;li id="animal-dog" role="option">Dog&lt;/li&gt;
@@ -48,9 +47,9 @@ browser-compat: api.Element.ariaAutoComplete
 &lt;/div&gt;</pre>
 
 <pre class="brush: js">let el = document.getElementById('animal');
-console.log(el.ariaAutoComplete); // list
-el.ariaAutoComplete = "inline";
-console.log(el.ariaAutoComplete); // inline</pre>
+console.log(el.ariaAutoComplete); // inline
+el.ariaAutoComplete = "list";
+console.log(el.ariaAutoComplete); // list</pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
revise example markup and wording to be inline with changes made in PR #7132.
* removal of unnecessary button in markup.
* adds missing aria attributes needed for a valid ARIA 1.2 combobox.
* JavaScript now changes the value of the attribute to be the correct value for the widget.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
