### PR TITLE
Remove broken links

### DIFF
--- a/files/en-us/webassembly/caching_modules/index.html
+++ b/files/en-us/webassembly/caching_modules/index.html
@@ -146,8 +146,6 @@ instantiateCachedURL(wasmCacheVersion, 'test.wasm').then(instance =&gt;
   console.error("Failure to instantiate: " + err)
 );</pre>
 
-<p>You can find the source code for this example on GitHub as <a href="https://github.com/mdn/webassembly-examples/blob/master/other-examples/indexeddb-cache.html">indexeddb-cache.html</a> (<a href="https://mdn.github.io/webassembly-examples/other-examples/indexeddb-cache.html">see it live also</a>).</p>
-
 <h2 id="Browser_support">Browser support</h2>
 
 <p>At the moment, this technique will work in Firefox and Edge, as they both have support for structured cloning of WebAssembly modules.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Links in section ["Caching a wasm module"](https://developer.mozilla.org/en-US/docs/WebAssembly/Caching_modules#caching_a_wasm_module) of [Caching compiled WebAssembly modules](https://developer.mozilla.org/en-US/docs/WebAssembly/Caching_modules) are broken as they were removed by this [commit](https://github.com/mdn/webassembly-examples/commit/48f1cbfaf095c2a251c46e15b21ad8e4e3b1a866).

> Issue number (if there is an associated issue)

#7204 

> Anything else that could help us review it
