### PR TITLE
Element.ariaPosInSet example typo fix

### DIFF
--- a/files/en-us/web/api/element/ariaposinset/index.html
+++ b/files/en-us/web/api/element/ariaposinset/index.html
@@ -28,7 +28,7 @@ browser-compat: api.Element.ariaPosInSet
 <p>In this example the <code>aria-posinset</code> attribute on the element with an ID of <code>article2</code> is set to "2". Using <code>ariaPosInSet</code> we update the value to "3".</p>
 
 <pre class="brush: html">&lt;article id="article1" aria-posinset="1"&gt; ... &lt;/article&gt;
-&lt;article id="article1" aria-posinset="2"&gt; ... &lt;/article&gt;
+&lt;article id="article2" aria-posinset="2"&gt; ... &lt;/article&gt;
 </pre>
 
 <pre class="brush: js">let el = document.getElementById('article2');


### PR DESCRIPTION
both `article` elements in the example markup have an `id=1`, where the second one is meant to have an `id=2`.  This pr fixes the `id` value typo.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
