### PR TITLE
Page macro: example fixes in VR API

### DIFF
--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -32,7 +32,7 @@ browser-compat: api.VREyeParameters.fieldOfView
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -17,7 +17,7 @@ browser-compat: api.VREyeParameters.offset
 
 <p>The <strong><code>offset</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface <dfn>r</dfn><dfn>epresents the o</dfn>ffset from the center point between the user's eyes to the center of the eye, measured in meters.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -37,7 +37,7 @@ browser-compat: api.VREyeParameters.offset
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.html
@@ -17,7 +17,7 @@ browser-compat: api.VRFieldOfView.downDegrees
 
 <p>The <strong><code>downDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees downwards that the field of view extends in.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -31,12 +31,12 @@ browser-compat: api.VRFieldOfView.downDegrees
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/index.html
@@ -16,7 +16,7 @@ browser-compat: api.VRFieldOfView
 
 <p>The <strong><code>VRFieldOfView</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a field of view defined by 4 different degree values describing the view from a center point.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -85,7 +85,7 @@ function reportFieldOfView() {
 <h2 id="Specifications">Specifications</h2>
 
 <p>This interface was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
@@ -17,7 +17,7 @@ browser-compat: api.VRFieldOfView.leftDegrees
 
 <p>The <strong><code>leftDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the left that the field of view extends in.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -31,12 +31,12 @@ browser-compat: api.VRFieldOfView.leftDegrees
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
@@ -17,7 +17,7 @@ browser-compat: api.VRFieldOfView.rightDegrees
 
 <p>The <strong><code>rightDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the right that the field of view extends in.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -31,12 +31,12 @@ browser-compat: api.VRFieldOfView.rightDegrees
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.html
@@ -17,7 +17,7 @@ browser-compat: api.VRFieldOfView.upDegrees
 
 <p>The <strong><code>upDegrees</code></strong> read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees upwards that the field of view extends in.</p>
 
-<div class="notepad note">
+<div class="notecard note">
   <p><strong>Note:</strong> This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a>. It has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>.</p>
 </div>
 
@@ -31,12 +31,12 @@ browser-compat: api.VRFieldOfView.upDegrees
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRFieldOfView", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRFieldOfView#examples"><code>VRFieldOfView</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>This property was part of the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.</p>
-<p>Until all browsers have implemented the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
+<p>Until all browsers have implemented the new <a href="/en-US/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/">[1]</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link (for a small bunch of cases)