### PR TITLE
Replace domxref by jsxref for ArrayBuffer

### DIFF
--- a/files/en-us/web/api/blob/index.html
+++ b/files/en-us/web/api/blob/index.html
@@ -43,7 +43,7 @@ browser-compat: api.Blob
 
 <dl>
  <dt>{{DOMxRef("Blob.prototype.arrayBuffer()")}}</dt>
- <dd>Returns a promise that resolves with an {{DOMxRef("ArrayBuffer")}} containing the entire contents of the <code>Blob</code> as binary data.</dd>
+ <dd>Returns a promise that resolves with an {{jsxref("ArrayBuffer")}} containing the entire contents of the <code>Blob</code> as binary data.</dd>
  <dt>{{DOMxRef("Blob.prototype.slice()")}}</dt>
  <dd>Returns a new <code>Blob</code> object containing the data in the specified range of bytes of the blob on which it's called.</dd>
  <dt>{{DOMxRef("Blob.prototype.stream()")}}</dt>

--- a/files/en-us/web/api/file/index.html
+++ b/files/en-us/web/api/file/index.html
@@ -13,7 +13,7 @@ browser-compat: api.File
 
 <p>The <strong><code>File</code></strong> interface provides information about files and allows JavaScript in a web page to access their content.</p>
 
-<p><code>File</code> objects are generally retrieved from a {{DOMxRef("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, from a drag and drop operation's {{DOMxRef("DataTransfer")}} object, or from the <code>mozGetAsFile()</code> API on an {{DOMxRef("HTMLCanvasElement")}}.</p>
+<p><code>File</code> objects are generally retrieved from a {{DOMxRef("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, from a drag and drop operation's {{DOMxRef("DataTransfer")}} object, or from the <code>mozGetAsFile()</code> API on an {{DOMxRef("HTMLCanvasElement")}}.</p>
 
 <p>A <code>File</code> object is a specific kind of a {{DOMxRef("Blob")}}, and can be used in any context that a Blob can. In particular, {{DOMxRef("FileReader")}}, {{DOMxRef("URL.createObjectURL()")}}, {{DOMxRef("WindowOrWorkerGlobalScope/createImageBitmap", "createImageBitmap()")}}, and {{DOMxRef("XMLHttpRequest", "", "send()")}} accept both <code>Blob</code>s and <code>File</code>s.</p>
 
@@ -28,7 +28,7 @@ browser-compat: api.File
  <dd>Returns a newly constructed <code>File</code>.</dd>
 </dl>
 
-<h2 id="Instance_properties">Instance properties</h2>
+<h2 id="Instance_properties">Instance properties</h2>
 
 <dl>
  <dt>{{DOMxRef("File.prototype.lastModified")}} {{ReadOnlyInline}}</dt>
@@ -50,7 +50,7 @@ browser-compat: api.File
  <dd>Returns the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME </a>type of the file.</dd>
 </dl>
 
-<h2 id="Instance_methods">Instance methods</h2>
+<h2 id="Instance_methods">Instance methods</h2>
 
 <p><em>The <code>File</code> interface doesn't define any methods, but inherits methods from the {{DOMxRef("Blob")}} interface:</em></p>
 
@@ -60,9 +60,9 @@ browser-compat: api.File
  <dt>{{DOMxRef("Blob.prototype.stream()")}}</dt>
  <dd>Transforms the <code>File</code> into a {{DOMxRef("ReadableStream")}} that can be used to read the <code>File</code> contents.</dd>
  <dt>{{DOMxRef("Blob.prototype.text()")}}</dt>
- <dd>Transforms the <code>File</code> into a stream and reads it to completion. It returns a promise that resolves with a {{DOMxRef("USVString")}} (text).</dd>
+ <dd>Transforms the <code>File</code> into a stream and reads it to completion. It returns a promise that resolves with a {{DOMxRef("USVString")}} (text).</dd>
  <dt>{{DOMxRef("Blob.prototype.arrayBuffer()")}}</dt>
- <dd>Transforms the <code>File</code> into a stream and reads it to completion. It returns a promise that resolves with an {{DOMxRef("ArrayBuffer")}}.</dd>
+ <dd>Transforms the <code>File</code> into a stream and reads it to completion. It returns a promise that resolves with an {{jsxref("ArrayBuffer")}}.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/filereadersync/index.html
+++ b/files/en-us/web/api/filereadersync/index.html
@@ -24,7 +24,7 @@ browser-compat: api.FileReaderSync
 
 <dl>
  <dt>{{DOMxRef("FileReaderSync.readAsArrayBuffer","FileReaderSync.readAsArrayBuffer()")}}</dt>
- <dd>This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into an {{DOMxRef("ArrayBuffer")}} representing the input data as a binary string.</dd>
+ <dd>This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into an {{jsxref("ArrayBuffer")}} representing the input data as a binary string.</dd>
  <dt>{{DOMxRef("FileReaderSync.readAsBinaryString","FileReaderSync.readAsBinaryString()")}} {{deprecated_inline}}</dt>
  <dd>This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a {{DOMxRef("DOMString")}} representing the input data as a binary string. This method is deprecated, consider using <code>readAsArrayBuffer()</code> instead.</dd>
  <dt>{{DOMxRef("FileReaderSync.readAsText","FileReaderSync.readAsText()")}}</dt>

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -5,7 +5,7 @@ browser-compat: api.FileReaderSync.readAsArrayBuffer
 ---
 <div>{{APIRef("File API")}}</div>
 
-<div><span class="seoSummary">The <code>readAsArrayBuffer()</code> method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{DOMxRef("ArrayBuffer")}}. This interface is <a href="/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers">only available</a> in <a href="/en-US/docs/Web/API/Worker">workers</a> as it enables synchronous I/O that could potentially block.</span></div>
+<div>The <code>readAsArrayBuffer()</code> method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{jsxref("ArrayBuffer")}}. This interface is <a href="/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers">only available</a> in <a href="/en-US/docs/Web/API/Worker">workers</a> as it enables synchronous I/O that could potentially block.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -18,12 +18,12 @@ browser-compat: api.FileReaderSync.readAsArrayBuffer
 
 <dl>
  <dt><code>blob</code></dt>
- <dd>The DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} to read into the {{DOMxRef("File")}} or {{DOMxRef("ArrayBuffer")}}.</dd>
+ <dd>The DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} to read into the {{DOMxRef("File")}} or {{jsxref("ArrayBuffer")}}.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An {{DOMxRef("ArrayBuffer")}} representing the file's data.</p>
+<p>An {{jsxref("ArrayBuffer")}} representing the file's data.</p>
 
 <h2 id="Exceptions">Exceptions</h2>
 
@@ -31,7 +31,7 @@ browser-compat: api.FileReaderSync.readAsArrayBuffer
 
 <dl>
  <dt><code>NotFoundError</code></dt>
- <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
+ <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
  <dt><code>SecurityError</code></dt>
  <dd>is raised when one of the following problematic situation is detected:
  <ul>


### PR DESCRIPTION
`{{DOMxRef("ArrayBuffer")}}` is wrong as `ArrayBuffer` is part of JavaScript.

This PR replaces all remaining occurences of it by `{{jsxref("ArrayBuffer"}}` (and removed a bunch of useless non-breaking spaces).