### PR TITLE
Clarify some wording in Array.prototype.map() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -100,8 +100,8 @@ determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/
 `callbackFn`, if invoked, may do so).
 
 The range of elements processed by `map` is set before the first invocation
-of `callbackFn`. Elements which are appended to the array after the
-call to `map` begins will not be visited by `callbackFn`.
+of `callbackFn`. Elements which are assigned to indexes already visited, or to indexes 
+outside the range, will not be visited by `callbackFn`.
 If existing elements of the array are changed after the call to `map`, their
 value will be the value at the time `callbackFn` visits them.
 Elements that are deleted after the call to `map` begins and before being

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -111,6 +111,8 @@ Due to the algorithm defined in the specification, if the array which `map`
 was called upon is sparse, resulting array will also be sparse keeping same indices
 blank.
 
+**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+
 ## Polyfill
 
 `map` was added to the ECMA-262 standard in the 5th edition. Therefore, it


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
This is a content bug for the issue #5968. The patch adds more clarity to the description of Array.prototype.map().


> Issue number (if there is an associated issue)
#5968

> Anything else that could help us review it
@teoli2003 , I have finished my first bug!