### PR TITLE
Fix usages of `<div class="hidden">` containing code blocks for Markdown conversion

### DIFF
--- a/files/en-us/web/css/-webkit-text-stroke-color/index.html
+++ b/files/en-us/web/css/-webkit-text-stroke-color/index.html
@@ -61,14 +61,10 @@ browser-compat: css.properties.-webkit-text-stroke-color
 }
 </pre>
 
-<div class="hidden">
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var colorPicker = document.querySelector("input");
+<pre class="brush: js hidden">var colorPicker = document.querySelector("input");
 colorPicker.addEventListener("change", function(evt) {
   document.querySelector("p").style.webkitTextStrokeColor = evt.target.value;
 });</pre>
-</div>
 
 <h4 id="Results">Results</h4>
 

--- a/files/en-us/web/css/@counter-style/system/index.html
+++ b/files/en-us/web/css/@counter-style/system/index.html
@@ -85,14 +85,12 @@ system: extends decimal;
 
 <h4 id="CSS">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul&gt;
+<pre class="brush: html hidden">&lt;ul&gt;
   &lt;li&gt;One&lt;/li&gt;
   &lt;li&gt;Two&lt;/li&gt;
   &lt;li&gt;Three&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
-</div>
 
 <pre class="brush: css">@counter-style fisheye {
  system: cyclic;
@@ -120,15 +118,14 @@ ul {
 
 <h4 id="CSS_2">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul&gt;
+
+<pre class="brush: html hidden">&lt;ul&gt;
  &lt;li&gt;One&lt;/li&gt;
  &lt;li&gt;Two&lt;/li&gt;
  &lt;li&gt;Three&lt;/li&gt;
  &lt;li&gt;Four&lt;/li&gt;
  &lt;li&gt;Five&lt;/li&gt;
 &lt;/ul&gt;</pre>
-</div>
 
 <pre class="brush: css">@counter-style circled-digits {
  system: fixed;
@@ -159,8 +156,8 @@ ul {
 
 <h4 id="CSS_3">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul&gt;
+
+<pre class="brush: html hidden">&lt;ul&gt;
  &lt;li&gt;One&lt;/li&gt;
  &lt;li&gt;Two&lt;/li&gt;
  &lt;li&gt;Three&lt;/li&gt;
@@ -170,7 +167,6 @@ ul {
  &lt;li&gt;Seven&lt;/li&gt;
  &lt;li&gt;Eight&lt;/li&gt;
 &lt;/ul&gt;</pre>
-</div>
 
 <pre class="brush: css">@counter-style abc {
  system: symbolic;
@@ -201,8 +197,7 @@ ul {
 
 <h4 id="CSS_4">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul&gt;
+<pre class="brush: html hidden">&lt;ul&gt;
  &lt;li&gt;One&lt;/li&gt;
  &lt;li&gt;Two&lt;/li&gt;
  &lt;li&gt;Three&lt;/li&gt;
@@ -213,7 +208,6 @@ ul {
  &lt;li&gt;Eight&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
-</div>
 
 <pre class="brush: css">@counter-style abc {
  system: alphabetic;
@@ -248,8 +242,8 @@ ul {
 <h4 id="CSS_5">CSS<br>
   </h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul&gt;
+
+<pre class="brush: html hidden">&lt;ul&gt;
  &lt;li&gt;One&lt;/li&gt;
  &lt;li&gt;Two&lt;/li&gt;
  &lt;li&gt;Three&lt;/li&gt;
@@ -259,7 +253,6 @@ ul {
  &lt;li&gt;Seven&lt;/li&gt;
  &lt;li&gt;Eight&lt;/li&gt;
 &lt;/ul&gt;</pre>
-</div>
 
 <pre class="brush: css">@counter-style abc {
  system: numeric;
@@ -281,8 +274,8 @@ ul {
 
 <h4 id="CSS_6">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul class="list"&gt;
+
+<pre class="brush: html hidden">&lt;ul class="list"&gt;
  &lt;li&gt;One&lt;/li&gt;
  &lt;li&gt;Two&lt;/li&gt;
  &lt;li&gt;Three&lt;/li&gt;
@@ -294,7 +287,6 @@ ul {
  &lt;li&gt;Nine&lt;/li&gt;
  &lt;li&gt;Ten&lt;/li&gt;
 &lt;/ul&gt;</pre>
-</div>
 
 <pre class="brush: css">@counter-style numbers {
  system: numeric;

--- a/files/en-us/web/css/@media/aspect-ratio/index.html
+++ b/files/en-us/web/css/@media/aspect-ratio/index.html
@@ -54,14 +54,9 @@ browser-compat: css.at-rules.media.aspect-ratio
 }
 </pre>
 
-<div class="hidden">
-<h2 id="_Example">_Example</h2>
+<div id="_Example">
 
-<p>used iframe and DataURL to enable this iframe could resize</p>
-
-<h3 id="HTML_2">HTML</h3>
-
-<pre class="brush: html">&lt;label id="wf" for="w"&gt;width:165&lt;/label&gt;
+<pre class="brush: html hidden">&lt;label id="wf" for="w"&gt;width:165&lt;/label&gt;
 &lt;input id="w" name="w" type="range" min="100" max="250" step="5" value="165"&gt;
 &lt;label id="hf" for="w"&gt;height:165&lt;/label&gt;
 &lt;input id="h" name="h" type="range" min="100" max="250" step="5" value="165"&gt;

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.html
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.html
@@ -67,8 +67,7 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">.animation {
+<pre class="brush: css hidden">.animation {
   background-color: #306;
   color: #fff;
   font: 1.2em sans-serif;
@@ -92,7 +91,6 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
   100% { opacity: 1; }
 }
 </pre>
-</div>
 
 <h3 id="Result">Result</h3>
 

--- a/files/en-us/web/css/_colon_empty/index.html
+++ b/files/en-us/web/css/_colon_empty/index.html
@@ -44,12 +44,10 @@ div:empty {
 
 <h3 id="CSS">CSS</h3>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   display: flex;
   justify-content: space-around;
 }</pre>
-</div>
 
 <pre class="brush: css">.box {
   background: pink;

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.html
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.html
@@ -40,14 +40,12 @@ browser-compat: css.selectors.file-selector-button
 
 <h4 id="CSS">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: css">form {
+<pre class="brush: css hidden">form {
   display: flex;
   gap: 1em;
   align-items: center;
 }
 </pre>
-</div>
 
 <pre class="brush: css">input[type=file]::file-selector-button {
   border: 2px solid #6c5ce7;
@@ -81,14 +79,12 @@ input[type=file]::file-selector-button:hover {
 
 <h4 id="CSS_2">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: css">form {
+<pre class="brush: css hidden">form {
   display: flex;
   gap: 1em;
   align-items: center;
 }
 </pre>
-</div>
 
 <pre class="brush: css">input[type=file]::-ms-browse {
   border: 2px solid #6c5ce7;

--- a/files/en-us/web/css/_doublecolon_selection/index.html
+++ b/files/en-us/web/css/_doublecolon_selection/index.html
@@ -48,8 +48,7 @@ browser-compat: css.selectors.selection
 
 <h3 id="CSS">CSS</h3>
 
-<div class="hidden">
-<pre class="brush: css">::-moz-selection {
+<pre class="brush: css hidden">::-moz-selection {
   color: gold;
   background-color: red;
 }
@@ -58,7 +57,6 @@ p::-moz-selection {
   color: white;
   background-color: blue;
 }</pre>
-</div>
 
 <pre class="brush: css">/* Make selected text gold on a red background */
 ::selection {

--- a/files/en-us/web/css/align-content/index.html
+++ b/files/en-us/web/css/align-content/index.html
@@ -226,10 +226,7 @@ select {
 &lt;/div&gt;
 </pre>
 
-<div class="hidden">
-<h3 id="JavaScript">JavaScript</h3>
-
-<pre class="brush: js">var values = document.getElementById('values');
+<pre class="brush: js hidden">var values = document.getElementById('values');
 var display = document.getElementById('display');
 var container = document.getElementById('container');
 
@@ -241,7 +238,6 @@ display.addEventListener('change', function (evt) {
   container.className = evt.target.value;
 });
 </pre>
-</div>
 
 <h3 id="Result">Result</h3>
 

--- a/files/en-us/web/css/align-items/index.html
+++ b/files/en-us/web/css/align-items/index.html
@@ -210,10 +210,7 @@ select {
 &lt;/div&gt;
 </pre>
 
-<div class="hidden">
-<h3 id="JavaScript">JavaScript</h3>
-
-<pre class="brush: js">var values = document.getElementById('values');
+<pre class="brush: js hidden">var values = document.getElementById('values');
 var display = document.getElementById('display');
 var container = document.getElementById('container');
 
@@ -225,7 +222,6 @@ display.addEventListener('change', function (evt) {
   container.className = evt.target.value;
 });
 </pre>
-</div>
 
 <h3 id="Result">Result</h3>
 

--- a/files/en-us/web/css/animation-timing-function/index.html
+++ b/files/en-us/web/css/animation-timing-function/index.html
@@ -116,8 +116,7 @@ animation-timing-function: unset;
 <div>
 <h3 id="Cubic-Bezier_examples">Cubic-Bezier examples</h3>
 
-<div class="hidden">
-<pre class="brush:html">&lt;div class="parent"&gt;
+<pre class="brush:html hidden">&lt;div class="parent"&gt;
   &lt;div class="ease"&gt;ease&lt;/div&gt;
   &lt;div class="easein"&gt;ease-in&lt;/div&gt;
   &lt;div class="easeout"&gt;ease-out&lt;/div&gt;
@@ -126,7 +125,7 @@ animation-timing-function: unset;
   &lt;div class="cb"&gt;cubic-bezier(0.2,-2,0.8,2)&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush:css;">.parent &gt; div[class] {
+<pre class="brush:css hidden">.parent &gt; div[class] {
     animation-name: changeme;
     animation-duration: 10s;
     animation-iteration-count: infinite;
@@ -149,7 +148,6 @@ animation-timing-function: unset;
    }
 }
 </pre>
-</div>
 
 <pre class="brush: css">.ease {
    animation-timing-function: ease;
@@ -176,8 +174,7 @@ animation-timing-function: unset;
 <div>
 <h3 id="Step_examples">Step examples</h3>
 
-<div class="hidden">
-<pre class="brush:html">&lt;div class="parent"&gt;
+<pre class="brush:html hidden">&lt;div class="parent"&gt;
   &lt;div class="jump-start"&gt;jump-start&lt;/div&gt;
   &lt;div class="jump-end"&gt;jump-end&lt;/div&gt;
   &lt;div class="jump-both"&gt;jump-both&lt;/div&gt;
@@ -188,7 +185,7 @@ animation-timing-function: unset;
   &lt;div class="step-end"&gt;step-end&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush:css;">.parent &gt; div[class] {
+<pre class="brush:css hidden">.parent &gt; div[class] {
     animation-name: changeme;
     animation-duration: 10s;
     animation-iteration-count: infinite;
@@ -211,7 +208,6 @@ animation-timing-function: unset;
    }
 }
 </pre>
-</div>
 
 <pre class="brush: css">.jump-start {
    animation-timing-function: steps(5, jump-start);

--- a/files/en-us/web/css/attr()/index.html
+++ b/files/en-us/web/css/attr()/index.html
@@ -168,11 +168,9 @@ attr(data-something, "default");
 
 <h4 id="CSS_2">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: css">.background {
+<pre class="brush: css hidden">.background {
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css highlight[6]">.background {
   background-color: red;

--- a/files/en-us/web/css/border-image-repeat/index.html
+++ b/files/en-us/web/css/border-image-repeat/index.html
@@ -77,10 +77,7 @@ border-image-repeat: unset;
 }
 </pre>
 
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="bordered"&gt;You can try out various border repetition rules on me!&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div id="bordered"&gt;You can try out various border repetition rules on me!&lt;/div&gt;
 
 &lt;select id="repetition"&gt;
   &lt;option value="stretch"&gt;stretch&lt;/option&gt;
@@ -92,14 +89,11 @@ border-image-repeat: unset;
 &lt;/select&gt;
 </pre>
 
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var repetition = document.getElementById("repetition");
+<pre class="brush: js hidden">var repetition = document.getElementById("repetition");
 repetition.addEventListener("change", function (evt) {
   document.getElementById("bordered").style.borderImageRepeat = evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="Results">Results</h4>
 

--- a/files/en-us/web/css/clip-path/index.html
+++ b/files/en-us/web/css/clip-path/index.html
@@ -100,8 +100,7 @@ clip-path: unset;
 
 <h3 id="Comparison_of_HTML_and_SVG">Comparison of HTML and SVG</h3>
 
-<div class="hidden" id="clip-path">
-<pre class="brush: html">&lt;svg class="defs"&gt;
+<pre id="clip-path" class="brush: html hidden">&lt;svg class="defs"&gt;
   &lt;defs&gt;
     &lt;clipPath id="myPath" clipPathUnits="objectBoundingBox"&gt;
       &lt;path d="M0.5,1 C0.5,1,0,0.7,0,0.3 A0.25,0.25,1,1,1,0.5,0.3 A0.25,0.25,1,1,1,1,0.3 C1,0.7,0.5,1,0.5,1 Z" /&gt;
@@ -518,7 +517,6 @@ svg text {
 svg text.em {
   font-style: italic;
 }</pre>
-</div>
 
 <p>{{EmbedLiveSample("Comparison_of_HTML_and_SVG", "100%", 800, "", "", "example-outcome-frame")}}</p>
 
@@ -556,15 +554,11 @@ svg text.em {
 }
 </pre>
 
-<div class="hidden">
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">const clipPathSelect = document.getElementById("clipPath");
+<pre class="brush: js hidden">const clipPathSelect = document.getElementById("clipPath");
 clipPathSelect.addEventListener("change", function (evt) {
   document.getElementById("clipped").style.clipPath = evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/color_value/color-mix()/index.html
+++ b/files/en-us/web/css/color_value/color-mix()/index.html
@@ -41,8 +41,7 @@ color-mix(in srgb, #34c9eb 20%, white);
 &lt;/ul></pre>
 
 <h3 id="CSS">CSS</h3>
-<div class="hidden">
-  <pre class="brush: css">ul {
+  <pre class="brush: css hidden">ul {
     display: flex;
     list-style-type: none;
     font-size: 150%;
@@ -55,7 +54,6 @@ color-mix(in srgb, #34c9eb 20%, white);
     padding: 10px;
   }
   </pre>
-</div>
 
 <pre class="brush: css">li:nth-child(1) {
   background-color: color-mix(in srgb, #34c9eb 10%, white);

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -1274,10 +1274,7 @@ Colors specified via the <a href="https://developer.mozilla.org/en-US/docs/Web/C
   height: 200px;
 }</pre>
 
-<div class="hidden">
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">const inputElem = document.querySelector('input');
+<pre class="brush: js hidden">const inputElem = document.querySelector('input');
 const divElem = document.querySelector('div');
 
 function validTextColor(stringToTest) {
@@ -1303,7 +1300,6 @@ inputElem.addEventListener('change', () =&gt; {
     divElem.textContent = 'Invalid color value';
   }
 });</pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/contain/index.html
+++ b/files/en-us/web/css/contain/index.html
@@ -133,8 +133,7 @@ article {
   &lt;p&gt;More content here.&lt;/p&gt;
 &lt;/article&gt;</pre>
 
-<div class="hidden">
-<pre class="brush: css">img {
+<pre class="brush: css hidden">img {
   float: left;
   border: 3px solid black;
 }
@@ -142,7 +141,6 @@ article {
 article {
   border: 1px solid black;
 }</pre>
-</div>
 
 <p>As you can see, because of the way floats work, the first image ends up inside the area of the second article:</p>
 
@@ -152,8 +150,7 @@ article {
 
 <p>If we give each <code>article</code> the <code>contain</code> property with a value of <code>content</code>, when new elements are inserted the browser understands it only needs to recalculate the containing element's subtree, and not anything outside it:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;h1&gt;My blog&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;My blog&lt;/h1&gt;
 &lt;article&gt;
   &lt;h2&gt;Heading of a nice article&lt;/h2&gt;
   &lt;p&gt;Content here.&lt;/p&gt;
@@ -164,7 +161,6 @@ article {
   &lt;img src="graphic.jpg" alt="photo"&gt;
   &lt;p&gt;More content here.&lt;/p&gt;
 &lt;/article&gt;</pre>
-</div>
 
 <pre class="brush: css">img {
   float: left;

--- a/files/en-us/web/css/containing_block/index.html
+++ b/files/en-us/web/css/containing_block/index.html
@@ -84,14 +84,12 @@ tags:
 
 <p>In this example, the paragraph is statically positioned, so its containing block is {{HTMLElement("section")}} because it's the nearest ancestor that is a block container.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;body&gt;
+<pre class="brush: html hidden">&lt;body&gt;
   &lt;section&gt;
     &lt;p&gt;This is a paragraph!&lt;/p&gt;
   &lt;/section&gt;
 &lt;/body&gt;
 </pre>
-</div>
 
 <pre class="brush: css">body {
   background: beige;
@@ -119,14 +117,12 @@ p {
 
 <p>In this example, the paragraph's containing block is the {{HTMLElement("body")}} element, because <code>&lt;section&gt;</code> is not a block container (because of <code>display: inline</code>) and doesn’t establish a formatting context.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;body&gt;
+<pre class="brush: html hidden">&lt;body&gt;
   &lt;section&gt;
     &lt;p&gt;This is a paragraph!&lt;/p&gt;
   &lt;/section&gt;
 &lt;/body&gt;
 </pre>
-</div>
 
 <pre class="brush: css">body {
   background: beige;
@@ -150,14 +146,12 @@ p {
 
 <p>In this example, the paragraph's containing block is <code>&lt;section&gt;</code> because the latter's <code>position</code> is <code>absolute</code>. The paragraph's percentage values are affected by the <code>padding</code> of its containing block, though if the containing block's {{cssxref("box-sizing")}} value were <code>border-box</code> this would not be the case.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;body&gt;
+<pre class="brush: html hidden">&lt;body&gt;
   &lt;section&gt;
     &lt;p&gt;This is a paragraph!&lt;/p&gt;
   &lt;/section&gt;
 &lt;/body&gt;
 </pre>
-</div>
 
 <pre class="brush: css">body {
   background: beige;
@@ -189,14 +183,12 @@ p {
 
 <p>In this example, the paragraph's <code>position</code> is <code>fixed</code>, so its containing block is the initial containing block (on screens, the viewport). Thus, the paragraph's dimensions change based on the size of the browser window.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;body&gt;
+<pre class="brush: html hidden">&lt;body&gt;
   &lt;section&gt;
     &lt;p&gt;This is a paragraph!&lt;/p&gt;
   &lt;/section&gt;
 &lt;/body&gt;
 </pre>
-</div>
 
 <pre class="brush: css">body {
   background: beige;
@@ -226,14 +218,12 @@ p {
 
 <p>In this example, the paragraph's <code>position</code> is <code>absolute</code>, so its containing block is <code>&lt;section&gt;</code>, which is the nearest ancestor with a {{cssxref("transform")}} property that isn't <code>none</code>.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;body&gt;
+<pre class="brush: html hidden">&lt;body&gt;
   &lt;section&gt;
     &lt;p&gt;This is a paragraph!&lt;/p&gt;
   &lt;/section&gt;
 &lt;/body&gt;
 </pre>
-</div>
 
 <pre class="brush: css">body {
   background: beige;

--- a/files/en-us/web/css/css_animations/tips/index.html
+++ b/files/en-us/web/css/css_animations/tips/index.html
@@ -31,8 +31,7 @@ tags:
 
 <p>Now we'll define the animation itself using CSS. Some CSS that's not important (the style of the "Run" button itself) isn't shown here, for brevity.</p>
 
-<div class="hidden">
-<pre class="brush: css">.runButton {
+<pre class="brush: css hidden">.runButton {
   cursor: pointer;
   width: 300px;
   border: 1px solid black;
@@ -45,7 +44,6 @@ tags:
   background-color: darkgreen;
   font: 14px "Open Sans", "Arial", sans-serif;
 }</pre>
-</div>
 
 <pre class="brush: css">@keyframes colorchange {
   0% { background: yellow }

--- a/files/en-us/web/css/css_background_and_borders/border-image_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/border-image_generator/index.html
@@ -7,12 +7,8 @@ tags:
 ---
 <p>This tool can be used to generate CSS3 {{cssxref("border-image")}} values.</p>
 
-<div class="hidden">
-<h2 id="Border_Image_Generator">Border Image Generator</h2>
-
-<h3 id="HTML_Content">HTML Content</h3>
-
-<pre class="brush: html">    &lt;div id="container"&gt;
+<div id="Border_Image_Generator">
+<pre class="brush: html hidden">    &lt;div id="container"&gt;
 
         &lt;div id="gallery"&gt;
             &lt;div id="image-gallery"&gt;
@@ -153,9 +149,7 @@ tags:
         &lt;/div&gt;
     &lt;/div&gt;</pre>
 
-<h3 id="CSS_Content">CSS Content</h3>
-
-<pre class="brush: css">/*  GRID OF TWELVE
+<pre class="brush: css hidden">/*  GRID OF TWELVE
  * ========================================================================== */
 
 .span_12 {
@@ -1205,9 +1199,7 @@ body[data-move='Y'] {
 
 </pre>
 
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js">'use strict';
+<pre class="brush: js hidden">'use strict';
 
 /**
  * UI-SlidersManager

--- a/files/en-us/web/css/css_background_and_borders/border-radius_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/border-radius_generator/index.html
@@ -8,12 +8,9 @@ tags:
 ---
 <p>This tool can be used to generate CSS3 {{cssxref("border-radius")}} effects.</p>
 
-<div class="hidden">
-<h2 id="border-radius-generator">border-radius</h2>
+<div id="border-radius-generator">
 
-<h3 id="HTML_Content">HTML Content</h3>
-
-<pre class="brush: html">&lt;div id="container"&gt;
+<pre class="brush: html hidden">&lt;div id="container"&gt;
     &lt;div class="group section"&gt;
         &lt;div id="preview" class="col span_12"&gt;
             &lt;div id="subject"&gt;
@@ -102,9 +99,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<h3 id="CSS_Content">CSS Content</h3>
-
-<pre class="brush: css">/*  GRID OF TEN
+<pre class="brush: css hidden">/*  GRID OF TEN
  * ========================================================================== */
 
 .span_12 {
@@ -808,9 +803,7 @@ body {
 
 </pre>
 
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js"><code class="language-js">'use strict';
+<pre class="brush: js hidden"><code class="language-js">'use strict';
 
 /**
  * UI-InputSliderManager

--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -8,12 +8,9 @@ tags:
 ---
 <p>This tool lets you construct CSS {{cssxref("box-shadow")}} effects, to add box shadow effects to your CSS objects.</p>
 
-<div class="hidden">
-<h2 id="box-shadow_generator">box-shadow generator</h2>
+<div id="box-shadow_generator">
 
-<h3 id="HTML_Content">HTML Content</h3>
-
-<pre class="brush: html">&lt;div id="container"&gt;
+<pre class="brush: html hidden">&lt;div id="container"&gt;
     &lt;div class="group section"&gt;
         &lt;div id="layer_manager"&gt;
             &lt;div class="group section"&gt;
@@ -212,9 +209,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<h3 id="CSS_Content">CSS Content</h3>
-
-<pre class="brush: css">/*  GRID OF TWELVE
+<pre class="brush: css hidden">/*  GRID OF TWELVE
  * ========================================================================== */
 
 .span_12 {
@@ -1155,9 +1150,7 @@ body {
 
 </pre>
 
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js">
+<pre class="brush: js hidden">
 
 'use strict';
 

--- a/files/en-us/web/css/css_colors/color_picker_tool/index.html
+++ b/files/en-us/web/css/css_colors/color_picker_tool/index.html
@@ -14,12 +14,10 @@ tags:
   - color
   - colors
 ---
-<div class="hidden">
-<h2 id="ColorPicker_Tool">ColorPicker tool</h2>
 
-<h3 id="HTML">HTML</h3>
+<div id="ColorPicker_Tool">
 
-<pre class="brush: html">    &lt;div id="container"&gt;
+<pre class="brush: html hidden">    &lt;div id="container"&gt;
         &lt;div id="palette" class="block"&gt;
             &lt;div id="color-palette"&gt;&lt;/div&gt;
             &lt;div id="color-info"&gt;
@@ -46,9 +44,7 @@ tags:
 
 </pre>
 
-<h3 id="CSS">CSS</h3>
-
-<pre class="brush: css">/*
+<pre class="brush: css hidden">/*
  * COLOR PICKER TOOL
  */
 
@@ -1047,9 +1043,7 @@ body {
 
 </pre>
 
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js">'use strict';
+<pre class="brush: js hidden">'use strict';
 
 var UIColorPicker = (function UIColorPicker() {
 

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
@@ -14,8 +14,7 @@ tags:
 
 <p>If you give the items no placement information they will position themselves on the grid, one in each grid cell.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -31,7 +30,7 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
+
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -62,8 +61,7 @@ tags:
 
 <p>You can however control the size of these rows with the property <code>grid-auto-rows</code>. To cause all created rows to be 100 pixels tall for example you would use:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -79,7 +77,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
     &lt;div&gt;One&lt;/div&gt;
@@ -104,8 +101,7 @@ tags:
 
 <p>You can use {{cssxref("minmax()","minmax()")}} in your value for {{cssxref("grid-auto-rows")}} enabling the creation of rows that are a minimum size but then grow to fit content if it is taller.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -121,7 +117,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
      &lt;div&gt;One&lt;/div&gt;
@@ -152,8 +147,7 @@ tags:
 
 <p>You can also pass in a track listing, this will repeat. The following track listing will create an initial implicit row track as 100 pixels and a second as <code>200px</code>. This will continue for as long as content is added to the implicit grid. </p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -169,7 +163,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div&gt;One&lt;/div&gt;
@@ -208,8 +201,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -225,7 +217,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div&gt;One&lt;/div&gt;
@@ -253,8 +244,8 @@ tags:
 
 <p>The first thing grid will do is place any items that have a position. In the example below I have 12 grid items. Item 2 and item 5 have been placed using line based placement on the grid. You can see how those items are placed and the other items then auto-place in the spaces. The auto-placed items will place themselves before the placed items in DOM order, they don’t start after the position of a placed item that comes before them.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -270,7 +261,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div&gt;One&lt;/div&gt;
@@ -312,8 +302,8 @@ tags:
 
 <p>You can see how this then leaves gaps in the grid, as for the auto-placed items if grid comes across an item that doesn’t fit into a track, it will move to the next row until it finds a space the item can fit in.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 .wrapper {
     border: 2px solid #f76707;
     border-radius: 5px;
@@ -328,7 +318,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div&gt;One&lt;/div&gt;
@@ -377,8 +366,8 @@ tags:
 
 <p>Having done this, grid will now backfill the gaps, as it moves through the grid it leaves gaps as before, but then if it finds an item that will fit in a previous gap it will pick it up and take it out of DOM order to place it in the gap. As with any other reordering in grid this does not change the logical order. Tab order for example, will still follow the document order. We will take a look at the potential accessibility issues of Grid Layout in a later guide, but you should take care when creating this disconnect between the visual order and display order.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 .wrapper {
     border: 2px solid #f76707;
     border-radius: 5px;
@@ -393,7 +382,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div&gt;One&lt;/div&gt;
@@ -458,8 +446,7 @@ tags:
 
 <p>Auto-placement can also help you lay out interface items which do have logical order. An example is the definition list in this next example. Definition lists are an interesting challenge to style as they are flat, there is nothing wrapping the groups of <code>dt</code> and <code>dd</code> items. In my example I am allowing auto-placement to place the items, however I have classes that start a <code>dt</code> in column 1, and <code>dd</code> in column 2, this ensure that terms go on one side and definitions on the other - no matter how many of each we have.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -467,7 +454,6 @@ tags:
     background-color: #fff4e6;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;dl&gt;

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -59,8 +59,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -76,7 +75,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('The_Grid_container', '200', '330') }}</p>
 
@@ -115,8 +113,8 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -132,7 +130,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('basic_example', '610', '140') }}</p>
 
@@ -155,8 +152,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -173,7 +169,6 @@ tags:
 }
 
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('the_fr_unit', '220', '140') }}</p>
 
@@ -196,8 +191,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -214,7 +208,6 @@ tags:
 }
 
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('unequal_fractions', '220', '140') }}</p>
 
@@ -237,8 +230,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -255,7 +247,6 @@ tags:
 }
 
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('mixing_fractions_and_absolute_sizes', '220', '140') }}</p>
 
@@ -319,8 +310,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -336,7 +326,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('The_implicit_and_explicit_grid', '230', '420') }}</p>
 
@@ -353,8 +342,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -370,7 +358,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
@@ -431,8 +418,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -448,7 +434,7 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
+
 
 <p>{{ EmbedLiveSample('Positioning_items_against_lines', '230', '420') }}</p>
 
@@ -493,8 +479,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   column-gap: 10px;
@@ -512,7 +497,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('Gutters') }}</p>
 
@@ -538,8 +522,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-  <pre class="brush: html">&lt;div class="wrapper"&gt;
+<pre class="brush: html hidden">&lt;div class="wrapper"&gt;
     &lt;div class="box box1"&gt;
       &lt;div class="nested"&gt;a&lt;/div&gt;
       &lt;div class="nested"&gt;b&lt;/div&gt;
@@ -550,7 +533,7 @@ tags:
     &lt;div class="box box4"&gt;Four&lt;/div&gt;
     &lt;div class="box box5"&gt;Five&lt;/div&gt;
   &lt;/div&gt;
-  </pre>
+</pre>
 
 <pre class="brush: css">* {box-sizing: border-box;}
 
@@ -644,8 +627,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -661,7 +643,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('overlapping_without_z-index', '230', '460') }}</p>
 
@@ -693,8 +674,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="wrapper"&gt;
+<pre class="brush: html hidden">&lt;div class="wrapper"&gt;
   &lt;div class="box box1"&gt;One&lt;/div&gt;
   &lt;div class="box box2"&gt;Two&lt;/div&gt;
   &lt;div class="box box3"&gt;Three&lt;/div&gt;
@@ -703,7 +683,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -719,7 +699,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('Controlling_the_order', '230', '460') }}</p>
 

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
@@ -49,8 +49,7 @@ tags:
  <li><code>last baseline</code></li>
 </ul>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -66,7 +65,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -112,8 +110,7 @@ tags:
 
 <p>In this next example, I am using the <code>align-self</code> property, to demonstrate the different alignment values. The first area, is showing the default behavior of <code>align-self</code>, which is to stretch. The second item, has an <code>align-self</code> value of <code>start</code>, the third <code>end</code> and the fourth <code>center</code>.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -129,7 +126,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -195,8 +191,7 @@ tags:
 
 <p>Once again the default is <code>stretch</code>, other than for items with an intrinsic aspect ratio. This means that by default, grid items will cover their grid area, unless you change that by setting alignment. The first item in the example demonstrates this default alignment:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -212,7 +207,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -266,8 +260,7 @@ tags:
 
 <p>By combining the align and justify properties we can easily center an item inside a grid area.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -283,7 +276,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -334,7 +326,6 @@ tags:
 
 <p>The default behavior in grid layout is <code>start</code>, which is why our grid tracks are in the top left corner of the grid, aligned against the start grid lines:</p>
 
-<div class="hidden">
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .wrapper {
@@ -393,8 +384,7 @@ tags:
 
 <p>If I add <code>align-content</code> to my container, with a value of <code>end</code>, the tracks all move to the end line of the grid container in the block dimension:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -410,7 +400,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -453,8 +442,7 @@ tags:
 
 <p>We can also use values for this property that you may be familiar with from flexbox; the space distribution values of <code>space-between</code>, <code>space-around</code> and <code>space-evenly</code>. If we update {{cssxref("align-content")}} to <code>space-between</code>, you can see how the elements on our grid space out:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -470,7 +458,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -521,8 +508,7 @@ tags:
 
 <p>Using the same example, I am setting {{cssxref("justify-content")}} to <code>space-around</code>. This once again causes tracks which span more than one column track to gain extra space:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -538,7 +524,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -584,8 +569,7 @@ tags:
 
 <p>In this next example, I have given item 1 a left margin of <code>auto</code>. You can see how the content is now pushed over to the right side of the area, as the auto margin takes up remaining space, after room for the content of that item has been assigned:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -601,7 +585,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
@@ -105,8 +105,7 @@ img {
 
 <p>In this next example, I have a set of floated cards. I have given the cards a {{cssxref("width")}}, in order to {{cssxref("float")}} them. To create gaps between the cards, I use a {{cssxref("margin")}} on the items, and then a negative margin on the container:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -123,7 +122,6 @@ img {
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper ul {
     overflow: hidden;
@@ -191,8 +189,7 @@ img {
 
 <p>I use an <code>@supports</code> rule to check for support of <code>display: grid</code>. I then do my grid code on the {{HTMLElement("ul")}}, set my width and {{cssxref("min-height")}} on the {{HTMLElement("li")}} to <code>auto</code>. I also remove the margins and negative margins, and replace the spacing with the {{cssxref("gap")}} property. This means I don’t get a final margin on the last row of boxes. The layout now works, even if there is more content in one of the cards, than the others:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -209,7 +206,6 @@ img {
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper ul {
     overflow: hidden;
@@ -270,8 +266,7 @@ img {
 
 <p>Once again I can use feature queries to overwrite a layout that uses <code>display: inline-block</code>, and again I don’t need to overwrite everything. An item that is set to <code>inline-block</code> becomes a grid item, and so the behavior of <code>inline-block</code> no longer applies. I have used the {{cssxref("vertical-align")}} property on my item when in the <code>inline-block</code> display mode, but this property does not apply to grid items and, therefore, is ignored once the item becomes a grid item:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -289,7 +284,6 @@ img {
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper ul {
     margin: 0 -10px;

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
@@ -41,8 +41,7 @@ tags:
 
 <p>In this example I have used grid to lay out a set of boxes that contain links. I have used the line-based placement properties to position box 1 on the second row of the grid. Visually it now appears as the fourth item in the list. However, if I tab from link to link the tab order still begins with box 1, as it comes first in the source.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -58,7 +57,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;

--- a/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
@@ -67,8 +67,7 @@ tags:
 
 <p>The value <code>horizontal-tb</code> is the default for text on the web. It is the direction in which you are reading this guide. The other properties will change the way that text flows in our document, matching the different writing modes found around the world. Again, for full details of these see <a href="https://24ways.org/2016/css-writing-modes/">Jen’s article</a>. As a simple example, I have two paragraphs below. The first uses the default <code>horizontal-tb</code>, and the second uses <code>vertical-rl</code>. In the mode text still runs left to right, however the direction of the text is vertical - inline text now runs down the page, from top to bottom.</p>
 
-<div class="hidden">
-<pre class="brush: css">.wrapper &gt; p {
+<pre class="brush: css hidden">.wrapper &gt; p {
     border: 2px solid #ffa94d;
     border-radius: 5px;
     background-color: #ffd8a8;
@@ -78,7 +77,6 @@ tags:
     max-width: 300px;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;p style="writing-mode: horizontal-tb"&gt;I have writing mode set to the default &lt;code&gt;horizontal-tb&lt;/code&gt;&lt;/p&gt;
@@ -96,8 +94,7 @@ tags:
 
 <p>The grid in this example has three columns and two row tracks. This means there are three tracks running down the block axis. In default writing mode, grid auto-places items starting at the top left, moving along to the right, filling up the three cells on the inline axis. It then moves onto the next line, creating a new Row track, and fills in more items:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -113,7 +110,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -138,8 +134,7 @@ gap: 10px;
 
 <p>If we add <code>writing-mode: vertical-lr</code> to the grid container, we can see that the block and inline Axis are now running in a different direction. The block or <em>column</em> axis now runs across the page from left to right, Inline runs down the page, creating rows from top to bottom.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -155,7 +150,6 @@ gap: 10px;
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   writing-mode: vertical-lr;
@@ -185,8 +179,7 @@ gap: 10px;
 
 <p>In this next example, I am using alignment to align items inside a grid that is set to <code>writing-mode: vertical-lr</code>. The <code>start</code> and <code>end</code> properties work in exactly the same way that they do in the default writing mode, and remain logical in a way that using left and right, top and bottom to align items would not do. This occurs once we've flipped the grid onto the side, like this:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -202,7 +195,6 @@ gap: 10px;
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   writing-mode: vertical-lr;
@@ -260,8 +252,7 @@ gap: 10px;
  <li>Item 3 starts at column line 1, spanning to column line 3.</li>
 </ul>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -277,7 +268,6 @@ gap: 10px;
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -310,8 +300,7 @@ gap: 10px;
 
 <p>If I now add the {{cssxref("direction")}} property with a value of <code>rtl</code> to the grid container, line 1 becomes the right hand side of the grid, and line -1 on the left.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -327,7 +316,6 @@ gap: 10px;
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   direction: rtl;

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
@@ -63,8 +63,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -82,7 +81,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
     &lt;div class="header"&gt;Header&lt;/div&gt;
@@ -113,8 +111,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -132,7 +129,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
     display: grid;
@@ -176,8 +172,7 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -195,7 +190,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
     display: grid;
@@ -208,14 +202,12 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="wrapper"&gt;
+<pre class="brush: html hidden">&lt;div class="wrapper"&gt;
     &lt;div class="header"&gt;Header&lt;/div&gt;
     &lt;div class="sidebar"&gt;Sidebar&lt;/div&gt;
     &lt;div class="content"&gt;Content&lt;/div&gt;
     &lt;div class="footer"&gt;Footer&lt;/div&gt;
 &lt;/div&gt;</pre>
-</div>
 
 <p>{{ EmbedLiveSample('Spanning_multiple_cells', '300', '330') }}</p>
 
@@ -229,8 +221,7 @@ tags:
 
 <p>For our layout above, we might like to have a very simple layout at narrow widths, defining a single column grid and stacking up our items.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -248,7 +239,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.header {
     grid-area: hd;
@@ -295,14 +285,13 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="wrapper"&gt;
+
+<pre class="brush: html hidden">&lt;div class="wrapper"&gt;
     &lt;div class="header"&gt;Header&lt;/div&gt;
     &lt;div class="sidebar"&gt;Sidebar&lt;/div&gt;
     &lt;div class="content"&gt;Content&lt;/div&gt;
     &lt;div class="footer"&gt;Footer&lt;/div&gt;
 &lt;/div&gt;</pre>
-</div>
 
 <p>{{ EmbedLiveSample('Redefining_the_grid_using_media_queries', '550', '330') }}</p>
 

--- a/files/en-us/web/css/css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/index.html
@@ -20,8 +20,7 @@ tags:
 
 <p>The example below shows a three-column track grid with new rows created at a minimum of 100 pixels and a maximum of auto. Items have been placed onto the grid using line-based placement.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 .wrapper {
   max-width: 940px;
   margin: 0 auto;
@@ -34,7 +33,6 @@ tags:
   padding: 1em;
   color: #d9480f;
 }</pre>
-</div>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
@@ -14,8 +14,7 @@ tags:
 
 <p>You can assign some or all of the lines in your grid a name when you define your grid with the <code>grid-template-rows</code> and <code>grid-template-columns</code> properties. To demonstrate I’ll use the simple layout created in the guide on line-based placement. This time I’ll create the grid using named lines.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -31,7 +30,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>When defining the grid, I name my lines inside square brackets. Those names can be anything you like. I have defined a name for the start and end of the container, both for rows and columns. Then defined the centre block of the grid as <code>content-start</code> and <code>content-end</code> again, both for columns and rows although you do not need to name all of the lines on your grid. You might choose to name just some key lines for your layout.</p>
 
@@ -90,8 +88,7 @@ tags:
 
 <p>While you can choose any name, if you append <code>-start</code> and <code>-end</code> to the lines around an area, as I have in the example above, grid will create you a named area of the main name used. Taking the above example, I have <code>content-start</code> and <code>content-end</code> both for rows and for columns. This means I get a grid area named <code>content</code>, and could place something in that area should I wish to.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -107,7 +104,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <p>I’m using the same grid definitions as above, however this time I am going to place a single item into the named area <code>content</code>.</p>
 
@@ -162,8 +158,7 @@ tags:
 
 <p>To position <code>overlay</code> using these implicit named lines is the same as positioning an item using lines that we have named.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -179,7 +174,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -239,8 +233,7 @@ tags:
 
 <p>In this next example I am creating a grid with twelve equal width columns. Before defining the 1fr size of the column track I am also defining a line name of <code>[col-start]</code>. This means that we will end up with a grid that has 12 column lines all named <code>col-start</code> before a <code>1fr</code> width column.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -256,7 +249,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -315,8 +307,7 @@ tags:
 
 <p>If you have used a track list then you can use the <code>span</code> keyword not just to span a number of lines but also to span a number of lines of a certain name.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -332,7 +323,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -372,8 +362,7 @@ tags:
 
 <p>We can then use that framework to layout our page. For example, to create a three column layout with a header and footer, I might have the following markup.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -389,7 +378,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;header class="main-header"&gt;I am the header&lt;/header&gt;

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
@@ -18,8 +18,7 @@ tags:
 
 <p><img alt="Our Grid highlighted in DevTools" src="3_hilighted_grid.png"></p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -35,7 +34,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
    display: grid;
@@ -70,8 +68,7 @@ tags:
 
 <p>Addressing each item individually we can place all four items spanning row and column tracks. Note that we can leave cells empty if we wish. One of the very nice things about Grid Layout is this ability to have white space in our designs without having to push things around using margins to prevent floats from rising up into the space we have left.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -90,7 +87,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -132,8 +128,7 @@ tags:
 
 <p>We have quite a lot of code here to position each item. It should come as no surprise to know there is a {{glossary("shorthand properties", "shorthand")}}. The {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties can be combined into {{cssxref("grid-column")}}, {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} into {{cssxref("grid-row")}}.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -152,7 +147,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -191,8 +185,7 @@ tags:
 
 <p>This means that our initial, long-hand, example would look like this:</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -211,7 +204,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -248,8 +240,7 @@ tags:
 
 <p>Our shorthand would look like the following code, with no forward slash and second value for the items spanning one track only.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -268,7 +259,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -309,8 +299,7 @@ tags:
  <li>grid-column-end</li>
 </ul>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -329,7 +318,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -374,8 +362,7 @@ tags:
 
 <p>In this next example I have flipped the layout we were working with by working from the right and bottom of our grid when placing the items.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -394,7 +381,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -453,8 +439,7 @@ tags:
 
 <p>Gaps only appear between tracks of the grid, they do not add space to the top and bottom, left or right of the container. We can add gaps to our earlier example by using these properties on the grid container.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -473,7 +458,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -528,8 +512,7 @@ tags:
 
 <p>In addition to specifying the start and end lines by number, you can specify a start line and then the number of tracks you would like the area to span.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
     border: 2px solid #f76707;
@@ -548,7 +531,6 @@ tags:
     color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
    &lt;div class="box1"&gt;One&lt;/div&gt;

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -20,8 +20,7 @@ tags:
 
 <p>My mark-up is a container with elements inside for a header, footer, main content, navigation, sidebar, and a block into which I am intending to place advertising.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
   .wrapper {
     max-width: 1024px;
     margin: 0 auto;
@@ -41,7 +40,6 @@ tags:
     padding: 0;
   }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;header class="main-head"&gt;The header&lt;/header&gt;
@@ -148,8 +146,7 @@ tags:
 
 <p>If you have been working with one of the many frameworks or grid systems you may be accustomed to laying out your site on a 12- or 16-column flexible grid. We can create this type of system using CSS Grid Layout. As a simple example, I am creating a 12-column flexible grid that has 12 <code>1fr</code>-unit column tracks, they all have a start line named <code>col-start</code>. This means that we will have twelve grid lines named <code>col-start</code>.</p>
 
-<div class="hidden">
-<pre class="brush: css">.wrapper {
+<pre class="brush: css hidden">.wrapper {
   max-width: 1024px;
   margin: 0 auto;
   font: 1.2em Helvetica, arial, sans-serif;
@@ -161,7 +158,6 @@ tags:
   padding: 10px;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.wrapper {
   display: grid;
@@ -213,8 +209,7 @@ tags:
 
 <p>To see how this layout method works in practice, we can create the same layout that we created with {{cssxref("grid-template-areas")}}, this time using the 12-column grid system. I am starting with the same markup as used for the grid template areas example.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
   .wrapper {
     max-width: 1024px;
     margin: 0 auto;
@@ -234,7 +229,6 @@ tags:
     padding: 0;
   }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;header class="main-head"&gt;The header&lt;/header&gt;
@@ -390,8 +384,7 @@ tags:
 &lt;/ul&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
     img {max-width: 100%; display: block;}
     body {
         font: 1.2em Helvetica, arial, sans-serif;
@@ -409,7 +402,6 @@ tags:
       padding: 20px;
     }
 </pre>
-</div>
 
 <p>We are going to create a grid with a flexible number of flexible columns. I want them never to become smaller than 200 pixels, and then to share any available remaining space equally – so we always get equal width column tracks. We achieve this with the <code>minmax()</code> function in our repeat notation for track sizing.</p>
 
@@ -455,8 +447,7 @@ tags:
 
 <p>I can cause a grid to backfill those gaps by setting {{cssxref("grid-auto-flow")}}<code>: dense </code> on the grid container. Take care when doing this however as it does take items away from their logical source order. You should only do this if your items do not have a set order – and be aware of the <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility#visual_not_logical_re-ordering">issues</a> of the tab order following the source and not your reordered display.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;ul class="listing"&gt;
+<pre class="brush: html hidden">&lt;ul class="listing"&gt;
   &lt;li&gt;
     &lt;h2&gt;Item One&lt;/h2&gt;
     &lt;div class="body"&gt;&lt;p&gt;The content of this listing item goes here.&lt;/p&gt;&lt;/div&gt;
@@ -488,7 +479,7 @@ tags:
 &lt;/ul&gt;
 </pre>
 
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
     img {max-width: 100%; display: block;}
     body {
         font: 1.2em Helvetica, arial, sans-serif;
@@ -522,7 +513,6 @@ tags:
   padding: 10px;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.listing {
   list-style: none;

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
@@ -22,8 +22,7 @@ tags:
 
 <p>I have also set the {{cssxref("flex-wrap")}} property to <code>wrap</code>, so that if the space in the container becomes too narrow to maintain the flex basis, items will wrap onto a new row.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -39,7 +38,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
@@ -70,8 +68,7 @@ tags:
 
 <p>In this next example, I create the same layout using Grid. This time we have three <code>1fr</code> column tracks. We do not need to set anything on the items themselves; they will lay themselves out one into each cell of the created grid. As you can see they stay in a strict grid, lining up in rows and columns. With five items, we get a gap on the end of row two.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -87,7 +84,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
@@ -131,8 +127,7 @@ tags:
 
 <p>In the first example, which uses flexbox, I have a container with three items inside. The wrapper {{cssxref("min-height")}} is set, so it defines the height of the flex container. I have set {{cssxref("align-items")}} on the flex container to <code>flex-end</code> so the items will line up at the end of the flex container. I have also set the {{cssxref("align-self")}} property on <code>box1</code> so it will override the default and stretch to the height of the container and on <code>box2</code> so it aligns to the start of the flex container.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -148,7 +143,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -176,8 +170,7 @@ tags:
 
 <p>This second example uses a grid to create the same layout. This time we are using the box alignment properties as they apply to a grid layout. So we align to <code>start</code> and <code>end</code> rather than <code>flex-start</code> and <code>flex-end</code>. In the case of a grid layout, we are aligning the items inside their grid area. In this case that is a single grid cell, but it could be an area made up of several grid cells.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -193,7 +186,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -232,8 +224,7 @@ tags:
 
 <p>In this next example, I have used the <code>auto-fill</code> keyword in place of an integer in the repeat notation and set the track listing to 200 pixels. This means that grid will create as many 200 pixels column tracks as will fit in the container.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -249,7 +240,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
@@ -270,8 +260,7 @@ tags:
 
 <p>This isn’t quite the same as flexbox. In the flexbox example, the items are larger than the 200 pixel basis before wrapping. We can achieve the same in grid by combining <code>auto-fit</code> and the {{cssxref("minmax()", "minmax()")}} function. In this next example, I create auto filled tracks with <code>minmax</code>. I want my tracks to be a minimum of 200 pixels, so I set the maximum to be <code>1fr</code>. Once the browser has worked out how many times 200 pixels will fit into the container–also taking account of grid gaps–it will treat the <code>1fr</code> maximum as an instruction to share out the remaining space between the items.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -287,7 +276,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div&gt;One&lt;/div&gt;
@@ -316,8 +304,7 @@ tags:
 
 <p>In the below example I have a wrapper containing four child items. Item three is absolutely positioned and also placed on the grid using line-based placement. The grid container has <code>position: relative</code> and so becomes the positioning context of this item.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -333,7 +320,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -383,8 +369,7 @@ tags:
 
 <p>I have given <code>.box3</code> position relative and then positioned the sub-item with the offset properties. In this case, the positioning context is the grid area.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -400,7 +385,6 @@ tags:
   color: #d9480f;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box1"&gt;One&lt;/div&gt;
@@ -454,8 +438,7 @@ tags:
 
 <p>In the following markup, I have a grid and the first item on the grid is set to span all three column tracks. It contains three nested items. As these items are not direct children, they don’t become part of the grid layout and so display using regular block layout.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -477,7 +460,6 @@ tags:
   padding: 1em;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box box1"&gt;
@@ -510,8 +492,7 @@ tags:
 
 <p>If I now add <code>display:</code> <code>contents</code> to the rules for <code>box1</code>, the box for that item vanishes and the sub-items now become grid items and lay themselves out using the auto-placement rules.</p>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -533,7 +514,6 @@ tags:
   padding: 1em;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box box1"&gt;

--- a/files/en-us/web/css/css_images/using_css_gradients/index.html
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.html
@@ -27,14 +27,12 @@ tags:
 
 <p>To create the most basic type of gradient, all you need is to specify two colors. These are called <em>color stops</em>. You must have at least two, but you can have as many as you want.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
+<pre class="brush: html hidden">&lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.simple-linear {
   background: linear-gradient(blue, pink);
@@ -48,14 +46,13 @@ tags:
 
 <p>By default, linear gradients run from top to bottom. You can change their rotation by specifying a direction.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="horizontal-gradient"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: html hidden">&lt;div class="horizontal-gradient"&gt;&lt;/div&gt;</pre>
+
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.horizontal-gradient {
   background: linear-gradient(to right, blue, pink);
@@ -70,14 +67,12 @@ tags:
 
 <p>You can even make the gradient run diagonally, from corner to corner.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="diagonal-gradient"&gt;&lt;/div&gt;</pre>
+<pre class="brush: html hidden">&lt;div class="diagonal-gradient"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 100px;
 }</pre>
-</div>
 
 <pre class="brush: css">.diagonal-gradient {
   background: linear-gradient(to bottom right, blue, pink);
@@ -92,14 +87,12 @@ tags:
 
 <p>If you want more control over its direction, you can give the gradient a specific angle.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="angled-gradient"&gt;&lt;/div&gt;</pre>
+<pre class="brush: html hidden">&lt;div class="angled-gradient"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.angled-gradient {
   background: linear-gradient(70deg, blue, pink);
@@ -122,15 +115,13 @@ tags:
 
 <p>You don't have to limit yourself to two colors—you may use as many as you like! By default, colors are evenly spaced along the gradient.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="auto-spaced-linear-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="auto-spaced-linear-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.auto-spaced-linear-gradient {
   background: linear-gradient(red, yellow, blue, orange);
@@ -145,15 +136,13 @@ tags:
 
 <p>You don't have to leave your color stops at their default positions. To fine-tune their locations, you can give each one zero, one, or two percentage or, for radial and linear gradients, absolute length values. If you specify the location as a percentage, <code>0%</code> represents the starting point, while <code>100%</code> represents the ending point; however, you can use values outside that range if necessary to get the effect you want. If you leave a location unspecified, the position of that particular color stop will be automatically calculated for you, with the first color stop being at <code>0%</code> and the last color stop being at <code>100%</code>, and any other color stops being half way between their adjacent color stops.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="multicolor-linear"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="multicolor-linear"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.multicolor-linear {
    background: linear-gradient(to left, lime 28px, red 77%, cyan);
@@ -168,15 +157,13 @@ tags:
 
 <p>To create a hard line between two colors, creating a stripe instead of a gradual transition, adjacent color stops can be set to the same location. In this example, the colors share a color stop at the <code>50%</code> mark, halfway through the gradient:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="striped"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="striped"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.striped {
    background: linear-gradient(to bottom left, cyan 50%, palegoldenrod 50%);
@@ -190,15 +177,13 @@ tags:
 
 <p>By default, the gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="color-hint"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="color-hint"&gt;&lt;/div&gt;
 &lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px; float: left; margin-right: 10px;
 }</pre>
-</div>
 
 <pre class="brush: css">.color-hint {
   background: linear-gradient(blue, 10%, pink);
@@ -215,17 +200,15 @@ tags:
 
 <p>To include a solid, non-transitioning color area within a gradient, include two positions for the color stop. Color stops can have two positions, which is equivalent to two consecutive color stops with the same color at different positions. The color will reach full saturation at the first color stop, maintain that saturation through to the second color stop, and transition to the adjacent color stop's color through the adjacent color stop's first position.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="multiposition-stops"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="multiposition-stops"&gt;&lt;/div&gt;
 &lt;div class="multiposition-stop2"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
   float: left; margin-right: 10px; box-sizing: border-box;
 }</pre>
-</div>
 
 <pre class="brush: css">.multiposition-stops {
    background: linear-gradient(to left,
@@ -255,17 +238,15 @@ tags:
 
 <p>By default, a gradient evenly progresses between the colors of two adjacent color stops, with the midpoint between those two color stops being the midpoint color value. You can control the interpolation, or progression, between two color stops by including a color hint location. In this example, the color reaches the midpoint between lime and cyan 20% of the way through the gradient rather than 50% of the way through. The second example does not contain the hint to highlight the difference the color hint can make:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="colorhint-gradient"&gt;&lt;/div&gt; &lt;div class="regular-progression"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="colorhint-gradient"&gt;&lt;/div&gt; &lt;div class="regular-progression"&gt;&lt;/div&gt;
 
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
   float: left; margin-right: 10px; box-sizing: border-box;
 }</pre>
-</div>
 
 <pre class="brush: css">.colorhint-gradient {
   background: linear-gradient(to top, black, 20%, cyan);
@@ -282,15 +263,13 @@ tags:
 
 <p>Gradients support transparency, so you can stack multiple backgrounds to achieve some pretty fancy effects. The backgrounds are stacked from top to bottom, with the first specified being on top.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="layered-image"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="layered-image"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 300px;
   height: 150px;
 }</pre>
-</div>
 
 <pre class="brush: css">.layered-image {
   background: linear-gradient(to right, transparent, mistyrose),
@@ -304,15 +283,13 @@ tags:
 
 <p>You can even stack gradients with other gradients. As long as the top gradients aren't entirely opaque, the gradients below will still be visible.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="stacked-linear"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="stacked-linear"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
-</div>
 
 <pre class="brush: css">.stacked-linear {
   background:
@@ -332,15 +309,13 @@ tags:
 
 <p>As with linear gradients, all you need to create a radial gradient are two colors. By default, the center of the gradient is at the 50% 50% mark, and the gradient is elliptical matching the aspect ratio of it's box:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="simple-radial"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="simple-radial"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.simple-radial {
   background: radial-gradient(red, blue);
@@ -353,15 +328,13 @@ tags:
 
 <p>Again like linear gradients, you can position each radial color stop with a percentage or absolute length.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background: radial-gradient(red 10px, yellow 30%, #1e90ff 50%);
@@ -374,15 +347,13 @@ tags:
 
 <p>You can position the center of the gradient with keyterms, percentage, or absolute lengths, length and percentage values repeating if only one is present, otherwise in the order of position from the left and position from the top.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 240px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background: radial-gradient(at 0% 30%, red 10px, yellow 30%, #1e90ff 50%);
@@ -399,15 +370,13 @@ tags:
 
 <p>This example uses the <code>closest-side</code> size value, which means the size is set by the distance from the starting point (the center) to the closest side of the enclosing box.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-ellipse-side"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-ellipse-side"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 100px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-ellipse-side {
   background: radial-gradient(ellipse closest-side,
@@ -421,15 +390,13 @@ tags:
 
 <p>This example is similar to the previous one, except that its size is specified as <code>farthest-corner</code>, which sets the size of the gradient by the distance from the starting point to the farthest corner of the enclosing box from the starting point.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-ellipse-far"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-ellipse-far"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 100px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-ellipse-far {
   background: radial-gradient(ellipse farthest-corner at 90% 90%,
@@ -443,15 +410,13 @@ tags:
 
 <p>This example uses <code>closest-side</code>, which makes the circle's size to be the distance between the starting point (the center) and the closest side. The circle's radius is the distance between the center of the gradient and the closest edge, which due to the positioning of the 25% from the top and 25% from the bottom, is closest to the bottom, since the height in this case is narrower than the width.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-circle-close"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-circle-close"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-circle-close {
   background: radial-gradient(circle closest-side at 25% 75%,
@@ -465,15 +430,13 @@ tags:
 
 <p>For ellipses only, you can size the ellipse using a length or percentage. The first value represents the horizontal radius, the second the vertical radius, where you use a percentage this corresponds to the size of the box in that dimension. In the below example I have used a percentage for the horizontal radius.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-ellipse-size"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-ellipse-size"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-ellipse-size {
    background: radial-gradient(ellipse 50% 50px,
@@ -487,15 +450,13 @@ tags:
 
 <p>For circles the size may be given as a <a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a>, which is the size of the circle.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-circle-size"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-circle-size"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-circle-size {
   background: radial-gradient(circle 50px,
@@ -509,15 +470,13 @@ tags:
 
 <p>Just like linear gradients, you can also stack radial gradients. The first specified is on top, the last on the bottom.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="stacked-radial"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="stacked-radial"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
-</div>
 
 <pre class="brush: css">.stacked-radial {
   background:
@@ -549,15 +508,13 @@ tags:
 
 <p>As with linear and radial gradients, all you need to create a conic gradient are two colors. By default, the center of the gradient is at the 50% 50% mark, with the start of the gradient facing up:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="simple-conic"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="simple-conic"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.simple-conic {
   background: conic-gradient(red, blue);
@@ -572,15 +529,13 @@ tags:
 
 <p>Like radial gradients, you can position the center of the conic gradient with keyterms, percentage, or absolute lengths, with the keyword "at"</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="conic-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="conic-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.conic-gradient {
   background: conic-gradient(at 0% 30%, red 10%, yellow 30%, #1e90ff 50%);
@@ -595,15 +550,13 @@ tags:
 
 <p>By default, the different color stops you specify are spaced equidistantly around the circle. You can position the starting angle of the conic gradient using the "from" keyword at the beginning followed by an angle or a length, and you can specify different positions for the colors stops by including an angle or length after them.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="conic-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="conic-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.conic-gradient {
   background: conic-gradient(from 45deg, red, orange 50%, yellow 85%, green);
@@ -624,15 +577,13 @@ tags:
 
 <p>This example uses {{cssxref("repeating-linear-gradient()")}} to create a gradient that progresses repeatedly in a straight line. The colors get cycled over again as the gradient repeats. In this case the gradient line is 10px long.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="repeating-linear"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="repeating-linear"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.repeating-linear {
   background: repeating-linear-gradient(-45deg, red, red 5px, blue 5px, blue 10px);
@@ -649,15 +600,13 @@ tags:
 
 <p>In this case the gradient lines are 300px, 230px, and 300px long.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="multi-repeating-linear"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="multi-repeating-linear"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 600px;
   height: 400px;
 }</pre>
-</div>
 
 <pre class="brush: css">.multi-repeating-linear {
   background:
@@ -684,14 +633,12 @@ tags:
 
 <p>To create plaid we include several overlapping gradients with transparency. In the first background declaration we listed every color stop separately. The second background property declaration using the multiple position color stop syntax:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="plaid-gradient"&gt;&lt;/div&gt;</pre>
+<pre class="brush: html hidden">&lt;div class="plaid-gradient"&gt;&lt;/div&gt;</pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
-</div>
 
 <pre class="brush: css">.plaid-gradient {
   background:
@@ -738,15 +685,13 @@ tags:
 
 <p>This example uses {{cssxref("repeating-radial-gradient()")}} to create a gradient that radiates repeatedly from a central point. The colors get cycled over and over as the gradient repeats.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="repeating-radial"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="repeating-radial"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.repeating-radial {
   background: repeating-radial-gradient(black, black 5px, white 5px, white 10px);
@@ -757,15 +702,13 @@ tags:
 
 <h3 id="Multiple_repeating_radial_gradients">Multiple repeating radial gradients</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="multi-target"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="multi-target"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 250px;
   height: 150px;
 }</pre>
-</div>
 
 <pre class="brush: css">.multi-target {
   background:

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.html
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.html
@@ -74,14 +74,10 @@ tags:
 
 <h3 id="Multiple_animated_properties_example">Multiple animated properties example</h3>
 
-<div class="hidden">
-<h4 id="HTML_Content">HTML Content</h4>
-
-<pre class="brush: html; highlight:[3]">&lt;body&gt;
+<pre class="brush: html hidden; highlight:[3]">&lt;body&gt;
     &lt;p&gt;The box below combines transitions for: width, height, background-color, transform. Hover over the box to see these properties animated.&lt;/p&gt;
     &lt;div class="box"&gt;Sample&lt;/div&gt;
 &lt;/body&gt;</pre>
-</div>
 
 <h4 id="CSS_Content">CSS Content</h4>
 

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.html
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.html
@@ -74,7 +74,7 @@ tags:
 
 <h3 id="Multiple_animated_properties_example">Multiple animated properties example</h3>
 
-<pre class="brush: html hidden; highlight:[3]">&lt;body&gt;
+<pre class="brush: html hidden highlight:[3]">&lt;body&gt;
     &lt;p&gt;The box below combines transitions for: width, height, background-color, transform. Hover over the box to see these properties animated.&lt;/p&gt;
     &lt;div class="box"&gt;Sample&lt;/div&gt;
 &lt;/body&gt;</pre>

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -232,15 +232,14 @@ flex: unset;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: js">var flex = document.getElementById("flex");
+<pre class="brush: js hidden">var flex = document.getElementById("flex");
 var raw = document.getElementById("raw");
 flex.addEventListener("click", function() {
   raw.style.display = raw.style.display == "none" ? "block" : "none";
 });
 </pre>
 
-<pre class="brush: css">#flex-container {
+<pre class="brush: css hidden">#flex-container {
   width: 100%;
   font-family: Consolas, Arial, sans-serif;
 }
@@ -254,7 +253,6 @@ flex.addEventListener("click", function() {
   border: 1px solid #000;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/font-family/index.html
+++ b/files/en-us/web/css/font-family/index.html
@@ -199,8 +199,7 @@ font-family: Gill Sans Extrabold, sans-serif;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: html;">&lt;div class="serif"&gt;
+<pre class="brush: html hidden">&lt;div class="serif"&gt;
   This is an example of a serif font.
 &lt;/div&gt;
 
@@ -231,7 +230,6 @@ font-family: Gill Sans Extrabold, sans-serif;
 &lt;div class="fangsong"&gt;
   This is an example of a fangsong font.
 &lt;/div&gt;</pre>
-</div>
 
 <p>{{EmbedLiveSample("Some_common_font_families", 600, 220)}}</p>
 

--- a/files/en-us/web/css/font-style/index.html
+++ b/files/en-us/web/css/font-style/index.html
@@ -100,8 +100,7 @@ label {
 
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">html, body {
+<pre class="brush: css hidden">html, body {
   max-height: 100vh;
   max-width: 100vw;
   overflow: hidden;
@@ -125,7 +124,6 @@ header {
   margin-bottom: 0;
 }
 </pre>
-</div>
 
 <h4 id="JavaScript">JavaScript</h4>
 
@@ -165,12 +163,10 @@ update();
 
 <h3 id="Font_styles">Font styles</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;p class="normal"&gt;This paragraph is normal.&lt;/p&gt;
+<pre class="brush: html hidden">&lt;p class="normal"&gt;This paragraph is normal.&lt;/p&gt;
 &lt;p class="italic"&gt;This paragraph is italic.&lt;/p&gt;
 &lt;p class="oblique"&gt;This paragraph is oblique.&lt;/p&gt;
 </pre>
-</div>
 
 <pre class="brush: css">.normal {
   font-style: normal;

--- a/files/en-us/web/css/font-weight/index.html
+++ b/files/en-us/web/css/font-weight/index.html
@@ -251,8 +251,7 @@ label {
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">html, body {
+<pre class="brush: css hidden">html, body {
   max-height: 100vh;
   max-width: 100vw;
   overflow: hidden;
@@ -276,7 +275,6 @@ header {
   margin-bottom: 0;
 }
 </pre>
-</div>
 
 <h4 id="JavaScript">JavaScript</h4>
 

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -134,10 +134,7 @@ p { font: status-bar }
 
 <h3 id="live_sample">Live sample</h3>
 
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;p&gt;
+<pre class="brush: html hidden">&lt;p&gt;
     Change the radio buttons below to see the generated shorthand and its effect.
 &lt;/p&gt;
 &lt;form action="createShortHand()"&gt;
@@ -231,9 +228,7 @@ p { font: status-bar }
 &lt;br/&gt;&lt;br/&gt;&lt;br/&gt;&lt;br/&gt;&lt;br/&gt;&lt;br/&gt;
 </pre>
 
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css">body, input {
+<pre class="brush: css hidden">body, input {
   font: 14px arial;
   overflow: hidden;
 }
@@ -284,9 +279,7 @@ p { font: status-bar }
   display: inline-block;
 }</pre>
 
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var textAreas = document.getElementsByClassName("curCss"),
+<pre class="brush: js hidden">var textAreas = document.getElementsByClassName("curCss"),
     shortText = "",
     getCheckedValue,
     setCss,

--- a/files/en-us/web/css/gradient/conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/conic-gradient()/index.html
@@ -126,15 +126,13 @@ background-size: 25% 25%;
 
 <h3 id="Gradient_at_40-degrees">Gradient at 40-degrees</h3>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 100px;
   height: 100px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background-image:
@@ -146,15 +144,13 @@ background-size: 25% 25%;
 
 <h3 id="Off-centered_gradient">Off-centered gradient</h3>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 100px;
   height: 100px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background: conic-gradient(from 0deg at 0% 25%, blue, green, yellow 180deg);
@@ -166,15 +162,13 @@ background-size: 25% 25%;
 
 <p>This example uses multi-position color stops, with adjacent colors having the same color stop value, creating a striped effect.</p>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 100px;
   height: 100px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background: conic-gradient(
@@ -186,15 +180,13 @@ background-size: 25% 25%;
 
 <h3 id="Checkerboard">Checkerboard</h3>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 100px;
   height: 100px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background:

--- a/files/en-us/web/css/gradient/index.html
+++ b/files/en-us/web/css/gradient/index.html
@@ -58,15 +58,13 @@ browser-compat: css.types.image.gradient
 
 <p>A simple linear gradient.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="linear-gradient"&gt;Linear gradient&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="linear-gradient"&gt;Linear gradient&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 80px;
 }</pre>
-</div>
 
 <pre class="brush: css">.linear-gradient {
   background: linear-gradient(to right,
@@ -79,15 +77,13 @@ browser-compat: css.types.image.gradient
 
 <p>A simple radial gradient.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;Radial gradient&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;Radial gradient&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 80px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background: radial-gradient(red, yellow, rgb(30, 144, 255));
@@ -100,17 +96,15 @@ browser-compat: css.types.image.gradient
 
 <p>Simple repeating linear and radial gradient examples.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="linear-repeat"&gt;Repeating linear gradient&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="linear-repeat"&gt;Repeating linear gradient&lt;/div&gt;
 &lt;br&gt;
 &lt;div class="radial-repeat"&gt;Repeating radial gradient&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 240px;
   height: 80px;
 }</pre>
-</div>
 
 <pre class="brush: css">.linear-repeat {
   background: repeating-linear-gradient(to top left,
@@ -127,15 +121,13 @@ browser-compat: css.types.image.gradient
 
 <p>A simple conic gradient example. Note that this isn't supported widely across browser as of yet.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="conic-gradient"&gt;Conic gradient&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="conic-gradient"&gt;Conic gradient&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
-</div>
 
 <pre class="brush: css">.conic-gradient {
   background: conic-gradient(lightpink, white, powderblue);

--- a/files/en-us/web/css/gradient/linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/linear-gradient()/index.html
@@ -116,12 +116,10 @@ linear-gradient(red 0%, orange 10% 30%, yellow 50% 70%, green 90% 100%);</pre>
 
 <h3 id="Gradient_at_a_45-degree_angle">Gradient at a 45-degree angle</h3>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 100vw;
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css">body {
   background: linear-gradient(45deg, red, blue);
@@ -132,12 +130,10 @@ linear-gradient(red 0%, orange 10% 30%, yellow 50% 70%, green 90% 100%);</pre>
 
 <h3 id="Gradient_that_starts_at_60_of_the_gradient_line">Gradient that starts at 60% of the gradient line</h3>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 100vw;
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css">body {
   background: linear-gradient(135deg, orange 60%, cyan);
@@ -149,12 +145,11 @@ linear-gradient(red 0%, orange 10% 30%, yellow 50% 70%, green 90% 100%);</pre>
 
 <p>This example uses multi-position color stops, with adjacent colors having the same color stop value, creating a striped effect.</p>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 100vw;
   height: 100vh;
 }</pre>
-</div>
+
 
 <pre class="brush: css">body {
   background: linear-gradient(to right,

--- a/files/en-us/web/css/gradient/radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/radial-gradient()/index.html
@@ -96,15 +96,13 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <h3 id="Simple_gradient">Simple gradient</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">.radial-gradient {
+<pre class="brush: css hidden">.radial-gradient {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background-image: radial-gradient(cyan 0%, transparent 20%, salmon 40%);
@@ -114,15 +112,13 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <h3 id="Non-centered_gradient">Non-centered gradient</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">.radial-gradient {
+<pre class="brush: css hidden">.radial-gradient {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background-image: radial-gradient(farthest-corner at 40px 40px,

--- a/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
@@ -113,15 +113,13 @@ repeating-conic-gradient(from -45deg, red 45deg, orange, yellow, green, blue 225
 
 <h3 id="Black_and_white_starburst">Black and white starburst</h3>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background-image:
@@ -135,15 +133,13 @@ repeating-conic-gradient(from -45deg, red 45deg, orange, yellow, green, blue 225
 
 <p>This gradient repeats 18 times, but since we only see the right half, we only see 9 repeats.</p>
 
-<div class="hidden">
-<pre class="brush: css">div {
+<pre class="brush: css hidden">div {
   width: 200px;
   height: 200px;
 }</pre>
 
-<pre class="brush: html">&lt;div&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: css">div {
   background: repeating-conic-gradient(

--- a/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
@@ -83,12 +83,10 @@ where &lt;side-or-corner&gt; = [left | right] || [top | bottom]
 
 <h3 id="Zebra_stripes">Zebra stripes</h3>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 100vw;
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css">body {
   background-image: repeating-linear-gradient(-45deg,
@@ -107,12 +105,10 @@ where &lt;side-or-corner&gt; = [left | right] || [top | bottom]
 
 <h3 id="Ten_repeating_horizontal_bars">Ten repeating horizontal bars</h3>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 100vw;
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css">body {
   background-image: repeating-linear-gradient(to bottom,

--- a/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
@@ -103,15 +103,13 @@ where &lt;extent-keyword&gt; = closest-corner | closest-side | farthest-corner |
 
 <h3 id="Black_and_white_gradient">Black and white gradient</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">.radial-gradient {
+<pre class="brush: css hidden">.radial-gradient {
   width: 120px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background: repeating-radial-gradient(black, black 5px, white 5px, white 10px);
@@ -122,15 +120,13 @@ where &lt;extent-keyword&gt; = closest-corner | closest-side | farthest-corner |
 
 <h3 id="Farthest-corner">Farthest-corner</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
+<pre class="brush: html hidden">&lt;div class="radial-gradient"&gt;&lt;/div&gt;
 </pre>
 
-<pre class="brush: css">.radial-gradient {
+<pre class="brush: css hidden">.radial-gradient {
   width: 240px;
   height: 120px;
 }</pre>
-</div>
 
 <pre class="brush: css">.radial-gradient {
   background: repeating-radial-gradient(ellipse farthest-corner at 20% 20%,

--- a/files/en-us/web/css/grid-column-end/index.html
+++ b/files/en-us/web/css/grid-column-end/index.html
@@ -113,8 +113,7 @@ grid-column-end: unset;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -137,7 +136,6 @@ grid-column-end: unset;
   padding: 1em;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/grid-column-start/index.html
+++ b/files/en-us/web/css/grid-column-start/index.html
@@ -123,8 +123,7 @@ grid-column-start: unset;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -147,7 +146,6 @@ grid-column-start: unset;
   padding: 1em;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/grid-row-end/index.html
+++ b/files/en-us/web/css/grid-row-end/index.html
@@ -112,8 +112,7 @@ grid-row-end: unset;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -136,7 +135,6 @@ grid-row-end: unset;
   padding: 1em;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/grid-row-start/index.html
+++ b/files/en-us/web/css/grid-row-start/index.html
@@ -121,8 +121,7 @@ grid-row-start: unset;
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">* {box-sizing: border-box;}
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 
 .wrapper {
   border: 2px solid #f76707;
@@ -145,7 +144,6 @@ grid-row-start: unset;
   padding: 1em;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/image-orientation/index.html
+++ b/files/en-us/web/css/image-orientation/index.html
@@ -78,10 +78,7 @@ image-orientation: flip; /* No rotation, only applies a horizontal flip */</pre>
 }
 </pre>
 
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;img id="image" src="mdn.svg"
+<pre class="brush: html hidden">&lt;img id="image" src="mdn.svg"
     alt="Orientation taken from the image"&gt;
 &lt;select id="imageOrientation"&gt;
   &lt;option value="from-image"&gt;from-image&lt;/option&gt;
@@ -89,14 +86,11 @@ image-orientation: flip; /* No rotation, only applies a horizontal flip */</pre>
 &lt;/select&gt;
 </pre>
 
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var imageOrientation = document.getElementById("imageOrientation");
+<pre class="brush: js hidden">var imageOrientation = document.getElementById("imageOrientation");
 imageOrientation.addEventListener("change", function (evt) {
   document.getElementById("image").style.imageOrientation = evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/image-rendering/index.html
+++ b/files/en-us/web/css/image-rendering/index.html
@@ -64,21 +64,17 @@ image-rendering: unset;</pre>
 
 <p>In practical use, the <code>pixelated</code> and <code>crisp-edges</code> rules can be combined to provide some fallback for each other. (Just prepend the actual rules with the fallback.) The <a href="/en-US/docs/Web/API/Canvas_API">Canvas API</a> can provide a <a href="http://phrogz.net/tmp/canvas_image_zoom.html">fallback solution for <code>pixelated</code></a> through manual image data manipulation or with <code><a href="/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled">imageSmoothingEnabled</a></code>.</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;div&gt;
+<pre class="brush: html hidden">&lt;div&gt;
   &lt;img class="auto" alt="auto" src="blumen.jpg" /&gt;
   &lt;img class="pixelated" alt="pixelated" src="blumen.jpg" /&gt;
   &lt;img class="crisp-edges" alt="crisp-edges" src="blumen.jpg" /&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
-<div class="hidden">
-<pre class="brush: css">img {
+<pre class="brush: css hidden">img {
   height: 200px;
 }
 </pre>
-</div>
 
 <h4 id="CSS">CSS</h4>
 

--- a/files/en-us/web/css/image/image()/index.html
+++ b/files/en-us/web/css/image/image()/index.html
@@ -106,9 +106,7 @@ xywh=percent:25,25,50,50    /* results in a 50%x50% image at x=25% and y=25% */<
 
 <h3 id="Putting_color_on_top_of_a_background_image">Putting color on top of a background image</h3>
 
-<div class="hidden">
-<pre class="brush: css;">.quarterlogo {height: 200px; width: 200px; border: 1px solid;}</pre>
-</div>
+<pre class="brush: css hidden">.quarterlogo {height: 200px; width: 200px; border: 1px solid;}</pre>
 
 <pre class="brush: css;">.quarterlogo {
   background-image:

--- a/files/en-us/web/css/justify-content/index.html
+++ b/files/en-us/web/css/justify-content/index.html
@@ -132,10 +132,7 @@ justify-content: unset;
 }
 </pre>
 
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="container"&gt;
+<pre class="brush: html hidden">&lt;div id="container"&gt;
   &lt;div&gt;&lt;/div&gt;
   &lt;div&gt;&lt;/div&gt;
   &lt;div&gt;&lt;/div&gt;
@@ -157,15 +154,12 @@ justify-content: unset;
   &lt;option value="stretch"&gt;stretch&lt;/option&gt;
 &lt;/select&gt;</pre>
 
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var justifyContent = document.getElementById("justifyContent");
+<pre class="brush: js hidden">var justifyContent = document.getElementById("justifyContent");
 justifyContent.addEventListener("change", function (evt) {
   document.getElementById("container").style.justifyContent =
       evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/mix-blend-mode/index.html
+++ b/files/en-us/web/css/mix-blend-mode/index.html
@@ -62,8 +62,8 @@ mix-blend-mode: unset;
 
 <h3 id="Effect_of_different_mix-blend-mode_values">Effect of different mix-blend-mode values</h3>
 
-<div class="hidden" id="mix-blend-mode">
-<pre class="brush: html">&lt;div class="grid"&gt;
+<div id="mix-blend-mode">
+<pre class="brush: html hidden">&lt;div class="grid"&gt;
   &lt;div class="col"&gt;
     &lt;div class="note"&gt;Blending in isolation (no blending with the background)&lt;/div&gt;
     &lt;div class="row isolate"&gt;
@@ -473,7 +473,7 @@ mix-blend-mode: unset;
   &lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush: css">html,body {
+<pre class="brush: css hidden">html,body {
   height: 100%;
   box-sizing: border-box;
   background: #EEE;

--- a/files/en-us/web/css/place-content/index.html
+++ b/files/en-us/web/css/place-content/index.html
@@ -118,8 +118,7 @@ place-content: unset;</pre>
 &lt;/div&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush:html">&lt;code&gt;writing-mode:&lt;/code&gt;&lt;select id="writingMode"&gt;
+<pre class="brush:html hidden">&lt;code&gt;writing-mode:&lt;/code&gt;&lt;select id="writingMode"&gt;
   &lt;option value="horizontal-tb" selected&gt;horizontal-tb&lt;/option&gt;
   &lt;option value="vertical-rl"&gt;vertical-rl&lt;/option&gt;
   &lt;option value="vertical-lr"&gt;vertical-lr&lt;/option&gt;
@@ -165,7 +164,7 @@ place-content: unset;</pre>
 &lt;/select&gt;&lt;code&gt;;&lt;/code&gt;
 </pre>
 
-<pre class="brush: js">var update = function () {
+<pre class="brush: js hidden">var update = function () {
    document.getElementById("container").style.placeContent = document.getElementById("alignContentAlignment").value + " " + document.getElementById("justifyContentAlignment").value;
 }
 
@@ -184,7 +183,6 @@ direction.addEventListener("change", function (evt) {
    document.getElementById("container").style.direction = evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="CSS">CSS</h4>
 

--- a/files/en-us/web/css/place-items/index.html
+++ b/files/en-us/web/css/place-items/index.html
@@ -111,8 +111,7 @@ place-items: unset;
 
 <h3 id="Placing_items_in_a_flex_container">Placing items in a flex container</h3>
 
-<div class="hidden">
-<pre class="brush: css;">div &gt; div {
+<pre class="brush: css hidden">div &gt; div {
   box-sizing: border-box;
   border: 2px solid #8c8c8c;
   width: 50px;
@@ -160,9 +159,7 @@ select {
   margin-top: 10px;
 }</pre>
 
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="container" class="flex"&gt;
+<pre class="brush: html hidden">&lt;div id="container" class="flex"&gt;
   &lt;div id="item1"&gt;1&lt;/div&gt;
   &lt;div id="item2"&gt;2&lt;/div&gt;
   &lt;div id="item3"&gt;3&lt;/div&gt;
@@ -206,9 +203,7 @@ select {
 &lt;/div&gt;
 </pre>
 
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var values = document.getElementById('values');
+<pre class="brush: js hidden">var values = document.getElementById('values');
 var display = document.getElementById('display');
 var container = document.getElementById('container');
 
@@ -220,7 +215,6 @@ display.addEventListener('change', function (evt) {
   container.className = evt.target.value;
 });
 </pre>
-</div>
 
 <h4 id="CSS">CSS</h4>
 

--- a/files/en-us/web/css/rotate/index.html
+++ b/files/en-us/web/css/rotate/index.html
@@ -73,8 +73,7 @@ rotate: unset;</pre>
 
 <h4 id="CSS">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: css">* {
+<pre class="brush: css hidden">* {
   box-sizing: border-box;
 }
 
@@ -96,7 +95,6 @@ p {
   text-align: center;
 }
 </pre>
-</div>
 
 <pre class="brush: css">.rotate {
   transition: rotate 1s;

--- a/files/en-us/web/css/specificity/index.html
+++ b/files/en-us/web/css/specificity/index.html
@@ -186,8 +186,7 @@ div p {
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush: css;">#no-where-support {
+<pre class="brush: css hidden">#no-where-support {
   margin: 0.5em;
   border: 1px solid red;
 }
@@ -196,16 +195,13 @@ div p {
   display: none !important;
 }
 </pre>
-</div>
 
 <p>... when used with the following HTML ...</p>
 
-<div class="hidden">
-<pre class="brush: html;">&lt;div id="no-where-support"&gt;
+<pre class="brush: html hidden">&lt;div id="no-where-support"&gt;
 ⚠️ Your browser doesn't support the &lt;code&gt;&lt;a href="https://developer.mozilla.org/docs/Web/CSS/:where" target="_top"&gt;:where()&lt;/a&gt;&lt;/code&gt; pseudo-class.
 &lt;/div&gt;
 </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="outer"&gt;
   &lt;p&gt;This is in the outer div.&lt;/p&gt;

--- a/files/en-us/web/css/text-align-last/index.html
+++ b/files/en-us/web/css/text-align-last/index.html
@@ -65,10 +65,8 @@ text-align-last: unset;
 
 <h3 id="Justifying_the_last_line">Justifying the last line</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;p&gt;Integer elementum massa at nulla placerat varius. Suspendisse in libero risus, in interdum massa. Vestibulum ac leo vitae metus faucibus gravida ac in neque. Nullam est eros, suscipit sed dictum quis, accumsan a ligula.&lt;/p&gt;
+<pre class="brush: html hidden">&lt;p&gt;Integer elementum massa at nulla placerat varius. Suspendisse in libero risus, in interdum massa. Vestibulum ac leo vitae metus faucibus gravida ac in neque. Nullam est eros, suscipit sed dictum quis, accumsan a ligula.&lt;/p&gt;
 </pre>
-</div>
 
 <h4 id="CSS">CSS</h4>
 

--- a/files/en-us/web/css/text-justify/index.html
+++ b/files/en-us/web/css/text-justify/index.html
@@ -55,13 +55,11 @@ text-justify: unset;</pre>
 
 <h3 id="Demonstration_of_the_different_values_of_text-justify">Demonstration of the different values of text-justify</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;p class="none"&gt;&lt;code&gt;text-justify: none&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;
+<pre class="brush: html hidden">&lt;p class="none"&gt;&lt;code&gt;text-justify: none&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;
 &lt;p class="auto"&gt;&lt;code&gt;text-justify: auto&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;
 &lt;p class="dist"&gt;&lt;code&gt;text-justify: distribute&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;
 &lt;p class="word"&gt;&lt;code&gt;text-justify: inter-word&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;
 &lt;p class="char"&gt;&lt;code&gt;text-justify: inter-character&lt;/code&gt; —&lt;br&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.&lt;/p&gt;</pre>
-</div>
 
 <pre class="brush: css">p {
   font-size: 1.5em;

--- a/files/en-us/web/css/tools/linear-gradient_generator/index.html
+++ b/files/en-us/web/css/tools/linear-gradient_generator/index.html
@@ -6,12 +6,10 @@ tags:
   - Guide
   - Tools
 ---
-<div class="hidden">
-<h2 id="linear-gradient_generator">linear-gradient generator</h2>
 
-<h3 id="HTML_Content">HTML Content</h3>
+<div id="linear-gradient_generator">linear-gradient generator
 
-<pre class="brush: html">    &lt;div id="container"&gt;
+<pre class="brush: html hidden">    &lt;div id="container"&gt;
         &lt;div id="gradient-container" data-alpha="true"&gt;
         &lt;/div&gt;
 
@@ -64,9 +62,7 @@ tags:
         &lt;/div&gt;
     &lt;/div&gt;</pre>
 
-<h3 id="CSS_Content">CSS Content</h3>
-
-<pre class="brush: css">/*
+<pre class="brush: css hidden">/*
  * COLOR PICKER TOOL
  */
 
@@ -1056,9 +1052,7 @@ body[data-dragging="true"] {
 
 </pre>
 
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js">var UIColorPicker = (function UIColorPicker() {
+<pre class="brush: js hidden">var UIColorPicker = (function UIColorPicker() {
 	'use strict';
 
 	function getElemById(id) {

--- a/files/en-us/web/css/transition-timing-function/index.html
+++ b/files/en-us/web/css/transition-timing-function/index.html
@@ -116,8 +116,7 @@ transition-timing-function: unset;</pre>
 
 <h3 id="Cubic-Bezier_examples">Cubic-Bezier examples</h3>
 
-<div class="hidden">
-<pre class="brush:html">&lt;div class="parent"&gt;
+<pre class="brush:html hidden">&lt;div class="parent"&gt;
   &lt;div class="ease"&gt;ease&lt;/div&gt;
   &lt;div class="easein"&gt;ease-in&lt;/div&gt;
   &lt;div class="easeout"&gt;ease-out&lt;/div&gt;
@@ -126,7 +125,7 @@ transition-timing-function: unset;</pre>
   &lt;div class="cb"&gt;cubic-bezier(0.2,-2,0.8,2)&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush:css;">.parent {}
+<pre class="brush:css hidden">.parent {}
 .parent &gt; div[class] {
     width: 12em;
     min-width: 12em;
@@ -148,7 +147,7 @@ transition-timing-function: unset;</pre>
 }
 </pre>
 
-<pre class="brush:js">function updateTransition() {
+<pre class="brush:js hidden">function updateTransition() {
   var els = document.querySelectorAll(".parent &gt; div[class]");
   for(var c = els.length, i = 0; i &lt; c; i++) {
      els[i].classList.toggle("box1");
@@ -157,7 +156,6 @@ transition-timing-function: unset;</pre>
 
 var intervalID = window.setInterval(updateTransition, 10000);
 </pre>
-</div>
 
 <pre class="brush: css">.ease {
    transition-timing-function: ease;
@@ -182,8 +180,8 @@ var intervalID = window.setInterval(updateTransition, 10000);
 
 <h3 id="Step_examples">Step examples</h3>
 
-<div class="hidden">
-<pre class="brush:html">&lt;div class="parent"&gt;
+
+<pre class="brush:html hidden">&lt;div class="parent"&gt;
   &lt;div class="jump-start"&gt;jump-start&lt;/div&gt;
   &lt;div class="jump-end"&gt;jump-end&lt;/div&gt;
   &lt;div class="jump-both"&gt;jump-both&lt;/div&gt;
@@ -192,7 +190,7 @@ var intervalID = window.setInterval(updateTransition, 10000);
   &lt;div class="step-end"&gt;step-end&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush:css;">.parent {}
+<pre class="brush:css hidden">.parent {}
 .parent &gt; div[class] {
     width: 12em;
     min-width: 12em;
@@ -214,7 +212,7 @@ var intervalID = window.setInterval(updateTransition, 10000);
 }
 </pre>
 
-<pre class="brush:js">function updateTransition() {
+<pre class="brush:js hidden">function updateTransition() {
   var els = document.querySelectorAll(".parent &gt; div[class]");
   for(var c = els.length, i = 0; i &lt; c; i++) {
      els[i].classList.toggle("box1");
@@ -223,7 +221,6 @@ var intervalID = window.setInterval(updateTransition, 10000);
 
 var intervalID = window.setInterval(updateTransition, 10000);
 </pre>
-</div>
 
 <pre class="brush: css">.jump-start {
    transition-timing-function: steps(5, jump-start);

--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -135,11 +135,9 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 
 <h4 id="CSS_2">CSS</h4>
 
-<div class="hidden">
-<pre class="brush: css">.background {
+<pre class="brush: css hidden">.background {
   height: 100vh;
 }</pre>
-</div>
 
 <pre class="brush: css highlight[6]">.background {
   background: yellow;

--- a/files/en-us/web/css/using_css_custom_properties/index.html
+++ b/files/en-us/web/css/using_css_custom_properties/index.html
@@ -142,15 +142,13 @@ tags:
 }
 </pre>
 
-<div class="hidden">
-<pre class="brush:html">&lt;div&gt;
+<pre class="brush:html hidden">&lt;div&gt;
     &lt;div class="one"&gt;&lt;/div&gt;
     &lt;div class="two"&gt;Text &lt;span class="five"&gt;- more text&lt;/span&gt;&lt;/div&gt;
     &lt;input class="three"&gt;
     &lt;textarea class="four"&gt;Lorem Ipsum&lt;/textarea&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
 </div>
 

--- a/files/en-us/web/css/white-space/index.html
+++ b/files/en-us/web/css/white-space/index.html
@@ -173,8 +173,7 @@ white-space: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<div class="hidden" id="See_it_in_action_LiveSample">
-<pre class="brush: html">&lt;div id="css-code" class="box"&gt;
+<pre class="brush: html hidden">&lt;div id="css-code" class="box"&gt;
   p { white-space:
   &lt;select&gt;
     &lt;option&gt;normal&lt;/option&gt;
@@ -195,7 +194,7 @@ white-space: unset;
     Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.&lt;/p&gt;
 &lt;/div&gt;</pre>
 
-<pre class="brush: css">.box {
+<pre class="brush: css hidden">.box {
   width: 300px;
   padding: 16px;
   border-radius: 10px;
@@ -219,12 +218,12 @@ white-space: unset;
   font-size: 14px;
 }</pre>
 
-<pre class="brush: js">var select  = document.querySelector("#css-code select");
+<pre class="brush: js hidden">var select  = document.querySelector("#css-code select");
 var results = document.querySelector("#results p");
 select.addEventListener("change", function(e) {
   results.setAttribute("style", "white-space: "+e.target.value);
 })</pre>
-</div>
+
 
 <pre class="brush: html">&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.&lt;/p&gt; </pre>
 

--- a/files/en-us/web/css/writing-mode/index.html
+++ b/files/en-us/web/css/writing-mode/index.html
@@ -125,10 +125,7 @@ writing-mode: unset;</pre>
 
 <h4 id="CSS">CSS</h4>
 
-<div class="hidden">
-<p>Some preparatory CSS just to make things look a little better:</p>
-
-<pre class="brush: css">table {
+<pre class="brush: css hidden">table {
   border-collapse:collapse;
 }
 td, th {
@@ -141,7 +138,6 @@ th {
   height:75px;
   width:75px;
 }</pre>
-</div>
 
 <p>The CSS that adjusts the directionality of the content looks like this:</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Fix usages of `<div class="hidden">` containing code blocks for Markdown conversion

> Issue number (if there is an associated issue)

Fixes #7256 

> Anything else that could help us review it

Related to #5865 