### PR TITLE
List <dialog> as taking the “open” attribute

### DIFF
--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -510,9 +510,9 @@ tags:
    <td>This attribute indicates that the form shouldn't be validated when submitted.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Element/details#attr-open">open</a></code></td>
-   <td>{{ HTMLElement("details") }}</td>
-   <td>Indicates whether the details will be shown on page load.</td>
+   <td><code><a href="/en-US/docs/Web/HTML/Attributes/open">open</a></code></td>
+   <td>{{ HTMLElement("details") }}, {{ HTMLElement("dialog") }}</td>
+   <td>Indicates whether the the contents are currently visible (in the case of a <code>&lt;details&gt;</code> element) or whether the dialog is active and can be interacted with (in the case of a <code>&lt;dialog&gt;</code> element).</td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Element/meter#attr-optimum">optimum</a></code></td>


### PR DESCRIPTION
[The `<dialog>` element also accepts an `open` attribute][1] so include it in the list of elements on the HTML attribute reference.

Update the link to point to a (currently non-existent) element-agnostic attribute page rather than to the `<details>` element, and the description to describe the `open` attribute when used with both the `<details>` and <dialog>` elements.

[1]: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open