### PR TITLE
Add some guidance to RegExp.exec() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -253,6 +253,10 @@ Found ab. Next match starts at 9
 >
 > Also, be sure that the global flag ("`g`") is set, or it will also cause
 > an infinite loop.
+> 
+> In addition, when matching zero-length characters (e.g. `/^/gm`),
+> increase its {{jsxref("RegExp.lastIndex", "lastIndex")}} each time to avoid
+> an infinite loop.
 
 ### Using exec() with RegExp literals
 


### PR DESCRIPTION
Add a case to the "Warning" section in the `RegExp.exec()` entry.

> Issue number (if there is an associated issue)
#2965
