### PR TITLE
Page macro: Fix MediaStreamTrackAudioSourceNode examples

### DIFF
--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.html
@@ -87,7 +87,7 @@ browser-compat: api.MediaStreamAudioSourceNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createMediaStreamSource","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext/createMediaStreamSource#example"><code>AudioContext.createMediaStreamSource()</code></a> for example code that uses this object.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
@@ -43,7 +43,7 @@ browser-compat: api.MediaStreamTrackAudioSourceNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createMediaStreamSource","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioContext/createMediaStreamSource#example"><code>AudioContext.createMediaStreamSource()</code></a> for example code that uses this object.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

It essentially removes the page macro from MediaStreamTrackAudioSourceNode and friends, replacing it with a link to the example. 