### PR TITLE
Page macro - example fixes for audio, navigator, mutation etc

### DIFF
--- a/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
@@ -18,10 +18,8 @@ browser-compat: api.MutationObserverInit.attributeOldValue
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
-<p><span class="seoSummary">The <strong>{{domxref("MutationObserverInit")}}</strong>
-    dictionary's optional <strong><code>attributeOldValue</code></strong> property is used
-    to specify whether or not to record the prior value of the altered attribute in
-    {{domxref("MutationRecord")}} objects denoting attribute value changes.</span></p>
+<p>The <strong>{{domxref("MutationObserverInit")}}</strong> dictionary's optional <strong><code>attributeOldValue</code></strong> property is used
+    to specify whether or not to record the prior value of the altered attribute in {{domxref("MutationRecord")}} objects denoting attribute value changes.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -43,7 +41,7 @@ browser-compat: api.MutationObserverInit.attributeOldValue
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/MutationObserverInit/attributes", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/MutationObserverInit/attributes#example"><code>MutationObserverInit.attributes</code></a> for example code that sets this property.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/navigator/getvrdisplays/index.html
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.html
@@ -2,17 +2,17 @@
 title: Navigator.getVRDisplays()
 slug: Web/API/Navigator/getVRDisplays
 tags:
-- API
-- Experimental
-- HTML DOM
-- Media
-- Method
-- Navigator
-- Reference
-- VR
-- Virtual Reality
-- WebVR
-- getVRDisplays()
+  - API
+  - Experimental
+  - HTML DOM
+  - Media
+  - Method
+  - Navigator
+  - Reference
+  - VR
+  - Virtual Reality
+  - WebVR
+  - getVRDisplays()
 browser-compat: api.Navigator.getVRDisplays
 ---
 <div>{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}</div>
@@ -38,7 +38,7 @@ browser-compat: api.Navigator.getVRDisplays
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplay", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRDisplay#examples"><code>VRDisplay</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/index.html
@@ -12,9 +12,7 @@ browser-compat: api.StereoPannerNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<div>
 <p>The <code>StereoPannerNode</code> interface of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> represents a simple stereo panner node that can be used to pan an audio stream left or right. It is an {{domxref("AudioNode")}} audio-processing module that positions an incoming audio stream in a stereo image using a low-cost equal-power <a href="https://webaudio.github.io/web-audio-api/#panning-algorithm">panning algorithm</a>.</p>
-</div>
 
 <p>The {{domxref("StereoPannerNode.pan", "pan")}} property takes a unitless value between <code>-1</code> (full left pan) and <code>1</code> (full right pan). This interface was introduced as a much simpler way to apply a simple panning effect than having to use a full {{domxref("PannerNode")}}.</p>
 
@@ -67,7 +65,7 @@ browser-compat: api.StereoPannerNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/BaseAudioContext/createStereoPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createStereoPanner#example"><code>BaseAudioContext.createStereoPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/stereopannernode/pan/index.html
+++ b/files/en-us/web/api/stereopannernode/pan/index.html
@@ -12,9 +12,7 @@ browser-compat: api.StereoPannerNode.pan
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<div>
 <p>The <code>pan</code> property of the {{ domxref("StereoPannerNode") }} interface is an <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} representing the amount of panning to apply. The value can range between <code>-1</code> (full left pan) and <code>1</code> (full right pan).</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -27,13 +25,13 @@ panNode.pan.value = -0.5;
 
 <p>An <a href="/en-US/docs/Web/API/AudioParam#a-rate">a-rate</a> {{domxref("AudioParam")}} containing the panning to apply.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the <code>AudioParam</code> returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> Though the <code>AudioParam</code> returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createStereoPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createStereoPanner#example"><code>BaseAudioContext.createStereoPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,5 +44,5 @@ panNode.pan.value = -0.5;
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -96,7 +96,7 @@ browser-compat: api.VRDisplay
 <h2 id="Specifications">Specifications</h2>
 
 <p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/#interface-vrdisplay">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/waveshapernode/curve/index.html
+++ b/files/en-us/web/api/waveshapernode/curve/index.html
@@ -18,8 +18,8 @@ browser-compat: api.WaveShaperNode.curve
 
 <p>If necessary, intermediate values of the distortion curve are linearly interpolated.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The array can be a <code>null</code> value: in that case, no distortion is applied to the input signal.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> The array can be a <code>null</code> value: in that case, no distortion is applied to the input signal.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -35,7 +35,7 @@ distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createWaveShaper","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createWaveShaper#example"><code>BaseAudioContext.createWaveShaper()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -48,5 +48,5 @@ distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
 </ul>

--- a/files/en-us/web/api/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/index.html
@@ -64,7 +64,7 @@ browser-compat: api.WaveShaperNode
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createWaveShaper","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createWaveShaper#example"><code>BaseAudioContext.createWaveShaper()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -77,5 +77,5 @@ browser-compat: api.WaveShaperNode
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
 </ul>

--- a/files/en-us/web/api/waveshapernode/oversample/index.html
+++ b/files/en-us/web/api/waveshapernode/oversample/index.html
@@ -55,7 +55,7 @@ browser-compat: api.WaveShaperNode.oversample
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createWaveShaper","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createWaveShaper#example"><code>BaseAudioContext.createWaveShaper()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -68,5 +68,5 @@ browser-compat: api.WaveShaperNode.oversample
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
 </ul>


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link (for a small bunch of cases)