### PR TITLE
Fix typo in padding-inline-start

### DIFF
--- a/files/en-us/web/css/padding-inline-start/index.html
+++ b/files/en-us/web/css/padding-inline-start/index.html
@@ -46,7 +46,7 @@ padding-inline-start: unset;
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>padding-inline-start</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the phsyical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
+<p>The <code>padding-inline-start</code> property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}</p>
 
 <p>It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Small typo in the `padding-inline-start` description section.



