### PR TITLE
Fix heading anchor in MSAA server docs

### DIFF
--- a/files/en-us/web/accessibility/implementing_msaa_server/index.html
+++ b/files/en-us/web/accessibility/implementing_msaa_server/index.html
@@ -418,7 +418,7 @@ tags:
 
 <p><span class="c1">Solution</span>: Use this document to see what is generally considered important by assistive technology manufacturers. Contact the top vendors early and often as you plan and implement your architecture, to see what's important to them. Implement only what's needed -- supporting everything would take too long for zero results.</p>
 
-<h3 id="Vendor_quirks_2"><a id="Vendor_quirks">Vendor quirks</a></h3>
+<h3 id="Vendor_quirks">Vendor quirks</h3>
 
 <p><span class="c1">Problem</span>: Because assistive technology tends to utilize MSAA as an additional solution resting on top of old hacks, rather than a completely clean and separate way to deal with an application, and because of the quirky nature of MSAA and of the inflexible heuristics that screen readers use, we do not have a "plug and play solution". In addition, assistive technology vendors are tiny companies, often scrambling to keep up with changes in the applications they already support, or new products other than yours which they need to support. It's very difficult to get vendors to spend time testing an MSAA implementation, send feedback or help find out why things aren't working. Time and version commitments often fall through. There is always a belated new version due around corner, after which you will be promised to be the next priority.</p>
 


### PR DESCRIPTION
An anchor was added to a heading to fix its incorrect `id`.

I fixed the `id` and removed the now useless anchor.