### PR TITLE
Updating referrerpolicy

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
@@ -23,17 +23,42 @@ browser-compat: api.HTMLAnchorElement.referrerPolicy
 <pre class="brush: js"><var>refStr</var> = <var>anchorElt</var>.referrerPolicy;
 <var>anchorElt</var>.referrerPolicy = <var>refStr</var>;</pre>
 
-<h3 id="Values">Values</h3>
+<h3 id="Values">Value</h3>
 
-<ul>
-  <li><code>"no-referrer"</code> meaning that the <code>Referer:</code> HTTP header will
-    not be sent.</li>
-  <li><code>"origin"</code> meaning that the referrer will be the origin of the page, that
-    is roughly the scheme, the host and the port.</li>
-  <li><code>"unsafe-url"</code> meaning that the referrer will include the origin and the
-    path (but not the fragment, password, or username). This case is unsafe as it can leak
-    path information that has been concealed to third-party by using TLS.</li>
-</ul>
+<p>A {{domxref("DOMString")}}; one of the following:</p>
+
+<dl>
+  <dt>no-referrer</dt>
+  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
+    information is sent along with requests.</dd>
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
+    as a referrer when the protocol security level stays the same (e.g.HTTP→HTTP,
+    HTTPS→HTTPS), but isn't sent to a less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>origin</dt>
+  <dd>Only send the origin of the document as the referrer in all cases.<br>
+    The document <code>https://example.com/page.html</code> will send the referrer
+    <code>https://example.com/</code>.</dd>
+  <dt>origin-when-cross-origin</dt>
+  <dd>Send a full URL when performing a same-origin request, but only send the origin of
+    the document for other cases.</dd>
+  <dt>same-origin</dt>
+  <dd>A referrer will be sent for <a
+      href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but
+    cross-origin requests will contain no referrer information.</dd>
+  <dt>strict-origin</dt>
+  <dd>Only send the origin of the document as the referrer when the protocol security
+    level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure
+    destination (e.g. HTTPS→HTTP).</dd>
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
+    protocol security level stays the same (e.g. HTTPS→HTTPS), and send no header to a
+    less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>unsafe-url</dt>
+  <dd>Send a full URL when performing a same-origin or cross-origin request. This policy
+    will leak origins and paths from TLS-protected resources to insecure origins.
+    Carefully consider the impact of this setting.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
@@ -23,17 +23,42 @@ browser-compat: api.HTMLAreaElement.referrerPolicy
 <pre class="brush: js"><var>refStr</var> = <var>areaElt</var>.referrerPolicy;
 <var>areaElt</var>.referrerPolicy = <var>refStr</var>;</pre>
 
-<h3 id="Values">Values</h3>
+<h3 id="Values">Value</h3>
 
-<ul>
-  <li><code>"no-referrer"</code> meaning that the <code>Referer:</code> HTTP header will
-    not be sent.</li>
-  <li><code>"origin"</code> meaning that the referrer will be the origin of the page, that
-    is roughly the scheme, the host and the port.</li>
-  <li><code>"unsafe-url"</code> meaning that the referrer will include the origin and the
-    path (but not the fragment, password, or username). This case is unsafe as it can leak
-    path information that has been concealed to third-party by using TLS.</li>
-</ul>
+<p>A {{domxref("DOMString")}}; one of the following:</p>
+
+<dl>
+  <dt>no-referrer</dt>
+  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
+    information is sent along with requests.</dd>
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
+    as a referrer when the protocol security level stays the same (e.g.HTTP→HTTP,
+    HTTPS→HTTPS), but isn't sent to a less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>origin</dt>
+  <dd>Only send the origin of the document as the referrer in all cases.<br>
+    The document <code>https://example.com/page.html</code> will send the referrer
+    <code>https://example.com/</code>.</dd>
+  <dt>origin-when-cross-origin</dt>
+  <dd>Send a full URL when performing a same-origin request, but only send the origin of
+    the document for other cases.</dd>
+  <dt>same-origin</dt>
+  <dd>A referrer will be sent for <a
+      href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but
+    cross-origin requests will contain no referrer information.</dd>
+  <dt>strict-origin</dt>
+  <dd>Only send the origin of the document as the referrer when the protocol security
+    level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure
+    destination (e.g. HTTPS→HTTP).</dd>
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
+    protocol security level stays the same (e.g. HTTPS→HTTPS), and send no header to a
+    less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>unsafe-url</dt>
+  <dd>Send a full URL when performing a same-origin or cross-origin request. This policy
+    will leak origins and paths from TLS-protected resources to insecure origins.
+    Carefully consider the impact of this setting.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
@@ -24,17 +24,40 @@ browser-compat: api.HTMLImageElement.referrerPolicy
 
 <h3 id="Values">Values</h3>
 
-<p>A {{domxref("DOMString")}} representing the referrer policy. Possible values are:</p>
+<p>A {{domxref("DOMString")}}; one of the following:</p>
 
-<ul>
-  <li><code>"no-referrer"</code> meaning that the <code>Referer:</code> HTTP header will
-    not be sent.</li>
-  <li><code>"origin"</code> meaning that the referrer will be the origin of the page, that
-    is roughly the scheme, the host and the port.</li>
-  <li><code>"unsafe-url"</code> meaning that the referrer will include the origin and the
-    path (but not the fragment, password, or username). This case is unsafe as it can leak
-    path information that has been concealed to third-party by using TLS.</li>
-</ul>
+<dl>
+  <dt>no-referrer</dt>
+  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
+    information is sent along with requests.</dd>
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
+    as a referrer when the protocol security level stays the same (e.g.HTTP→HTTP,
+    HTTPS→HTTPS), but isn't sent to a less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>origin</dt>
+  <dd>Only send the origin of the document as the referrer in all cases.<br>
+    The document <code>https://example.com/page.html</code> will send the referrer
+    <code>https://example.com/</code>.</dd>
+  <dt>origin-when-cross-origin</dt>
+  <dd>Send a full URL when performing a same-origin request, but only send the origin of
+    the document for other cases.</dd>
+  <dt>same-origin</dt>
+  <dd>A referrer will be sent for <a
+      href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but
+    cross-origin requests will contain no referrer information.</dd>
+  <dt>strict-origin</dt>
+  <dd>Only send the origin of the document as the referrer when the protocol security
+    level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure
+    destination (e.g. HTTPS→HTTP).</dd>
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
+    protocol security level stays the same (e.g. HTTPS→HTTPS), and send no header to a
+    less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>unsafe-url</dt>
+  <dd>Send a full URL when performing a same-origin or cross-origin request. This policy
+    will leak origins and paths from TLS-protected resources to insecure origins.
+    Carefully consider the impact of this setting.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
@@ -23,6 +23,43 @@ browser-compat: api.HTMLLinkElement.referrerPolicy
 
 <pre class="brush: js">DOMString HTMLLinkElement.referrerPolicy</pre>
 
+<h3 id="Values">Value</h3>
+
+<p>A {{domxref("DOMString")}}; one of the following:</p>
+
+<dl>
+  <dt>no-referrer</dt>
+  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
+    information is sent along with requests.</dd>
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
+    as a referrer when the protocol security level stays the same (e.g.HTTP→HTTP,
+    HTTPS→HTTPS), but isn't sent to a less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>origin</dt>
+  <dd>Only send the origin of the document as the referrer in all cases.<br>
+    The document <code>https://example.com/page.html</code> will send the referrer
+    <code>https://example.com/</code>.</dd>
+  <dt>origin-when-cross-origin</dt>
+  <dd>Send a full URL when performing a same-origin request, but only send the origin of
+    the document for other cases.</dd>
+  <dt>same-origin</dt>
+  <dd>A referrer will be sent for <a
+      href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but
+    cross-origin requests will contain no referrer information.</dd>
+  <dt>strict-origin</dt>
+  <dd>Only send the origin of the document as the referrer when the protocol security
+    level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure
+    destination (e.g. HTTPS→HTTP).</dd>
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
+    protocol security level stays the same (e.g. HTTPS→HTTPS), and send no header to a
+    less secure destination (e.g. HTTPS→HTTP).</dd>
+  <dt>unsafe-url</dt>
+  <dd>Send a full URL when performing a same-origin or cross-origin request. This policy
+    will leak origins and paths from TLS-protected resources to insecure origins.
+    Carefully consider the impact of this setting.</dd>
+</dl>
+
 <h2 id="Example">Example</h2>
 
 <pre class="brush: js;">var links = document.getElementsByTagName("link");

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
@@ -30,8 +30,8 @@ browser-compat: api.HTMLScriptElement.referrerPolicy
   <dt>no-referrer</dt>
   <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
     information is sent along with requests.</dd>
-  <dt>no-referrer-when-downgrade (default)</dt>
-  <dd>This is the user agent's default behavior if no policy is specified. The URL is sent
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
     as a referrer when the protocol security level stays the same (e.g.HTTP→HTTP,
     HTTPS→HTTPS), but isn't sent to a less secure destination (e.g. HTTPS→HTTP).</dd>
   <dt>origin</dt>
@@ -49,8 +49,8 @@ browser-compat: api.HTMLScriptElement.referrerPolicy
   <dd>Only send the origin of the document as the referrer when the protocol security
     level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure
     destination (e.g. HTTPS→HTTP).</dd>
-  <dt>strict-origin-when-cross-origin</dt>
-  <dd>Send a full URL when performing a same-origin request, only send the origin when the
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
     protocol security level stays the same (e.g. HTTPS→HTTPS), and send no header to a
     less secure destination (e.g. HTTPS→HTTP).</dd>
   <dt>unsafe-url</dt>

--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -76,8 +76,19 @@ browser-compat: html.elements.a
  <dd>Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as <a href="/en-US/docs/Web/HTML/Global_attributes/lang">the global <code>lang</code> attribute</a>.</dd>
  <dt id="ping">{{HTMLAttrDef("ping")}}</dt>
  <dd>A space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body <code>PING</code> to the URLs. Typically for tracking.</dd>
- <dt id="referrerpolicy">{{HTMLAttrDef("referrerpolicy")}}{{Experimental_Inline}}</dt>
- <dd>How much of the <a href="/en-US/docs/Web/HTTP/Headers/Referer">referrer</a> to send when following the link. See <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy"><code>Referrer-Policy</code></a> for possible values and their effects.</dd>
+ <dt id="referrerpolicy">{{HTMLAttrDef("referrerpolicy")}}</dt>
+ <dd>How much of the <a href="/en-US/docs/Web/HTTP/Headers/Referer">referrer</a> to send when following the link.
+
+  <ul>
+    <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
+    <li><code>no-referrer-when-downgrade</code>: The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
+    <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">scheme</a>, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
+    <li><code>origin-when-cross-origin</code>: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.</li>
+    <li><code>same-origin</code>: A referrer will be sent for {{Glossary("Same-origin policy", "same origin")}}, but cross-origin requests will contain no referrer information.</li>
+    <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</li>
+    <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
+    <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
+   </ul></dd>
  <dt id="rel">{{HTMLAttrDef("rel")}}</dt>
  <dd>The relationship of the linked URL as space-separated <a href="/en-US/docs/Web/HTML/Link_types">link types</a>.</dd>
  <dt id="target">{{HTMLAttrDef("target")}}</dt>

--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -80,15 +80,18 @@ browser-compat: html.elements.area
  <dd>Indicates the language of the linked resource. Allowed values are determined by <a href="https://www.ietf.org/rfc/bcp/bcp47.txt" title="Tags for Identifying Languages">BCP47</a>. Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.</dd>
  <dt>{{htmlattrdef("ping")}}</dt>
  <dd>Contains a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body <code>PING</code> will be sent by the browser (in the background). Typically used for tracking.</dd>
- <dt>{{htmlattrdef("referrerpolicy")}} {{experimental_inline}}</dt>
+ <dt>{{htmlattrdef("referrerpolicy")}}</dt>
  <dd>A string indicating which referrer to use when fetching the resource:
- <ul>
-  <li>"<code>no-referrer</code>" meaning that the <code>Referer:</code> header will not be sent.</li>
-  <li>"<code>no-referrer-when-downgrade</code>" meaning that no <code>Referer:</code> header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent’s default behavior, if no policy is otherwise specified.</li>
-  <li>"<code>origin</code>" meaning that the referrer will be the origin of the page, that is roughly the scheme, the host and the port.</li>
-  <li>"<code>origin-when-cross-origin</code>" meaning that navigations to other origins will be limited to the scheme, the host and the port, while navigations on the same origin will include the referrer's path.</li>
-  <li>"<code>unsafe-url</code>" meaning that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins.</li>
- </ul>
+  <ul>
+    <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
+    <li><code>no-referrer-when-downgrade</code>: The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
+    <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">scheme</a>, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
+    <li><code>origin-when-cross-origin</code>: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.</li>
+    <li><code>same-origin</code>: A referrer will be sent for {{Glossary("Same-origin policy", "same origin")}}, but cross-origin requests will contain no referrer information.</li>
+    <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</li>
+    <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
+    <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
+   </ul>
  </dd>
  <dt>{{htmlattrdef("rel")}}</dt>
  <dd>For anchors containing the {{htmlattrxref("href", "area")}} attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of <a href="/en-US/docs/Web/HTML/Link_types">link types values</a>. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.</dd>

--- a/files/en-us/web/html/element/iframe/index.html
+++ b/files/en-us/web/html/element/iframe/index.html
@@ -97,12 +97,12 @@ browser-compat: html.elements.iframe
  <dd>Indicates which <a href="/en-US/docs/Web/API/Document/referrer">referrer</a> to send when fetching the frame's resource:
  <ul>
   <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
-  <li><code>no-referrer-when-downgrade</code> (default): The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
+  <li><code>no-referrer-when-downgrade</code>: The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
   <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">scheme</a>, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
   <li><code>origin-when-cross-origin</code>: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.</li>
   <li><code>same-origin</code>: A referrer will be sent for {{Glossary("Same-origin policy", "same origin")}}, but cross-origin requests will contain no referrer information.</li>
   <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</li>
-  <li><code>strict-origin-when-cross-origin</code>: Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
+  <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
   <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
  </ul>
  </dd>

--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -149,15 +149,18 @@ browser-compat: html.elements.img
 		</li>
 	</ul>
 	</dd>
-	<dt>{{htmlattrdef("referrerpolicy")}} {{experimental_inline}}</dt>
+	<dt>{{htmlattrdef("referrerpolicy")}}</dt>
 	<dd>A string indicating which referrer to use when fetching the resource:
-	<ul>
-		<li><code>no-referrer</code>: The {{httpheader("Referer")}} header will not be sent.</li>
-		<li><code>no-referrer-when-downgrade</code>: No <code>Referer</code> header is sent when navigating to an origin without {{glossary("HTTPS")}}. This is the default if no policy is otherwise specified.</li>
-		<li><code>origin</code>: The <code>Referer</code> header will include the page's origin scheme, {{glossary("host")}}, and {{glossary("port")}}).</li>
-		<li><code>origin-when-cross-origin</code>: Navigating to other origins will limit the included referral data to the scheme, host, and port, while navigating from the same origin will include the full path and query string.</li>
-		<li><code>unsafe-url</code>: The <code>Referer</code> header will always include the origin, path and query string, but not the fragment, password, or username. <strong>This is unsafe</strong> because it can leak information from TLS-protected resources to insecure origins.</li>
-	</ul>
+    <ul>
+      <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
+      <li><code>no-referrer-when-downgrade</code>: The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
+      <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">scheme</a>, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
+      <li><code>origin-when-cross-origin</code>: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.</li>
+      <li><code>same-origin</code>: A referrer will be sent for {{Glossary("Same-origin policy", "same origin")}}, but cross-origin requests will contain no referrer information.</li>
+      <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</li>
+      <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
+      <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
+     </ul>
 	</dd>
 	<dt>{{htmlattrdef("sizes")}}</dt>
 	<dd>One or more strings separated by commas, indicating a set of source sizes. Each source size consists of:

--- a/files/en-us/web/html/element/script/index.html
+++ b/files/en-us/web/html/element/script/index.html
@@ -95,19 +95,19 @@ browser-compat: html.elements.script
  <dd>A cryptographic nonce (number used once) to whitelist scripts in a <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src">script-src Content-Security-Policy</a>. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.</dd>
  <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
  <dd>Indicates which <a href="/en-US/docs/Web/API/Document/referrer">referrer</a> to send when fetching the script, or resources fetched by the script:
- <ul>
+  <ul>
   <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
-  <li><code>no-referrer-when-downgrade</code> (default): The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
-  <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its {{Glossary("protocol", "scheme")}}, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
+  <li><code>no-referrer-when-downgrade</code>: The {{HTTPHeader("Referer")}} header will not be sent to {{Glossary("origin")}}s without {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).</li>
+  <li><code>origin</code>: The sent referrer will be limited to the origin of the referring page: its <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">scheme</a>, {{Glossary("host")}}, and {{Glossary("port")}}.</li>
   <li><code>origin-when-cross-origin</code>: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.</li>
-  <li><code>same-origin</code>: A referrer will be sent for <a href="/en-US/docs/Web/Security/Same-origin_policy">same origin</a>, but cross-origin requests will contain no referrer information.</li>
-  <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure destination (e.g. HTTPS→HTTP).</li>
-  <li><code>strict-origin-when-cross-origin</code>: Send a full URL when performing a same-origin request, but only send the origin when the protocol security level stays the same (e.g.HTTPS→HTTPS), and send no header to a less secure destination (e.g. HTTPS→HTTP).</li>
+  <li><code>same-origin</code>: A referrer will be sent for {{Glossary("Same-origin policy", "same origin")}}, but cross-origin requests will contain no referrer information.</li>
+  <li><code>strict-origin</code>: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</li>
+  <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
   <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
  </ul>
 
  <div class="notecard note">
- <p><strong>Note</strong>: An empty string value (<code>""</code>) is both the default value, and a fallback value if <code>referrerpolicy</code> is not supported. If <code>referrerpolicy</code> is not explicitly specified on the <code>&lt;script&gt;</code> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to <code>no-referrer-when-downgrade</code>.</p>
+ <p><strong>Note</strong>: An empty string value (<code>""</code>) is both the default value, and a fallback value if <code>referrerpolicy</code> is not supported. If <code>referrerpolicy</code> is not explicitly specified on the <code>&lt;script&gt;</code> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to <code>strict-origin-when-cross-origin</code>.</p>
  </div>
  </dd>
  <dt>{{htmlattrdef("src")}}</dt>


### PR DESCRIPTION
Fixes: #1489

The default value of referrerpolicy has changed, I spotted this while working on an API a while back and raised the above issue. This PR fixes the default (and normalizes all of the pages to have the same text) in both the API, and HTML Element pages.
