### PR TITLE
updates to CSS text-align property

### DIFF
--- a/files/en-us/web/css/text-align/index.html
+++ b/files/en-us/web/css/text-align/index.html
@@ -18,13 +18,13 @@ browser-compat: css.properties.text-align
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: css no-line-numbers">/* Keyword values */
+text-align: start;
+text-align: end;
 text-align: left;
 text-align: right;
 text-align: center;
 text-align: justify;
 text-align: justify-all;
-text-align: start;
-text-align: end;
 text-align: match-parent;
 
 /* Character-based alignment in a table column */
@@ -53,9 +53,9 @@ text-align: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="start"><code>start</code> {{experimental_inline}}</dt>
+ <dt id="start"><code>start</code></dt>
  <dd>The same as <code>left</code> if direction is left-to-right and <code>right</code> if direction is right-to-left.</dd>
- <dt id="end"><code>end</code> {{experimental_inline}}</dt>
+ <dt id="end"><code>end</code></dt>
  <dd>The same as <code>right</code> if direction is left-to-right and <code>left</code> if direction is right-to-left.</dd>
  <dt id="left"><code>left</code></dt>
  <dd>The inline contents are aligned to the left edge of the line box.</dd>
@@ -67,7 +67,7 @@ text-align: unset;
  <dd>The inline contents are justified. Text should be spaced to line up its left and right edges to the left and right edges of the line box, except for the last line.</dd>
  <dt id="justify-all"><code>justify-all</code> {{experimental_inline}}</dt>
  <dd>Same as <code>justify</code>, but also forces the last line to be justified.</dd>
- <dt id="match-parent"><code>match-parent</code> {{experimental_inline}}</dt>
+ <dt id="match-parent"><code>match-parent</code></dt>
  <dd>Similar to <code>inherit</code>, but the values <code>start</code> and <code>end</code> are calculated according to the parent's {{cssxref("direction")}} and are replaced by the appropriate <code>left</code> or <code>right</code> value.</dd>
  <dt id="string">{{cssxref("&lt;string&gt;")}} {{experimental_inline}}</dt>
  <dd>When applied to a table cell, specifies the alignment character around which the cell's contents will align.</dd>
@@ -92,7 +92,7 @@ text-align: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Left_alignment">Left alignment</h3>
+<h3 id="Start_alignment">Start alignment</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -106,13 +106,13 @@ text-align: unset;
 <h4 id="CSS">CSS</h4>
 
 <pre class="brush: css; highlight:[2]">.example {
-  text-align: left;
+  text-align: start;
   border: solid;
 }</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample("Left_alignment","100%","100%")}}</p>
+<p>{{EmbedLiveSample("Start_alignment","100%","100%")}}</p>
 
 <h3 id="Centered_text">Centered text</h3>
 


### PR DESCRIPTION
Fixes #7295 by improving the visibility of `start` and `end` over `left` and `right`.