### PR TITLE
Fix bad-pre-flaws in Speech Synthesis API

### DIFF
--- a/files/en-us/web/api/speechsynthesis/speak/index.html
+++ b/files/en-us/web/api/speechsynthesis/speak/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesis.speak()
 slug: Web/API/SpeechSynthesis/speak
 tags:
-- API
-- Experimental
-- Method
-- Reference
-- SpeechSynthesis
-- Web Speech API
-- speak
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Method
+  - Reference
+  - SpeechSynthesis
+  - Web Speech API
+  - speak
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesis.speak
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -48,19 +48,19 @@ browser-compat: api.SpeechSynthesis.speak
 
   ...
 
-<code class="language-js">inputForm<span class="punctuation token">.</span>onsubmit <span class="operator token">=</span> <span class="keyword token">function</span><span class="punctuation token">(</span>event<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-  event<span class="punctuation token">.</span><span class="function token">preventDefault</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+inputForm.onsubmit = function(event) {
+  event.preventDefault();
 
-  <span class="keyword token">var</span> utterThis <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">SpeechSynthesisUtterance</span><span class="punctuation token">(</span>inputTxt<span class="punctuation token">.</span>value<span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="keyword token">var</span> selectedOption <span class="operator token">=</span> voiceSelect<span class="punctuation token">.</span>selectedOptions<span class="punctuation token">[</span><span class="number token">0</span><span class="punctuation token">]</span><span class="punctuation token">.</span><span class="function token">getAttribute</span><span class="punctuation token">(</span><span class="string token">'data-name'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="keyword token">for</span><span class="punctuation token">(</span>i <span class="operator token">=</span> <span class="number token">0</span><span class="punctuation token">;</span> i <span class="operator token">&lt;</span> voices<span class="punctuation token">.</span>length <span class="punctuation token">;</span> i<span class="operator token">++</span><span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    <span class="keyword token">if</span><span class="punctuation token">(</span>voices<span class="punctuation token">[</span>i<span class="punctuation token">]</span><span class="punctuation token">.</span>name <span class="operator token">===</span> selectedOption<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-      utterThis<span class="punctuation token">.</span>voice <span class="operator token">=</span> voices<span class="punctuation token">[</span>i<span class="punctuation token">]</span><span class="punctuation token">;</span>
-    <span class="punctuation token">}</span>
-  <span class="punctuation token">}</span>
-  synth<span class="punctuation token">.</span><span class="function token">speak</span><span class="punctuation token">(</span>utterThis<span class="punctuation token">)</span><span class="punctuation token">;</span>
-  inputTxt<span class="punctuation token">.</span><span class="function token">blur</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="punctuation token">}</span></code></pre>
+  var utterThis = new SpeechSynthesisUtterance(inputTxt.value);
+  var selectedOption = voiceSelect.selectedOptions[0].getAttribute('data-name');
+  for(i = 0; i &lt; voices.length ; i++) {
+    if(voices[i].name === selectedOption) {
+      utterThis.voice = voices[i];
+    }
+  }
+  synth.speak(utterThis);
+  inputTxt.blur();
+}</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.html
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisErrorEvent.error
 slug: Web/API/SpeechSynthesisErrorEvent/error
 tags:
-- API
-- Error
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisErrorEvent
-- Web Speech API
-- speech
-- synthesis
+  - API
+  - Error
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisErrorEvent
+  - Web Speech API
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisErrorEvent.error
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -29,41 +29,41 @@ browser-compat: api.SpeechSynthesisErrorEvent.error
 <p>A {{domxref("DOMString")}} containing an error code. Possible codes are:</p>
 
 <dl>
-  <dt>canceled</dt>
+  <dt><code>canceled</code></dt>
   <dd>A {{domxref("SpeechSynthesis.cancel")}} method call caused the
     {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before it had
     begun being spoken.</dd>
-  <dt>interrupted</dt>
+  <dt><code>interrupted</code></dt>
   <dd>A {{domxref("SpeechSynthesis.cancel")}} method call caused the
     {{domxref("SpeechSynthesisUtterance")}} to be interrupted after it had begun being
     spoken and before it completed.</dd>
-  <dt>audio-busy</dt>
+  <dt><code>audio-busy</code></dt>
   <dd>The operation couldn't be completed at this time because the user-agent couldn't
     access the audio output device (for example, the user may need to correct this by
     closing another application.)</dd>
-  <dt>audio-hardware</dt>
+  <dt><code>audio-hardware</code></dt>
   <dd>The operation couldn't be completed at this time because the user-agent couldn't
     identify an audio output device (for example, the user may need to connect a speaker
     or configure system settings.)</dd>
-  <dt>network</dt>
+  <dt><code>network</code></dt>
   <dd>The operation couldn't be completed at this time because some required network
     communication failed.</dd>
-  <dt>synthesis-unavailable</dt>
+  <dt><code>synthesis-unavailable</code></dt>
   <dd>The operation couldn't be completed at this time because no synthesis engine was
     available (For example, the user may need to install or configure a synthesis engine.)
   </dd>
-  <dt>synthesis-failed</dt>
+  <dt><code>synthesis-failed</code></dt>
   <dd>The operation failed because the synthesis engine raised an error.</dd>
-  <dt>language-unavailable</dt>
+  <dt><code>language-unavailable</code></dt>
   <dd>No appropriate voice was available for the language set in
     {{domxref("SpeechSynthesisUtterance.lang")}}.</dd>
-  <dt>voice-unavailable</dt>
+  <dt><code>voice-unavailable</code></dt>
   <dd>The voice set in {{domxref("SpeechSynthesisUtterance.voice")}} was not available.
   </dd>
-  <dt>text-too-long</dt>
+  <dt><code>text-too-long</code></dt>
   <dd>The contents of the {{domxref("SpeechSynthesisUtterance.text")}} attribute was too
     long to synthesize.</dd>
-  <dt>invalid-argument</dt>
+  <dt><code>invalid-argument</code></dt>
   <dd>The content of the {{domxref("SpeechSynthesisUtterance.rate")}},
     {{domxref("SpeechSynthesisUtterance.pitch")}} or
     {{domxref("SpeechSynthesisUtterance.volume")}} property was not valid.</dd>
@@ -71,13 +71,13 @@ browser-compat: api.SpeechSynthesisErrorEvent.error
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.html
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.html
@@ -31,13 +31,13 @@ browser-compat: api.SpeechSynthesisErrorEvent
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.lang
 slug: Web/API/SpeechSynthesisUtterance/lang
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- lang
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - lang
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.lang
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -34,13 +34,13 @@ speechSynthesisUtteranceInstance.lang = 'en-US';
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onboundary/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onboundary/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onboundary
 slug: Web/API/SpeechSynthesisUtterance/onboundary
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onboundary
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onboundary
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onboundary
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -28,13 +28,13 @@ browser-compat: api.SpeechSynthesisUtterance.onboundary
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onend/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onend/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onend
 slug: Web/API/SpeechSynthesisUtterance/onend
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onend
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onend
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onend
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -28,13 +28,13 @@ browser-compat: api.SpeechSynthesisUtterance.onend
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onerror/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onerror/index.html
@@ -2,14 +2,14 @@
 title: SpeechSynthesisUtterance.onerror
 slug: Web/API/SpeechSynthesisUtterance/onerror
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- onerror
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - onerror
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onerror
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -26,13 +26,13 @@ browser-compat: api.SpeechSynthesisUtterance.onerror
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onmark/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onmark/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onmark
 slug: Web/API/SpeechSynthesisUtterance/onmark
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onmark
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onmark
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onmark
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -29,13 +29,13 @@ browser-compat: api.SpeechSynthesisUtterance.onmark
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onpause/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onpause/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onpause
 slug: Web/API/SpeechSynthesisUtterance/onpause
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onpause
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onpause
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onpause
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -29,13 +29,13 @@ browser-compat: api.SpeechSynthesisUtterance.onpause
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onresume/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onresume/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onresume
 slug: Web/API/SpeechSynthesisUtterance/onresume
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onresume
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onresume
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onresume
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -31,13 +31,13 @@ browser-compat: api.SpeechSynthesisUtterance.onresume
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/onstart/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/onstart/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.onstart
 slug: Web/API/SpeechSynthesisUtterance/onstart
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- onstart
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - onstart
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.onstart
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -30,13 +30,13 @@ browser-compat: api.SpeechSynthesisUtterance.onstart
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.pitch
 slug: Web/API/SpeechSynthesisUtterance/pitch
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- pitch
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - pitch
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.pitch
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -38,13 +38,13 @@ speechSynthesisUtteranceInstance.pitch = 1.5;
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.rate
 slug: Web/API/SpeechSynthesisUtterance/rate
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- rate
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - rate
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.rate
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -42,13 +42,13 @@ speechSynthesisUtteranceInstance.rate = 1.5;
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.html
@@ -2,13 +2,13 @@
 title: SpeechSynthesisUtterance()
 slug: Web/API/SpeechSynthesisUtterance/SpeechSynthesisUtterance
 tags:
-- API
-- Constructor
-- Reference
-- SpeechSynthesisUtterance
-- Web Speech API
-- speech
-- synthesis
+  - API
+  - Constructor
+  - Reference
+  - SpeechSynthesisUtterance
+  - Web Speech API
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.SpeechSynthesisUtterance
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -36,13 +36,13 @@ browser-compat: api.SpeechSynthesisUtterance.SpeechSynthesisUtterance
     href="https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis">Speech
     synthesizer demo</a>.</p>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/text/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.text
 slug: Web/API/SpeechSynthesisUtterance/text
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Text
-- Web Speech API
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Text
+  - Web Speech API
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.text
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -36,13 +36,13 @@ speechSynthesisUtteranceInstance.text = 'Hello I am speaking';
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/voice/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/voice/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.voice
 slug: Web/API/SpeechSynthesisUtterance/voice
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Voice
-- Web Speech API
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Voice
+  - Web Speech API
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.voice
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -36,13 +36,13 @@ speechSynthesisUtteranceInstance.voice = speechSynthesisVoiceInstance;
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

--- a/files/en-us/web/api/speechsynthesisutterance/volume/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/volume/index.html
@@ -2,15 +2,15 @@
 title: SpeechSynthesisUtterance.volume
 slug: Web/API/SpeechSynthesisUtterance/volume
 tags:
-- API
-- Experimental
-- Property
-- Reference
-- SpeechSynthesisUtterance
-- Volume
-- Web Speech API
-- speech
-- synthesis
+  - API
+  - Experimental
+  - Property
+  - Reference
+  - SpeechSynthesisUtterance
+  - Volume
+  - Web Speech API
+  - speech
+  - synthesis
 browser-compat: api.SpeechSynthesisUtterance.volume
 ---
 <div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
@@ -37,13 +37,13 @@ speechSynthesisUtteranceInstance.volume = 0.5;
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 


### PR DESCRIPTION
The flaw dashboards reported a bunch of `<pre>` flaws in Speech Synthesis API. This PR fixes them.

(I also added some `<code>` around string litteral in `SpeechSynthesisErrorEvent`)