### PR TITLE
Correct aria-hidden default value

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-hidden_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-hidden_attribute/index.html
@@ -62,7 +62,7 @@ tags:
 
 <dl>
 	<dt><code>false</code></dt>
-	<dd>(default) The element is exposed to the accessibility API.</dd>
+	<dd>The element is exposed to the accessibility API.</dd>
 	<dt><code>true</code></dt>
 	<dd>The element is not exposed to the accessibility API. </dd>
 	<dt><code>undefined</code></dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There were two values marked as (default). According to the [spec](https://www.w3.org/TR/wai-aria/#aria-hidden) the correct default value is `undefined`

> Issue number (if there is an associated issue)

Fixes #6900