### PR TITLE
Convert unconverted dl elements in JS

### DIFF
--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
@@ -196,8 +196,12 @@ In general, the only time {{jsxref("Object.is")}}'s special behavior towards zer
 
 Here's a non-exhaustive list of built-in methods and operators that might cause a distinction between `-0` and `+0` to manifest itself in your code:
 
-<dl><dt><a href="/en-US/docs/Web/JavaScript/Reference/Operators#-_.28unary_negation.29"><code>- (unary negation)</code></a></dt><dd><pre class="brush: js">let stoppingForce = obj.mass * -obj.velocity;</pre><p>If <code>obj.velocity</code> is <code>0</code> (or computes to <code>0</code>), a <code>-0</code> is introduced at that place and propagates out into <code>stoppingForce</code>.</p></dd></dl>
-
+- {{jsxref("Operators/Unary_negation", "- (unary negation)")}}
+  - : Consider the following example:
+      ```js
+      let stoppingForce = obj.mass * -obj.velocity;
+      ```
+      If `obj.velocity` is `0` (or computes to `0`), a `-0` is introduced at that place and propagates out into `stoppingForce`.
 - {{jsxref("Math.atan2")}}, {{jsxref("Math.ceil")}}, {{jsxref("Math.pow")}}, {{jsxref("Math.round")}}
   - : In some cases,it's possible for a `-0` to be introduced into an expression as a return value of these methods even when no `-0` exists as one of the parameters. For example, using {{jsxref("Math.pow")}} to raise {{jsxref("Infinity", "-Infinity")}} to the power of any negative, odd exponent evaluates to `-0`. Refer to the documentation for the individual methods.
 - {{jsxref("Math.floor")}}, {{jsxref("Math.max")}}, {{jsxref("Math.min")}}, {{jsxref("Math.sin")}}, {{jsxref("Math.sqrt")}}, {{jsxref("Math.tan")}}

--- a/files/en-us/web/javascript/reference/global_objects/generator/throw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/throw/index.md
@@ -32,12 +32,12 @@ throw(exception)
 
 An {{jsxref("Global_Objects/Object", "Object")}} with two properties:
 
-<dl><dt><code>done</code> (boolean)</dt><dd><ul><li>Has the value <code>true</code> if the iterator is past the end of the iterated
-sequence. In this case <code>value</code> optionally specifies the <em>return
-value</em> of the iterator.</li><li>Has the value <code>false</code> if the iterator was able to produce the next
-value in the sequence. This is equivalent of not specifying the <code>done</code>
-property altogether.</li></ul></dd><dt><code>value</code></dt><dd>Any JavaScript value returned by the iterator. Can be omitted when <code>done</code>
-is <code>true</code>.</dd></dl>
+- `done`
+  - : A boolean value:
+    - `true` if the iterator is past the end of the iterated sequence. In this case `value` optionally specifies the return value of the iterator.
+    - `false` if the iterator was able to produce the next value in the sequence. This is equivalent to not specifying the `done` property altogether.
+- `value`
+  - : Any JavaScript value returned by the iterator. Can be omitted when `done` is true.
 
 ## Examples
 


### PR DESCRIPTION
This PR converts two `<dl>` elements that didn't make it into Markdown.

See https://github.com/mdn/content/issues/7303 and https://github.com/mdn/yari/issues/4307.

I think our `<dl>` can't handle `<dd>` elements which start with not-text, like code blocks or lists. So this fix also adds a bit of text at the start. of the `<dd>`. I think this is actually better, from a content point of view, although it is a workaround.

I guess we should decide whether we want to support starting `<dd>` elements with not-text. I would be OK not to, since I haven't seen any cases which would not be improved by an introductory sentence.