### PR TITLE
Fix image path to be relative to document

### DIFF
--- a/files/en-us/web/api/pannernode/orientationx/index.html
+++ b/files/en-us/web/api/pannernode/orientationx/index.html
@@ -60,7 +60,7 @@ browser-compat: api.PannerNode.orientationX
 
 <p><img
     alt="This chart visualises how the PannerNode orientation vectors affect the direction of the sound cone."
-    src="/en-US/docs/Web/API/PannerNode/orientationX/pannernode-orientation.png"></p>
+    src="pannernode-orientation.png"></p>
 
 <p>First, let's start by writing a utility function to figure out our <em>orientation vector.</em>
   The X and Z components are always at a 90° to each other, so we can


### PR DESCRIPTION
This is the last _Image_ flaw in `Web/*`: an image path was absolute instead of relative.


_Note: there is a last _Image_ flaw on the whole of MDN, but in `NSS/*` and it is a missing image that I don't know how to find…_