### PR TITLE
Fix typo in macro name

### DIFF
--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -36,7 +36,7 @@ browser-compat: api.Gamepad
  <dd>An integer that is auto-incremented to be unique for each device currently connected to the system.</dd>
  <dt>{{domxref("Gamepad.mapping")}} {{readonlyInline}}</dt>
  <dd>A string indicating whether the browser has remapped the controls on the device to a known layout.</dd>
- <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}{{ExperimentalInline}}</dt>
+ <dt>{{domxref("Gamepad.pose")}} {{readonlyInline}}{{Experimental_Inline}}</dt>
  <dd>A {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).</dd>
  <dt>{{domxref("Gamepad.timestamp")}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the last time the data for this gamepad was updated.</dd>


### PR DESCRIPTION
`{{Experimental_Inline}}` and not `{{ExperimentalInline}}`