### PR TITLE
Fix variable name

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -39,8 +39,8 @@ let F = function () {
 let o = new F(); // {a: 1, b: 2}
 
 // add properties in F function's prototype
-f.prototype.b = 3;
-f.prototype.c = 4;
+F.prototype.b = 3;
+F.prototype.c = 4;
 
 // do not set the prototype F.prototype = {b:3,c:4}; this will break the prototype chain
 // o.[[Prototype]] has properties b and c.


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

```
f.prototype.b = 3;
f.prototype.c = 4;
```
here `f` is not defined instead `F` is defined.

So correct code will be  =>

```
F.prototype.b = 3;
F.prototype.c = 4;
```


> Issue number (if there is an associated issue)



> Anything else that could help us review it
