### PR TITLE
Fix sectioning flaws

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
@@ -671,7 +671,7 @@ var AuthorSchema = new Schema(
   }
 );
 
-<strong>// Virtual for author's full name
+// Virtual for author's full name
 AuthorSchema
 .virtual('name')
 .get(function () {

--- a/files/en-us/mozilla/firefox/releases/58/index.html
+++ b/files/en-us/mozilla/firefox/releases/58/index.html
@@ -83,7 +83,7 @@ tags:
 <ul>
  <li>Support for prefixed WebGL extensions has been removed ({{bug(1403413)}}):
   <ul>
-   <li>For <code>MOZ_WEBGL_compressed_texture_atc</code> use <code>WEBGL_compressed_texture_atc<code> instead.</li>
+   <li>For <code>MOZ_WEBGL_compressed_texture_atc</code> use <code>WEBGL_compressed_texture_atc</code> instead.</li>
    <li>For <code>MOZ_WEBGL_compressed_texture_pvrtc</code> use {{domxref("WEBGL_compressed_texture_pvrtc")}} instead.</li>
    <li>For <code>MOZ_WEBGL_compressed_texture_s3tc</code> use {{domxref("WEBGL_compressed_texture_s3tc")}} instead.</li>
    <li>For <code>MOZ_WEBGL_depth_texture</code> use {{domxref("WEBGL_depth_texture")}} instead.</li>

--- a/files/en-us/mozilla/firefox/releases/7/index.html
+++ b/files/en-us/mozilla/firefox/releases/7/index.html
@@ -23,7 +23,7 @@ tags:
 <h4 id="Canvas">Canvas</h4>
 
 <ul>
- <li>As part of the <a class="external" href="http://blog.mozilla.com/joe/2011/04/26/introducing-the-azure-project/">Azure project</a> the Direct2D Azure Backend <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=651858">has been implemented</a> and will significantly improve the performance of the 2D canvas.</li>
+ <li>As part of the <a class="external" href="https://blog.mozilla.com/joe/2011/04/26/introducing-the-azure-project/">Azure project</a> the Direct2D Azure Backend <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=651858">has been implemented</a> and will significantly improve the performance of the 2D canvas.</li>
  <li>Specifying invalid values when calling <code>setTransform()</code>, <code>bezierCurveTo()</code>, or <code>arcTo()</code> no longer throws an exception; these calls are now correctly silently ignored.</li>
  <li>The <a href="/en-US/docs/Web/API/CanvasRenderingContext2D#ispointinpath()"><code>isPointInPath()</code></a> method now correctly considers the transformation matrix when comparing the specified point to the current path.</li>
  <li>Calling <code>strokeRect()</code> with a zero width and height now correctly does nothing.</li>
@@ -50,7 +50,7 @@ tags:
  <li>XLink href has been restored and the MathML3 <code>href</code> attribute is now supported. Developers are encouraged to move to the latter syntax.</li>
  <li>Support for the <code>voffset</code> attribute on {{ MathMLElement("mpadded") }} elements has been added and behavior of <code>lspace</code> attribute has been fixed.</li>
  <li>The top-level {{ MathMLElement("math") }} element now accepts any attributes of the {{ MathMLElement("mstyle") }} element.</li>
- <li>Support for <a class="external" href="http://www.ctan.org/tex-archive/fonts/Asana-Math/">Asana Math</a> fonts has been added.</li>
+ <li>Support for <a class="external" href="https://www.ctan.org/tex-archive/fonts/Asana-Math/">Asana Math</a> fonts has been added.</li>
  <li>The <code>medium</code> line thickness of fraction bars in {{ MathMLElement("mfrac") }} elements has been corrected to match the default thickness.</li>
  <li><a href="/en-US/docs/Web/MathML/Attribute/Values#constants_(namedspaces)">Names for negative spaces</a> are now supported.</li>
 </ul>
@@ -92,7 +92,6 @@ tags:
  <li>Message logged with <code>console.log</code> while the <a href="/en-US/docs/Tools/Web_Console" title="Using the Web Console">web console</a> isn't open are still logged, although they aren't displayed when the web console is opened.</li>
 </ul>
 
-<div class="changelog">
 <h3 id="Web_timing">Web timing</h3>
 
 <ul>
@@ -104,7 +103,6 @@ tags:
 <ul>
  <li>In addition to the previously supported <code>text/xsl</code>, XSLT stylesheets can now use the official internet media (MIME) type <code>application/xslt+xml</code> (in the <a class="external" href="https://www.w3.org/TR/xml-stylesheet/">stylesheet processing instruction</a> or the <a class="external" href="https://datatracker.ietf.org/doc/html/rfc5988">HTTP Link header field</a>).</li>
 </ul>
-</div>
 
 <h2 id="Changes_for_Mozilla_and_add-on_developers">Changes for Mozilla and add-on developers</h2>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/aria_technique_template/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/aria_technique_template/index.html
@@ -4,8 +4,6 @@ slug: Web/Accessibility/ARIA/ARIA_Techniques/ARIA_Technique_Template
 tags:
   - Accessibility
 ---
-<div>
-<div>
 <h3 id="Description">Description</h3>
 
 
@@ -34,5 +32,3 @@ tags:
 <p class="comment">TBD: Add support information for common UA and AT product combinations</p>
 
 <h3 id="Additional_resources">Additional resources</h3>
-</div>
-</div>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
@@ -5,8 +5,6 @@ tags:
   - ARIA
   - Accessibility
 ---
-<div>
-<div>
 <h3 id="Description">Description</h3>
 
 <p id="The_aria-valuemax_attribute_is_used_to_define_the_maximum_value_allowed_for_a_range_widget_such_as_a_slider.2C_spinbutton_or_progressbar._If_the_aria-valuenow_has_a_known_maximum_and_minimum.2C_the_author_SHOULD_provide_properties_for_aria-valuemax_and_aria-valuemin._The_value_of_aria-valuemax_MUST_be_greater_than_or_equal_to_the_value_of_aria-valuemin."><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax">aria-valuemax</a> attribute is used to define the maximum value allowed for a range widget such as a slider, spinbutton or progressbar.</span> If the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> has a known maximum and minimum, the author <strong class="rfc2119">SHOULD</strong> provide properties for <code>aria-valuemax</code> and <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a>. The value of <code>aria-valuemax</code> <strong class="rfc2119">MUST</strong> be greater than or equal to the value of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a>.<span class="seoSummary"> </span></p>
@@ -89,5 +87,3 @@ tags:
 <ul>
  <li><a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax">WAI-ARIA specification for the <code>aria-valuemax</code> attribute</a></li>
 </ul>
-</div>
-</div>

--- a/files/en-us/web/accessibility/aria/forms/multipart_labels/index.html
+++ b/files/en-us/web/accessibility/aria/forms/multipart_labels/index.html
@@ -18,7 +18,6 @@ tags:
   - trouble shoot
   - troubleshoot
 ---
-<div>
 <h2 id="Problem_2"><span class="mw-headline" id="Problem">Problem</span></h2>
 
 <p>You have a form where you ask your user a question, but the answer is mentioned in the question itself. A classic example we all know from our browser settings is the setting “Delete history after x days”. “Delete history after” is to the left of the textbox, x is the number, for example 21, and the word “days” follows the textbox, forming a sentence that is easy to understand.</p>
@@ -47,5 +46,3 @@ tags:
 <h2 id="Can_this_be_done_without_ARIA"><span class="mw-headline" id="Can_this_be_done_without_ARIA.3F">Can this be done without ARIA?</span></h2>
 
 <p>Community member Ben Millard has pointed out in a blog post that <a class="external text" href="https://projectcerbera.com/blog/2008/03#day24" rel="nofollow">controls can be embedded in labels as shown in the above example using HTML 4</a>, by embedding the input into the label. Thanks for that info, Ben! It is very useful and shows that some techniques that have been available for years escape even the gurus sometimes. This technique works in Firefox; however, it doesn't currently work in many other browsers, including IE. For labels with embedded form controls, using <strong>aria-labelledby</strong> is still the best approach.</p>
-
-</div>

--- a/files/en-us/web/api/cookiestore/delete/index.html
+++ b/files/en-us/web/api/cookiestore/delete/index.html
@@ -39,8 +39,7 @@ var <var>promise</var> = cookieStore.delete(<var>options</var>);</pre>
 </dl>
 
 <div class="notecard note">
-  <h3>Note:</h3>
-  <p>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
+  <p><strong>Note:</strong>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
 </div>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -37,8 +37,7 @@ var <var>cookie</var> = CookieStore.get(<var>options</var>);</pre>
 </dl>
 
 <div class="notecard note">
-  <h3>Note:</h3>
-  <p>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
+  <p><strong>Note:</strong>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
 </div>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/cookiestore/getall/index.html
+++ b/files/en-us/web/api/cookiestore/getall/index.html
@@ -35,8 +35,7 @@ var <var>list</var> = cookieStore.getAll(<var>options</var>);</pre>
 </dl>
 
 <div class="notecard note">
-  <h3>Note:</h3>
-  <p>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
+  <p><strong>Note:</strong>The <code>url</code> option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.</p>
 </div>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
@@ -2,17 +2,17 @@
 title: MediaTrackSupportedConstraints.frameRate
 slug: Web/API/MediaTrackSupportedConstraints/frameRate
 tags:
-- API
-- Constraints
-- Media
-- Media Capture and Streams API
-- Media Streams API
-- MediaTrackSupportedConstraints
-- Property
-- Reference
-- Web
-- WebRTC
-- frameRate
+  - API
+  - Constraints
+  - Media
+  - Media Capture and Streams API
+  - Media Streams API
+  - MediaTrackSupportedConstraints
+  - Property
+  - Reference
+  - Web
+  - WebRTC
+  - frameRate
 browser-compat: api.MediaTrackSupportedConstraints.frameRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
@@ -62,24 +62,16 @@ if (navigator.mediaDevices.getSupportedConstraints().frameRate) {
     result.textContent = "Not supported!";
 }</pre>
 
-<details>
-  <summary>
-    <h3 id="HTML">HTML</h3>
-  </summary>
+<h3 id="HTML">HTML</h3>
 
-  <pre class="brush: html">&lt;div id="result"&gt;
+<pre class="brush: html">&lt;div id="result"&gt;
 &lt;/div&gt;</pre>
-</details>
 
-<details>
-  <summary>
-    <h3 id="CSS">CSS</h3>
-  </summary>
+<h3 id="CSS">CSS</h3>
 
-  <pre class="brush: css">#result {
+<pre class="brush: css">#result {
   font: 14px "Arial", sans-serif;
 }</pre>
-</details>
 
 <h3 id="Result">Result</h3>
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.html
@@ -19,11 +19,11 @@ browser-compat: api.RTCRtpSender.setParameters
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
-<p><span class="seoSummary">The <strong><code>setParameters()</code></strong> method of
+<p>The <strong><code>setParameters()</code></strong> method of
     the {{domxref("RTCRtpSender")}} interface applies changes the configuration of
     sender's {{domxref("RTCRtpSender.track", "track")}}, which is the
     {{domxref("MediaStreamTrack")}} for which the <code>RTCRtpSender</code> is
-    responsible.</span></p>
+    responsible.</p>
 
 <p>In other words, <code>setParameters()</code> updates the configuration of the
   {{Glossary("RTP")}} transmission as well as the encoding configuration for a specific
@@ -40,12 +40,24 @@ browser-compat: api.RTCRtpSender.setParameters
 <dl>
   <dt><code>parameters</code></dt>
   <dd>
-    <p>A parameters object previously obtained by calling the same
-      sender's {{domxref("RTCRtpSender.getParameters", "getParameters()")}} method, with
+    <p>
+      A parameters object previously obtained by calling the same
+      sender's {{domxref("RTCRtpSender.getParameters", "getParameters()")}} method, with
       the desired changes to the sender's configuration parameters. These parameters
       include potential codecs that could be use for encoding the sender's
-      {{domxref("RTCRtpSender.track", "track")}}. The available parameters are:</p>
-    {{page("/en-US/docs/Web/API/RTCRtpSendParameters", "property-list")}}
+      {{domxref("RTCRtpSender.track", "track")}}. The available parameters are:
+    </p>
+    <dl>
+      <dt><code>encodings</code></dt>
+      <dd>An array of {{domxref("RTCRtpEncodingParameters")}} objects, each specifying the parameters for a single codec that could be used to encode the track's media.</dd>
+      <dt><code>transactionId</code></dt>
+      <dd>A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}. Once this parameter is initially set, it cannot be changed.</dd>
+      <dt><code>degradationPreference</code> {{deprecated_inline}}</dt>
+      <dd>Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the value comes from the {{domxref("RTCDegradationPreference")}} enumerated string type, and the default is <code>balanced</code>.</dd>
+      <dt><code>priority</code> {{deprecated_inline}}</dt>
+      <dd>A string from the {{domxref("RTCPriorityType")}} enumerated type which indicates the encoding's priority. The default value is <code>low</code>.</dd>
+
+    </dl>
   </dd>
 </dl>
 

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.html
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.html
@@ -18,7 +18,6 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<div id="keyframe-syntax">
 <p>There are two different ways to format keyframes:</p>
 
 <ol>
@@ -122,14 +121,13 @@ tags:
  </dd>
  <dt>easing</dt>
  <dd>
- <p>The <a href="/en-US/docs/Web/CSS/timing-function">timing function</a> used from this keyframe until the next keyframe in the series.</p>
+ <p>The <a href="/en-US/docs/Web/CSS/easing-function">timing function</a> used from this keyframe until the next keyframe in the series.</p>
  </dd>
  <dt>composite</dt>
  <dd>
  <p>The {{domxref("KeyframeEffect.composite")}} operation used to combine the values specified in this keyframe with the underlying value. This will be <code>auto</code> if the composite operation specified on the effect is being used.</p>
  </dd>
 </dl>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -152,10 +150,8 @@ tags:
 
 <h3 id="Element.animate"><code>Element.animate</code></h3>
 
-<div>
-
 <p>{{Compat("api.Element.animate")}}</p>
-</div>
+
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
@@ -28,7 +28,6 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs
   <p>If you learn better by following step-by-step code, we've also provided this <a href="https://github.com/SamsungInternet/WebPhone/tree/master/tutorial">tutorial in code</a>, which you can use instead.</p>
 </div>
 
-<div>
   <h3>Table of Contents</h3>
   <ol>
     <li>
@@ -61,6 +60,5 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs
       <a href="Build_a_phone_with_peerjs/Deployment_and_further_reading">Deployment and Further Reading</a>
     </li>
   </ol>
-</div>
 
 <p>{{NextMenu("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup")}}</p>

--- a/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.html
+++ b/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.html
@@ -50,7 +50,7 @@ tags:
 
 <h2 id="How_do_I_do_transformNode.3F">How do I do <code>transformNode</code>?</h2>
 
-<p>There is <code>transformToDocument</code> and <code>transformToFragment</code> starting with Mozilla 1.2 final, see <a href="/en-US/docs/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations">Using the Mozilla JavaScript interface to XSL Transformations</a>.</p>
+<p>There is <code>transformToDocument</code> and <code>transformToFragment</code> starting with Mozilla 1.2 final, see <a href="/en-US/docs/Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations">Using the Mozilla JavaScript interface to XSL Transformations</a>.</p>
 
 <h2 id="Why_does_Internet_Explorer_require_a_different_XSLT_namespace_than_Mozilla.3F">Why does Internet Explorer require a different XSLT namespace than Mozilla?</h2>
 
@@ -60,7 +60,6 @@ tags:
 
 <p>See the <a href="/en-US/docs/Building_TransforMiiX_standalone">Building TransforMiiX standalone</a> page.</p>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
@@ -68,4 +67,3 @@ tags:
  <li>Last Updated Date: February 2, 2005</li>
  <li>Copyright Information: Portions of this content are © 1998–2006 by individual mozilla.org contributors; content available under a Creative Commons license</li>
 </ul>
-</div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The first part of this article, <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index">Stacking without the z-index property</a>, explains how stacking is arranged by default. If you want to create a custom stacking order, you can use the {{cssxref("z-index")}} property on a <a href="/en-US/docs/Web/CSS/position#Types_of_positioning">positioned</a> element.</p>
+<p>The first part of this article, <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index">Stacking without the z-index property</a>, explains how stacking is arranged by default. If you want to create a custom stacking order, you can use the {{cssxref("z-index")}} property on a <a href="/en-US/docs/Web/CSS/position#types_of_positioning">positioned</a> element.</p>
 
 <p>The <code>z-index</code> property can be specified with an integer value (positive, zero, or negative), which represents the position of the element along the z-axis. If you are not familiar with the z-axis, imagine the page as a stack of layers, each one having a number. Layers are rendered in numerical order, with larger numbers above smaller numbers.</p>
 
@@ -152,12 +152,10 @@ b {
  <li><a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3">Stacking context example 3</a>: 3-level HTML hierarchy, z-index on the second level</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: November 3, 2014</li>
 </ul>
-</div>

--- a/files/en-us/web/guide/introduction_to_web_development/index.html
+++ b/files/en-us/web/guide/introduction_to_web_development/index.html
@@ -12,86 +12,77 @@ tags:
 ---
 <p>Whether you're just getting started with Web development, or are just expanding your horizons into new realms of Web awesomeness, the links here should help you get started.</p>
 
-<p>For another (overlapping) set of links to learning resources, see the <a href="/en-US/docs/Learn">MDN Learning</a> pages.</p>
+<p>For another (overlapping) set of links to learning resources, see the <a href="/en-US/docs/Learn">MDN Learning</a> pages.</p>
 
 <div class="note"><strong>Note:</strong> The recommended resources on this page are subject to change.</div>
 
-<table>
- <tbody>
-  <tr>
-   <td style="vertical-align: top;">
-    <h2 id="Documentation_topics">Documentation topics</h2>
+<h2 id="Documentation_topics">Documentation topics</h2>
 
-    <h3 id="HTML">HTML</h3>
+<h3 id="HTML">HTML</h3>
 
-    <ul>
-     <li><a href="https://www.w3.org/community/webed/wiki/The_basics_of_HTML">The basics of Hypertext Mark-up Language (HTML)</a> — what exactly is HTML?</li>
-     <li><a href="http://reference.sitepoint.com/html/page-structure">Basic structure of a web page</a> — the doctype and document 'tree'</li>
-     <li><a href="http://reference.sitepoint.com/html/elements">Fundamental HTML elements</a> — structural, head, list, form elements and more, explained by category.</li>
-     <li><a href="http://htmldog.com/guides/htmlbeginner/">HTML beginners tutorial</a> — a tutorial and exercise that recap and take you through the basics you've learned above.</li>
-     <li><a href="/en-US/docs/Web/HTML/Element">HTML elements reference guide</a> — a comprehensive guide to HTML elements with details on how browsers support them</li>
-    </ul>
+<ul>
+  <li><a href="https://www.w3.org/community/webed/wiki/The_basics_of_HTML">The basics of Hypertext Mark-up Language (HTML)</a> — what exactly is HTML?</li>
+  <li><a href="https://reference.sitepoint.com/html/page-structure">Basic structure of a web page</a> — the doctype and document 'tree'</li>
+  <li><a href="https://reference.sitepoint.com/html/elements">Fundamental HTML elements</a> — structural, head, list, form elements and more, explained by category.</li>
+  <li><a href="https://htmldog.com/guides/htmlbeginner/">HTML beginners tutorial</a> — a tutorial and exercise that recap and take you through the basics you've learned above.</li>
+  <li><a href="/en-US/docs/Web/HTML/Element">HTML elements reference guide</a> — a comprehensive guide to HTML elements with details on how browsers support them</li>
+</ul>
 
-    <h3 id="CSS">CSS</h3>
+<h3 id="CSS">CSS</h3>
 
-    <ul>
-     <li><a href="/en-US/docs/Learn/CSS/First_steps">Getting started with CSS</a> — an absolute beginners guide to CSS covers basic concepts and fundamentals</li>
-     <li><a href="/en-US/docs/Web/CSS/Reference">CSS reference guide</a> — a complete guide to CSS with details on the level of Gecko/Firefox support for each.</li>
-     <li><a href="https://www.w3.org/MarkUp/Guide/Style">The W3C introduction to styling with CSS</a> — a brief guide to styling web pages for beginners.</li>
-     <li><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS questions</a> — common questions and answers for beginners</li>
-     <li><a href="http://www.html.net/tutorials/css/">Intermediate CSS concepts</a> — grouping, pseudo-classes and more.</li>
-    </ul>
+<ul>
+  <li><a href="/en-US/docs/Learn/CSS/First_steps">Getting started with CSS</a> — an absolute beginners guide to CSS covers basic concepts and fundamentals</li>
+  <li><a href="/en-US/docs/Web/CSS/Reference">CSS reference guide</a> — a complete guide to CSS with details on the level of Gecko/Firefox support for each.</li>
+  <li><a href="https://www.w3.org/MarkUp/Guide/Style">The W3C introduction to styling with CSS</a> — a brief guide to styling web pages for beginners.</li>
+  <li><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS questions</a> — common questions and answers for beginners</li>
+  <li><a href="http://www.html.net/tutorials/css/">Intermediate CSS concepts</a> — grouping, pseudo-classes and more.</li>
+</ul>
 
-    <h3 id="JavaScript">JavaScript</h3>
+<h3 id="JavaScript">JavaScript</h3>
 
-    <h4 id="Beginning">Beginning</h4>
+<h4 id="Beginning">Beginning</h4>
 
-    <ul>
-     <li><a href="/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics">Getting started with JavaScript</a> — what is JavaScript and how can it help you?</li>
-     <li><a href="/en-US/docs/Web/JavaScript/Guide">JavaScript reference guide</a> — a comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.</li>
-     <li><a href="https://www.youtube.com/playlist?list=PL7664379246A246CB">Crockford on JavaScript</a> — an in-depth video series on the JavaScript language.</li>
-     <li><a href="http://eloquentjavascript.net/contents.html">Eloquent JavaScript </a> — a comprehensive guide to intermediate and advanced JavaScript methodologies</li>
-    </ul>
+<ul>
+  <li><a href="/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics">Getting started with JavaScript</a> — what is JavaScript and how can it help you?</li>
+  <li><a href="/en-US/docs/Web/JavaScript/Guide">JavaScript reference guide</a> — a comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.</li>
+  <li><a href="https://www.youtube.com/playlist?list=PL7664379246A246CB">Crockford on JavaScript</a> — an in-depth video series on the JavaScript language.</li>
+  <li><a href="https://eloquentjavascript.net/contents.html">Eloquent JavaScript</a> — a comprehensive guide to intermediate and advanced JavaScript methodologies</li>
+</ul>
 
-    <h4 id="Intermediate">Intermediate</h4>
+<h4 id="Intermediate">Intermediate</h4>
 
-    <ul>
-     <li><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-introduction to JavaScript</a> — a recap on the JavaScript programming language aimed at intermediate-level developers</li>
-     <li><a href="http://www.addyosmani.com/resources/essentialjsdesignpatterns/book/">Essential JavaScript design patterns</a> — an introduction to essential JavaScript design patterns</li>
-     <li><a href="/en-US/docs/Learn/JavaScript/Objects">Introduction to object-oriented JavaScript</a> — learn about the JavaScript object model.</li>
-     <li><a href="http://dev.opera.com/articles/view/javascript-best-practices/">Christian Heilmann's JavaScript best practices</a> — learn about some of the obvious and (not so) obvious best practices when writing JavaScript.</li>
-    </ul>
+<ul>
+  <li><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-introduction to JavaScript</a> — a recap on the JavaScript programming language aimed at intermediate-level developers</li>
+  <li><a href="https://www.addyosmani.com/resources/essentialjsdesignpatterns/book/">Essential JavaScript design patterns</a> — an introduction to essential JavaScript design patterns</li>
+  <li><a href="/en-US/docs/Learn/JavaScript/Objects">Introduction to object-oriented JavaScript</a> — learn about the JavaScript object model.</li>
+  <li><a href="https://dev.opera.com/articles/view/javascript-best-practices/">Christian Heilmann's JavaScript best practices</a> — learn about some of the obvious and (not so) obvious best practices when writing JavaScript.</li>
+</ul>
 
-    <h4 id="Advanced">Advanced</h4>
+<h4 id="Advanced">Advanced</h4>
 
-    <ul>
-     <li><a href="http://ejohn.org/apps/learn/">Learning advanced JavaScript</a> — John Resig's guide to advanced JavaScript</li>
-     <li><a href="http://uk.video.yahoo.com/watch/111585/1027823">Crockford on Advanced JavaScript</a> — a three part video series on advanced JavaScript concepts</li>
-     <li><a href="https://bonsaiden.github.com/JavaScript-Garden/">JavaScript Garden</a> — Documentation of the most quirky parts of JavaScript.</li>
-    </ul>
-   </td>
-   <td style="vertical-align: top;">
-    <h2 id="Resources">Resources</h2>
+<ul>
+  <li><a href="http://ejohn.org/apps/learn/">Learning advanced JavaScript</a> — John Resig's guide to advanced JavaScript</li>
+  <li><a href="https://uk.video.yahoo.com/watch/111585/1027823">Crockford on Advanced JavaScript</a> — a three part video series on advanced JavaScript concepts</li>
+  <li><a href="https://bonsaiden.github.com/JavaScript-Garden/">JavaScript Garden</a> — Documentation of the most quirky parts of JavaScript.</li>
+</ul>
 
-    <dl>
-     <dt><a href="https://www.w3.org/community/webed/wiki/Main_Page">W3C Web Education Community Group Wiki</a></dt>
-     <dd>Covers web design, HTML and HTML5, CSS, JavaScript and accessibility. This is a good starting point for beginners wishing to learn web development fundamentals across a number of areas.</dd>
-     <dt><a href="http://reference.sitepoint.com/">SitePoint</a></dt>
-     <dd>A reliable reference site for learning HTML, CSS and JavaScript which also mentions feature support across different browsers and known browser bugs.</dd>
-     <dt><a href="http://htmldog.com/">HTMLDog</a></dt>
-     <dd>An excellent and comprehensive reference site on HTML and CSS for beginners.</dd>
-     <dt><a href="http://code.google.com/edu/submissions/html-css-javascript/">Google's HTML, CSS, and Javascript from the Ground Up</a></dt>
-     <dd>These easily digestible video tutorials from Google's expert web developers cover the basics of HTML, CSS and JavaScript.</dd>
-     <dt><a href="http://www.csstutorial.net/">CSSTutorial.net Beginner Tutorials</a></dt>
-     <dd>A broad range of useful text and video tutorials that cover the basics through to intermediate aspects of CSS.</dd>
-     <dt><a href="http://www.tizag.com/cssT/">Tizag CSS Tutorials</a></dt>
-     <dd>An easy-to-follow reference for those wishing to learn CSS through short, concise tutorials.</dd>
-     <dt><a href="http://jqfundamentals.com/">jQuery Fundamentals</a></dt>
-     <dd>An open-source reference book featuring detailed introductions to both JavaScript and JQuery for beginners.</dd>
-     <dt><a href="http://net.tutsplus.com/tutorials/javascript-ajax/javascript-from-null-video-series/">JavaScript From Null: A Video Series</a></dt>
-     <dd>A video series on JavaScript for absolute beginners looking for more 'visual'-based learning</dd>
-    </dl>
-   </td>
-  </tr>
- </tbody>
-</table>
+<h2 id="Resources">Resources</h2>
+
+<dl>
+  <dt><a href="https://www.w3.org/community/webed/wiki/Main_Page">W3C Web Education Community Group Wiki</a></dt>
+  <dd>Covers web design, HTML and HTML5, CSS, JavaScript and accessibility. This is a good starting point for beginners wishing to learn web development fundamentals across a number of areas.</dd>
+  <dt><a href="https://reference.sitepoint.com/">SitePoint</a></dt>
+  <dd>A reliable reference site for learning HTML, CSS and JavaScript which also mentions feature support across different browsers and known browser bugs.</dd>
+  <dt><a href="https://htmldog.com/">HTMLDog</a></dt>
+  <dd>An excellent and comprehensive reference site on HTML and CSS for beginners.</dd>
+  <dt><a href="https://code.google.com/edu/submissions/html-css-javascript/">Google's HTML, CSS, and Javascript from the Ground Up</a></dt>
+  <dd>These easily digestible video tutorials from Google's expert web developers cover the basics of HTML, CSS and JavaScript.</dd>
+  <dt><a href="https://www.csstutorial.net/">CSSTutorial.net Beginner Tutorials</a></dt>
+  <dd>A broad range of useful text and video tutorials that cover the basics through to intermediate aspects of CSS.</dd>
+  <dt><a href="http://www.tizag.com/cssT/">Tizag CSS Tutorials</a></dt>
+  <dd>An easy-to-follow reference for those wishing to learn CSS through short, concise tutorials.</dd>
+  <dt><a href="http://jqfundamentals.com/">jQuery Fundamentals</a></dt>
+  <dd>An open-source reference book featuring detailed introductions to both JavaScript and JQuery for beginners.</dd>
+  <dt><a href="https://net.tutsplus.com/tutorials/javascript-ajax/javascript-from-null-video-series/">JavaScript From Null: A Video Series</a></dt>
+  <dd>A video series on JavaScript for absolute beginners looking for more 'visual'-based learning</dd>
+</dl>

--- a/files/en-us/web/performance/optimizing_startup_performance/index.html
+++ b/files/en-us/web/performance/optimizing_startup_performance/index.html
@@ -78,11 +78,9 @@ tags:
  <li><a href="/en-US/docs/Games">Games</a></li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
  <li>Author(s): Alon Zakai</li>
- <li>Source Link: <a href="http://mozakai.blogspot.com/2012/07/bananabread-or-any-compiled-codebase.html">BananaBread (or any compiled codebase) Startup Experience</a></li>
+ <li>Source Link: <a href="https://mozakai.blogspot.com/2012/07/bananabread-or-any-compiled-codebase.html">BananaBread (or any compiled codebase) Startup Experience</a></li>
 </ul>
-</div>

--- a/files/en-us/web/security/firefox_security_guidelines/index.html
+++ b/files/en-us/web/security/firefox_security_guidelines/index.html
@@ -4,7 +4,6 @@ slug: Web/Security/Firefox_Security_Guidelines
 tags:
   - Security
 ---
-<div class="wiki-content">
 <h2 id="Purpose">Purpose</h2>
 
 <p>This document outlines a set of security guidelines that will generally apply to all client applications, such as Firefox and Thunderbird.</p>
@@ -286,7 +285,6 @@ tags:
 <ul>
  <li><a class="external-link" href="https://wiki.mozilla.org/WebAppSec/Web_Security_Verification" rel="nofollow">Web Security Verification</a></li>
  <li><a class="external-link" href="https://www.mozilla.org/projects/security/components/reviewguide.html" rel="nofollow">Mozilla Security Review and Best Practices</a></li>
- <li><a class="external-link" href="http://www.squarefree.com/securitytips/mozilla-developers.html" rel="nofollow">Security tips for Mozilla and extension developers</a></li>
+ <li><a class="external-link" href="https://www.squarefree.com/securitytips/mozilla-developers.html" rel="nofollow">Security tips for Mozilla and extension developers</a></li>
  <li><a class="external-link" href="https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf" rel="nofollow">OWASP Secure Coding Practices - Quick Reference Guide</a></li>
 </ul>
-</div>

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
@@ -410,16 +410,14 @@ var thisitemEl = thislevel.iterateNext();
 
 <ul>
  <li><a href="/en-US/docs/Web/XPath">XPath</a></li>
- <li><a href="http://www.xml.com/pub/a/2000/08/holman/index.html?page=2#xpath-info">XML Path Language </a>from <em><a href="http://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></em> by G. Ken Holman</li>
+ <li><a href="https://www.xml.com/pub/a/2000/08/holman/index.html?page=2#xpath-info">XML Path Language </a>from <em><a href="https://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></em> by G. Ken Holman</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
- <li>Based Upon Original Document <a href="http://www-xray.ast.cam.ac.uk/~jgraham/mozilla/xpath-tutorial.html">Mozilla XPath Tutorial</a></li>
+ <li>Based Upon Original Document <a href="https://www-xray.ast.cam.ac.uk/~jgraham/mozilla/xpath-tutorial.html">Mozilla XPath Tutorial</a></li>
  <li>Original Source Author: James Graham.</li>
  <li>Other Contributors: James Thompson.</li>
  <li>Last Updated Date: 2006-3-25.</li>
 </ul>
-</div>


### PR DESCRIPTION
We still have a few sectioning flaws: these are pages where the heading structure is not at the top level–some `<hx>` tags are not at the top-level.

The causes are diverses:
- spurious useless `<div>`
- tags that were not closed before the heading
- use of html tables in lieu of CSS, for styling
- heading introduced via the `{{page}}` macro
- …

This fixes a bunch of them (and some broken links)