### PR TITLE
Add missing whitespace in KeyframeObject with offset

### DIFF
--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.html
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.html
@@ -74,7 +74,7 @@ tags:
 
 <pre class="brush: js">var aliceTumbling = [
   { transform: 'rotate(0) translate3D(-50%, -50%, 0)', color: '#000' },
-  { color: '#431236', offset: 0.3},
+  { color: '#431236', offset: 0.3 },
   { transform: 'rotate(360deg) translate3D(-50%, -50%, 0)', color: '#000' }
 ];</pre>
 
@@ -122,7 +122,7 @@ tags:
 <pre class="brush: js">document.getElementById("alice").animate(
   [
     { transform: 'rotate(0) translate3D(-50%, -50%, 0)', color: '#000' },
-    { color: '#431236', offset: 0.3},
+    { color: '#431236', offset: 0.3 },
     { transform: 'rotate(360deg) translate3D(-50%, -50%, 0)', color: '#000' }
   ], {
     duration: 3000,
@@ -135,7 +135,7 @@ tags:
 <pre class="brush: js">document.getElementById("alice").animate(
   [
     { transform: 'rotate(0) translate3D(-50%, -50%, 0)', color: '#000' },
-    { color: '#431236', offset: 0.3},
+    { color: '#431236', offset: 0.3 },
     { transform: 'rotate(360deg) translate3D(-50%, -50%, 0)', color: '#000' }
   ], 3000);</pre>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The code samples demonstrating the use of a KeyframeObject were missing trailing whitespace between the offset parameter and the closing `}` of the object. This was inconsistent with other code samples on this page.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

This was just a tiny stylistic nit I noticed while reading through the excellent [Using the Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API) tutorial! The goal of this PR is to ensure all object literals conform to the same stylistic conventions around whitespace :smile: