### PR TITLE
Fix {{domxref("Boolean")}} (part 1)

### DIFF
--- a/files/en-us/web/api/animationevent/initanimationevent/index.html
+++ b/files/en-us/web/api/animationevent/initanimationevent/index.html
@@ -64,10 +64,10 @@ browser-compat: api.AnimationEvent.initAnimationEvent
     </table>
   </dd>
   <dt><code>canBubbleArg</code></dt>
-  <dd>A Boolean flag indicating if the event can bubble (<code>true</code>)
+  <dd>A boolean flag indicating if the event can bubble (<code>true</code>)
     or not (<code>false)</code>.</dd>
   <dt><code>cancelableArg</code></dt>
-  <dd>A Boolean flag indicating if the event associated action can be
+  <dd>A boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><code>animationNameArg</code></dt>
   <dd>A {{domxref("DOMString")}} containing the value of the {{cssxref("animation-name")}}

--- a/files/en-us/web/api/animationevent/initanimationevent/index.html
+++ b/files/en-us/web/api/animationevent/initanimationevent/index.html
@@ -64,10 +64,10 @@ browser-compat: api.AnimationEvent.initAnimationEvent
     </table>
   </dd>
   <dt><code>canBubbleArg</code></dt>
-  <dd>A {{domxref("Boolean")}} flag indicating if the event can bubble (<code>true</code>)
+  <dd>A Boolean flag indicating if the event can bubble (<code>true</code>)
     or not (<code>false)</code>.</dd>
   <dt><code>cancelableArg</code></dt>
-  <dd>A {{domxref("Boolean")}} flag indicating if the event associated action can be
+  <dd>A Boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><code>animationNameArg</code></dt>
   <dd>A {{domxref("DOMString")}} containing the value of the {{cssxref("animation-name")}}

--- a/files/en-us/web/api/bluetooth/requestdevice/index.html
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.html
@@ -37,7 +37,7 @@ browser-compat: api.Bluetooth.requestDevice
         <code>name</code> parameter, and a <code>namePrefix</code> parameter.</li>
       <li><code>optionalServices[]</code>: An array of <code>BluetoothServiceUUID</code>s.
       </li>
-      <li><code>acceptAllDevices</code>: A Boolean value indicating that the
+      <li><code>acceptAllDevices</code>: A boolean value indicating that the
         requesting script can accept all Bluetooth devices. The default is
         <code>false</code>.</li>
     </ul>

--- a/files/en-us/web/api/bluetooth/requestdevice/index.html
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.html
@@ -37,7 +37,7 @@ browser-compat: api.Bluetooth.requestDevice
         <code>name</code> parameter, and a <code>namePrefix</code> parameter.</li>
       <li><code>optionalServices[]</code>: An array of <code>BluetoothServiceUUID</code>s.
       </li>
-      <li><code>acceptAllDevices</code>: A {{domxref("Boolean")}} indicating that the
+      <li><code>acceptAllDevices</code>: A Boolean value indicating that the
         requesting script can accept all Bluetooth devices. The default is
         <code>false</code>.</li>
     </ul>

--- a/files/en-us/web/api/bluetoothremotegattservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.html
@@ -45,7 +45,7 @@ browser-compat: api.BluetoothRemoteGATTService
   <dd>Returns information about a Bluetooth device through an instance of
     {{domxref("BluetoothDevice")}}.</dd>
   <dt>{{domxref("BluetoothRemoteGATTService.isPrimary")}}{{readonlyinline}}</dt>
-  <dd>Returns a Boolean value indicating whether this is a primary or secondary
+  <dd>Returns a boolean value indicating whether this is a primary or secondary
     service.</dd>
   <dt>{{domxref("BluetoothRemoteGATTService.uuid")}}{{readonlyinline}}</dt>
   <dd>Returns a {{domxref("DOMString")}} representing the UUID of this service.</dd>

--- a/files/en-us/web/api/bluetoothremotegattservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.html
@@ -45,8 +45,8 @@ browser-compat: api.BluetoothRemoteGATTService
   <dd>Returns information about a Bluetooth device through an instance of
     {{domxref("BluetoothDevice")}}.</dd>
   <dt>{{domxref("BluetoothRemoteGATTService.isPrimary")}}{{readonlyinline}}</dt>
-  <dd>Returns a {{domxref("Boolean")}} Indicating whether this is a primary or secondary
-    service. </dd>
+  <dd>Returns a Boolean value indicating whether this is a primary or secondary
+    service.</dd>
   <dt>{{domxref("BluetoothRemoteGATTService.uuid")}}{{readonlyinline}}</dt>
   <dd>Returns a {{domxref("DOMString")}} representing the UUID of this service.</dd>
 </dl>

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -31,9 +31,9 @@ browser-compat: api.CompositionEvent.initCompositionEvent
     one of <code>compositionstart</code>, <code>compositionupdate</code>, or
     <code>compositionend</code>.</dd>
   <dt><code>canBubbleArg</code></dt>
-  <dd>A Boolean value specifying whether or not the event can bubble.</dd>
+  <dd>A boolean value specifying whether or not the event can bubble.</dd>
   <dt><code>cancelableArg</code></dt>
-  <dd>A {{domxref("Boolean")}} whether or not the event can be canceled.</dd>
+  <dd>A boolean value indicating whether or not the event can be canceled.</dd>
   <dt><code>viewArg</code></dt>
   <dd>The {{domxref("Window")}} object from which the event was generated.</dd>
   <dt><code>dataArg</code></dt>

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -31,7 +31,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
     one of <code>compositionstart</code>, <code>compositionupdate</code>, or
     <code>compositionend</code>.</dd>
   <dt><code>canBubbleArg</code></dt>
-  <dd>A {{domxref("Boolean")}} specifying whether or not the event can bubble.</dd>
+  <dd>A Boolean value specifying whether or not the event can bubble.</dd>
   <dt><code>cancelableArg</code></dt>
   <dd>A {{domxref("Boolean")}} whether or not the event can be canceled.</dd>
   <dt><code>viewArg</code></dt>

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -35,7 +35,7 @@ browser-compat: api.ConvolverNode.ConvolverNode
           4-channel <em>{{domxref("AudioBuffer")}}</em> containing the
           (possibly multichannel) impulse response used by the <code>ConvolverNode</code>
           to create the reverb effect.</li>
-      <li><code>disableNormalization</code>: A {{domxref("Boolean")}} controlling
+      <li><code>disableNormalization</code>: A Boolean value controlling
           whether the impulse response from the buffer will be scaled by an equal-power
           normalization, or not. The default is '<code>false</code>'.</li>
     </ul>

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -35,7 +35,7 @@ browser-compat: api.ConvolverNode.ConvolverNode
           4-channel <em>{{domxref("AudioBuffer")}}</em> containing the
           (possibly multichannel) impulse response used by the <code>ConvolverNode</code>
           to create the reverb effect.</li>
-      <li><code>disableNormalization</code>: A Boolean value controlling
+      <li><code>disableNormalization</code>: A boolean value controlling
           whether the impulse response from the buffer will be scaled by an equal-power
           normalization, or not. The default is '<code>false</code>'.</li>
     </ul>

--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -116,7 +116,7 @@ browser-compat: api.Document.createTreeWalker
     whether or not to accept a node that has passed the <code>whatToShow</code> check.
   </dd>
   <dt><code>expandEntityReferences</code> {{optional_inline}} {{deprecated_inline}}</dt>
-  <dd>A Boolean flag indicating if when discarding an
+  <dd>A boolean flag indicating if when discarding an
     entity reference its whole sub-tree must be discarded at the same time.
   </dd>
 </dl>

--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -116,7 +116,7 @@ browser-compat: api.Document.createTreeWalker
     whether or not to accept a node that has passed the <code>whatToShow</code> check.
   </dd>
   <dt><code>expandEntityReferences</code> {{optional_inline}} {{deprecated_inline}}</dt>
-  <dd>A {{domxref("Boolean")}} flag indicating if when discarding an
+  <dd>A Boolean flag indicating if when discarding an
     entity reference its whole sub-tree must be discarded at the same time.
   </dd>
 </dl>

--- a/files/en-us/web/api/document/fullscreenenabled/index.html
+++ b/files/en-us/web/api/document/fullscreenenabled/index.html
@@ -33,7 +33,7 @@ browser-compat: api.Document.fullscreenEnabled
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value which is <code>true</code> if the document and the
+<p>A boolean value which is <code>true</code> if the document and the
   elements within can be placed into full-screen mode by calling
   {{domxref("Element.requestFullscreen()")}}. If full-screen mode isn't available, this
   value is <code>false</code>.</p>

--- a/files/en-us/web/api/document/fullscreenenabled/index.html
+++ b/files/en-us/web/api/document/fullscreenenabled/index.html
@@ -33,7 +33,7 @@ browser-compat: api.Document.fullscreenEnabled
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} value which is <code>true</code> if the document and the
+<p>A Boolean value which is <code>true</code> if the document and the
   elements within can be placed into full-screen mode by calling
   {{domxref("Element.requestFullscreen()")}}. If full-screen mode isn't available, this
   value is <code>false</code>.</p>

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.html
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.html
@@ -33,7 +33,7 @@ browser-compat: api.Document.pictureInPictureEnabled
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value, which is <code>true</code> if a video can enter
+<p>A boolean value, which is <code>true</code> if a video can enter
   picture-in-picture and be displayed in a floating window by calling
   {{domxref("HTMLVideoElement.requestFullscreen()")}}. If picture-in-picture mode isn't
   available, this value is <code>false</code>.</p>

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.html
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.html
@@ -33,7 +33,7 @@ browser-compat: api.Document.pictureInPictureEnabled
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} value, which is <code>true</code> if a video can enter
+<p>A Boolean value, which is <code>true</code> if a video can enter
   picture-in-picture and be displayed in a floating window by calling
   {{domxref("HTMLVideoElement.requestFullscreen()")}}. If picture-in-picture mode isn't
   available, this value is <code>false</code>.</p>

--- a/files/en-us/web/api/domimplementation/hasfeature/index.html
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.html
@@ -16,7 +16,7 @@ browser-compat: api.DOMImplementation.hasFeature
 
 <p><span class="seoSummary">The
     <strong><code>DOMImplementation.hasFeature()</code></strong> method returns a
-    Boolean flag indicating if a given feature is supported. It is
+    boolean flag indicating if a given feature is supported. It is
     deprecated and modern browsers return <code>true</code> in all cases.</span></p>
 
 <p>The different implementations fairly diverged in what kind of features were reported.

--- a/files/en-us/web/api/domimplementation/hasfeature/index.html
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.html
@@ -16,7 +16,7 @@ browser-compat: api.DOMImplementation.hasFeature
 
 <p><span class="seoSummary">The
     <strong><code>DOMImplementation.hasFeature()</code></strong> method returns a
-    {{domxref("Boolean")}} flag indicating if a given feature is supported. It is
+    Boolean flag indicating if a given feature is supported. It is
     deprecated and modern browsers return <code>true</code> in all cases.</span></p>
 
 <p>The different implementations fairly diverged in what kind of features were reported.

--- a/files/en-us/web/api/domimplementation/index.html
+++ b/files/en-us/web/api/domimplementation/index.html
@@ -28,7 +28,7 @@ browser-compat: api.DOMImplementation
  <dt>{{domxref("DOMImplementation.createHTMLDocument()")}}</dt>
  <dd>Creates and returns an HTML {{domxref("Document")}}.</dd>
  <dt>{{domxref("DOMImplementation.hasFeature()")}}</dt>
- <dd>Returns a Boolean value indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns <code>true</code>. Old browsers are very inconsistent in their behavior.</dd>
+ <dd>Returns a boolean value indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns <code>true</code>. Old browsers are very inconsistent in their behavior.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/domimplementation/index.html
+++ b/files/en-us/web/api/domimplementation/index.html
@@ -28,7 +28,7 @@ browser-compat: api.DOMImplementation
  <dt>{{domxref("DOMImplementation.createHTMLDocument()")}}</dt>
  <dd>Creates and returns an HTML {{domxref("Document")}}.</dd>
  <dt>{{domxref("DOMImplementation.hasFeature()")}}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns <code>true</code>. Old browsers are very inconsistent in their behavior.</dd>
+ <dd>Returns a Boolean value indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns <code>true</code>. Old browsers are very inconsistent in their behavior.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/event/returnvalue/index.html
+++ b/files/en-us/web/api/event/returnvalue/index.html
@@ -39,7 +39,7 @@ var <em>bool</em> = <em>event</em>.returnValue;
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value which is <code>true</code> if the event has not been
+<p>A boolean value which is <code>true</code> if the event has not been
   canceled; otherwise, if the event has been canceled or the default has been prevented,
   the value is <code>false</code>.</p>
 

--- a/files/en-us/web/api/event/returnvalue/index.html
+++ b/files/en-us/web/api/event/returnvalue/index.html
@@ -39,7 +39,7 @@ var <em>bool</em> = <em>event</em>.returnValue;
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} value which is <code>true</code> if the event has not been
+<p>A Boolean value which is <code>true</code> if the event has not been
   canceled; otherwise, if the event has been canceled or the default has been prevented,
   the value is <code>false</code>.</p>
 

--- a/files/en-us/web/api/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/index.html
@@ -41,7 +41,7 @@ browser-compat: api.EventSource
  <dt>{{domxref("EventSource.url")}} {{readonlyinline}}</dt>
  <dd>A {{domxref("DOMString")}} representing the URL of the source.</dd>
  <dt>{{domxref("EventSource.withCredentials")}} {{readonlyinline}}</dt>
- <dd>A {{domxref("Boolean")}} indicating whether the <code>EventSource</code> object was instantiated with cross-origin (<a href="/en-US/docs/Web/HTTP/CORS">CORS</a>) credentials set (<code>true</code>), or not (<code>false</code>, the default).</dd>
+ <dd>A Boolean value indicating whether the <code>EventSource</code> object was instantiated with cross-origin (<a href="/en-US/docs/Web/HTTP/CORS">CORS</a>) credentials set (<code>true</code>), or not (<code>false</code>, the default).</dd>
 </dl>
 
 <h3 id="Event_handlers">Event handlers</h3>

--- a/files/en-us/web/api/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/index.html
@@ -41,7 +41,7 @@ browser-compat: api.EventSource
  <dt>{{domxref("EventSource.url")}} {{readonlyinline}}</dt>
  <dd>A {{domxref("DOMString")}} representing the URL of the source.</dd>
  <dt>{{domxref("EventSource.withCredentials")}} {{readonlyinline}}</dt>
- <dd>A Boolean value indicating whether the <code>EventSource</code> object was instantiated with cross-origin (<a href="/en-US/docs/Web/HTTP/CORS">CORS</a>) credentials set (<code>true</code>), or not (<code>false</code>, the default).</dd>
+ <dd>A boolean value indicating whether the <code>EventSource</code> object was instantiated with cross-origin (<a href="/en-US/docs/Web/HTTP/CORS">CORS</a>) credentials set (<code>true</code>), or not (<code>false</code>, the default).</dd>
 </dl>
 
 <h3 id="Event_handlers">Event handlers</h3>

--- a/files/en-us/web/api/eventsource/withcredentials/index.html
+++ b/files/en-us/web/api/eventsource/withcredentials/index.html
@@ -13,7 +13,7 @@ browser-compat: api.EventSource.withCredentials
 <div>{{APIRef('WebSockets API')}}</div>
 
 <p>The <code><strong>withCredentials</strong></code> read-only property of the
-  {{domxref("EventSource")}} interface returns a {{domxref("Boolean")}} indicating whether
+  {{domxref("EventSource")}} interface returns a Boolean value indicating whether
   the <code>EventSource</code> object was instantiated with CORS credentials set.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -23,7 +23,7 @@ browser-compat: api.EventSource.withCredentials
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} indicating whether the <code>EventSource</code> object was
+<p>A Boolean value indicating whether the <code>EventSource</code> object was
   instantiated with CORS credentials set (<code>true</code>), or not (<code>false</code>,
   the default).</p>
 

--- a/files/en-us/web/api/eventsource/withcredentials/index.html
+++ b/files/en-us/web/api/eventsource/withcredentials/index.html
@@ -13,7 +13,7 @@ browser-compat: api.EventSource.withCredentials
 <div>{{APIRef('WebSockets API')}}</div>
 
 <p>The <code><strong>withCredentials</strong></code> read-only property of the
-  {{domxref("EventSource")}} interface returns a Boolean value indicating whether
+  {{domxref("EventSource")}} interface returns a boolean value indicating whether
   the <code>EventSource</code> object was instantiated with CORS credentials set.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -23,7 +23,7 @@ browser-compat: api.EventSource.withCredentials
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value indicating whether the <code>EventSource</code> object was
+<p>A boolean value indicating whether the <code>EventSource</code> object was
   instantiated with CORS credentials set (<code>true</code>), or not (<code>false</code>,
   the default).</p>
 

--- a/files/en-us/web/api/gamepadbutton/index.html
+++ b/files/en-us/web/api/gamepadbutton/index.html
@@ -26,7 +26,7 @@ browser-compat: api.GamepadButton
  <dt>{{domxref("GamepadButton.value")}} {{readonlyInline}}</dt>
  <dd>A double value used to represent the current state of analog buttons, such as the triggers on many modern gamepads. The values are normalized to the range 0.0 —1.0, with 0.0 representing a button that is not pressed, and 1.0 representing a button that is fully pressed.</dd>
  <dt>{{domxref("GamepadButton.pressed")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Boolean")}} value indicating whether the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).</dd>
+ <dd>A Boolean value indicating whether the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/gamepadbutton/index.html
+++ b/files/en-us/web/api/gamepadbutton/index.html
@@ -26,7 +26,7 @@ browser-compat: api.GamepadButton
  <dt>{{domxref("GamepadButton.value")}} {{readonlyInline}}</dt>
  <dd>A double value used to represent the current state of analog buttons, such as the triggers on many modern gamepads. The values are normalized to the range 0.0 —1.0, with 0.0 representing a button that is not pressed, and 1.0 representing a button that is fully pressed.</dd>
  <dt>{{domxref("GamepadButton.pressed")}} {{readonlyInline}}</dt>
- <dd>A Boolean value indicating whether the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).</dd>
+ <dd>A boolean value indicating whether the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/gamepadbutton/pressed/index.html
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.html
@@ -32,7 +32,7 @@ if(gp.buttons[0].pressed == true) {
 
 <h2 id="Value">Value</h2>
 
-<p>A {{domxref("boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.html
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GamepadPose.hasOrientation
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a Boolean value stating whether the {{domxref("Gamepad")}} can track and return orientation information.</p>
+<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a boolean value stating whether the {{domxref("Gamepad")}} can track and return orientation information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -23,7 +23,7 @@ browser-compat: api.GamepadPose.hasOrientation
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.html
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GamepadPose.hasOrientation
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a {{domxref("Boolean")}} stating whether the {{domxref("Gamepad")}} can track and return orientation information.</p>
+<p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a Boolean value stating whether the {{domxref("Gamepad")}} can track and return orientation information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasposition/index.html
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GamepadPose.hasPosition
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a Boolean value stating whether the {{domxref("Gamepad")}} can track and return position information.</p>
+<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a boolean value stating whether the {{domxref("Gamepad")}} can track and return position information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -23,7 +23,7 @@ browser-compat: api.GamepadPose.hasPosition
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasposition/index.html
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.html
@@ -15,7 +15,7 @@ browser-compat: api.GamepadPose.hasPosition
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a {{domxref("Boolean")}} stating whether the {{domxref("Gamepad")}} can track and return position information.</p>
+<p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("GamepadPose")}} interface returns a Boolean value stating whether the {{domxref("Gamepad")}} can track and return position information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmldialogelement/index.html
+++ b/files/en-us/web/api/htmldialogelement/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLDialogElement
 
 <dl>
  <dt>{{domxref("HTMLDialogElement.open")}}</dt>
- <dd>A {{domxref("Boolean")}} reflecting the {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is available for interaction.</dd>
+ <dd>A Boolean value reflecting the {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is available for interaction.</dd>
  <dt>{{domxref("HTMLDialogElement.returnValue")}}</dt>
  <dd>A {{domxref("DOMString")}} that sets or returns the return value for the dialog.</dd>
 </dl>

--- a/files/en-us/web/api/htmldialogelement/index.html
+++ b/files/en-us/web/api/htmldialogelement/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLDialogElement
 
 <dl>
  <dt>{{domxref("HTMLDialogElement.open")}}</dt>
- <dd>A Boolean value reflecting the {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is available for interaction.</dd>
+ <dd>A boolean value reflecting the {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is available for interaction.</dd>
  <dt>{{domxref("HTMLDialogElement.returnValue")}}</dt>
  <dd>A {{domxref("DOMString")}} that sets or returns the return value for the dialog.</dd>
 </dl>

--- a/files/en-us/web/api/htmldialogelement/open/index.html
+++ b/files/en-us/web/api/htmldialogelement/open/index.html
@@ -17,7 +17,7 @@ browser-compat: api.HTMLDialogElement.open
   <p>{{ SeeCompatTable() }}</p>
 
   <p>The <strong><code>open</code></strong> property of the
-    {{domxref("HTMLDialogElement")}} interface is a {{domxref("Boolean")}} reflecting the
+    {{domxref("HTMLDialogElement")}} interface is a Boolean value reflecting the
     {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is
     available for interaction.</p>
 </div>
@@ -29,7 +29,7 @@ var myOpenValue = dialogInstance.open;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} representing the state of the {{htmlattrxref("open",
+<p>A Boolean value representing the state of the {{htmlattrxref("open",
   "dialog")}} HTML attribute. <code>true</code> means it is set, and therefore the dialog
   is shown. <code>false</code> means it not set, and therefore the dialog is not shown.
 </p>

--- a/files/en-us/web/api/htmldialogelement/open/index.html
+++ b/files/en-us/web/api/htmldialogelement/open/index.html
@@ -17,7 +17,7 @@ browser-compat: api.HTMLDialogElement.open
   <p>{{ SeeCompatTable() }}</p>
 
   <p>The <strong><code>open</code></strong> property of the
-    {{domxref("HTMLDialogElement")}} interface is a Boolean value reflecting the
+    {{domxref("HTMLDialogElement")}} interface is a boolean value reflecting the
     {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is
     available for interaction.</p>
 </div>
@@ -29,7 +29,7 @@ var myOpenValue = dialogInstance.open;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value representing the state of the {{htmlattrxref("open",
+<p>A boolean value representing the state of the {{htmlattrxref("open",
   "dialog")}} HTML attribute. <code>true</code> means it is set, and therefore the dialog
   is shown. <code>false</code> means it not set, and therefore the dialog is not shown.
 </p>

--- a/files/en-us/web/api/htmldlistelement/index.html
+++ b/files/en-us/web/api/htmldlistelement/index.html
@@ -21,7 +21,7 @@ browser-compat: api.HTMLDListElement
 
 <dl>
  <dt>{{domxref("HTMLDListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a Boolean value indicating that spacing between list items should be reduced.</dd>
+ <dd>Is a boolean value indicating that spacing between list items should be reduced.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmldlistelement/index.html
+++ b/files/en-us/web/api/htmldlistelement/index.html
@@ -21,7 +21,7 @@ browser-compat: api.HTMLDListElement
 
 <dl>
  <dt>{{domxref("HTMLDListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating that spacing between list items should be reduced.</dd>
+ <dd>Is a Boolean value indicating that spacing between list items should be reduced.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
@@ -16,7 +16,7 @@ browser-compat: api.HTMLIFrameElement.allowPaymentRequest
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}{{non-standard_header}}</p>
 
 <p>The <strong><code>allowPaymentRequest</code></strong> property of the
-  {{domxref("HTMLIFrameElement")}} interface returns a {{domxref("Boolean")}} indicating
+  {{domxref("HTMLIFrameElement")}} interface returns a Boolean value indicating
   whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request
     API</a> may be invoked on a cross-origin iframe.</p>
 

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
@@ -16,9 +16,9 @@ browser-compat: api.HTMLIFrameElement.allowPaymentRequest
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}{{non-standard_header}}</p>
 
 <p>The <strong><code>allowPaymentRequest</code></strong> property of the
-  {{domxref("HTMLIFrameElement")}} interface returns a Boolean value indicating
+  {{domxref("HTMLIFrameElement")}} interface returns a boolean value indicating
   whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request
-    API</a> may be invoked on a cross-origin iframe.</p>
+    API</a> may be invoked on a cross-origin iframe.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -26,7 +26,7 @@ browser-compat: api.HTMLIFrameElement.allowPaymentRequest
 
 <h3 id="Value">Value</h3>
 
-<p>A {{jsxref("Boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/htmliframeelement/index.html
+++ b/files/en-us/web/api/htmliframeelement/index.html
@@ -24,9 +24,9 @@ browser-compat: api.HTMLIFrameElement
  <dt>{{domxref("HTMLIFrameElement.allow")}} {{experimental_inline}}</dt>
  <dd>Is a list of origins the frame is allowed to display content from. This attribute also accepts the values <code>self</code> and <code>src</code> which represent the origin in the iframe's src attribute. The default value is <code>src</code>.</dd>
  <dt>{{domxref("HTMLIFrameElement.allowfullscreen")}} {{experimental_inline}}</dt>
- <dd>Is a Boolean value indicating whether the inline frame is willing to be placed into full screen mode. See <a href="/en-US/docs/Web/API/Fullscreen_API">Using full-screen mode</a> for details.</dd>
+ <dd>Is a boolean value indicating whether the inline frame is willing to be placed into full screen mode. See <a href="/en-US/docs/Web/API/Fullscreen_API">Using full-screen mode</a> for details.</dd>
  <dt>{{domxref("HTMLIFrameElement.allowPaymentRequest")}}</dt>
- <dd>Is a Boolean value indicating whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> may be invoked inside a cross-origin iframe.</dd>
+ <dd>Is a boolean value indicating whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> may be invoked inside a cross-origin iframe.</dd>
  <dt>{{domxref("HTMLIFrameElement.contentDocument")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("Document")}}, the active document in the inline frame's nested browsing context.</dd>
  <dt>{{domxref("HTMLIFrameElement.contentWindow")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/htmliframeelement/index.html
+++ b/files/en-us/web/api/htmliframeelement/index.html
@@ -24,9 +24,9 @@ browser-compat: api.HTMLIFrameElement
  <dt>{{domxref("HTMLIFrameElement.allow")}} {{experimental_inline}}</dt>
  <dd>Is a list of origins the frame is allowed to display content from. This attribute also accepts the values <code>self</code> and <code>src</code> which represent the origin in the iframe's src attribute. The default value is <code>src</code>.</dd>
  <dt>{{domxref("HTMLIFrameElement.allowfullscreen")}} {{experimental_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating whether the inline frame is willing to be placed into full screen mode. See <a href="/en-US/docs/Web/API/Fullscreen_API">Using full-screen mode</a> for details.</dd>
+ <dd>Is a Boolean value indicating whether the inline frame is willing to be placed into full screen mode. See <a href="/en-US/docs/Web/API/Fullscreen_API">Using full-screen mode</a> for details.</dd>
  <dt>{{domxref("HTMLIFrameElement.allowPaymentRequest")}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> may be invoked inside a cross-origin iframe.</dd>
+ <dd>Is a Boolean value indicating whether the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> may be invoked inside a cross-origin iframe.</dd>
  <dt>{{domxref("HTMLIFrameElement.contentDocument")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("Document")}}, the active document in the inline frame's nested browsing context.</dd>
  <dt>{{domxref("HTMLIFrameElement.contentWindow")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/htmlolistelement/index.html
+++ b/files/en-us/web/api/htmlolistelement/index.html
@@ -36,7 +36,7 @@ browser-compat: api.HTMLOListElement
  </ul>
  </dd>
  <dt>{{domxref("HTMLOListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ol")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
+ <dd>Is a Boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ol")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmlolistelement/index.html
+++ b/files/en-us/web/api/htmlolistelement/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLOListElement
 
 <dl>
  <dt>{{domxref("HTMLOListElement.reversed")}}</dt>
- <dd>Is a Boolean value reflecting the {{htmlattrxref("reversed", "ol")}} and defining if the numbering is descending, that is its value is <code>true</code>, or ascending (<code>false</code>).</dd>
+ <dd>Is a boolean value reflecting the {{htmlattrxref("reversed", "ol")}} and defining if the numbering is descending, that is its value is <code>true</code>, or ascending (<code>false</code>).</dd>
  <dt>{{domxref("HTMLOListElement.start")}}</dt>
  <dd>Is a <code>long</code> value reflecting the {{htmlattrxref("start", "ol")}} and defining the value of the first number of the first element of the list.</dd>
  <dt>{{domxref("HTMLOListElement.type")}}</dt>
@@ -36,7 +36,7 @@ browser-compat: api.HTMLOListElement
  </ul>
  </dd>
  <dt>{{domxref("HTMLOListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a Boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ol")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
+ <dd>Is a boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ol")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmlolistelement/index.html
+++ b/files/en-us/web/api/htmlolistelement/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLOListElement
 
 <dl>
  <dt>{{domxref("HTMLOListElement.reversed")}}</dt>
- <dd>Is a {{domxref("Boolean")}} value reflecting the {{htmlattrxref("reversed", "ol")}} and defining if the numbering is descending, that is its value is <code>true</code>, or ascending (<code>false</code>).</dd>
+ <dd>Is a Boolean value reflecting the {{htmlattrxref("reversed", "ol")}} and defining if the numbering is descending, that is its value is <code>true</code>, or ascending (<code>false</code>).</dd>
  <dt>{{domxref("HTMLOListElement.start")}}</dt>
  <dd>Is a <code>long</code> value reflecting the {{htmlattrxref("start", "ol")}} and defining the value of the first number of the first element of the list.</dd>
  <dt>{{domxref("HTMLOListElement.type")}}</dt>

--- a/files/en-us/web/api/htmlstyleelement/index.html
+++ b/files/en-us/web/api/htmlstyleelement/index.html
@@ -29,11 +29,11 @@ browser-compat: api.HTMLStyleElement
  <dt>{{domxref("HTMLStyleElement.type")}} {{deprecated_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} representing the type of style being applied by this statement.</dd>
  <dt>{{domxref("HTMLStyleElement.disabled")}}</dt>
- <dd>Is a Boolean value representing whether or not the stylesheet is disabled (true) or not (false).</dd>
+ <dd>Is a boolean value representing whether or not the stylesheet is disabled (true) or not (false).</dd>
  <dt>{{domxref("HTMLStyleElement.sheet")}} {{readonlyInline}}</dt>
  <dd>Returns the {{domxref("StyleSheet")}} object associated with the given element, or <code>null</code> if there is none</dd>
  <dt>{{domxref("HTMLStyleElement.scoped")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Is a Boolean value indicating if the element applies to the whole document (<code>false</code>) or only to the parent's sub-tree (<code>true</code>).</dd>
+ <dd>Is a boolean value indicating if the element applies to the whole document (<code>false</code>) or only to the parent's sub-tree (<code>true</code>).</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmlstyleelement/index.html
+++ b/files/en-us/web/api/htmlstyleelement/index.html
@@ -29,11 +29,11 @@ browser-compat: api.HTMLStyleElement
  <dt>{{domxref("HTMLStyleElement.type")}} {{deprecated_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} representing the type of style being applied by this statement.</dd>
  <dt>{{domxref("HTMLStyleElement.disabled")}}</dt>
- <dd>Is a {{domxref("Boolean")}} value representing whether or not the stylesheet is disabled (true) or not (false).</dd>
+ <dd>Is a Boolean value representing whether or not the stylesheet is disabled (true) or not (false).</dd>
  <dt>{{domxref("HTMLStyleElement.sheet")}} {{readonlyInline}}</dt>
  <dd>Returns the {{domxref("StyleSheet")}} object associated with the given element, or <code>null</code> if there is none</dd>
  <dt>{{domxref("HTMLStyleElement.scoped")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} value indicating if the element applies to the whole document (<code>false</code>) or only to the parent's sub-tree (<code>true</code>).</dd>
+ <dd>Is a Boolean value indicating if the element applies to the whole document (<code>false</code>) or only to the parent's sub-tree (<code>true</code>).</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmltablecellelement/index.html
+++ b/files/en-us/web/api/htmltablecellelement/index.html
@@ -76,7 +76,7 @@ browser-compat: api.HTMLTableCellElement
  <dt>{{domxref("HTMLTableCellElement.height")}} {{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} containing a length of pixel of the hinted height of the cell. It reflects the obsolete {{htmlattrxref("height", "td")}} attribute.</dd>
  <dt>{{domxref("HTMLTableCellElement.noWrap")}} {{deprecated_inline}}</dt>
- <dd>A {{domxref("Boolean")}} value reflecting the {{htmlattrxref("nowrap", "td")}} attribute and indicating if cell content can be broken in several lines.</dd>
+ <dd>A Boolean value reflecting the {{htmlattrxref("nowrap", "td")}} attribute and indicating if cell content can be broken in several lines.</dd>
  <dt>{{domxref("HTMLTableCellElement.vAlign")}} {{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "td")}} attribute and can have one of the following values: <code>"top"</code>, <code>"middle"</code>, <code>"bottom"</code>, or <code>"baseline"</code>. Use the CSS {{cssxref("vertical-align")}} property instead.</dd>
  <dt>{{domxref("HTMLTableCellElement.width")}} {{deprecated_inline}}</dt>

--- a/files/en-us/web/api/htmltablecellelement/index.html
+++ b/files/en-us/web/api/htmltablecellelement/index.html
@@ -76,7 +76,7 @@ browser-compat: api.HTMLTableCellElement
  <dt>{{domxref("HTMLTableCellElement.height")}} {{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} containing a length of pixel of the hinted height of the cell. It reflects the obsolete {{htmlattrxref("height", "td")}} attribute.</dd>
  <dt>{{domxref("HTMLTableCellElement.noWrap")}} {{deprecated_inline}}</dt>
- <dd>A Boolean value reflecting the {{htmlattrxref("nowrap", "td")}} attribute and indicating if cell content can be broken in several lines.</dd>
+ <dd>A boolean value reflecting the {{htmlattrxref("nowrap", "td")}} attribute and indicating if cell content can be broken in several lines.</dd>
  <dt>{{domxref("HTMLTableCellElement.vAlign")}} {{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "td")}} attribute and can have one of the following values: <code>"top"</code>, <code>"middle"</code>, <code>"bottom"</code>, or <code>"baseline"</code>. Use the CSS {{cssxref("vertical-align")}} property instead.</dd>
  <dt>{{domxref("HTMLTableCellElement.width")}} {{deprecated_inline}}</dt>

--- a/files/en-us/web/api/htmltrackelement/index.html
+++ b/files/en-us/web/api/htmltrackelement/index.html
@@ -30,7 +30,7 @@ browser-compat: api.HTMLTrackElement
  <dt>{{domxref("HTMLTrackElement.label")}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("label", "track")}} HTML attribute, indicating a user-readable title for the track.</dd>
  <dt>{{domxref("HTMLTrackElement.default")}}</dt>
- <dd>A Boolean value reflecting the {{htmlattrxref("default", "track")}}  attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.</dd>
+ <dd>A boolean value reflecting the {{htmlattrxref("default", "track")}} attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.</dd>
  <dt>{{domxref("HTMLTrackElement.readyState")}} {{ReadOnlyInline}}</dt>
  <dd>Returns  an <code>unsigned short</code> that show the readiness state of the track:
  <table class="standard-table">

--- a/files/en-us/web/api/htmltrackelement/index.html
+++ b/files/en-us/web/api/htmltrackelement/index.html
@@ -30,7 +30,7 @@ browser-compat: api.HTMLTrackElement
  <dt>{{domxref("HTMLTrackElement.label")}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("label", "track")}} HTML attribute, indicating a user-readable title for the track.</dd>
  <dt>{{domxref("HTMLTrackElement.default")}}</dt>
- <dd>A {{domxref("Boolean")}} reflecting the {{htmlattrxref("default", "track")}}  attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.</dd>
+ <dd>A Boolean value reflecting the {{htmlattrxref("default", "track")}}  attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.</dd>
  <dt>{{domxref("HTMLTrackElement.readyState")}} {{ReadOnlyInline}}</dt>
  <dd>Returns  an <code>unsigned short</code> that show the readiness state of the track:
  <table class="standard-table">

--- a/files/en-us/web/api/htmlulistelement/index.html
+++ b/files/en-us/web/api/htmlulistelement/index.html
@@ -24,7 +24,7 @@ browser-compat: api.HTMLUListElement
  <dt>{{domxref("HTMLUListElement.type")}} {{deprecated_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} value reflecting the {{htmlattrxref("type", "ul")}} and defining the kind of marker to be used to display. The values are browser dependent and have never been standardized.</dd>
  <dt>{{domxref("HTMLUListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ul")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
+ <dd>Is a Boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ul")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmlulistelement/index.html
+++ b/files/en-us/web/api/htmlulistelement/index.html
@@ -24,7 +24,7 @@ browser-compat: api.HTMLUListElement
  <dt>{{domxref("HTMLUListElement.type")}} {{deprecated_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} value reflecting the {{htmlattrxref("type", "ul")}} and defining the kind of marker to be used to display. The values are browser dependent and have never been standardized.</dd>
  <dt>{{domxref("HTMLUListElement.compact")}} {{deprecated_inline}}</dt>
- <dd>Is a Boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ul")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
+ <dd>Is a boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ul")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -27,7 +27,7 @@ browser-compat: api.IDBIndex
 
 <dl>
  <dt>{{domxref("IDBIndex.isAutoLocale")}} {{readonlyInline}} {{ Non-Standard_inline() }}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
+ <dd>Returns a Boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
  <dt>{{domxref("IDBIndex.locale")}} {{readonlyInline}} {{ Non-Standard_inline() }}</dt>
  <dd>Returns the locale of the index (for example <code>en-US</code>, or <code>pl</code>) if it had a <code>locale</code> value specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
  <dt>{{domxref("IDBIndex.name")}}</dt>

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -27,7 +27,7 @@ browser-compat: api.IDBIndex
 
 <dl>
  <dt>{{domxref("IDBIndex.isAutoLocale")}} {{readonlyInline}} {{ Non-Standard_inline() }}</dt>
- <dd>Returns a Boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
+ <dd>Returns a boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
  <dt>{{domxref("IDBIndex.locale")}} {{readonlyInline}} {{ Non-Standard_inline() }}</dt>
  <dd>Returns the locale of the index (for example <code>en-US</code>, or <code>pl</code>) if it had a <code>locale</code> value specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</dd>
  <dt>{{domxref("IDBIndex.name")}}</dt>

--- a/files/en-us/web/api/idbindex/isautolocale/index.html
+++ b/files/en-us/web/api/idbindex/isautolocale/index.html
@@ -15,7 +15,7 @@ browser-compat: api.IDBIndex.isAutoLocale
 ---
 <div>{{APIRef("IndexedDB")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>isAutoLocale</code></strong> read-only property of the {{domxref("IDBIndex")}} interface returns a Boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</p>
+<p>The <strong><code>isAutoLocale</code></strong> read-only property of the {{domxref("IDBIndex")}} interface returns a boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ console.log(myIndex.isAutoLocale);</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/idbindex/isautolocale/index.html
+++ b/files/en-us/web/api/idbindex/isautolocale/index.html
@@ -15,7 +15,7 @@ browser-compat: api.IDBIndex.isAutoLocale
 ---
 <div>{{APIRef("IndexedDB")}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>isAutoLocale</code></strong> read-only property of the {{domxref("IDBIndex")}} interface returns a {{domxref("Boolean")}} indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</p>
+<p>The <strong><code>isAutoLocale</code></strong> read-only property of the {{domxref("IDBIndex")}} interface returns a Boolean value indicating whether the index had a <code>locale</code> value of <code>auto</code> specified upon its creation (see <a href="/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters"><code>createIndex()</code>'s optionalParameters</a>.)</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/index.html
@@ -73,7 +73,7 @@ browser-compat: api.MediaSource
 
 <dl>
  <dt>{{domxref("MediaSource.isTypeSupported()")}}</dt>
- <dd>Returns a {{domxref("Boolean")}} value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.</dd>
+ <dd>Returns a Boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/index.html
@@ -73,7 +73,7 @@ browser-compat: api.MediaSource
 
 <dl>
  <dt>{{domxref("MediaSource.isTypeSupported()")}}</dt>
- <dd>Returns a Boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.</dd>
+ <dd>Returns a boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -59,7 +59,7 @@ browser-compat: api.Navigator
  <dt>{{domxref("Navigator.mediaSession")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns {{domxref("MediaSession")}} object which can be used to provide metadata that can be used by the browser to present information about the currently-playing media to the user, such as in a global media controls UI.</dd>
  <dt>{{domxref("Navigator.onLine")}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value indicating whether the browser is working online.</dd>
+ <dd>Returns a boolean value indicating whether the browser is working online.</dd>
  <dt>{{domxref("Navigator.permissions")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
  <dt>{{domxref("Navigator.presentation")}} {{readonlyInline}} {{experimental_inline}}</dt>

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -59,7 +59,7 @@ browser-compat: api.Navigator
  <dt>{{domxref("Navigator.mediaSession")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns {{domxref("MediaSession")}} object which can be used to provide metadata that can be used by the browser to present information about the currently-playing media to the user, such as in a global media controls UI.</dd>
  <dt>{{domxref("Navigator.onLine")}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating whether the browser is working online.</dd>
+ <dd>Returns a Boolean value indicating whether the browser is working online.</dd>
  <dt>{{domxref("Navigator.permissions")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
  <dt>{{domxref("Navigator.presentation")}} {{readonlyInline}} {{experimental_inline}}</dt>

--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -12,7 +12,7 @@ browser-compat: api.NodeIterator.expandEntityReferences
 <p>{{APIRef("DOM")}} {{deprecated_header}}</p>
 
 <p>The <code><strong>NodeIterator.expandEntityReferences</strong></code> read-only
-  property returns a {{domxref("Boolean")}} flag indicating whether or not the children of
+  property returns a Boolean flag indicating whether or not the children of
   entity reference nodes are visible to the {{domxref("NodeIterator")}}.</p>
 
 <p>If this value is <code>false</code>, the children of entity reference nodes (as well as

--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -12,11 +12,11 @@ browser-compat: api.NodeIterator.expandEntityReferences
 <p>{{APIRef("DOM")}} {{deprecated_header}}</p>
 
 <p>The <code><strong>NodeIterator.expandEntityReferences</strong></code> read-only
-  property returns a Boolean flag indicating whether or not the children of
+  property returns a boolean flag indicating whether or not the children of
   entity reference nodes are visible to the {{domxref("NodeIterator")}}.</p>
 
 <p>If this value is <code>false</code>, the children of entity reference nodes (as well as
-  all of their descendants) are rejected. This takes precedence over the value of the 
+  all of their descendants) are rejected. This takes precedence over the value of the
   {{domxref("NodeIterator.whatToShow")}} method and the associated filter.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/nodeiterator/index.html
+++ b/files/en-us/web/api/nodeiterator/index.html
@@ -127,7 +127,7 @@ browser-compat: api.NodeIterator
 	<dd>Returns a {{domxref("NodeFilter")}} used to select the relevant nodes.</dd>
 	<dt>{{domxref("NodeIterator.expandEntityReferences")}} {{readonlyInline}}
 		{{deprecated_inline}}</dt>
-	<dd>Is a Boolean value indicating if, when discarding an
+	<dd>Is a boolean value indicating if, when discarding an
 		{{domxref("EntityReference")}} its whole sub-tree must be discarded at the same
 		time.</dd>
 	<dt>{{domxref("NodeIterator.referenceNode")}} {{readonlyInline}}
@@ -135,7 +135,7 @@ browser-compat: api.NodeIterator
 	<dd>Returns the {{domxref("Node")}} to which the iterator is anchored.</dd>
 	<dt>{{domxref("NodeIterator.pointerBeforeReferenceNode")}} {{readonlyInline}} {{
 		experimental_inline() }}</dt>
-	<dd>Returns a Boolean flag that indicates whether the
+	<dd>Returns a boolean flag that indicates whether the
 		{{domxref("NodeIterator")}} is anchored before, the flag being <code>true</code>,
 		or after, the flag being <code>false</code>, the anchor node.</dd>
 </dl>

--- a/files/en-us/web/api/nodeiterator/index.html
+++ b/files/en-us/web/api/nodeiterator/index.html
@@ -127,7 +127,7 @@ browser-compat: api.NodeIterator
 	<dd>Returns a {{domxref("NodeFilter")}} used to select the relevant nodes.</dd>
 	<dt>{{domxref("NodeIterator.expandEntityReferences")}} {{readonlyInline}}
 		{{deprecated_inline}}</dt>
-	<dd>Is a {{domxref("Boolean")}} indicating if, when discarding an
+	<dd>Is a Boolean value indicating if, when discarding an
 		{{domxref("EntityReference")}} its whole sub-tree must be discarded at the same
 		time.</dd>
 	<dt>{{domxref("NodeIterator.referenceNode")}} {{readonlyInline}}

--- a/files/en-us/web/api/nodeiterator/index.html
+++ b/files/en-us/web/api/nodeiterator/index.html
@@ -135,7 +135,7 @@ browser-compat: api.NodeIterator
 	<dd>Returns the {{domxref("Node")}} to which the iterator is anchored.</dd>
 	<dt>{{domxref("NodeIterator.pointerBeforeReferenceNode")}} {{readonlyInline}} {{
 		experimental_inline() }}</dt>
-	<dd>Returns a {{domxref("Boolean")}} flag that indicates whether the
+	<dd>Returns a Boolean flag that indicates whether the
 		{{domxref("NodeIterator")}} is anchored before, the flag being <code>true</code>,
 		or after, the flag being <code>false</code>, the anchor node.</dd>
 </dl>

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
@@ -12,7 +12,7 @@ browser-compat: api.NodeIterator.pointerBeforeReferenceNode
 <p>{{APIRef("DOM")}} {{SeeCompatTable}}</p>
 
 <p>The <strong><code>NodeIterator.pointerBeforeReferenceNode</code></strong> read-only
-	property returns a {{domxref("Boolean")}} flag that indicates whether the
+	property returns a Boolean flag that indicates whether the
 	{{domxref("NodeFilter")}} is anchored before (if this value is <code>true</code>) or
 	after (if this value is <code>false</code>) the anchor node indicated by the
 	{{domxref("NodeIterator.referenceNode")}} property.</p>

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
@@ -12,7 +12,7 @@ browser-compat: api.NodeIterator.pointerBeforeReferenceNode
 <p>{{APIRef("DOM")}} {{SeeCompatTable}}</p>
 
 <p>The <strong><code>NodeIterator.pointerBeforeReferenceNode</code></strong> read-only
-	property returns a Boolean flag that indicates whether the
+	property returns a boolean flag that indicates whether the
 	{{domxref("NodeFilter")}} is anchored before (if this value is <code>true</code>) or
 	after (if this value is <code>false</code>) the anchor node indicated by the
 	{{domxref("NodeIterator.referenceNode")}} property.</p>

--- a/files/en-us/web/api/notification/notification/index.html
+++ b/files/en-us/web/api/notification/notification/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Notification.Notification
           href="/en-US/docs/Web/API/Vibration_API#vibration_patterns">vibration
           pattern</a> for the device's vibration hardware to emit with the notification.
       </li>
-      <li><code>renotify</code>: A {{domxref("Boolean")}} specifying whether the user
+      <li><code>renotify</code>: A Boolean value specifying whether the user
         should be notified after a new notification replaces an old one. The default is
         <code>false</code>, which means they won't be notified.</li>
       <li><code>requireInteraction</code>: Indicates that a notification should remain
@@ -68,7 +68,7 @@ browser-compat: api.Notification.Notification
         the context of the notification itself. The action's name is sent to the service
         worker notification handler to let it know the action was selected by the user.
       </li>
-      <li><code>silent</code>: A {{domxref("Boolean")}} specifying whether the
+      <li><code>silent</code>: A Boolean value specifying whether the
         notification is silent (no sounds or vibrations issued), regardless of the device
         settings. The default is <code>false</code>, which means it won't be silent.</li>
     </ul>

--- a/files/en-us/web/api/notification/notification/index.html
+++ b/files/en-us/web/api/notification/notification/index.html
@@ -56,7 +56,7 @@ browser-compat: api.Notification.Notification
           href="/en-US/docs/Web/API/Vibration_API#vibration_patterns">vibration
           pattern</a> for the device's vibration hardware to emit with the notification.
       </li>
-      <li><code>renotify</code>: A Boolean value specifying whether the user
+      <li><code>renotify</code>: A boolean value specifying whether the user
         should be notified after a new notification replaces an old one. The default is
         <code>false</code>, which means they won't be notified.</li>
       <li><code>requireInteraction</code>: Indicates that a notification should remain
@@ -68,7 +68,7 @@ browser-compat: api.Notification.Notification
         the context of the notification itself. The action's name is sent to the service
         worker notification handler to let it know the action was selected by the user.
       </li>
-      <li><code>silent</code>: A Boolean value specifying whether the
+      <li><code>silent</code>: A boolean value specifying whether the
         notification is silent (no sounds or vibrations issued), regardless of the device
         settings. The default is <code>false</code>, which means it won't be silent.</li>
     </ul>

--- a/files/en-us/web/api/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.ProgressEvent
 
 <dl>
  <dt>{{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}</dt>
- <dd>A Boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.</dd>
+ <dd>A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.</dd>
  <dt>{{domxref("ProgressEvent.loaded")}} {{readonlyInline}}</dt>
  <dd>A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing <code>total</code> by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.</dd>
  <dt>{{domxref("ProgressEvent.total")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.ProgressEvent
 
 <dl>
  <dt>{{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Boolean")}} flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.</dd>
+ <dd>A Boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.</dd>
  <dt>{{domxref("ProgressEvent.loaded")}} {{readonlyInline}}</dt>
  <dd>A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing <code>total</code> by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.</dd>
  <dt>{{domxref("ProgressEvent.total")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/progressevent/initprogressevent/index.html
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.html
@@ -71,13 +71,13 @@ browser-compat: api.ProgressEvent.initProgressEvent
     </table>
   </dd>
   <dt><em>canBubbleArg</em></dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the event can bubble
+  <dd>Is a Boolean flag indicating if the event can bubble
     (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>cancelableArg</em></dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the event associated action can be
+  <dd>Is a Boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>lengthComputable</em></dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the total work to be done, and the
+  <dd>Is a Boolean flag indicating if the total work to be done, and the
     amount of work already done, by the underlying process is calculable. In other words,
     it tells if the progress is measurable or not.</dd>
   <dt><em>loaded</em></dt>

--- a/files/en-us/web/api/progressevent/initprogressevent/index.html
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.html
@@ -71,13 +71,13 @@ browser-compat: api.ProgressEvent.initProgressEvent
     </table>
   </dd>
   <dt><em>canBubbleArg</em></dt>
-  <dd>Is a Boolean flag indicating if the event can bubble
+  <dd>Is a boolean flag indicating if the event can bubble
     (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>cancelableArg</em></dt>
-  <dd>Is a Boolean flag indicating if the event associated action can be
+  <dd>Is a boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>lengthComputable</em></dt>
-  <dd>Is a Boolean flag indicating if the total work to be done, and the
+  <dd>Is a boolean flag indicating if the total work to be done, and the
     amount of work already done, by the underlying process is calculable. In other words,
     it tells if the progress is measurable or not.</dd>
   <dt><em>loaded</em></dt>

--- a/files/en-us/web/api/progressevent/lengthcomputable/index.html
+++ b/files/en-us/web/api/progressevent/lengthcomputable/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ProgressEvent.lengthComputable
 
 <p><span class="seoSummary">The
     <code><strong>ProgressEvent.lengthComputable</strong></code> read-only property is a
-    {{domxref("Boolean")}} flag indicating if the resource concerned by the
+    Boolean flag indicating if the resource concerned by the
     {{domxref("ProgressEvent")}} has a length that can be calculated. If not, the
     {{domxref("ProgressEvent.total")}} property has no significant value.</span></p>
 

--- a/files/en-us/web/api/progressevent/lengthcomputable/index.html
+++ b/files/en-us/web/api/progressevent/lengthcomputable/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ProgressEvent.lengthComputable
 
 <p><span class="seoSummary">The
     <code><strong>ProgressEvent.lengthComputable</strong></code> read-only property is a
-    Boolean flag indicating if the resource concerned by the
+    boolean flag indicating if the resource concerned by the
     {{domxref("ProgressEvent")}} has a length that can be calculated. If not, the
     {{domxref("ProgressEvent.total")}} property has no significant value.</span></p>
 

--- a/files/en-us/web/api/progressevent/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/progressevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.ProgressEvent.ProgressEvent
   <dd>Is a {{domxref("DOMString")}} representing the name of the type of the
     <code>ProgressEvent</code>. It is case-sensitive.</dd>
   <dt><code>lengthComputable</code> {{optional_inline}}</dt>
-  <dd>Is a Boolean flag indicating if the total work to be done, and the
+  <dd>Is a boolean flag indicating if the total work to be done, and the
     amount of work already done, by the underlying process is calculable. In other words,
     it tells if the progress is measurable or not. It defaults to <code>false</code>.</dd>
   <dt><code>loaded</code> {{optional_inline}}</dt>

--- a/files/en-us/web/api/progressevent/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/progressevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.ProgressEvent.ProgressEvent
   <dd>Is a {{domxref("DOMString")}} representing the name of the type of the
     <code>ProgressEvent</code>. It is case-sensitive.</dd>
   <dt><code>lengthComputable</code> {{optional_inline}}</dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the total work to be done, and the
+  <dd>Is a Boolean flag indicating if the total work to be done, and the
     amount of work already done, by the underlying process is calculable. In other words,
     it tells if the progress is measurable or not. It defaults to <code>false</code>.</dd>
   <dt><code>loaded</code> {{optional_inline}}</dt>

--- a/files/en-us/web/api/range/collapsed/index.html
+++ b/files/en-us/web/api/range/collapsed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Range.collapsed
 <div>{{ APIRef("DOM") }}</div>
 
 <p>The <code><strong>Range.collapsed</strong></code> read-only property returns a
-  {{domxref("Boolean")}} flag indicating whether the start and end points of the
+  Boolean flag indicating whether the start and end points of the
   {{domxref("Range")}} are at the same position. It returns <code>true</code> if the start
   and end boundary points of the {{domxref("Range")}} are the same point in the DOM,
   <code>false</code> if not.</p>

--- a/files/en-us/web/api/range/collapsed/index.html
+++ b/files/en-us/web/api/range/collapsed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Range.collapsed
 <div>{{ APIRef("DOM") }}</div>
 
 <p>The <code><strong>Range.collapsed</strong></code> read-only property returns a
-  Boolean flag indicating whether the start and end points of the
+  boolean flag indicating whether the start and end points of the
   {{domxref("Range")}} are at the same position. It returns <code>true</code> if the start
   and end boundary points of the {{domxref("Range")}} are the same point in the DOM,
   <code>false</code> if not.</p>

--- a/files/en-us/web/api/range/index.html
+++ b/files/en-us/web/api/range/index.html
@@ -20,7 +20,7 @@ browser-compat: api.Range
 
 <dl>
  <dt>{{domxref("Range.collapsed")}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating whether the range's start and end points are at the same position.</dd>
+ <dd>Returns a Boolean value indicating whether the range's start and end points are at the same position.</dd>
  <dt>{{domxref("Range.commonAncestorContainer")}} {{readonlyInline}}</dt>
  <dd>Returns the deepest {{ domxref("Node") }} that contains the <code>startContainer</code> and <code>endContainer</code> nodes.</dd>
  <dt>{{domxref("Range.endContainer")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/range/index.html
+++ b/files/en-us/web/api/range/index.html
@@ -20,7 +20,7 @@ browser-compat: api.Range
 
 <dl>
  <dt>{{domxref("Range.collapsed")}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value indicating whether the range's start and end points are at the same position.</dd>
+ <dd>Returns a boolean value indicating whether the range's start and end points are at the same position.</dd>
  <dt>{{domxref("Range.commonAncestorContainer")}} {{readonlyInline}}</dt>
  <dd>Returns the deepest {{ domxref("Node") }} that contains the <code>startContainer</code> and <code>endContainer</code> nodes.</dd>
  <dt>{{domxref("Range.endContainer")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/speechrecognition/continuous/index.html
+++ b/files/en-us/web/api/speechrecognition/continuous/index.html
@@ -29,7 +29,7 @@ mySpeechRecognition.continuous = true;
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value representing the current <code>SpeechRecognition</code>'s
+<p>A boolean value representing the current <code>SpeechRecognition</code>'s
   continuous status. <code>true</code> means continuous, and <code>false</code> means not
   continuous (single result each time.)</p>
 

--- a/files/en-us/web/api/speechrecognition/continuous/index.html
+++ b/files/en-us/web/api/speechrecognition/continuous/index.html
@@ -29,7 +29,7 @@ mySpeechRecognition.continuous = true;
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} representing the current <code>SpeechRecognition</code>'s
+<p>A Boolean value representing the current <code>SpeechRecognition</code>'s
   continuous status. <code>true</code> means continuous, and <code>false</code> means not
   continuous (single result each time.)</p>
 

--- a/files/en-us/web/api/speechrecognition/interimresults/index.html
+++ b/files/en-us/web/api/speechrecognition/interimresults/index.html
@@ -31,7 +31,7 @@ mySpeechRecognition.interimResults = false;
 
 <h3 id="Value">Value</h3>
 
-<p>A Boolean value representing the state of the current
+<p>A boolean value representing the state of the current
   <code>SpeechRecognition</code>'s interim results. <code>true</code> means interim
   results are returned, and <code>false</code> means they aren't.</p>
 

--- a/files/en-us/web/api/speechrecognition/interimresults/index.html
+++ b/files/en-us/web/api/speechrecognition/interimresults/index.html
@@ -31,7 +31,7 @@ mySpeechRecognition.interimResults = false;
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}} representing the state of the current
+<p>A Boolean value representing the state of the current
   <code>SpeechRecognition</code>'s interim results. <code>true</code> means interim
   results are returned, and <code>false</code> means they aren't.</p>
 

--- a/files/en-us/web/api/speechsynthesisvoice/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/index.html
@@ -20,11 +20,11 @@ browser-compat: api.SpeechSynthesisVoice
 
 <dl>
 	<dt>{{domxref("SpeechSynthesisVoice.default")}} {{readonlyinline}}</dt>
-	<dd>A Boolean value indicating whether the voice is the default voice for the current app language (<code>true</code>), or not (<code>false</code>.)</dd>
+	<dd>A boolean value indicating whether the voice is the default voice for the current app language (<code>true</code>), or not (<code>false</code>.)</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.lang")}} {{readonlyinline}}</dt>
 	<dd>Returns a BCP 47 language tag indicating the language of the voice.</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.localService")}} {{readonlyinline}}</dt>
-	<dd>A Boolean value indicating whether the voice is supplied by a local speech synthesizer service (<code>true</code>), or a remote speech synthesizer service (<code>false</code>.)</dd>
+	<dd>A boolean value indicating whether the voice is supplied by a local speech synthesizer service (<code>true</code>), or a remote speech synthesizer service (<code>false</code>.)</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.name")}} {{readonlyinline}}</dt>
 	<dd>Returns a human-readable name that represents the voice.</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.voiceURI")}} {{readonlyinline}}</dt>

--- a/files/en-us/web/api/speechsynthesisvoice/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/index.html
@@ -20,11 +20,11 @@ browser-compat: api.SpeechSynthesisVoice
 
 <dl>
 	<dt>{{domxref("SpeechSynthesisVoice.default")}} {{readonlyinline}}</dt>
-	<dd>A {{domxref("Boolean")}} indicating whether the voice is the default voice for the current app language (<code>true</code>), or not (<code>false</code>.)</dd>
+	<dd>A Boolean value indicating whether the voice is the default voice for the current app language (<code>true</code>), or not (<code>false</code>.)</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.lang")}} {{readonlyinline}}</dt>
 	<dd>Returns a BCP 47 language tag indicating the language of the voice.</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.localService")}} {{readonlyinline}}</dt>
-	<dd>A {{domxref("Boolean")}} indicating whether the voice is supplied by a local speech synthesizer service (<code>true</code>), or a remote speech synthesizer service (<code>false</code>.)</dd>
+	<dd>A Boolean value indicating whether the voice is supplied by a local speech synthesizer service (<code>true</code>), or a remote speech synthesizer service (<code>false</code>.)</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.name")}} {{readonlyinline}}</dt>
 	<dd>Returns a human-readable name that represents the voice.</dd>
 	<dt>{{domxref("SpeechSynthesisVoice.voiceURI")}} {{readonlyinline}}</dt>

--- a/files/en-us/web/api/stylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/index.html
@@ -19,7 +19,7 @@ browser-compat: api.StyleSheet
 
 <dl>
  <dt>{{domxref("StyleSheet.disabled")}}</dt>
- <dd>Is a {{domxref("Boolean")}} representing whether the current stylesheet has been applied or not.</dd>
+ <dd>Is a Boolean value representing whether the current stylesheet has been applied or not.</dd>
  <dt>{{domxref("StyleSheet.href")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} representing the location of the stylesheet.</dd>
  <dt>{{domxref("StyleSheet.media")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/stylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/index.html
@@ -19,7 +19,7 @@ browser-compat: api.StyleSheet
 
 <dl>
  <dt>{{domxref("StyleSheet.disabled")}}</dt>
- <dd>Is a Boolean value representing whether the current stylesheet has been applied or not.</dd>
+ <dd>Is a boolean value representing whether the current stylesheet has been applied or not.</dd>
  <dt>{{domxref("StyleSheet.href")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} representing the location of the stylesheet.</dd>
  <dt>{{domxref("StyleSheet.media")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -34,7 +34,7 @@ browser-compat: api.Text
  <dd>Returns a {{domxref("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.</dd>
  <dt>{{domxref("Text.isElementContentWhitespace")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>
- <p>Returns a {{domxref("Boolean")}} flag indicating whether or not the text node contains only whitespace.</p>
+ <p>Returns a Boolean flag indicating whether or not the text node contains only whitespace.</p>
  </dd>
  <dt>{{domxref("Text.wholeText")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the text of all <code>Text</code> nodes logically adjacent to this {{domxref("Node")}}, concatenated in document order.</dd>

--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -34,7 +34,7 @@ browser-compat: api.Text
  <dd>Returns a {{domxref("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.</dd>
  <dt>{{domxref("Text.isElementContentWhitespace")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>
- <p>Returns a Boolean flag indicating whether or not the text node contains only whitespace.</p>
+ <p>Returns a boolean flag indicating whether or not the text node contains only whitespace.</p>
  </dd>
  <dt>{{domxref("Text.wholeText")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the text of all <code>Text</code> nodes logically adjacent to this {{domxref("Node")}}, concatenated in document order.</dd>

--- a/files/en-us/web/api/text/iselementcontentwhitespace/index.html
+++ b/files/en-us/web/api/text/iselementcontentwhitespace/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Text.isElementContentWhitespace
 <p><strong>Note:</strong> You may replace it with <code>/\s+/.test(Text.data)</code>, <code>/\s+/.test(Text.nodeValue)</code>, or <code>/\s+/.test(Text.textContent)</code>. Putting any property that represents the textual content of the <code>Text</code> node into <code>test()</code> should do the same work just like the three example above.</p>
 </div>
 
-<p>The <strong><code>Text.isElementContentWhitespace</code></strong> read-only property returns a {{domxref("Boolean")}} flag indicating whether or not the text node's content consists solely of whitespace.</p>
+<p>The <strong><code>Text.isElementContentWhitespace</code></strong> read-only property returns a Boolean flag indicating whether or not the text node's content consists solely of whitespace.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/text/iselementcontentwhitespace/index.html
+++ b/files/en-us/web/api/text/iselementcontentwhitespace/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Text.isElementContentWhitespace
 <p><strong>Note:</strong> You may replace it with <code>/\s+/.test(Text.data)</code>, <code>/\s+/.test(Text.nodeValue)</code>, or <code>/\s+/.test(Text.textContent)</code>. Putting any property that represents the textual content of the <code>Text</code> node into <code>test()</code> should do the same work just like the three example above.</p>
 </div>
 
-<p>The <strong><code>Text.isElementContentWhitespace</code></strong> read-only property returns a Boolean flag indicating whether or not the text node's content consists solely of whitespace.</p>
+<p>The <strong><code>Text.isElementContentWhitespace</code></strong> read-only property returns a boolean flag indicating whether or not the text node's content consists solely of whitespace.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.html
@@ -57,10 +57,10 @@ browser-compat: api.TransitionEvent.initTransitionEvent
     </table>
   </dd>
   <dt><em>canBubbleArg</em></dt>
-  <dd>Is a Boolean flag indicating if the event can bubble
+  <dd>Is a boolean flag indicating if the event can bubble
     (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>cancelableArg</em></dt>
-  <dd>Is a Boolean flag indicating if the event associated action can be
+  <dd>Is a boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>transitionNameArg</em></dt>
   <dd>Is a {{domxref("DOMString")}} containing the name of the CSS property associated

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.html
@@ -57,10 +57,10 @@ browser-compat: api.TransitionEvent.initTransitionEvent
     </table>
   </dd>
   <dt><em>canBubbleArg</em></dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the event can bubble
+  <dd>Is a Boolean flag indicating if the event can bubble
     (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>cancelableArg</em></dt>
-  <dd>Is a {{domxref("Boolean")}} flag indicating if the event associated action can be
+  <dd>Is a Boolean flag indicating if the event associated action can be
     avoided (<code>true</code>) or not (<code>false)</code>.</dd>
   <dt><em>transitionNameArg</em></dt>
   <dd>Is a {{domxref("DOMString")}} containing the name of the CSS property associated

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TreeWalker.expandEntityReferences
 <p>{{ APIRef("DOM") }}{{deprecated_header}}</p>
 
 <p>The <code><strong>TreeWalker.expandEntityReferences</strong></code> read-only property
-  returns a {{domxref("Boolean")}} flag indicating whether or not the children of entity
+  returns a Boolean flag indicating whether or not the children of entity
   reference nodes are visible to the {{domxref("TreeWalker")}}.</p>
 
 <p>If this value is <code>false</code>, the children of entity reference nodes (as well as

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TreeWalker.expandEntityReferences
 <p>{{ APIRef("DOM") }}{{deprecated_header}}</p>
 
 <p>The <code><strong>TreeWalker.expandEntityReferences</strong></code> read-only property
-  returns a Boolean flag indicating whether or not the children of entity
+  returns a boolean flag indicating whether or not the children of entity
   reference nodes are visible to the {{domxref("TreeWalker")}}.</p>
 
 <p>If this value is <code>false</code>, the children of entity reference nodes (as well as

--- a/files/en-us/web/api/treewalker/index.html
+++ b/files/en-us/web/api/treewalker/index.html
@@ -101,7 +101,7 @@ browser-compat: api.TreeWalker
  <dt>{{domxref("TreeWalker.filter")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("NodeFilter")}} used to select the relevant nodes.</dd>
  <dt>{{domxref("TreeWalker.expandEntityReferences")}} {{readonlyInline}}{{deprecated_inline}}</dt>
- <dd>Is a {{domxref("Boolean")}} indicating, when discarding an entity reference its whole sub-tree must be discarded at the same time.</dd>
+ <dd>Is a Boolean value indicating, when discarding an entity reference its whole sub-tree must be discarded at the same time.</dd>
  <dt>{{domxref("TreeWalker.currentNode")}}</dt>
  <dd>Is the {{domxref("Node")}} on which the <code>TreeWalker</code> is currently pointing at.</dd>
 </dl>

--- a/files/en-us/web/api/treewalker/index.html
+++ b/files/en-us/web/api/treewalker/index.html
@@ -101,7 +101,7 @@ browser-compat: api.TreeWalker
  <dt>{{domxref("TreeWalker.filter")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("NodeFilter")}} used to select the relevant nodes.</dd>
  <dt>{{domxref("TreeWalker.expandEntityReferences")}} {{readonlyInline}}{{deprecated_inline}}</dt>
- <dd>Is a Boolean value indicating, when discarding an entity reference its whole sub-tree must be discarded at the same time.</dd>
+ <dd>Is a boolean value indicating, when discarding an entity reference its whole sub-tree must be discarded at the same time.</dd>
  <dt>{{domxref("TreeWalker.currentNode")}}</dt>
  <dd>Is the {{domxref("Node")}} on which the <code>TreeWalker</code> is currently pointing at.</dd>
 </dl>

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -40,9 +40,9 @@ browser-compat: api.VRDisplay
  <dt>{{domxref("VRDisplay.hardwareUnitId")}} {{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} defining the shared ID of the display, and any other devices that are part of that hardware set (e.g. controllers). This is no longer needed, and has been removed from the spec. Displays now use {{domxref("VRDisplay.displayId")}}, and corresponsing controllers will now return the same ID under {{domxref("Gamepad.displayId")}}.</dd>
  <dt>{{domxref("VRDisplay.isConnected")}} {{readonlyInline}} {{deprecated_inline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is connected to the computer.</dd>
+ <dd>Returns a Boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</dd>
  <dt>{{domxref("VRDisplay.isPresenting")}} {{readonlyInline}} {{deprecated_inline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is currently having content presented through it.</dd>
+ <dd>Returns a Boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</dd>
  <dt>{{domxref("VRDisplay.stageParameters")}} {{readonlyInline}} {{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("VRStageParameters")}} object containing room-scale parameters, if the <code>VRDisplay</code> is capable of supporting room-scale experiences.</dd>
 </dl>

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -40,9 +40,9 @@ browser-compat: api.VRDisplay
  <dt>{{domxref("VRDisplay.hardwareUnitId")}} {{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} defining the shared ID of the display, and any other devices that are part of that hardware set (e.g. controllers). This is no longer needed, and has been removed from the spec. Displays now use {{domxref("VRDisplay.displayId")}}, and corresponsing controllers will now return the same ID under {{domxref("Gamepad.displayId")}}.</dd>
  <dt>{{domxref("VRDisplay.isConnected")}} {{readonlyInline}} {{deprecated_inline}}</dt>
- <dd>Returns a Boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</dd>
+ <dd>Returns a boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</dd>
  <dt>{{domxref("VRDisplay.isPresenting")}} {{readonlyInline}} {{deprecated_inline}}</dt>
- <dd>Returns a Boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</dd>
+ <dd>Returns a boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</dd>
  <dt>{{domxref("VRDisplay.stageParameters")}} {{readonlyInline}} {{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("VRStageParameters")}} object containing room-scale parameters, if the <code>VRDisplay</code> is capable of supporting room-scale experiences.</dd>
 </dl>

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -16,7 +16,7 @@ browser-compat: api.VRDisplay.isConnected
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
+<p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a Boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -16,7 +16,7 @@ browser-compat: api.VRDisplay.isConnected
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a Boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
+<p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a boolean value indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -29,7 +29,7 @@ browser-compat: api.VRDisplay.isConnected
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}; <code>true</code> means the display is connected; <code>false</code> means it isn't.</p>
+<p>A boolean value; <code>true</code> means the display is connected; <code>false</code> means it isn't.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplay.isPresenting
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
+<p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a Boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplay.isPresenting
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a Boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
+<p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a boolean value indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -28,7 +28,7 @@ browser-compat: api.VRDisplay.isPresenting
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}; <code>true</code> means the display is presenting; <code>false</code> means it isn't.</p>
+<p>A boolean value; <code>true</code> means the display is presenting; <code>false</code> means it isn't.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a Boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
+<p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
@@ -29,7 +29,7 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}.</p>
+<p>A boolean value.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -15,7 +15,7 @@ browser-compat: api.VRDisplayCapabilities.canPresent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
+<p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a Boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
 
 <div class="notepad note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -26,13 +26,13 @@ browser-compat: api.VRDisplayCapabilities
 
 <dl>
  <dt>{{domxref("VRDisplayCapabilities.canPresent")}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} stating whether the VR display is capable of presenting content (e.g. through an HMD).</dd>
+ <dd>Returns a Boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasExternalDisplay")}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} stating whether the VR display is separate from the device's primary display.</dd>
+ <dd>Returns a Boolean value stating whether the VR display is separate from the device's primary display.</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasOrientation")}} {{deprecated_inline}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} stating whether the VR display can track and return orientation information.</dd>
+ <dd>Returns a Boolean value stating whether the VR display can track and return orientation information.</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasPosition")}} {{readonlyInline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} stating whether the VR display can track and return position information.</dd>
+ <dd>Returns a Boolean value stating whether the VR display can track and return position information.</dd>
  <dt>{{domxref("VRDisplayCapabilities.maxLayers")}} {{readonlyInline}}</dt>
  <dd>Returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("VRDisplay.requestPresent()")}} can accept.)</dd>
 </dl>

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -26,13 +26,13 @@ browser-compat: api.VRDisplayCapabilities
 
 <dl>
  <dt>{{domxref("VRDisplayCapabilities.canPresent")}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</dd>
+ <dd>Returns a boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasExternalDisplay")}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value stating whether the VR display is separate from the device's primary display.</dd>
+ <dd>Returns a boolean value stating whether the VR display is separate from the device's primary display.</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasOrientation")}} {{deprecated_inline}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value stating whether the VR display can track and return orientation information.</dd>
+ <dd>Returns a boolean value stating whether the VR display can track and return orientation information.</dd>
  <dt>{{domxref("VRDisplayCapabilities.hasPosition")}} {{readonlyInline}}</dt>
- <dd>Returns a Boolean value stating whether the VR display can track and return position information.</dd>
+ <dd>Returns a boolean value stating whether the VR display can track and return position information.</dd>
  <dt>{{domxref("VRDisplayCapabilities.maxLayers")}} {{readonlyInline}}</dt>
  <dd>Returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("VRDisplay.requestPresent()")}} can accept.)</dd>
 </dl>


### PR DESCRIPTION
`{{domxref("Boolean"}}` is always wrong.

It should be `{{jsxref("Boolean")}}` but, in most case we don't have a JS object but just a Boolean value.

This fixes a bunch of them (there will be more)