### PR TITLE
Use a <dl> instead of <h3> headers with links in TouchEvent

### DIFF
--- a/files/en-us/web/api/touchevent/index.html
+++ b/files/en-us/web/api/touchevent/index.html
@@ -53,36 +53,72 @@ browser-compat: api.TouchEvent
 <h2 id="Touch_event_types">Touch event types</h2>
 
 <p>There are several types of event that can be fired to indicate that touch-related changes have occurred. You can determine which of these has happened by looking at the event's {{domxref("event.type", "TouchEvent.type")}} property.</p>
+<dl>
+  <dt>{{domxref("Element/touchstart_event", "touchstart")}}</dt>
+  <dd>Sent when the user places a touch point on the touch surface.
+    The event's target will be the {{domxref("element")}} in which the touch occurred.
+  </dd>
 
-<h3 id="touchstart_event">{{domxref("Element/touchstart_event", "touchstart")}}</h3>
+  <dt>{{domxref("Element/touchend_event", "touchend")}}</dt>
+  <dd>
+    <p>
+      Sent when the user removes a touch point from the surface;
+      that is, when they lift a finger or stylus from the surface.
+      This is also sent
+      if the touch point moves off the edge of the surface;
+      for example, if the user's finger slides off the edge of the screen.
+    </p>
 
-<p>Sent when the user places a touch point on the touch surface. The event's target will be the {{domxref("element")}} in which the touch occurred.</p>
+    <p>
+      The event's target is the same {{domxref("element")}}
+      that received the <code>touchstart</code> event
+      corresponding to the touch point,
+      even if the touch point has moved outside that element.
+    </p>
 
-<h3 id="touchend_event">{{domxref("Element/touchend_event", "touchend")}}</h3>
+    <p>
+      The touch point (or points)
+      that were removed from the surface
+      can be found in the {{domxref("TouchList")}}
+      specified by the <code>changedTouches</code> attribute.
+    </p>
+  </dd>
 
-<p>Sent when the user removes a touch point from the surface (that is, when they lift a finger or stylus from the surface). This is also sent if the touch point moves off the edge of the surface; for example, if the user's finger slides off the edge of the screen.</p>
+  <dt>{{domxref("Element/touchmove_event", "touchmove")}}</dt>
+  <dd>
+    <p>
+      Sent when the user moves a touch point along the surface.
+      The event's target is the same {{domxref("element")}}
+      that received the <code>touchstart</code> event corresponding to the touch point,
+      even if the touch point has moved outside that element.
+    </p>
 
-<p>The event's target is the same {{domxref("element")}} that received the <code>touchstart</code> event corresponding to the touch point, even if the touch point has moved outside that element.</p>
+    <p>This event is also sent
+      if the values of the radius, rotation angle, or force attributes of a touch point change.
+    </p>
 
-<p>The touch point (or points) that were removed from the surface can be found in the {{domxref("TouchList")}} specified by the <code>changedTouches</code> attribute.</p>
+    <div class="note"><strong>Note:</strong>
+      The rate at which <code>touchmove</code> events is sent is browser-specific,
+      and may also vary depending on the capability of the user's hardware.
+      You must not rely on a specific granularity of these events.
+    </div>
+  </dd>
 
-<h3 id="touchmove_event">{{domxref("Element/touchmove_event", "touchmove")}}</h3>
+  <dt>{{domxref("Element/touchcancel_event", "touchcancel")}}</dt>
+  <dd>
+    <p>
+      Sent when a touch point has been disrupted in some way.
+      There are several possible reasons why this might happen
+      (and the exact reasons will vary from device to device, as well as browser to browser):
+    </p>
 
-<p>Sent when the user moves a touch point along the surface. The event's target is the same {{domxref("element")}} that received the <code>touchstart</code> event corresponding to the touch point, even if the touch point has moved outside that element.</p>
-
-<p>This event is also sent if the values of the radius, rotation angle, or force attributes of a touch point change.</p>
-
-<div class="note"><strong>Note:</strong> The rate at which <code>touchmove</code> events is sent is browser-specific, and may also vary depending on the capability of the user's hardware. You must not rely on a specific granularity of these events.</div>
-
-<h3 id="touchcancel_event">{{domxref("Element/touchcancel_event", "touchcancel")}}</h3>
-
-<p>Sent when a touch point has been disrupted in some way. There are several possible reasons why this might happen (and the exact reasons will vary from device to device, as well as browser to browser):</p>
-
-<ul>
- <li>An event of some kind occurred that canceled the touch; this might happen if a modal alert pops up during the interaction.</li>
- <li>The touch point has left the document window and moved into the browser's UI area, a plug-in, or other external content.</li>
- <li>The user has placed more touch points on the screen than can be supported, in which case the earliest {{domxref("Touch")}} in the {{domxref("TouchList")}} gets canceled.</li>
-</ul>
+    <ul>
+      <li>An event of some kind occurred that canceled the touch; this might happen if a modal alert pops up during the interaction.</li>
+      <li>The touch point has left the document window and moved into the browser's UI area, a plug-in, or other external content.</li>
+      <li>The user has placed more touch points on the screen than can be supported, in which case the earliest {{domxref("Touch")}} in the {{domxref("TouchList")}} gets canceled.</li>
+    </ul>
+  </dd>
+</dl>
 
 <h3 id="Using_with_addEventListener_and_preventDefault">Using with addEventListener() and preventDefault()</h3>
 


### PR DESCRIPTION
`<h3>` full of links; a `<dl>` is much more coherent with what we did all over the place.