### PR TITLE
FF91: Error with option.cause docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/error/index.md
@@ -9,39 +9,42 @@ browser-compat: javascript.builtins.Error.Error
 ---
 {{JSRef}}
 
-The **`Error`** constructor creates an
-error object.
+The **`Error`** constructor creates an error object.
 
 ## Syntax
 
 ```js
 new Error()
 new Error(message)
-new Error(message, fileName)
-new Error(message, fileName, lineNumber)
+new Error(message, options)
+new Error(message, options, fileName)
+new Error(message, options, fileName, lineNumber)
 ```
 
 ### Parameters
 
-- `message`{{Optional_Inline}}
+- `message` {{Optional_Inline}}
   - : A human-readable description of the error.
+- `options` {{Optional_Inline}}
+  - : An object that has the following properties:
+
+    - `cause` {{Optional_Inline}}
+      - : A property indicating the specific cause of the error.
+          When catching and re-throwing an error with a more-specific or useful error message, this property should be used to pass the original error.
 - `fileName` {{Optional_Inline}}{{Non-standard_inline}}
-  - : The value for the `fileName` property on the created
-    `Error` object. Defaults to the name of the file containing the code that
+  - : The value for the `fileName` property on the created `Error` object.
+    Defaults to the name of the file containing the code that
     called the `Error()` constructor.
 - `lineNumber` {{Optional_Inline}}{{Non-standard_inline}}
-  - : The value for the `lineNumber` property on the created
-    `Error` object. Defaults to the line number containing the
-    `Error()` constructor invocation.
+  - : The value for the `lineNumber` property on the created `Error` object. 
+     Defaults to the line number containing the `Error()` constructor invocation.
 
 ## Examples
 
 ### Function call or new construction
 
-When `Error` is used like a function -- without {{JSxRef("Operators/new",
-  "new")}}, it will return an `Error` object. Therefore, a mere call to
-`Error` will produce the same output that constructing an `Error`
-object via the `new` keyword would.
+When `Error` is used like a function -- without {{JSxRef("Operators/new",  "new")}}, it will return an `Error` object.
+Therefore, a mere call to `Error` will produce the same output that constructing an `Error` object via the `new` keyword would.
 
 ```js
 // this...
@@ -50,6 +53,21 @@ const x = Error('I was created using a function call!')
 // ...has the same functionality as this.
 const y = new Error('I was constructed via the "new" keyword!')
 ```
+
+### Rethrowing an error with a `cause`
+
+It is sometimes useful to catch an error and re-throw it with a new message.
+In this case you should pass the original error into the constructor for the new `Error`, as shown.
+
+```js
+  try {
+    frameworkThatCanThrow();
+  } catch (err) {
+    throw new Error('New error message', { cause: err });
+  }
+```
+
+For a more detailed example see [Error > Differentiate between similar errors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#differentiate_between_similar_errors).
 
 ## Specifications
 
@@ -63,3 +81,4 @@ const y = new Error('I was constructed via the "new" keyword!')
 
 - {{JSxRef("Statements/throw", "throw")}}
 - {{JSxRef("Statements/try...catch", "try...catch")}}
+- [Error causes](https://v8.dev/features/error-cause) (v8.dev/features)

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -18,10 +18,10 @@ Runtime errors result in new `Error` objects being created and thrown.
 
 ### Error types
 
-Besides the generic `Error` constructor, there are other core error constructors in JavaScript. For client-side exceptions, see [Exception handling statements](/en-US/docs/Web/JavaScript/Guide/Statements#Exception_handling_statements).
+Besides the generic `Error` constructor, there are other core error constructors in JavaScript. For client-side exceptions, see [Exception handling statements](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#exception_handling_statements).
 
 - {{JSxRef("EvalError")}}
-  - : Creates an instance representing an error that occurs regarding the global function {{JSxRef("eval", "eval()")}}.
+  - : Creates an instance representing an error that occurs regarding the global function {{JSxRef("Global_Objects/eval", "eval()")}}.
 - {{JSxRef("RangeError")}}
   - : Creates an instance representing an error that occurs when a numeric variable or parameter is outside of its valid range.
 - {{JSxRef("ReferenceError")}}
@@ -75,7 +75,8 @@ Besides the generic `Error` constructor, there are other core error constructors
 
 ### Throwing a generic error
 
-Usually you create an `Error` object with the intention of raising it using the {{JSxRef("Statements/throw", "throw")}} keyword. You can handle the error using the {{JSxRef("Statements/try...catch", "try...catch")}} construct:
+Usually you create an `Error` object with the intention of raising it using the {{JSxRef("Statements/throw", "throw")}} keyword.
+You can handle the error using the {{JSxRef("Statements/try...catch", "try...catch")}} construct:
 
 ```js
 try {
@@ -85,7 +86,7 @@ try {
 }
 ```
 
-### Handling a specific error
+### Handling a specific error type
 
 You can choose to handle only specific error types by testing the error type with the error's {{JSxRef("Object.prototype.constructor", "constructor")}} property or, if you're writing for modern JavaScript engines, {{JSxRef("Operators/instanceof", "instanceof")}} keyword:
 
@@ -107,11 +108,51 @@ try {
 }
 ```
 
+### Differentiate between similar errors
+
+Sometimes a block of code can fail for reasons that require different handling, but which throw very similar errors (i.e. with the same type and message).
+
+If you don't have control over the original errors that are thrown, one option is to catch them and throw new <code>Error</code> objects that have more specific messages.
+The original error should be passed to the new <code>Error</code> in the constructor `option` parameter (`cause` property), as this ensures that the original error and stack trace are available to higher level try/catch blocks.
+
+The example below shows this for two methods that would otherwise fail with similar errors (`doFailSomeWay()` and `doFailAnotherWay()`):
+
+```js
+function doWork() {
+  try {
+    doFailSomeWay();
+  } catch (err) {
+    throw new Error('Failed in some way', { cause: err });
+  }
+  try {
+    doFailAnotherWay();
+  } catch (err) {
+    throw new Error('Failed in another way', { cause: err });
+  }
+}
+
+try {
+  doWork();
+} catch (err) {
+  switch(err.message) {
+    case 'Failed in some way':
+      handleFailSomeWay(err.cause);
+      break;
+    case 'Failed in another way':
+      handleFailAnotherWay(err.cause);
+      break;
+  }
+}
+```
+
+> **Note** You should also use the `cause` property if re-throwing [custom error types](#custom_error_types). 
+
+
 ### Custom Error Types
 
 You might want to define your own error types deriving from `Error` to be able to `throw new MyError()` and use `instanceof MyError` to check the kind of error in the exception handler.  This results in cleaner and more consistent error handling code.
 
-See ["What's a good way to extend Error in JavaScript?"](http://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript) on StackOverflow for an in-depth discussion.
+See ["What's a good way to extend Error in JavaScript?"](https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript) on StackOverflow for an in-depth discussion.
 
 #### ES6 Custom Error Class
 
@@ -186,6 +227,7 @@ try {
   console.error(e.message); //bazMessage
 }
 ```
+
 
 ## Specifications
 


### PR DESCRIPTION
FF91 adds support for specifying an `options` parameters with a `cause` property in the [`Error` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error). If you have several similar errors that might be throw from a code block, this allows you to provide the context for handling the error. YOu can provide whatever you like in the cause, but the spec and other usage examples around the place suggest passing in the original error. 

This is part of fixing #6714, and the bug fix is https://bugzilla.mozilla.org/show_bug.cgi?id=1679653

UPDATE: So in particular you'd use this when you don't have much control over the original error thrown by the code you're using. I decided to document this as a constructor option with very simple example. A slightly more detailed example is linked to in the parent `Error` doc which is where I assume people will first find out about Errors.

I decided not to include info in docs for try-catch and throw. These do talk about catch and rethrow, but not so much "catch and change error" - I think it is a bit more of a niche case.