### PR TITLE
Page macro - Remove macro from panner orientation examples

### DIFF
--- a/files/en-us/web/api/pannernode/coneinnerangle/index.html
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.html
@@ -12,11 +12,9 @@ browser-compat: api.PannerNode.coneInnerAngle
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
 <p>The <code>coneInnerAngle</code> property of the {{ domxref("PannerNode") }} interface is a double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.</p>
 
 <p>The <code>coneInnerAngle</code> property's default value is <code>360</code>, suitable for a non-directional source.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,7 +28,7 @@ panner.coneInnerAngle = 360;</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/PannerNode/orientationX","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/PannerNode/orientationX#example"><code>PannerNode.orientationX</code></a> for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/pannernode/coneouterangle/index.html
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.html
@@ -12,11 +12,9 @@ browser-compat: api.PannerNode.coneOuterAngle
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
-<p>The <code>coneOuterAngle</code> property of the {{ domxref("PannerNode") }} interface is a double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the {{domxref("coneOuterGain")}} property.</p>
+<p>The <code>coneOuterAngle</code> property of the {{ domxref("PannerNode") }} interface is a double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the {{domxref("PannerNode.coneOuterGain","coneOuterGain")}} property.</p>
 
 <p>The <code>coneOuterAngle</code> property's default value is <code>0</code>.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,7 +28,7 @@ panner.coneOuterAngle = 0;</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/PannerNode/orientationX","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/PannerNode/orientationX#example"><code>PannerNode.orientationX</code></a> for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/pannernode/coneoutergain/index.html
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.html
@@ -37,7 +37,7 @@ panner.coneOuterGain = 0;</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/PannerNode/orientationX","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/PannerNode/orientationX#example"><code>PannerNode.orientationX</code></a> for example code that demonstrates how changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}} affects volume.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/pannernode/orientationx/index.html
+++ b/files/en-us/web/api/pannernode/orientationx/index.html
@@ -11,12 +11,12 @@ browser-compat: api.PannerNode.orientationX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
-  <p>The <strong><code>orientationX</code></strong> property of the {{
+
+<p>The <strong><code>orientationX</code></strong> property of the {{
     domxref("PannerNode") }} interface indicates the X (horizontal) component of the
     direction in which the audio source is facing, in a 3D Cartesian coordinate space.</p>
 
-  <p>The complete vector is defined by the position of the audio source, given as
+<p>The complete vector is defined by the position of the audio source, given as
     ({{domxref("PannerNode.positionX", "positionX")}}, {{domxref("PannerNode.positionY",
     "positionY")}}, {{domxref("PannerNode.positionZ", "positionZ")}}), and the orientation
     of the audio source (that is, the direction in which it's facing), given as
@@ -24,7 +24,7 @@ browser-compat: api.PannerNode.orientationX
     {{domxref("PannerNode.orientationY", "orientationY")}},
     {{domxref("PannerNode.orientationZ", "orientationZ")}}).</p>
 
-  <p>Depending on the directionality of the sound (as specified using the attributes
+<p>Depending on the directionality of the sound (as specified using the attributes
     {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}},
     {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}, and
     {{domxref("PannerNode.coneOuterGain", "coneOuterGain")}}), the orientation of the
@@ -32,10 +32,10 @@ browser-compat: api.PannerNode.orientationX
     is pointing toward the listener, it will be louder than if the sound is pointed away
     from the listener.</p>
 
-  <p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
+<p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
     can still change the value of the parameter by assigning a new value to its
     {{domxref("AudioParam.value")}} property.</p>
-</div>
+
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -62,14 +62,12 @@ browser-compat: api.PannerNode.orientationX
     alt="This chart visualises how the PannerNode orientation vectors affect the direction of the sound cone."
     src="/en-US/docs/Web/API/PannerNode/orientationX/pannernode-orientation.png"></p>
 
-<p>First, let's start by writing a utility function to figure out our <em>orientation
-    vector.</em> The X and Z components are always at a 90° to each other, so we can
+<p>First, let's start by writing a utility function to figure out our <em>orientation vector.</em>
+  The X and Z components are always at a 90° to each other, so we can
   use the sine and cosine functions, which are offset by the same amount in radians.
   However, normally this would mean the {{ domxref("PannerNode") }} points to
-  the <strong>left</strong> of the listener at 0° rotation – since `x = cos(0) = 1` and `z
-  = sin(0) = 0`. It's more useful to offset the angle by -90°, which means the {{
-  domxref("PannerNode") }} will point <strong>directly at the listener</strong> at 0°
-  rotation.</p>
+  the <strong>left</strong> of the listener at 0° rotation – since <code>x = cos(0) = 1</code> and <code>z = sin(0) = 0</code>.
+  It's more useful to offset the angle by -90°, which means the {{domxref("PannerNode")}} will point <strong>directly at the listener</strong> at 0° rotation.</p>
 
 <pre class="brush: js">// this utility converts amount of rotation around the Y axis
 // (i.e. rotation in the 'horizontal plane') to an orientation vector

--- a/files/en-us/web/api/pannernode/orientationy/index.html
+++ b/files/en-us/web/api/pannernode/orientationy/index.html
@@ -12,12 +12,10 @@ browser-compat: api.PannerNode.orientationY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
-  <p>The <strong><code>orientationY</code></strong> property of the {{
-    domxref("PannerNode") }} interface indicates the Y (vertical) component of the
-    direction the audio source is facing, in 3D Cartesian coordinate space.</p>
+<p>The <strong><code>orientationY</code></strong> property of the {{ domxref("PannerNode") }} interface
+  indicates the Y (vertical) component of the direction the audio source is facing, in 3D Cartesian coordinate space.</p>
 
-  <p>The complete vector is defined by the position of the audio source, given as
+<p>The complete vector is defined by the position of the audio source, given as
     ({{domxref("PannerNode.positionX", "positionX")}}, {{domxref("PannerNode.positionY",
     "positionY")}}, {{domxref("PannerNode.positionZ", "positionZ")}}), and the orientation
     of the audio source (that is, the direction in which it's facing), given as
@@ -25,7 +23,7 @@ browser-compat: api.PannerNode.orientationY
     {{domxref("PannerNode.orientationY", "orientationY")}},
     {{domxref("PannerNode.orientationZ", "orientationZ")}}).</p>
 
-  <p>Depending on the directionality of the sound (as specified using the attributes
+<p>Depending on the directionality of the sound (as specified using the attributes
     {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}},
     {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}, and
     {{domxref("PannerNode.coneOuterGain", "codeOuterGain")}}), the orientation of the
@@ -33,10 +31,10 @@ browser-compat: api.PannerNode.orientationY
     is pointing toward the listener, it will be louder than if the sound is pointed away
     from the listener.</p>
 
-  <p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
+<p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
     can still change the value of the parameter by assigning a new value to its
     {{domxref("AudioParam.value")}} property.</p>
-</div>
+
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -52,7 +50,7 @@ browser-compat: api.PannerNode.orientationY
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/PannerNode/orientationX","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/PannerNode/orientationX#example"><code>PannerNode.orientationX</code></a> for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/pannernode/orientationz/index.html
+++ b/files/en-us/web/api/pannernode/orientationz/index.html
@@ -10,12 +10,10 @@ browser-compat: api.PannerNode.orientationZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
-  <p>The <strong><code>orientationZ</code></strong> property of the {{
-    domxref("PannerNode") }} interface indicates the Z (depth) component of the direction
-    the audio source is facing, in 3D Cartesian coordinate space.</p>
+<p>The <strong><code>orientationZ</code></strong> property of the {{ domxref("PannerNode") }} interface
+  indicates the Z (depth) component of the direction the audio source is facing, in 3D Cartesian coordinate space.</p>
 
-  <p>The complete vector is defined by the position of the audio source, given as
+<p>The complete vector is defined by the position of the audio source, given as
     ({{domxref("PannerNode.positionX", "positionX")}}, {{domxref("PannerNode.positionY",
     "positionY")}}, {{domxref("PannerNode.positionZ", "positionZ")}}), and the orientation
     of the audio source (that is, the direction in which it's facing), given as
@@ -23,7 +21,7 @@ browser-compat: api.PannerNode.orientationZ
     {{domxref("PannerNode.orientationY", "orientationY")}},
     {{domxref("PannerNode.orientationZ", "orientationZ")}}).</p>
 
-  <p>Depending on the directionality of the sound (as specified using the attributes
+<p>Depending on the directionality of the sound (as specified using the attributes
     {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}},
     {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}, and
     {{domxref("PannerNode.coneOuterGain", "codeOuterGain")}}), the orientation of the
@@ -31,10 +29,9 @@ browser-compat: api.PannerNode.orientationZ
     is pointing toward the listener, it will be louder than if the sound is pointed away
     from the listener.</p>
 
-  <p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
+<p>The {{domxref("AudioParam")}} contained by this property is read only; however, you
     can still change the value of the parameter by assigning a new value to its
     {{domxref("AudioParam.value")}} property.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -50,7 +47,7 @@ browser-compat: api.PannerNode.orientationZ
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/PannerNode/orientationX","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/PannerNode/orientationX#example"><code>PannerNode.orientationX</code></a> for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

It essentially removes the page macro, replacing it with a link to the example. Note that the example itself is a bit confusing, but that is outside the scope of this job. Also  I do not understand it well enough to fix it :-(
