### PR TITLE
Remove Experimental Tag

### DIFF
--- a/files/en-us/web/api/path2d/index.html
+++ b/files/en-us/web/api/path2d/index.html
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.Path2D
 ---
-<div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
+<div>{{APIRef("Canvas API")}}</div>
 
 <p>The <strong><code>Path2D</code></strong> interface of the Canvas 2D API is used to declare a path that can then be used on a {{domxref("CanvasRenderingContext2D")}} object. The<a href="/en-US/docs/Web/API/CanvasRenderingContext2D#paths"> path methods</a> of the <code>CanvasRenderingContext2D</code> interface are also present on this interface, which gives you the convenience of being able to retain and replay your path whenever desired.</p>
 

--- a/files/en-us/web/api/path2d/path2d/index.html
+++ b/files/en-us/web/api/path2d/path2d/index.html
@@ -12,7 +12,7 @@ tags:
 - Reference
 browser-compat: api.Path2D.Path2D
 ---
-<div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
+<div>{{APIRef("Canvas API")}}</div>
 
 <p>The <code><strong>Path2D()</strong></code> constructor returns a newly instantiated
   <code>Path2D</code> object, optionally with another path as an argument (creates a


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The experimental tag should be removed as the status of experimental had been changed to `false` in this [commit](https://github.com/mdn/browser-compat-data/commit/8bea4a5f8c84b92f3ed09a8beacbbbd2fbf01906#diff-6c927b62a4c3807438386e8a4b724fc0b2005bedd077828b48de2cafec4411e1).

> Issue number (if there is an associated issue)

#7208 

> Anything else that could help us review it
