### PR TITLE
Update `Promise.any()` documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Promise.any
 ---
 {{JSRef}}
 
-`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects and, as soon as one of the promises in the iterable fulfills, returns a single promise that resolves with the value from that promise. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors. Essentially, this method is the opposite of {{JSxRef("Promise.all()")}}.
+`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects and, as soon as one of the promises in the iterable fulfills, returns a single promise that resolves with the value from that promise. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors.
 
 {{EmbedInteractiveExample("pages/js/promise-any.html")}}
 


### PR DESCRIPTION
I removed the statement "Essentially, this method is the opposite of `Promise.all()`." The statement doesn't seem to clarify how `Promise.any()` works and may even be confusing, since "opposite of `Promise.all()`" could be interpreted in a few different ways.

If we want to compare `Promise.any()` to another method, `Promise.race()` seems a better candidate, since the two differ only in rejection handling.
