### PR TITLE
remove useless 'title' attributes on links

### DIFF
--- a/files/en-us/mozilla/projects/nss/jss/4.3.1_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/jss/4.3.1_release_notes/index.html
@@ -96,8 +96,7 @@ The mode of renegotiation that the peer must use can be set to the following:
   </li>
   <li>JSS 4.3.1 works with JDK versions 4 or higher we suggest the latest.</li>
   <li>JSS 4.3.1 requires <a href="/NSS_3.12.5" title="NSS 3.12.5">NSS 3.12.5</a> or higher.</li>
-  <li>JSS 4.3.1 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/"
-      title="http://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.7.1</a> or higher.</li>
+  <li>JSS 4.3.1 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.7.1</a> or higher.</li>
   <li>JSS only supports the native threading model (no green threads).</li>
 </ul>
 <h3 id="Known_Bugs_and_Issues">Known Bugs and Issues</h3>

--- a/files/en-us/mozilla/projects/nss/jss/4_3_releasenotes/index.html
+++ b/files/en-us/mozilla/projects/nss/jss/4_3_releasenotes/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p> A list of bug fixes and enhancement requests were implemented in this release can be obtained by running this <a class="external" href="http://bugzilla.mozilla.org/buglist.cgi?product=JSS&amp;target_milestone=4.2.5&amp;target_milestone=4.3&amp;bug_status=RESOLVED&amp;resolution=FIXED">bugzilla query</a></p>
 
-<p><strong>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html" title="http://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html">NSS 3.12</a> or higher. </strong></p>
+<p><strong>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html">NSS 3.12</a> or higher. </strong></p>
 
 <ul>
  <li>New <a class="link-https" href="https://wiki.mozilla.org/NSS_Shared_DB">SQLite-Based Shareable Certificate and Key Databases</a> by prepending the string "sql:" to the directory path passed to configdir parameter for Crypomanager.initialize method or using the NSS environment variable <a class="external" href="/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_environment_variables" rel="external nofollow" title="https://developer.mozilla.org/editor/fckeditor/core/editor/en/NSS_reference/NSS_environment_variables">NSS_DEFAULT_DB_TYPE</a>.</li>
@@ -95,8 +95,8 @@ tags:
 
 <ul>
  <li>JSS 4.3 works with JDK versions 4 or higher we suggest the latest.</li>
- <li>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html" title="http://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html">NSS 3.12</a> or higher.</li>
- <li>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" title="http://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.7.1</a> or higher.</li>
+ <li>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/nss-3.12/nss-3.12-release-notes.html">NSS 3.12</a> or higher.</li>
+ <li>JSS 4.3 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.7.1</a> or higher.</li>
  <li>JSS only supports the native threading model (no green threads).</li>
 </ul>
 

--- a/files/en-us/mozilla/projects/nss/nss_3.12.5_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.5_release_notes/index.html
@@ -20,7 +20,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.5_release_notes
 
 <p>The CVS tag for the NSS 3.12.5 release is <code>NSS_3_12_5_RTM</code>. </p>
 
-<p>NSS 3.12.5 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" rel="external nofollow" title="http://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.8</a>.</p>
+<p>NSS 3.12.5 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" rel="external nofollow">NSPR 4.8</a>.</p>
 
 <p>You can check out the source from CVS by</p>
 
@@ -32,7 +32,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 <p>NSS 3.12.5 source is also available on <code>ftp.mozilla.org</code> for secure HTTPS download:</p>
 
 <ul>
- <li>Source tarball: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_5_RTM/src/" rel="external nofollow" title="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_5_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_5_RTM/src/</a>.</li>
+ <li>Source tarball: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_5_RTM/src/" rel="external nofollow">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_5_RTM/src/</a>.</li>
 </ul>
 
 <p><a name="new"></a></p>
@@ -202,19 +202,19 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 <p>The following bugs have been fixed in NSS 3.12.5.</p>
 
 <ul>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=510435" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=510435">Bug 510435</a>: Remove unused make variable DSO_LDFLAGS</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=510436" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=510436">Bug 510436</a>: Add macros for build numbers (4th component of version number) to nssutil.h</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511227" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=511227">Bug 511227</a>: Firefox 3.0.13 fails to compile on FreeBSD/powerpc</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511312" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=511312">Bug 511312</a>: NSS fails to load softoken, looking for sqlite3.dll</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511781" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=511781">Bug 511781</a>: Add new TLS 1.2 cipher suites implemented in Windows 7 to ssltap</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=516101" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=516101">Bug 516101</a>: If PK11_ImportCert fails, it leaves the certificate undiscoverable by CERT_PKIXVerifyCert</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518443" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=518443">Bug 518443</a>: PK11_ImportAndReturnPrivateKey leaks an arena</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518446" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=518446">Bug 518446</a>: PK11_DEREncodePublicKey leaks a CERTSubjectPublicKeyInfo</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518457" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=518457">Bug 518457</a>: SECKEY_EncodeDERSubjectPublicKeyInfo and PK11_DEREncodePublicKey are duplicate</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=522510" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=522510">Bug 522510</a>: Add deprecated comments to key.h and pk11func.h</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=522580" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=522580">Bug 522580</a>: NSS uses PORT_Memcmp for comparing secret data.</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=525056" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=525056">Bug 525056</a>: Timing attack against ssl3ext.c:ssl3_ServerHandleSessionTicketXtn()</li>
- <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=526689" rel="external nofollow" title="https://bugzilla.mozilla.org/show_bug.cgi?id=526689">Bug 526689</a>: SSL3 &amp; TLS Renegotiation Vulnerability</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=510435" rel="external nofollow">Bug 510435</a>: Remove unused make variable DSO_LDFLAGS</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=510436" rel="external nofollow">Bug 510436</a>: Add macros for build numbers (4th component of version number) to nssutil.h</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511227" rel="external nofollow">Bug 511227</a>: Firefox 3.0.13 fails to compile on FreeBSD/powerpc</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511312" rel="external nofollow">Bug 511312</a>: NSS fails to load softoken, looking for sqlite3.dll</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=511781" rel="external nofollow">Bug 511781</a>: Add new TLS 1.2 cipher suites implemented in Windows 7 to ssltap</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=516101" rel="external nofollow">Bug 516101</a>: If PK11_ImportCert fails, it leaves the certificate undiscoverable by CERT_PKIXVerifyCert</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518443" rel="external nofollow">Bug 518443</a>: PK11_ImportAndReturnPrivateKey leaks an arena</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518446" rel="external nofollow">Bug 518446</a>: PK11_DEREncodePublicKey leaks a CERTSubjectPublicKeyInfo</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518457" rel="external nofollow">Bug 518457</a>: SECKEY_EncodeDERSubjectPublicKeyInfo and PK11_DEREncodePublicKey are duplicate</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=522510" rel="external nofollow">Bug 522510</a>: Add deprecated comments to key.h and pk11func.h</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=522580" rel="external nofollow">Bug 522580</a>: NSS uses PORT_Memcmp for comparing secret data.</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=525056" rel="external nofollow">Bug 525056</a>: Timing attack against ssl3ext.c:ssl3_ServerHandleSessionTicketXtn()</li>
+ <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=526689" rel="external nofollow">Bug 526689</a>: SSL3 &amp; TLS Renegotiation Vulnerability</li>
 </ul>
 
 <p><a name="docs"></a></p>
@@ -223,7 +223,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 <div id="section_13">
 <h1 id="Documentation">Documentation</h1>
 
-<p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external nofollow" title="http://www.mozilla.org/projects/security/pki/nss/#documentation">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
+<p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external nofollow">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
 
 <ul>
  <li><a href="https://dev.mozilla.jp/localmdc/localmdc_5142.html" rel="internal">Build Instructions</a></li>
@@ -236,13 +236,13 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 <div id="section_14">
 <h1 id="Compatibility">Compatibility</h1>
 
-<p>NSS 3.12.5 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.5 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external nofollow" title="http://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
+<p>NSS 3.12.5 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.5 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external nofollow">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
 </div>
 
 <div id="section_15">
 <h1 id="Feedback">Feedback</h1>
 
-<p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external nofollow" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
+<p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external nofollow">mozilla.org Bugzilla</a> (product NSS).</p>
 </div>
 </div>
 

--- a/files/en-us/mozilla/projects/nss/nss_3.12.6_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.6_release_notes/index.html
@@ -13,20 +13,20 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
        </div>
        <div id="section_2">
         <h1 id="Distribution_Information">Distribution Information</h1>
-        <p>The CVS tag for the NSS 3.12.6 release is <code>NSS_3_12_6_RTM</code>.  NSS 3.12.6 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" rel="external" title="http://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.8.4</a>.<br>
+        <p>The CVS tag for the NSS 3.12.6 release is <code>NSS_3_12_6_RTM</code>.  NSS 3.12.6 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" rel="external">NSPR 4.8.4</a>.<br>
          <br>
          See the <a href="http://mdn.beonex.com/en/NSS_3.12.6_release_notes.html#docs">Documentation</a> section for the build instructions.</p>
         <p>NSS 3.12.6 source and binary distributions are also available on <code>ftp.mozilla.org</code> for secure HTTPS download:</p>
         <ul>
-         <li>Source tarballs: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_6_RTM/src/" rel="external" title="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_6_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_6_RTM/src/</a>.</li>
+         <li>Source tarballs: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_6_RTM/src/" rel="external">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_12_6_RTM/src/</a>.</li>
         </ul>
-        <p>You also need to download the NSPR 4.8.4 binary distributions to get the NSPR 4.8.4 header files and shared libraries, which NSS 3.12.6 requires. NSPR 4.8.4 binary distributions are in <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.4/" rel="external" title="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.4/">https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.4/</a>.<br>
+        <p>You also need to download the NSPR 4.8.4 binary distributions to get the NSPR 4.8.4 header files and shared libraries, which NSS 3.12.6 requires. NSPR 4.8.4 binary distributions are in <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.4/" rel="external">https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.4/</a>.<br>
          <a name="new"></a></p>
        </div>
        <div id="section_3">
         <h1 id="New_in_NSS_3.12.6">New in NSS 3.12.6</h1>
         <div id="section_4">
-         <h3 id="SSL3_TLS_Renegotiation_Indication_Extension_(RFC_5746)">SSL3 &amp; TLS Renegotiation Indication Extension (<a class="external" href="https://datatracker.ietf.org/doc/html/rfc5746" rel="external" title="http://tools.ietf.org/html/rfc5746">RFC 5746</a>)</h3>
+         <h3 id="SSL3_TLS_Renegotiation_Indication_Extension_(RFC_5746)">SSL3 &amp; TLS Renegotiation Indication Extension (<a class="external" href="https://datatracker.ietf.org/doc/html/rfc5746" rel="external">RFC 5746</a>)</h3>
          <ul>
           <li>By default, NSS 3.12.6 uses the new TLS Renegotiation Indication Extension for TLS renegotiation but allows simple SSL/TLS connections (without renegotiation) with peers that don't support the TLS Renegotiation Indication Extension.
            <p>The behavior of NSS for renegotiation can be changed through API function calls, or with the following environment variables:</p>
@@ -83,7 +83,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          <h3 id="TLS_Server_Name_Indication_for_servers">TLS Server Name Indication for servers</h3>
          <ul>
           <li>TLS Server Name Indication (SNI) for servers is almost fully implemented in NSS 3.12.6.<br>
-           See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=360421" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=360421">bug 360421</a> for details.<br>
+           See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=360421" rel="external">bug 360421</a> for details.<br>
            <p>Note: The TLS Server Name Indication for clients is already fully implemented in NSS.</p>
            <ul>
             <li>New functions for SNI <em>(see ssl.h for more information)</em>:
@@ -183,43 +183,43 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
         <h1 id="Bugs_Fixed">Bugs Fixed</h1>
         <p>The following bugs have been fixed in NSS 3.12.6.</p>
         <ul>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=275744" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=275744">Bug 275744</a>: Support for TLS compression RFC 3749</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=494603" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=494603">Bug 494603</a>: Update NSS's copy of sqlite3 to 3.6.22 to get numerous bug fixes</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=496993" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=496993">Bug 496993</a>: Add accessor functions for SSL_ImplementedCiphers</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=515279" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=515279">Bug 515279</a>: CERT_PKIXVerifyCert considers a certificate revoked if cert_ProcessOCSPResponse fails for any reason</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=515870" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=515870">Bug 515870</a>: GCC compiler warnings in NSS 3.12.4</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518255" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=518255">Bug 518255</a>: The input buffer for SGN_Update should be declared const</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=519550" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=519550">Bug 519550</a>: Allow the specification of an alternate library for SQLite</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=524167" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=524167">Bug 524167</a>: Crash in [[@ find_objects_by_template - nssToken_FindCertificateByIssuerAndSerialNumber]</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=526910" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=526910">Bug 526910</a>: maxResponseLength (initialized to PKIX_DEFAULT_MAX_RESPONSE_LENGTH) is too small for downloading some CRLs.</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=527759" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=527759">Bug 527759</a>: Add multiple roots to NSS (single patch)</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=528741" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=528741">Bug 528741</a>: pkix_hash throws a null-argument exception on empty strings</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=530907" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=530907">Bug 530907</a>: The peerID argument to SSL_SetSockPeerID should be declared const</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=531188" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=531188">Bug 531188</a>: Decompression failure with <a class="link-https" href="https://livechat.merlin.pl/" rel="external" title="https://livechat.merlin.pl/">https://livechat.merlin.pl/</a></li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=532417" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=532417">Bug 532417</a>: Build problem with spaces in path names</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=534943" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=534943">Bug 534943</a>: Clean up the makefiles in lib/ckfw/builtins</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=534945" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=534945">Bug 534945</a>: lib/dev does not need to include headers from lib/ckfw</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=535669" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=535669">Bug 535669</a>: Move common makefile code in if and else to the outside</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536023" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=536023">Bug 536023</a>: DER_UTCTimeToTime and DER_GeneralizedTimeToTime ignore all bytes after an embedded null</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536474" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=536474">Bug 536474</a>: Add support for logging pre-master secrets</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537356" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=537356">Bug 537356</a>: Implement new safe SSL3 &amp; TLS renegotiation</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537795" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=537795">Bug 537795</a>: NSS_InitContext does not work with NSS_RegisterShutdown</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537829" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=537829">Bug 537829</a>: Allow NSS to build for Android</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=540304" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=540304">Bug 540304</a>: Implement SSL_HandshakeNegotiatedExtension</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=541228" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=541228">Bug 541228</a>: Remove an obsolete NSPR version check in lib/util/secport.c</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=541231" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=541231">Bug 541231</a>: nssinit.c doesn't need to include ssl.h and sslproto.h.</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=542538" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=542538">Bug 542538</a>: NSS: Add function for recording OCSP stapled replies</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544191" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=544191">Bug 544191</a>: Use system zlib on Mac OS X</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544584" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=544584">Bug 544584</a>: segmentation fault when enumerating the nss database</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544586" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=544586">Bug 544586</a>: Various nss-sys-init patches from Fedora</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=545273" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=545273">Bug 545273</a>: Remove unused function SEC_Init</li>
-         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=546389" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=546389">Bug 546389</a>: nsssysinit binary built inside source tree</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=275744" rel="external">Bug 275744</a>: Support for TLS compression RFC 3749</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=494603" rel="external">Bug 494603</a>: Update NSS's copy of sqlite3 to 3.6.22 to get numerous bug fixes</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=496993" rel="external">Bug 496993</a>: Add accessor functions for SSL_ImplementedCiphers</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=515279" rel="external">Bug 515279</a>: CERT_PKIXVerifyCert considers a certificate revoked if cert_ProcessOCSPResponse fails for any reason</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=515870" rel="external">Bug 515870</a>: GCC compiler warnings in NSS 3.12.4</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518255" rel="external">Bug 518255</a>: The input buffer for SGN_Update should be declared const</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=519550" rel="external">Bug 519550</a>: Allow the specification of an alternate library for SQLite</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=524167" rel="external">Bug 524167</a>: Crash in [[@ find_objects_by_template - nssToken_FindCertificateByIssuerAndSerialNumber]</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=526910" rel="external">Bug 526910</a>: maxResponseLength (initialized to PKIX_DEFAULT_MAX_RESPONSE_LENGTH) is too small for downloading some CRLs.</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=527759" rel="external">Bug 527759</a>: Add multiple roots to NSS (single patch)</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=528741" rel="external">Bug 528741</a>: pkix_hash throws a null-argument exception on empty strings</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=530907" rel="external">Bug 530907</a>: The peerID argument to SSL_SetSockPeerID should be declared const</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=531188" rel="external">Bug 531188</a>: Decompression failure with <a class="link-https" href="https://livechat.merlin.pl/" rel="external">https://livechat.merlin.pl/</a></li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=532417" rel="external">Bug 532417</a>: Build problem with spaces in path names</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=534943" rel="external">Bug 534943</a>: Clean up the makefiles in lib/ckfw/builtins</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=534945" rel="external">Bug 534945</a>: lib/dev does not need to include headers from lib/ckfw</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=535669" rel="external">Bug 535669</a>: Move common makefile code in if and else to the outside</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536023" rel="external">Bug 536023</a>: DER_UTCTimeToTime and DER_GeneralizedTimeToTime ignore all bytes after an embedded null</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536474" rel="external">Bug 536474</a>: Add support for logging pre-master secrets</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537356" rel="external">Bug 537356</a>: Implement new safe SSL3 &amp; TLS renegotiation</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537795" rel="external">Bug 537795</a>: NSS_InitContext does not work with NSS_RegisterShutdown</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=537829" rel="external">Bug 537829</a>: Allow NSS to build for Android</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=540304" rel="external">Bug 540304</a>: Implement SSL_HandshakeNegotiatedExtension</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=541228" rel="external">Bug 541228</a>: Remove an obsolete NSPR version check in lib/util/secport.c</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=541231" rel="external">Bug 541231</a>: nssinit.c doesn't need to include ssl.h and sslproto.h.</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=542538" rel="external">Bug 542538</a>: NSS: Add function for recording OCSP stapled replies</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544191" rel="external">Bug 544191</a>: Use system zlib on Mac OS X</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544584" rel="external">Bug 544584</a>: segmentation fault when enumerating the nss database</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=544586" rel="external">Bug 544586</a>: Various nss-sys-init patches from Fedora</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=545273" rel="external">Bug 545273</a>: Remove unused function SEC_Init</li>
+         <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=546389" rel="external">Bug 546389</a>: nsssysinit binary built inside source tree</li>
         </ul>
         <p><a name="docs"></a></p>
        </div>
        <div id="section_11">
         <h1 id="Documentation">Documentation</h1>
-        <p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external" title="http://www.mozilla.org/projects/security/pki/nss/#documentation">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
+        <p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
         <ul>
          <li><a href="http://mdn.beonex.com/en/NSS_reference/Building_and_installing_NSS/Build_instructions.html" rel="internal">Build Instructions</a></li>
          <li><a class="external" href="http://wiki.mozilla.org/NSS_Shared_DB" rel="external" title="http://wiki.mozilla.org/NSS_Shared_DB">NSS Shared DB</a></li>
@@ -228,10 +228,10 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
        </div>
        <div id="section_12">
         <h1 id="Compatibility">Compatibility</h1>
-        <p>NSS 3.12.6 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.6 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external" title="http://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
+        <p>NSS 3.12.6 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.6 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
        </div>
        <div id="section_13">
         <h1 id="Feedback">Feedback</h1>
-        <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
+        <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external">mozilla.org Bugzilla</a> (product NSS).</p>
        </div>
       </div>

--- a/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
@@ -13,14 +13,14 @@ tags:
 </div>
 <div id="section_2">
  <h1 id="Distribution_Information"><a name="distribution">Distribution Information</a></h1>
- <p><a name="distribution">The CVS tag for the NSS 3.12.9 release is <code>NSS_3.12.9_RTM</code>.  NSS 3.12.9 requires </a><a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/nspr486.html" rel="external" title="http://www.mozilla.org/projects/nspr/release-notes/nspr486.html">NSPR 4.8.7</a>.<br>
+ <p><a name="distribution">The CVS tag for the NSS 3.12.9 release is <code>NSS_3.12.9_RTM</code>.  NSS 3.12.9 requires </a><a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/nspr486.html" rel="external">NSPR 4.8.7</a>.<br>
   <br>
   See the <a href="#docs">Documentation</a> section for the build instructions.</p>
  <p>NSS 3.12.9 source distribution is also available on <code>ftp.mozilla.org</code> for secure HTTPS download:</p>
  <ul>
-  <li>Source tarballs: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3.12.9_RTM/src/" rel="external" title="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3.12.9_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3.12.9_RTM/src/</a>.</li>
+  <li>Source tarballs: <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3.12.9_RTM/src/" rel="external">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3.12.9_RTM/src/</a>.</li>
  </ul>
- <p>You also need to download the NSPR 4.8.7 binary distributions to get the NSPR 4.8.7 header files and shared libraries, which NSS 3.12.9 requires. NSPR 4.8.7 binary distributions are in <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/" rel="external" title="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/">https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/</a>.</p>
+ <p>You also need to download the NSPR 4.8.7 binary distributions to get the NSPR 4.8.7 header files and shared libraries, which NSS 3.12.9 requires. NSPR 4.8.7 binary distributions are in <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/" rel="external">https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/</a>.</p>
 </div>
 <div id="section_3">
  <h1 id="New_in_NSS_3.12.9">New in NSS 3.12.9</h1>
@@ -38,23 +38,23 @@ tags:
  <h1 id="Bugs_Fixed">Bugs Fixed</h1>
  <p>The following bugs have been fixed in NSS 3.12.9.</p>
  <ul>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=609068" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=609068">Bug 609068</a>: Implement J-PAKE in FreeBL</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=607058" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=607058">Bug 607058</a>: crash [@ nss_cms_decoder_work_data]</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=613394" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=613394">Bug 613394</a>: November/December 2010 batch of NSS root CA changes</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=610843" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=610843">Bug 610843</a>: Need way to recover softoken in child after fork()</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=617492" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=617492">Bug 617492</a>: Add PK11_KeyGenWithTemplate function to pk11wrap (for Firefox Sync)</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=610162" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=610162">Bug 610162</a>: SHA-512 and SHA-384 hashes are incorrect for inputs of 512MB or larger when running under Windows and other 32-bit platforms (Fx 3.6.12 and 4.0b6)</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518551" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=518551">Bug 518551</a>: Vfychain crashes in PKITS tests.</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536485" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=536485">Bug 536485</a>: crash during ssl handshake in [@ intel_aes_decrypt_cbc_256]</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=444367" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=444367">Bug 444367</a>: NSS 3.12 softoken returns the certificate type of a certificate object as CKC_X_509_ATTR_CERT.</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=620908" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=620908">Bug 620908</a>: certutil -T -d "sql:." dumps core</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=584257" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=584257">Bug 584257</a>: Need a way to expand partial private keys.</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=596798" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=596798">Bug 596798</a>: win_rand.c (among others) uses unsafe _snwprintf</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=597622" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=597622">Bug 597622</a>: Do not use the SEC_ERROR_BAD_INFO_ACCESS_LOCATION error code for bad CRL distribution point URLs</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=619268" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=619268">Bug 619268</a>: Memory leaks in CERT_ChangeCertTrust and CERT_SaveSMimeProfile</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=585518" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=585518">Bug 585518</a>: AddTrust Qualified CA Root serial wrong in certdata.txt trust entry</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=337433" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=337433">Bug 337433</a>: Need CERT_FindCertByNicknameOrEmailAddrByUsage</li>
-  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=592939" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=592939">Bug 592939</a>: Expired CAs in certdata.txt</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=609068" rel="external">Bug 609068</a>: Implement J-PAKE in FreeBL</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=607058" rel="external">Bug 607058</a>: crash [@ nss_cms_decoder_work_data]</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=613394" rel="external">Bug 613394</a>: November/December 2010 batch of NSS root CA changes</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=610843" rel="external">Bug 610843</a>: Need way to recover softoken in child after fork()</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=617492" rel="external">Bug 617492</a>: Add PK11_KeyGenWithTemplate function to pk11wrap (for Firefox Sync)</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=610162" rel="external">Bug 610162</a>: SHA-512 and SHA-384 hashes are incorrect for inputs of 512MB or larger when running under Windows and other 32-bit platforms (Fx 3.6.12 and 4.0b6)</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=518551" rel="external">Bug 518551</a>: Vfychain crashes in PKITS tests.</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=536485" rel="external">Bug 536485</a>: crash during ssl handshake in [@ intel_aes_decrypt_cbc_256]</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=444367" rel="external">Bug 444367</a>: NSS 3.12 softoken returns the certificate type of a certificate object as CKC_X_509_ATTR_CERT.</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=620908" rel="external">Bug 620908</a>: certutil -T -d "sql:." dumps core</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=584257" rel="external">Bug 584257</a>: Need a way to expand partial private keys.</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=596798" rel="external">Bug 596798</a>: win_rand.c (among others) uses unsafe _snwprintf</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=597622" rel="external">Bug 597622</a>: Do not use the SEC_ERROR_BAD_INFO_ACCESS_LOCATION error code for bad CRL distribution point URLs</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=619268" rel="external">Bug 619268</a>: Memory leaks in CERT_ChangeCertTrust and CERT_SaveSMimeProfile</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=585518" rel="external">Bug 585518</a>: AddTrust Qualified CA Root serial wrong in certdata.txt trust entry</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=337433" rel="external">Bug 337433</a>: Need CERT_FindCertByNicknameOrEmailAddrByUsage</li>
+  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=592939" rel="external">Bug 592939</a>: Expired CAs in certdata.txt</li>
  </ul>
 </div>
 <div id="section_9">
@@ -71,5 +71,5 @@ tags:
 </div>
 <div id="section_11">
  <h1 id="Feedback">Feedback</h1>
- <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
+ <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external">mozilla.org Bugzilla</a> (product NSS).</p>
 </div>

--- a/files/en-us/mozilla/projects/nss/nss_3.15.1_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.15.1_release_notes/index.html
@@ -13,7 +13,7 @@ slug: Mozilla/Projects/NSS/NSS_3.15.1_release_notes
 <h2 id="New_in_NSS_3.15.1">New in NSS 3.15.1</h2>
 <h3 id="New_Functionality">New Functionality</h3>
 <ul>
-  <li>TLS 1.2: TLS 1.2 (<a href="https://datatracker.ietf.org/doc/html/rfc5246" title="http://tools.ietf.org/html/rfc5246">RFC 5246</a>) is supported. HMAC-SHA256 cipher suites (<a href="https://datatracker.ietf.org/doc/html/rfc5246" title="http://tools.ietf.org/html/rfc5246">RFC 5246</a> and <a href="https://datatracker.ietf.org/doc/html/rfc5289" title="http://tools.ietf.org/html/rfc5289">RFC 5289</a>) are supported, allowing TLS to be used without MD5 and SHA-1. Note the following limitations.
+  <li>TLS 1.2: TLS 1.2 (<a href="https://datatracker.ietf.org/doc/html/rfc5246">RFC 5246</a>) is supported. HMAC-SHA256 cipher suites (<a href="https://datatracker.ietf.org/doc/html/rfc5246">RFC 5246</a> and <a href="https://datatracker.ietf.org/doc/html/rfc5289">RFC 5289</a>) are supported, allowing TLS to be used without MD5 and SHA-1. Note the following limitations.
     <ul>
       <li>The hash function used in the signature for TLS 1.2 client authentication must be the hash function of the TLS 1.2 PRF, which is always SHA-256 in NSS 3.15.1.</li>
       <li>AES GCM cipher suites are not yet supported.</li>

--- a/files/en-us/mozilla/projects/nss/nss_3.16_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.16_release_notes/index.html
@@ -9,7 +9,7 @@ slug: Mozilla/Projects/NSS/NSS_3.16_release_notes
 <p>NSS 3.16 source distributions are available on ftp.mozilla.org for secure HTTPS download:</p>
 <ul>
  <li>Source tarballs:<br>
-  <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_16_RTM/src/" title="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_15_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_16_RTM/src/</a></li>
+  <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_16_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_16_RTM/src/</a></li>
 </ul>
 <h2 id="New_in_NSS_3.16">New in NSS 3.16</h2>
 <h3 id="New_Functionality">New Functionality</h3>

--- a/files/en-us/mozilla/projects/nss/nss_sources_building_testing/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_sources_building_testing/index.html
@@ -11,7 +11,7 @@ tags:
 
 <h2 id="Getting_source_code_and_a_quick_overview">Getting source code, and a quick overview</h2>
 
-<p>The easiest way is to download archives of NSS releases from <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/" title="https://ftp.mozilla.org/pub/security/nss/releases/">Mozilla's download server</a>. Find the directory that contains the highest version number. Because NSS depends on the base library <a href="/en-US/docs/NSPR">NSPR</a>, you should download the archive that combines both NSS and NSPR.</p>
+<p>The easiest way is to download archives of NSS releases from <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/">Mozilla's download server</a>. Find the directory that contains the highest version number. Because NSS depends on the base library <a href="/en-US/docs/NSPR">NSPR</a>, you should download the archive that combines both NSS and NSPR.</p>
 
 <p>If you are a software developer and intend to contribute enhancements to NSS, you should obtain the latest development snapshot of NSS using mercurial/hg (a <a href="https://www.mercurial-scm.org/">distributed source control management tool</a>). In order to get started, anonymous read-only access is sufficient. Create a new directory on your computer that you will use as your local work area, and run the following commands.</p>
 

--- a/files/en-us/mozilla/projects/nss/reference/nspr_functions/index.html
+++ b/files/en-us/mozilla/projects/nss/reference/nspr_functions/index.html
@@ -2,7 +2,7 @@
 title: NSPR functions
 slug: Mozilla/Projects/NSS/Reference/NSPR_functions
 ---
-<p><a class="external" href="https://www.mozilla.org/projects/nspr/" title="http://www.mozilla.org/projects/nspr/">NSPR</a> is a platform abstraction library that provides a cross-platform API to common OS services.  NSS uses NSPR internally as the porting layer.  However, a small number of NSPR functions are required for using the certificate verification and SSL functions in NSS.  These NSPR functions are listed in this section.</p>
+<p><a class="external" href="https://www.mozilla.org/projects/nspr/">NSPR</a> is a platform abstraction library that provides a cross-platform API to common OS services.  NSS uses NSPR internally as the porting layer.  However, a small number of NSPR functions are required for using the certificate verification and SSL functions in NSS.  These NSPR functions are listed in this section.</p>
 <h3 id="NSPR_initialization_and_shutdown">NSPR initialization and shutdown</h3>
 <p>NSPR is automatically initialized by the first NSPR function called by the application.  Call <a class="internal" href="/en-US/PR_Cleanup"><code>PR_Cleanup</code></a> to shut down NSPR and clean up its resources.<a class="internal" href="/en-US/PR_Init"><br>
 </a></p>

--- a/files/en-us/web/api/server-sent_events/index.html
+++ b/files/en-us/web/api/server-sent_events/index.html
@@ -77,7 +77,7 @@ tags:
 <h3 id="Other_resources">Other resources</h3>
 
 <ul>
- <li>A <a href="http://hacks.mozilla.org/2011/06/a-wall-powered-by-eventsource-and-server-sent-events/">Twitter like application</a> powered by server-sent events and <a class="link-https" href="https://github.com/mozilla/webowonder-demos/tree/master/demos/friends%20timeline" title="https://github.com/mozilla/webowonder-demos/tree/master/demos/friends timeline">its code on Github</a>.</li>
+ <li>A <a href="http://hacks.mozilla.org/2011/06/a-wall-powered-by-eventsource-and-server-sent-events/">Twitter like application</a> powered by server-sent events and <a class="link-https" href="https://github.com/mozilla/webowonder-demos/tree/master/demos/friends%20timeline">its code on Github</a>.</li>
  <li><a href="http://dsheiko.com/weblog/html5-and-server-sent-events">HTML5 and Server-sent events</a></li>
  <li><a href="http://rajudasa.blogspot.in/2012/05/html5-server-sent-events-using-aspnet.html">Server-sent events using Asp.Net</a></li>
 </ul>

--- a/files/en-us/web/css/webkit_extensions/index.html
+++ b/files/en-us/web/css/webkit_extensions/index.html
@@ -626,7 +626,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a href="https://trac.webkit.org/wiki/Styling%20Form%20Controls" title="https://trac.webkit.org/wiki/Styling Form Controls">Styling Form Controls on the WebKit Trac</a></li>
+	<li><a href="https://trac.webkit.org/wiki/Styling%20Form%20Controls">Styling Form Controls on the WebKit Trac</a></li>
 	<li><a href="/en-US/docs/Web/CSS/Microsoft_Extensions">Microsoft CSS Extensions</a></li>
 	<li><a href="/en-US/docs/Web/CSS/Mozilla_Extensions">Mozilla CSS Extensions</a></li>
 </ul>

--- a/files/en-us/web/html/viewport_meta_tag/index.html
+++ b/files/en-us/web/html/viewport_meta_tag/index.html
@@ -71,7 +71,7 @@ tags:
 
 <h2 id="Common_viewport_sizes_for_mobile_and_tablet_devices">Common viewport sizes for mobile and tablet devices</h2>
 
-<p>If you want to know what mobile and tablet devices have which viewport widths, there is a comprehensive list of <a href="https://docs.adobe.com/content/help/en/target/using/experiences/vec/mobile-viewports.html" title="https://viewportsizer.com/">mobile and tablet viewport sizes here</a>. This gives information such as viewport width on portrait and landscape orientation as well as physical screen size, operating system and the pixel density of the device.</p>
+<p>If you want to know what mobile and tablet devices have which viewport widths, there is a comprehensive list of <a href="https://docs.adobe.com/content/help/en/target/using/experiences/vec/mobile-viewports.html">mobile and tablet viewport sizes here</a>. This gives information such as viewport width on portrait and landscape orientation as well as physical screen size, operating system and the pixel density of the device.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/link_prefetching_faq/index.html
+++ b/files/en-us/web/http/link_prefetching_faq/index.html
@@ -106,7 +106,7 @@ tags:
 
 <h3 id="Privacy_implications">Privacy implications</h3>
 
-<p>Along with the referral and URL-following implications already mentioned above, prefetching will generally cause the cookies of the prefetched site to be accessed. (For example, if you google amazon, the google results page will prefetch <a class="linkification-ext external" href="https://www.amazon.com" title="Linkification: https://www.amazon.com">www.amazon.com</a>, causing amazon cookies to be sent back and forth. You can block 3rd party cookies in Firefox, see <a href="https://support.mozilla.com/en-US/kb/Disabling%20third%20party%20cookies" title="https://support.mozilla.com/en-US/kb/Disabling third party cookies">Disabling third party cookies</a>.)</p>
+<p>Along with the referral and URL-following implications already mentioned above, prefetching will generally cause the cookies of the prefetched site to be accessed. (For example, if you google amazon, the google results page will prefetch <a class="linkification-ext external" href="https://www.amazon.com" title="Linkification: https://www.amazon.com">www.amazon.com</a>, causing amazon cookies to be sent back and forth. You can block 3rd party cookies in Firefox, see <a href="https://support.mozilla.com/en-US/kb/Disabling%20third%20party%20cookies">Disabling third party cookies</a>.)</p>
 
 <h3 id="What_about....3F">What about...?</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Lots of links look like this:

```html
<a href="https://trac.webkit.org/wiki/Styling%20Form%20Controls" title="https://trac.webkit.org/wiki/Styling Form Controls">Styling Form Controls on the WebKit Trac</a>
```
where the `title="..."` attribute is just the URL all over again. 
Not very helpful. 


> Anything else that could help us review it

I first thought it could be a Yari flaw but then I discovered it's mostly in the content that we don't really care that much about so it was easier to just put together a quick script. 