### PR TITLE
Use jsxref instead of domxref for remaining TypedArray

### DIFF
--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
@@ -11,7 +11,7 @@ browser-compat: api.AnalyserNode.getFloatFrequencyData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <strong><code>getFloatFrequencyData()</code></strong> method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{domxref("Float32Array")}} array passed into it.</p>
+<p>The <strong><code>getFloatFrequencyData()</code></strong> method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{jsxref("Float32Array")}} array passed into it.</p>
 
 <p>Each item in the array represents the decibel value for a specific frequency. The frequencies are spread linearly from 0 to 1/2 of the sample rate. For example, for a <code>48000</code> Hz sample rate, the last item of the array will represent the decibel value for <code>24000</code> Hz.</p>
 
@@ -30,7 +30,7 @@ void <em>analyser</em>.getFloatFrequencyData(dataArray); // fill the Float32Arra
 
 <dl>
  <dt><code>array</code></dt>
- <dd>The {{domxref("Float32Array")}} that the frequency domain data will be copied to. For any sample which is silent, the value is <code>-<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a></code>.<br>
+ <dd>The {{jsxref("Float32Array")}} that the frequency domain data will be copied to. For any sample which is silent, the value is <code>-<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a></code>.<br>
  If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCount")}}, excess elements are dropped. If it has more elements than needed, excess elements are ignored.</dd>
 </dl>
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
@@ -11,7 +11,7 @@ browser-compat: api.AnalyserNode.getFloatTimeDomainData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <strong><code>getFloatTimeDomainData()</code></strong> method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{domxref("Float32Array")}} array passed into it.</p>
+<p>The <strong><code>getFloatTimeDomainData()</code></strong> method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -26,7 +26,7 @@ analyser.getFloatTimeDomainData(dataArray); // fill the Float32Array with data r
 
 <dl>
  <dt><code>array</code></dt>
- <dd>The {{domxref("Float32Array")}} that the time domain data will be copied to.<br>
+ <dd>The {{jsxref("Float32Array")}} that the time domain data will be copied to.<br>
  If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCount")}}, excess elements are dropped. If it has more elements than needed, excess elements are ignored.</dd>
 </dl>
 
@@ -86,7 +86,7 @@ draw();</pre>
 
 <dl>
  <dt>array</dt>
- <dd>The {{domxref("Float32Array")}} that the time domain data will be copied to.</dd>
+ <dd>The {{jsxref("Float32Array")}} that the time domain data will be copied to.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/index.html
@@ -78,11 +78,11 @@ browser-compat: api.AnalyserNode
 
 <dl>
  <dt>{{domxref("AnalyserNode.getFloatFrequencyData()")}}</dt>
- <dd>Copies the current frequency data into a {{domxref("Float32Array")}} array passed into it.</dd>
+ <dd>Copies the current frequency data into a {{jsxref("Float32Array")}} array passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getByteFrequencyData()")}}</dt>
  <dd>Copies the current frequency data into a {{jsxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getFloatTimeDomainData()")}}</dt>
- <dd>Copies the current waveform, or time-domain, data into a {{domxref("Float32Array")}} array passed into it.</dd>
+ <dd>Copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getByteTimeDomainData()")}}</dt>
  <dd>Copies the current waveform, or time-domain, data into a {{jsxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
 </dl>

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
@@ -23,7 +23,7 @@ browser-compat: api.AudioBuffer.copyFromChannel
     <strong><code>copyFromChannel()</code></strong> method of the
     {{domxref("AudioBuffer")}} interface copies the audio sample data from the specified
     channel of the <code>AudioBuffer</code> to a specified
-    {{domxref("Float32Array")}}.</span></p>
+    {{jsxref("Float32Array")}}.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -34,7 +34,7 @@ browser-compat: api.AudioBuffer.copyFromChannel
 
 <dl>
   <dt><code><var>destination</var></code></dt>
-  <dd>A {{domxref("Float32Array")}} to copy the channel's samples to.</dd>
+  <dd>A {{jsxref("Float32Array")}} to copy the channel's samples to.</dd>
   <dt><code><var>channelNumber</var></code></dt>
   <dd>The channel number of the current <code>AudioBuffer</code> to copy the channel data
     from.</dd>

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.html
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.html
@@ -11,7 +11,7 @@ browser-compat: api.AudioBuffer.getChannelData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <strong><code>getChannelData()</code></strong> method of the {{ domxref("AudioBuffer") }} Interface returns a {{domxref("Float32Array")}} containing the PCM data associated with the channel, defined by the channel parameter (with 0 representing the first channel).</p>
+<p>The <strong><code>getChannelData()</code></strong> method of the {{ domxref("AudioBuffer") }} Interface returns a {{jsxref("Float32Array")}} containing the PCM data associated with the channel, defined by the channel parameter (with 0 representing the first channel).</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -27,7 +27,7 @@ var nowBuffering = myArrayBuffer.getChannelData(channel);</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("Float32Array")}}.</p>
+<p>A {{jsxref("Float32Array")}}.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepadpose/angularvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/angularvelocity/index.html
@@ -25,7 +25,7 @@ browser-compat: api.GamepadPose.angularVelocity
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide angular velocity information.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide angular velocity information.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearacceleration/index.html
+++ b/files/en-us/web/api/gamepadpose/linearacceleration/index.html
@@ -25,7 +25,7 @@ browser-compat: api.GamepadPose.linearAcceleration
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide linear acceleration data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide linear acceleration data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/linearvelocity/index.html
@@ -25,7 +25,7 @@ browser-compat: api.GamepadPose.linearVelocity
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide linear velocity data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide linear velocity data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/orientation/index.html
+++ b/files/en-us/web/api/gamepadpose/orientation/index.html
@@ -17,7 +17,7 @@ browser-compat: api.GamepadPose.orientation
 
 <p>The <strong><code>orientation</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns the orientation of the {{domxref("Gamepad")}}, as a quarternion value.</p>
 
-<p>The value is a {{domxref("Float32Array")}}, made up of the following values:</p>
+<p>The value is a {{jsxref("Float32Array")}}, made up of the following values:</p>
 
 <ul>
  <li>pitch — rotation around the X axis.</li>
@@ -34,7 +34,7 @@ browser-compat: api.GamepadPose.orientation
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide orientation data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide orientation data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/position/index.html
+++ b/files/en-us/web/api/gamepadpose/position/index.html
@@ -33,7 +33,7 @@ browser-compat: api.GamepadPose.position
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide position data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the gamepad is not able to provide position data.</p>
 
 <div class="note">
 <p><strong>Note</strong>: User agents may provide emulated position values through certain techniques; when doing so they should still report {{domxref("GamepadPose.hasPosition")}} as false.</p>

--- a/files/en-us/web/api/periodicwave/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.html
@@ -37,10 +37,10 @@ browser-compat: api.PeriodicWave.PeriodicWave
       href="https://webaudio.github.io/web-audio-api/#idl-def-PeriodicWaveConstraints">PeriodicWaveConstraints</a>
     dictionary.):
     <ul>
-      <li><code>real</code>: A {{domxref("Float32Array")}} containing the cosine terms
+      <li><code>real</code>: A {{jsxref("Float32Array")}} containing the cosine terms
         that you want to use to form the wave (equivalent to the <code>real</code>
         parameter of {{domxref("BaseAudioContext.createPeriodicWave")}}).</li>
-      <li><code>imag</code>: A {{domxref("Float32Array")}} containing the sine terms that
+      <li><code>imag</code>: A {{jsxref("Float32Array")}} containing the sine terms that
         you want to use to form the wave (equivalent to the <code>imag</code> parameter of
         {{domxref("BaseAudioContext.createPeriodicWave")}}).</li>
     </ul>

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VREyeParameters.offset
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} representing a vector describing the offset from the center point between the users eyes to the center of the eye in meters.</p>
+<p>A {{jsxref("Float32Array")}} representing a vector describing the offset from the center point between the users eyes to the center of the eye in meters.</p>
 
 <div class="note">
 <p><dfn><strong>Note</strong>: </dfn>Values for the left eye will be negative; values for the right eye will be positive.</p>

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -31,15 +31,15 @@ browser-compat: api.VRFrameData
 
 <dl>
  <dt>{{domxref("VRFrameData.leftProjectionMatrix")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</dd>
+ <dd>A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</dd>
  <dt>{{domxref("VRFrameData.leftViewMatrix")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</dd>
+ <dd>A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</dd>
  <dt>{{domxref("VRFrameData.pose")}} {{readonlyInline}}</dt>
  <dd>The {{domxref("VRPose")}} of the {{domxref("VRDisplay")}} at the current {{domxref("VRFrameData.timestamp")}}.</dd>
  <dt>{{domxref("VRFrameData.rightProjectionMatrix")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</dd>
+ <dd>A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</dd>
  <dt>{{domxref("VRFrameData.rightViewMatrix")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</dd>
+ <dd>A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</dd>
  <dt>{{domxref("VRFrameData.timestamp")}} {{readonlyInline}}</dt>
  <dd>A constantly increasing timestamp value representing the time a frame update occurred.</dd>
 </dl>

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>leftProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</p>
+<p>The <strong><code>leftProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.leftProjectionMatrix
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} object.</p>
+<p>A {{jsxref("Float32Array")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRFrameData.leftViewMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>leftViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</p>
+<p>The <strong><code>leftViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.leftViewMatrix
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} object.</p>
+<p>A {{jsxref("Float32Array")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>rightProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</p>
+<p>The <strong><code>rightProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.rightProjectionMatrix
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} object.</p>
+<p>A {{jsxref("Float32Array")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRFrameData.rightViewMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>rightViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</p>
+<p>The <strong><code>rightViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -33,7 +33,7 @@ browser-compat: api.VRFrameData.rightViewMatrix
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} object.</p>
+<p>A {{jsxref("Float32Array")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRPose.angularAcceleration
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide angular acceleration information.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide angular acceleration information.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRPose.angularVelocity
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide angular velocity information.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide angular velocity information.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRPose.linearAcceleration
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide linear acceleration data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide linear acceleration data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRPose.linearVelocity
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide linear velocity data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide linear velocity data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -21,7 +21,7 @@ browser-compat: api.VRPose.orientation
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
-<p>The value is a {{domxref("Float32Array")}}, made up of the following values:</p>
+<p>The value is a {{jsxref("Float32Array")}}, made up of the following values:</p>
 
 <ul>
  <li>pitch — rotation around the X axis.</li>
@@ -38,7 +38,7 @@ browser-compat: api.VRPose.orientation
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide orientation data.</p>
+<p>A {{jsxref("Float32Array")}}, or <code>null</code> if the VR sensor is not able to provide orientation data.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -41,7 +41,7 @@ browser-compat: api.VRPose.position
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}, or null if the VR sensor is not able to provide position data.</p>
+<p>A {{jsxref("Float32Array")}}, or null if the VR sensor is not able to provide position data.</p>
 
 <div class="note">
 <p><strong>Note</strong>: User agents may provide emulated position values through techniques such as neck modeling; when doing so they should still report {{domxref("VRDisplayCapabilities.hasPosition")}} as false.</p>

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -29,7 +29,7 @@ browser-compat: api.VRStageParameters.sittingToStandingTransform
 
 <h3 id="Value">Value</h3>
 
-<p>A 16-element {{domxref("Float32Array")}} containing the components of a 4×4 transform matrix.</p>
+<p>A 16-element {{jsxref("Float32Array")}} containing the components of a 4×4 transform matrix.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/waveshapernode/curve/index.html
+++ b/files/en-us/web/api/waveshapernode/curve/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WaveShaperNode.curve
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <code>curve</code> property of the {{ domxref("WaveShaperNode") }} interface is a {{domxref("Float32Array")}} of numbers describing the distortion to apply.</p>
+<p>The <code>curve</code> property of the {{ domxref("WaveShaperNode") }} interface is a {{jsxref("Float32Array")}} of numbers describing the distortion to apply.</p>
 
 <p>The mid-element of the array is applied to any signal value of <code>0</code>, the first one to signal values of <code>-1</code>, and the last to signal values of <code>1</code>; values lower than <code>-1</code> or greater than <code>1</code> are treated like <code>-1</code> or <code>1</code> respectively.</p>
 
@@ -31,7 +31,7 @@ distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}}.</p>
+<p>A {{jsxref("Float32Array")}}.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/index.html
@@ -53,7 +53,7 @@ browser-compat: api.WaveShaperNode
 
 <dl>
  <dt>{{domxref("WaveShaperNode.curve")}}</dt>
- <dd>Is a {{domxref("Float32Array")}} of numbers describing the distortion to apply.</dd>
+ <dd>Is a {{jsxref("Float32Array")}} of numbers describing the distortion to apply.</dd>
  <dt>{{domxref("WaveShaperNode.oversample")}}</dt>
  <dd>Is an enumerated value indicating if oversampling must be used. Oversampling is a technique for creating more samples (up-sampling) before applying the distortion effect to the audio signal.</dd>
 </dl>

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
@@ -45,7 +45,7 @@ distortion.connect(audioCtx.destination);</pre>
 
 <p>To capture data, you need to use the methods {{ domxref("AnalyserNode.getFloatFrequencyData()") }} and {{ domxref("AnalyserNode.getByteFrequencyData()") }} to capture frequency data, and {{ domxref("AnalyserNode.getByteTimeDomainData()") }} and {{ domxref("AnalyserNode.getFloatTimeDomainData()") }} to capture waveform data.</p>
 
-<p>These methods copy data into a specified array, so you need to create a new array to receive the data before invoking one. The first one produces 32-bit floating point numbers, and the second and third ones produce 8-bit unsigned integers, therefore a standard JavaScript array won't do — you need to use a {{ domxref("Float32Array") }} or {{ domxref("Uint8Array") }} array, depending on what data you are handling.</p>
+<p>These methods copy data into a specified array, so you need to create a new array to receive the data before invoking one. The first one produces 32-bit floating point numbers, and the second and third ones produce 8-bit unsigned integers, therefore a standard JavaScript array won't do — you need to use a {{jsxref("Float32Array")}} or {{jsxref("Uint8Array")}} array, depending on what data you are handling.</p>
 
 <p>So for example, say we are dealing with an fft size of 2048. We return the {{ domxref("AnalyserNode.frequencyBinCount") }} value, which is half the fft, then call Uint8Array() with the frequencyBinCount as its length argument — this is how many data points we will be collecting, for that fft size.</p>
 

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
@@ -387,7 +387,7 @@ document.body.onload = start;</pre>
 
 <p>In this section we'll discuss the <code>displayPoseStats()</code> function, which displays our updated pose data on each frame. The function is fairly simple.</p>
 
-<p>First of all, we store the six different property values obtainable from the {{domxref("VRPose")}} object in their own variables — each one is a {{domxref("Float32Array")}}.</p>
+<p>First of all, we store the six different property values obtainable from the {{domxref("VRPose")}} object in their own variables — each one is a {{jsxref("Float32Array")}}.</p>
 
 <pre class="brush: js">function displayPoseStats(pose) {
   var pos = pose.position;

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
@@ -209,7 +209,7 @@ if(gp) {
              ]);
 }</pre>
 
-<p>Here we alter the position of the cube on the screen according to the {{domxref("GamepadPose.position","position")}} and {{domxref("GamepadPose.orientation","orientation")}} data received from the connected controller. These values (stored in <code>curPos</code> and <code>curOrient</code>) are {{domxref("Float32Array")}}s containing the X, Y, and Z values (here we are just using [0] which is X, and [1] which is Y).</p>
+<p>Here we alter the position of the cube on the screen according to the {{domxref("GamepadPose.position","position")}} and {{domxref("GamepadPose.orientation","orientation")}} data received from the connected controller. These values (stored in <code>curPos</code> and <code>curOrient</code>) are {{jsxref("Float32Array")}}s containing the X, Y, and Z values (here we are just using [0] which is X, and [1] which is Y).</p>
 
 <p>If the <code>gp</code> variable has a <code>Gamepad</code> object inside it and it can return position values (<code>gpPose.hasPosition</code>), indicating a 6DoF controller, we modify the cube position using position and orientation values. If only the former is true, indicating a 3DoF controller, we modify the cube position using the orientation values only. If there is no gamepad connected, we don't modify the cube position at all.</p>
 

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.html
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.html
@@ -37,7 +37,7 @@ browser-compat: api.XRRigidTransform.matrix
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Float32Array")}} containing 16 entries which represents the 4x4 transform
+<p>A {{jsxref("Float32Array")}} containing 16 entries which represents the 4x4 transform
   matrix which is described by
   the {{domxref("XRRigidTransform.position", "position")}} and
   {{domxref("XRRigidTransform.orientation",
@@ -48,7 +48,7 @@ browser-compat: api.XRRigidTransform.matrix
 <h3 id="Matrix_format">Matrix format</h3>
 
 <p>All 4x4 transform matrices used in WebGL are stored in 16-element
-  {{domxref("Float32Array")}}s. The values are stored
+  {{jsxref("Float32Array")}}s. The values are stored
   into the array in column-major order; that is, each column is written into the array
   top-down before moving to the
   right one column and writing the next column into the array. Thus, for an array [a0, a1,

--- a/files/en-us/webassembly/using_the_javascript_api/index.html
+++ b/files/en-us/webassembly/using_the_javascript_api/index.html
@@ -167,7 +167,7 @@ console.log(sum);</pre>
  </li>
 </ol>
 
-<p>Note how we create the {{domxref("Uint32Array")}} view on the Memory object’s buffer (<code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer">Memory.prototype.buffer</a></code>), not on the Memory itself.</p>
+<p>Note how we create the {{jsxref("Uint32Array")}} view on the Memory object's buffer (<code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer">Memory.prototype.buffer</a></code>), not on the Memory itself.</p>
 
 <p>Memory imports work just like function imports, only Memory objects are passed as values instead of JavaScript functions. Memory imports are useful for two reasons:</p>
 


### PR DESCRIPTION
A few less!
{{domxref("Float32Array")}} -> {{jsxref("Float32Array")}}
And two others.

If I have not missed any, all TypedArray are fixed