### PR TITLE
Sync text of Map.prototype.forEach() doc to Syntax updates

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
@@ -41,14 +41,14 @@ forEach(function callbackFn(value, key, map) { ... }, thisArg)
 ### Parameters
 
 - `callbackFn`
-  - : Function to execute for each entry of `myMap`. It takes the following
+  - : Function to execute for each entry in the map. It takes the following
     arguments:
     - `value` {{Optional_Inline}}
       - : Value of each iteration.
     - `key` {{Optional_Inline}}
       - : Key of each iteration.
     - `map` {{Optional_Inline}}
-      - : The map being iterated (`myMap` in the above Syntax box).
+      - : The map being iterated.
 - `thisArg` {{Optional_Inline}}
   - : Value to use as `this` when executing `callback`.
 


### PR DESCRIPTION
The Syntax section no longer mentions a “myMap” map by name (and it’s not otherwise necessary to have a named map o refer to).

---

See https://github.com/mdn/content/pull/7073#pullrequestreview-710477903 for some context.