### PR TITLE
Element.ariaOrientation example updates

### DIFF
--- a/files/en-us/web/api/element/ariaorientation/index.html
+++ b/files/en-us/web/api/element/ariaorientation/index.html
@@ -34,16 +34,17 @@ browser-compat: api.Element.ariaOrientation
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example the <code>aria-orientation</code> attribute on the element with an ID of <code>handle_zoomSlider</code> is set to "vertical". Using <code>ariaOrientation</code> we update the value to "horizontal".</p>
+<p>In this example the <code>aria-orientation</code> attribute on the element with an ID of <code>handle_zoomSlider</code> is set to "<code>vertical</code>". Using <code>ariaOrientation</code> we update the value to "<code>horizontal</code>".</p>
 
-<pre class="brush: html">&lt;a href="#" id="handle_zoomSlider"
+<pre class="brush: html">&lt;div id="handle_zoomSlider"
   role="slider"
   aria-orientation="vertical"
   aria-valuemin="0"
   aria-valuemax="17"
-  aria-valuenow="14" >
+  aria-valuenow="14" 
+  tabindex="0">
 &lt;span&gt;11&lt;/span&gt;
-&lt;/a&gt;</pre>
+&lt;/div&gt;</pre>
 
 <pre class="brush: js">let el = document.getElementById('handle_zoomSlider');
 console.log(el.ariaOrientation); // "vertical"


### PR DESCRIPTION
An `<a href>` element is not allowed the role `slider` to be specified on it.  The example has been updated to change this element to a `div` instead, removing the `href` and adding in a `tabindex=0`.

Per [editorial changes](https://github.com/mdn/content/pull/7132/files#diff-08c408e31b6a6fe3ec7ad41333acc9dac122ee8f8d172444c8060fd3c6e9be65R49) that were made in my PR the other day, "vertical" and "horizontal" have now been wrapped in `<code>` tags in the example's explaining text.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
