### PR TITLE
Correct Uint8Array constructor call in code exampl

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
@@ -76,7 +76,7 @@ browser-compat: api.RTCPeerConnection.generateCertificate
 <pre class="brush: js">let stdRSACertificate = {
   name: "RSASSA-PKCS1-v1_5",
   modulusLength: 2048,
-  publicExponent: new UInt8Array([1, 0, 1]),
+  publicExponent: new Uint8Array([1, 0, 1]),
   hash: "SHA-256"
 };
 </pre>
@@ -107,7 +107,7 @@ browser-compat: api.RTCPeerConnection.generateCertificate
     name: 'RSASSA-PKCS1-v1_5',
     hash: 'SHA-256',
     modulusLength: 2048,
-    publicExponent: new UInt8Array([1, 0, 1])
+    publicExponent: new Uint8Array([1, 0, 1])
 }).then(function(cert) {
   var pc = new RTCPeerConnection({certificates: [cert]});
 });</pre>


### PR DESCRIPTION
Corrected the constructor name spelling from UInt8Array to Uint8Array. Simply lowercased the first "i" in the constructor name.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The spelling of the constructor name was incorrect and would result in an Uncaught ReferenceError.

> Issue number (if there is an associated issue)



> Anything else that could help us review it
