### PR TITLE
Remove links in headings in CSS Typed OM API

### DIFF
--- a/files/en-us/web/api/css_typed_om_api/index.html
+++ b/files/en-us/web/api/css_typed_om_api/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Interfaces">Interfaces</h2>
 
-<h3 id="domxrefCSSStyleValue">{{domxref('CSSStyleValue')}}</h3>
+<h3 id="domxrefCSSStyleValue"><code>CSSStyleValue</code></h3>
 
 <p>The {{domxref('CSSStyleValue')}} interface of the CSS Typed Object Model API is the base class of all CSS values accessible through the Typed OM API. An instance of this class may be used anywhere a string is expected.</p>
 
@@ -28,7 +28,7 @@ tags:
 	<dd>The parseAll() method of the CSSStyleValue interface sets all occurrences of a specific CSS property to the specified value and returns an array of CSSStyleValue objects, each containing one of the supplied values.</dd>
 </dl>
 
-<h3 id="domxrefStylePropertyMap">{{domxref('StylePropertyMap')}}</h3>
+<h3 id="domxrefStylePropertyMap"><code>StylePropertyMap</code></h3>
 
 <p>The {{domxref('StylePropertyMap')}} interface of the CSS Typed Object Model API provides a representation of a CSS declaration block that is an alternative to CSSStyleDeclaration.</p>
 
@@ -43,7 +43,7 @@ tags:
 	<dd>Method that removes all declarations in the StylePropertyMap.</dd>
 </dl>
 
-<h3 id="domxrefCSSUnparsedValue">{{domxref('CSSUnparsedValue')}}</h3>
+<h3 id="domxrefCSSUnparsedValue"><code>CSSUnparsedValue</code></h3>
 
 <p>The {{domxref('CSSUnparsedValue')}} interface of the CSS Typed Object Model API represents property values that reference custom properties. It consists of a list of string fragments and variable references.</p>
 
@@ -58,7 +58,7 @@ tags:
 	<dd>Method returning a new Array Iterator object that contains the keys for each index in the array.</dd>
 </dl>
 
-<h3 id="domxrefCSSKeywordValue_Serialization">{{domxref('CSSKeywordValue')}} Serialization</h3>
+<h3 id="domxrefCSSKeywordValue_Serialization"><code>CSSKeywordValue</code> Serialization</h3>
 
 <p>The {{domxref('CSSKeywordValue')}} interface of the CSS Typed Object Model API creates an object to represent CSS keywords and other identifiers.</p>
 


### PR DESCRIPTION
The links were useless as the very same links were immediately below each time.