### PR TITLE
Show arguments passed to callback & thisArg for URLSearchParams.forEach()

### DIFF
--- a/files/en-us/web/api/urlsearchparams/foreach/index.html
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.html
@@ -23,18 +23,22 @@ browser-compat: api.URLSearchParams.forEach
 
 <h3 id="Parameters">Parameters</h3>
 
-- `callback`
-  - : Function to execute on each element, which is passed the following arguments:
-
-    - `value`
-      - : The value of the current entry being processed in the URLSearchParams.
-    - `key`
-      - : The key of the current entry being processed in the URLSearchParams.
-    - `searchParams`
-      - : The URLSearchParams `forEach()` was called upon.
-
-- `thisArg` {{optional_inline}}
-  - : Value to use as `this` when executing `callback`.
+<dl>
+  <dt><code>callback</code></dt>
+    <dd>
+      <p>Function to execute on each element, which is passed the following arguments:</p>
+      <dl>
+        <dt><code>value</code></dt>
+        <dd><p>The value of the current entry being processed in the <code>URLSearchParams</code> object.</p></dd>
+        <dt><code>key</code></dt>
+        <dd><p>The key of the current entry being processed in the <code>URLSearchParams</code> object.</p></dd>
+        <dt><code>searchParams</code></dt>
+        <dd><p>The <code>URLSearchParams</code> object the <code>forEach()</code> was called upon.</p></dd>
+      </dl>
+    </dd>
+  <dt><code>thisArg</code> {{optional_inline}}</dt>
+    <dd><p>Value to use as <code>this</code> when executing <code>callback</code>.</p></dd>
+</dl>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/urlsearchparams/foreach/index.html
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.html
@@ -23,11 +23,18 @@ browser-compat: api.URLSearchParams.forEach
 
 <h3 id="Parameters">Parameters</h3>
 
-<dl>
-  <dt>callback</dt>
-  <dd>A callback function that is executed against each parameter, with the param value
-    provided as its parameter.</dd>
-</dl>
+- `callback`
+  - : Function to execute on each element, which is passed the following arguments:
+
+    - `value`
+      - : The value of the current entry being processed in the URLSearchParams.
+    - `key`
+      - : The key of the current entry being processed in the URLSearchParams.
+    - `searchParams`
+      - : The URLSearchParams `forEach()` was called upon.
+
+- `thisArg` {{optional_inline}}
+  - : Value to use as `this` when executing `callback`.
 
 <h3 id="Return_value">Return value</h3>
 


### PR DESCRIPTION
Based on testing:
- these are the arguments which are actually passed to the callback function, and
- the `this` argument which is available as an argument to `.forEach()` here.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This information was missing and is data which is necessary in order to be able to use the described method.

> Issue number (if there is an associated issue)

I didn't check for an issue number. I encountered the page on MDN which didn't contain sufficient information to actually use the method which was being described.


> Anything else that could help us review it

The formatting for the arguments and callback function arguments was taken from the `Array` pages, with the exception of not marking the arguments which are passed to the callback function as "optional", because they are not optional (i.e. they must be included when the `.foreach()` makes the call to the callback). Obviously, the callback doesn't have to do anything with any or all of the arguments, but that's the case for any called function, anywhere (well, at least in JavaScript).