### PR TITLE
Page macro removal: examples in audio, geolocation, animation

### DIFF
--- a/files/en-us/web/api/audioworkletprocessor/port/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/port/index.html
@@ -26,17 +26,15 @@ browser-compat: api.AudioWorkletProcessor.port
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><em>AudioWorkletProcessorInstance</em>.port;</pre>
+<pre class="brush: js"><em>AudioWorkletProcessorInstance</em>.port;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>The {{domxref("MessagePort")}} object that is connecting the
-  <code>AudioWorkletProcessor</code> and the associated <code>AudioWorkletNode</code>.</p>
+<p>The {{domxref("MessagePort")}} object that is connecting the <code>AudioWorkletProcessor</code> and the associated <code>AudioWorkletNode</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioWorkletNode/port", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioWorkletNode/port#examples"><code>AudioWorkletNode.port</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -14,14 +14,12 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <code>createChannelMerger()</code> method of the {{ domxref("BaseAudioContext")
-  }} interface creates a {{domxref("ChannelMergerNode")}}, which combines channels from
-  multiple audio streams into a single audio stream.</p>
+<p>The <code>createChannelMerger()</code> method of the {{domxref("BaseAudioContext")}} interface creates a {{domxref("ChannelMergerNode")}},
+  which combines channels from multiple audio streams into a single audio stream.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">baseAudioContext.createChannelMerger(<em>numberOfInputs</em>);</pre>
+<pre class="brush: js">createChannelMerger(<em>numberOfInputs</em>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -39,11 +37,11 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 
 <p>The following example shows how you could separate a stereo track (say, a piece of
   music), and process the left and right channel differently. To use them, you need to use
-  the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode")}}
+  the second and third parameters of the {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode)")}}
   method, which allow you to specify both the index of the channel to connect from and the
   index of the channel to connect to.</p>
 
-<pre class="brush: js;highlight[7,16,17,24]">var ac = new AudioContext();
+<pre class="brush: js">var ac = new AudioContext();
 ac.decodeAudioData(someStereoBuffer, function(data) {
  var source = ac.createBufferSource();
  source.buffer = data;
@@ -80,6 +78,5 @@ ac.decodeAudioData(someStereoBuffer, function(data) {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a>
-  </li>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
 </ul>

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -13,16 +13,12 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
-  <p>The <code>createChannelSplitter()</code> method of the {{ domxref("BaseAudioContext")
-    }} Interface is used to create a {{domxref("ChannelSplitterNode")}}, which is used to
-    access the individual channels of an audio stream and process them separately.</p>
-</div>
+<p>The <code>createChannelSplitter()</code> method of the {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("ChannelSplitterNode")}},
+  which is used to access the individual channels of an audio stream and process them separately.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">baseAudioContext.createChannelSplitter(<em>numberOfOutputs</em>);</pre>
+<pre class="brush: js">createChannelSplitter(<em>numberOfOutputs</em>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/index.html
@@ -61,7 +61,7 @@ browser-compat: api.ChannelMergerNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createChannelMerger","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createChannelMerger#example"><code>BaseAudioContext.createChannelMerger()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/index.html
@@ -62,7 +62,7 @@ browser-compat: api.ChannelSplitterNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createChannelSplitter","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createChannelSplitter#example"><code>BaseAudioContext.createChannelSplitter()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
@@ -22,11 +22,9 @@ browser-compat: api.DataTransferItem.webkitGetAsEntry
   {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file,
   <code>null</code> is returned.</p>
 
-<div class="note">
-  <p>This function is implemented as <code>webkitGetAsEntry()</code> in non-WebKit
-    browsers including Firefox at this time; it may be renamed to
-    <code>getAsEntry()</code> in the future, so you should code defensively, looking for
-    both.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> This function is implemented as <code>webkitGetAsEntry()</code> in non-WebKit browsers including Firefox at this time; it may be renamed to
+    <code>getAsEntry()</code> in the future, so you should code defensively, looking for both.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -40,8 +38,7 @@ browser-compat: api.DataTransferItem.webkitGetAsEntry
 <h3 id="Return_value">Return value</h3>
 
 <p>A {{domxref("FileSystemEntry")}}-based object describing the dropped item. This will be
-  either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
-</p>
+  either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.</p>
 
 <h2 id="Example">Example</h2>
 
@@ -104,7 +101,7 @@ body {
   to insert the list of contents (the <code>container</code> parameter).</p>
 
 <div class="notecard note">
-  <p>Note that to read all files in a directory, <code>readEntries</code> needs to be
+  <p><strong>Note:</strong> To read all files in a directory, <code>readEntries</code> needs to be
     called repeatedly until it returns an empty array. In Chromium-based browsers, the
     following example will only return a max of 100 entries.</p>
 </div>
@@ -212,13 +209,9 @@ function scanFiles(item, container) {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory
-      Entries API</a></li>
-  <li><a
-      href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction">Introduction
-      to the File System API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory Entries API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction">Introduction to the File System API</a></li>
   <li>{{domxref("DataTransferItem")}}</li>
-  <li>{{domxref("FileSystemEntry")}}, {{domxref("FileSystemFileEntry")}}, and
-    {{domxref("FileSystemDirectoryEntry")}}</li>
+  <li>{{domxref("FileSystemEntry")}}, {{domxref("FileSystemFileEntry")}}, and {{domxref("FileSystemDirectoryEntry")}}</li>
   <li>Events: {{event("dragover")}} and {{event("drop")}}</li>
 </ul>

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
@@ -19,17 +19,16 @@ browser-compat: api.FileSystemDirectoryReader.readEntries
 
 <p>{{Deprecated_Header}}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
-<p><span class="seoSummary">The {{domxref("FileSystemDirectoryReader")}} interface's
-    <strong><code>readEntries()</code></strong> method retrieves the directory entries
-    within the directory being read and delivers them in an array to a provided callback
-    function.</span> The objects in the array are all based upon
-  {{domxref("FileSystemEntry")}}. Generally, they are either
-  {{domxref("FileSystemFileEntry")}} objects, which represent standard files, or
-  {{domxref("FileSystemDirectoryEntry")}} objects, which represent directories.</p>
+<p>The {{domxref("FileSystemDirectoryReader")}} interface's <strong><code>readEntries()</code></strong> method retrieves the directory entries
+    within the directory being read and delivers them in an array to a provided callback function.</p>
+
+<p>The objects in the array are all based upon {{domxref("FileSystemEntry")}}.
+  Generally, they are either {{domxref("FileSystemFileEntry")}} objects, which represent standard files, or {{domxref("FileSystemDirectoryEntry")}} objects, which represent directories.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">readEntries(<em>successCallback</em>[, <em>errorCallback</em>]);
+<pre class="brush: js">readEntries(<em>successCallback</em>);
+readEntries(<em>successCallback</em>, <em>errorCallback</em>);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -55,7 +54,7 @@ browser-compat: api.FileSystemDirectoryReader.readEntries
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry#example"><code>DataTransferItem.webkitGetAsEntry()</code></a> for example code that uses this method.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -67,18 +66,14 @@ browser-compat: api.FileSystemDirectoryReader.readEntries
 
 <p>{{Compat}}</p>
 
-<p>On Chrome 77, <code>readEntries()</code> will only return the first
-  100 <code>FileSystemEntry</code> instances. In order to obtain all of the
+<p>On Chrome 77, <code>readEntries()</code> will only return the first 100 <code>FileSystemEntry</code> instances. In order to obtain all of the
   instances, <code>readEntries()</code> must be called multiple times.</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory
-      Entries API</a></li>
-  <li><a
-      href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction">Introduction
-      to the File System API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API">File and Directory Entries API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction">Introduction to the File System API</a></li>
   <li>{{domxref("FileSystemDirectoryEntry")}}</li>
   <li>{{domxref("FileSystem")}}</li>
 </ul>

--- a/files/en-us/web/api/geolocation_api/index.html
+++ b/files/en-us/web/api/geolocation_api/index.html
@@ -60,24 +60,11 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/Geolocation_API/Using_the_Geolocation_API","Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/Geolocation_API/Using_the_Geolocation_API#examples">Using the Geolocation API</a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Geolocation")}}</td>
-   <td>{{Spec2("Geolocation")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.Geolocation")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -25,17 +25,15 @@ browser-compat: api.GlobalEventHandlers.onanimationend
   {{domxref("GlobalEventHandlers")}} mixin is the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for
   processing {{event("animationend")}} events.</p>
 
-<p>The <code>animationend</code> event fires when a <a
-    href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a> reaches the end of its
-  active period (which is calculated as
+<p>The <code>animationend</code> event fires when a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS animation</a>
+  reaches the end of its active period (which is calculated as
   <code>{{cssxref("animation-duration")}} * {{cssxref("animation-iteration-count")}}) + {{cssxref("animation-delay")}}</code>).
 </p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <em>animEndHandler</em> = <em>target</em>.onanimationend;
-
-<em>target</em>.onanimationend = <em>{{jsxref("Function")}}</em>
+<em>target</em>.onanimationend = <em>Function</em>
 </pre>
 
 <h3 id="Value">Value</h3>
@@ -49,7 +47,7 @@ browser-compat: api.GlobalEventHandlers.onanimationend
 
 <h2 id="Example">Example</h2>
 
-<p>{{Page("/en-US/docs/Web/API/GlobalEventHandlers/onanimationstart", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/GlobalEventHandlers/onanimationstart#example"><code>GlobalEventHandlers.onanimationstart</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -18,14 +18,12 @@ browser-compat: api.GlobalEventHandlers.onanimationstart
 ---
 <div>{{APIRef("CSS3 Animations")}}</div>
 
-<p>An event handler for the {{event("animationstart")}} event. This event is sent when a
-  <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS Animation</a> starts to play.</p>
+<p>An event handler for the {{event("animationstart")}} event. This event is sent when a <a href="/en-US/docs/Web/CSS/CSS_Animations">CSS Animation</a> starts to play.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">var <em>animStartHandler</em> = <em>target</em>.onanimationstart;
-
-<em>target</em>.onanimationstart = <em>{{jsxref("Function")}}</em>
+<em>target</em>.onanimationstart = Function</em>
 </pre>
 
 <h3 id="Value">Value</h3>
@@ -146,8 +144,7 @@ browser-compat: api.GlobalEventHandlers.onanimationstart
 <p>Before we get to the animation code, we define a function which logs information to a
   box on the user's screen. We'll use this to show information about the events we
   receive. Note the use of {{domxref("AnimationEvent.animationName")}} and
-  {{domxref("AnimationEvent.elapsedTime")}} to get information about the event which
-  occurred.</p>
+  {{domxref("AnimationEvent.elapsedTime")}} to get information about the event which occurred.</p>
 
 <pre class="brush: js">function log(msg, event) {
   let logBox = document.getElementById("log");


### PR DESCRIPTION
This is part of global removal/reduction in Page macro tracked in #3196

In a mixed bag of examples it replaces page macros inclusion with a link to the original examples.

Some other minor tidy as I went along, mostly due to removing irrelevant divs and tidy up of syntax boxes.