### PR TITLE
Fix wrong xref macros

### DIFF
--- a/files/en-us/web/api/barcodedetector/detect/index.html
+++ b/files/en-us/web/api/barcodedetector/detect/index.html
@@ -31,7 +31,7 @@ browser-compat: api.BarcodeDetector.detect
 
 <h3 id="Return_value">Return value</h3>
 
-<p>Returns a {{domxref('Promise')}} which fulfills with an array of
+<p>Returns a {{jsxref('Promise')}} which fulfills with an array of
   <code>detectedBarcode</code> objects with the following properties:</p>
 
 <ul>

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -24,7 +24,7 @@ browser-compat: api.BarcodeDetector
 
 <dl>
  <dt>{{domxref('BarcodeDetector.detect', 'detect()')}}</dt>
- <dd>Returns a {{domxref('Promise')}} which fulfills with an array of <code>detectedBarcode</code> objects with the following properties:
+ <dd>Returns a {{jsxref('Promise')}} which fulfills with an array of <code>detectedBarcode</code> objects with the following properties:
  <ul>
   <li><code>boundingBox</code>: A {{domxref('DOMRectReadOnly')}}, which returns the dimensions of a rectangle representing the extent of a detected barcode, aligned with the image.</li>
   <li><code>cornerPoints</code>: The x and y co-ordinates of the four corner points of the detected barcode relative to the image, starting with the top left and working clockwise. This may not be square due to perspective distortions within the image.</li>

--- a/files/en-us/web/api/hiddevice/oninputreport/index.html
+++ b/files/en-us/web/api/hiddevice/oninputreport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.oninputreport
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>oninputreport</code></strong> EventHandler of the {{domxref("HIDDevice")}} interface is an {{domxref("EventHandler")}} that processes inputreport events.</p>
+<p class="summary">The <strong><code>oninputreport</code></strong> event handler of the {{domxref("HIDDevice")}} interface processes inputreport events.</p>
 
 <p> The event fires when a new report is received from the HID device.</p>
 

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
@@ -28,7 +28,7 @@ browser-compat: api.HIDDevice.receiveFeatureReport
 
 <h3 id="Returns">Return value</h3>
 
-<p>A {{jsxref("Promise")}} which resolves with a {{domxref("DataView")}} object containing the feature report.</p>
+<p>A {{jsxref("Promise")}} which resolves with a {{jsxref("DataView")}} object containing the feature report.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 

--- a/files/en-us/web/api/htmlelement/index.html
+++ b/files/en-us/web/api/htmlelement/index.html
@@ -30,7 +30,7 @@ browser-compat: api.HTMLElement
  <dt>{{DOMxRef("HTMLElement.contentEditable")}}</dt>
  <dd>Is a {{DOMxRef("DOMString")}}, where a value of <code>true</code> means the element is editable and a value of <code>false</code> means it isn't.</dd>
  <dt>{{DOMxRef("HTMLElement.isContentEditable")}} {{ReadOnlyInline}}</dt>
- <dd>Returns a {{DOMxRef("Boolean")}} that indicates whether or not the content of the element can be edited.</dd>
+ <dd>Returns a boolean value indicating whether or not the content of the element can be edited.</dd>
  <dt>{{DOMxRef("HTMLElement.contextMenu")}} {{Deprecated_Inline}}</dt>
  <dd>Is a {{DOMxRef("HTMLMenuElement")}} representing the contextual menu associated with the element. It may be <code>null</code>.</dd>
  <dt>{{DOMxRef("HTMLElement.dataset")}} {{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/htmlformelement/elements/index.html
+++ b/files/en-us/web/api/htmlformelement/elements/index.html
@@ -21,8 +21,7 @@ browser-compat: api.HTMLFormElement.elements
   property.</p>
 
 <p>You can access a particular form control in the returned collection by using either an
-  index or the element's {{domxref("Element.name", "name")}} or {{domxref("Element.id",
-  "id")}}.</p>
+  index or the element's <code>name</code> or<code>id</code> attributes.</p>
 
 <p>Prior to HTML 5, the returned object was an {{domxref("HTMLCollection")}}, on which
   <code>HTMLFormControlsCollection</code> is based.</p>

--- a/files/en-us/web/api/htmlformelement/index.html
+++ b/files/en-us/web/api/htmlformelement/index.html
@@ -101,7 +101,7 @@ browser-compat: api.HTMLFormElement
  <dt><code>document.forms[<var>id</var>]</code></dt>
  <dd>Returns the form whose ID is <code><var>id</var></code>.</dd>
  <dt><code>document.forms[<var>name</var>]</code></dt>
- <dd>Returns the form whose {{domxref("Element.name", "name")}} attribute's value is <code><var>name</var></code>.</dd>
+ <dd>Returns the form whose <code>name</code> attribute's value is <code><var>name</var></code>.</dd>
 </dl>
 
 <h3 id="Accessing_the_forms_elements">Accessing the form's elements</h3>

--- a/files/en-us/web/api/htmlimageelement/decode/index.html
+++ b/files/en-us/web/api/htmlimageelement/decode/index.html
@@ -62,7 +62,7 @@ browser-compat: api.HTMLImageElement.decode
 <h2 id="Examples">Examples</h2>
 
 <p>The following example shows how to use the <code>decode()</code> method to control when
-  an image is appended to the DOM. Without a {{domxref('Promise')}}-returning method, you
+  an image is appended to the DOM. Without a {{jsxref('Promise')}}-returning method, you
   would add the image to the DOM in a {{event("load")}} event handler, such as by using
   the {{domxref("GlobalEventHandlers.onload", "img.onload")}} event handler, and by
   handling the error in the {{event("error")}} event's handler.</p>

--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -100,9 +100,9 @@ browser-compat: api.HTMLMediaElement
 
 <dl>
  <dt>{{domxref("HTMLMediaElement.onencrypted")}}</dt>
- <dd>Sets the {{domxref('EventHandler')}} called when the media is encrypted.</dd>
+ <dd>Sets the event handler called when the media is encrypted.</dd>
  <dt>{{domxref("HTMLMediaElement.onwaitingforkey")}}</dt>
- <dd>Sets the {{domxref('EventHandler')}} called when playback is blocked while waiting for an encryption key.</dd>
+ <dd>Sets the event handler called when playback is blocked while waiting for an encryption key.</dd>
 </dl>
 
 <h2 id="Obsolete_attributes">Obsolete properties</h2>
@@ -134,7 +134,7 @@ browser-compat: api.HTMLMediaElement
  <dt>{{domxref("HTMLMediaElement.onmozinterruptbegin")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>Sets the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when the media element is interrupted because of the Audio Channel manager. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
  <dt>{{domxref("HTMLMediaElement.onmozinterruptend")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Sets the {{domxref('EventHandler')}} called when the interruption is concluded. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
+ <dd>Sets the event handler called when the interruption is concluded. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.html
@@ -29,7 +29,7 @@ browser-compat: api.HTMLVideoElement.autoPictureInPicture
 
 <h3 id="Value">Value</h3>
 
-<p>A {{DOMxRef("Boolean")}} whose value is <code>true</code> if the video should enter or
+<p>A boolean value that is <code>true</code> if the video should enter or
   leave picture-in-picture mode automatically when changing tab and/or application.</p>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.html
@@ -29,7 +29,7 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 <h3 id="Value">Value</h3>
 
-<p>A {{DOMxRef("Boolean")}} whose value is <code>true</code> if the user agent should
+<p>A boolean value that is <code>true</code> if the user agent should
   suggest that feature to users.</p>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/mediakeysession/index.html
+++ b/files/en-us/web/api/mediakeysession/index.html
@@ -34,9 +34,9 @@ browser-compat: api.MediaKeySession
 
 <dl>
  <dt>{{domxref("MediaKeySession.onkeystatuseschange")}}</dt>
- <dd>Sets the {{domxref('EventHandler')}} called when there has been a change in the keys in a session or their statuses.</dd>
+ <dd>Sets the event handler called when there has been a change in the keys in a session or their statuses.</dd>
  <dt>{{domxref("MediaKeySession.onmessage")}}</dt>
- <dd>Sets the {{domxref('EventHandler')}} called when the content decryption module has generated a message for the session.</dd>
+ <dd>Sets the event handler called when the content decryption module has generated a message for the session.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/mediaquerylist/matches/index.html
+++ b/files/en-us/web/api/mediaquerylist/matches/index.html
@@ -32,7 +32,7 @@ browser-compat: api.MediaQueryList.matches
 
 <h3 id="Value">Value</h3>
 
-<p>A {{DOMxRef("Boolean")}} which is <code>true</code> if the {{DOMxRef("document")}}
+<p>A boolean value that is <code>true</code> if the {{DOMxRef("document")}}
   currently matches the media query list; otherwise, it's <code>false</code>.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/index.html
@@ -18,7 +18,7 @@ browser-compat: api.MediaQueryListEvent
 
 <dl>
  <dt>{{DOMxRef("MediaQueryListEvent.MediaQueryListEvent()", "MediaQueryListEvent()")}}</dt>
- <dd> Creates a new <code>MediaQueryListEvent</code> instance.</dd>
+ <dd>Creates a new <code>MediaQueryListEvent</code> instance.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>
@@ -27,9 +27,9 @@ browser-compat: api.MediaQueryListEvent
 
 <dl>
  <dt>{{DOMxRef("MediaQueryListEvent.matches")}}{{ReadOnlyInline}}</dt>
- <dd> A {{DOMxRef("Boolean")}} that returns <code>true</code> if the {{DOMxRef("document")}} currently matches the media query list, or <code>false</code> if not.</dd>
+ <dd>A boolean value that is <code>true</code> if the {{DOMxRef("document")}} currently matches the media query list, or <code>false</code> if not.</dd>
  <dt>{{DOMxRef("MediaQueryListEvent.media")}}{{ReadOnlyInline}}</dt>
- <dd> A {{DOMxRef("DOMString")}} representing a serialized media query.</dd>
+ <dd>A {{DOMxRef("DOMString")}} representing a serialized media query.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/mediaquerylistevent/matches/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/matches/index.html
@@ -14,7 +14,7 @@ browser-compat: api.MediaQueryListEvent.matches
 <p>{{APIRef("CSSOM")}}</p>
 
 <p>The <strong><code>matches</code></strong> read-only property of the
-  {{DOMxRef("MediaQueryListEvent")}} interface is a {{DOMxRef("Boolean")}} that returns
+  {{DOMxRef("MediaQueryListEvent")}} interface is a boolean value that is
   <code>true</code> if the {{DOMxRef("document")}} currently matches the media query list,
   or <code>false</code> if not.</p>
 
@@ -25,7 +25,7 @@ browser-compat: api.MediaQueryListEvent.matches
 
 <h3 id="Value">Value</h3>
 
-<p>A {{DOMxRef("Boolean")}}; returns <code>true</code> if the {{DOMxRef("document")}}
+<p>A boolean value; returns <code>true</code> if the {{DOMxRef("document")}}
   currently matches the media query list, <code>false</code> if not.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/midiport/onstatechange/index.html
+++ b/files/en-us/web/api/midiport/onstatechange/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.onstatechange
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>onstatechange</code></strong> <code>EventHandler</code> of the {{domxref("MIDIPort")}} interface is an {{domxref("EventHandler")}} that processes state change events.</p>
+<p class="summary">The <strong><code>onstatechange</code></strong> event handler of the {{domxref("MIDIPort")}} interface processes {{domxref("MIDIPort/statechange_event", "statechange")}} events.</p>
 
 <p> The event fires when a port changes from open to closed, or closed to open.</p>
 

--- a/files/en-us/web/api/node/clonenode/index.html
+++ b/files/en-us/web/api/node/clonenode/index.html
@@ -66,11 +66,11 @@ let p_prime = p.cloneNode(true)
   <p><strong>Warning:</strong> <code>cloneNode()</code> may lead to duplicate element IDs
     in a document!</p>
 
-  <p>If the original node has an {{domxref("Element/id", "id attribute")}}, and the clone
-    will be placed in the same document, then you should modify the clone's ID to be
+  <p>If the original node has an <code>id</code> attribute, and the clone
+    will be placed in the same document, then you should modify the clone's ID to be
     unique.</p>
 
-  <p>{{domxref("Element/name", "Name")}} attributes may need to be modified also,
+  <p>Also, <code>name</code> attributes may need to be modified also,
     depending on whether duplicate names are expected.</p>
 </div>
 

--- a/files/en-us/web/api/remoteplayback/onconnect/index.html
+++ b/files/en-us/web/api/remoteplayback/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.onconnect
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> EventHandler of the {{domxref("RemotePlayback")}} interface is an {{domxref("EventHandler")}} that processes the events fired when the user agent connects to the remote device.</p>
+<p class="summary">The <strong><code>onconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent connects to the remote device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/onconnecting/index.html
+++ b/files/en-us/web/api/remoteplayback/onconnecting/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.onconnecting
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>onconnecting</code></strong> EventHandler of the {{domxref("RemotePlayback")}} interface is an {{domxref("EventHandler")}} that processes the events fired when the user agent initiates remote playback.</p>
+<p class="summary">The <strong><code>onconnecting</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent initiates remote playback.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/ondisconnect/index.html
+++ b/files/en-us/web/api/remoteplayback/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.ondisconnect
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> EventHandler of the {{domxref("RemotePlayback")}} interface is an {{domxref("EventHandler")}} that processes the events fired when the user agent disconnects from the remote device.</p>
+<p class="summary">The <strong><code>ondisconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent disconnects from the remote device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoder/decode/index.html
+++ b/files/en-us/web/api/textdecoder/decode/index.html
@@ -35,7 +35,7 @@ browser-compat: api.TextDecoder.decode
   <dd>Is a <code>TextDecodeOptions</code> dictionary with the property:
     <dl>
       <dt><code>stream</code></dt>
-      <dd>A {{DOMxRef("Boolean")}} flag indicating that additional data will follow in
+      <dd>A boolean flag indicating that additional data will follow in
         subsequent calls to decode(). Set to true if processing the data in chunks, and
         false for the final chunk or if the data is not chunked. It defaults to false.
       </dd>

--- a/files/en-us/web/api/textencoder/encodeinto/index.html
+++ b/files/en-us/web/api/textencoder/encodeinto/index.html
@@ -30,7 +30,7 @@ browser-compat: api.TextEncoder.encodeInto
     <dt><code><var>string</var></code></dt>
     <dd>Is a {{DOMxRef("USVString")}} containing the text to encode.</dd>
     <dt><code><var>uint8Array</var></code></dt>
-    <dd>Is a {{DOMxRef("Uint8Array")}} object instance to place the resulting UTF-8
+    <dd>Is a {{jsxref("Uint8Array")}} object instance to place the resulting UTF-8
         encoded text into.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
@@ -229,7 +229,7 @@ browser-compat: api.WebGLRenderingContext.vertexAttribPointer
 <h3 id="Creating_the_array_buffer">Creating the array buffer</h3>
 
 <p>First, we dynamically create the array buffer from JSON data using a
-  {{domxref("DataView")}}. Note the use of <code>true</code> because WebGL expects our
+  {{jsxref("DataView")}}. Note the use of <code>true</code> because WebGL expects our
   data to be in little-endian.</p>
 
 <pre class="brush: js">//load geometry with fetch() and Response.json()

--- a/files/en-us/web/api/workernavigator/index.html
+++ b/files/en-us/web/api/workernavigator/index.html
@@ -37,7 +37,7 @@ browser-compat: api.WorkerNavigator
  <dt>{{DOMxRef("WorkerNavigator.locks")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("LockManager")}} object which provides methods for requesting a new {{DOMxRef('Lock')}} object and querying for an existing <code>Lock</code> object.</dd>
  <dt>{{DOMxRef("WorkerNavigator.onLine")}}{{ReadOnlyInline}}</dt>
- <dd>Returns a {{DOMxRef("Boolean")}} indicating whether the browser is online.</dd>
+ <dd>Returns a boolean value indicating whether the browser is online.</dd>
  <dt>{{DOMxRef("WorkerNavigator.permissions")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
  <dt>{{DOMxRef("WorkerNavigator.platform")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/html/global_attributes/id/index.html
+++ b/files/en-us/web/html/global_attributes/id/index.html
@@ -11,7 +11,7 @@ browser-compat: html.global_attributes.id
 ---
 <div>{{HTMLSidebar("Global_attributes")}}</div>
 
-<p><span class="seoSummary">The <strong><code>id</code> {{glossary("global attribute")}}</strong> defines an identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#Fragment">fragment identifier</a>), scripting, or styling (with {{glossary("CSS")}}).</span></p>
+<p><span class="seoSummary">The <strong><code>id</code></strong> <a href="/en-US/docs/Web/HTML/Global_attributes">global attribute</a> defines an identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#Fragment">fragment identifier</a>), scripting, or styling (with {{glossary("CSS")}}).</span></p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-id.html","tabbed-shorter")}}</div>
 


### PR DESCRIPTION
I fixed here:
- {{domxref('Promise')}}  -> {{jsxref('Promise')}} (_I missed the ones with tick previously_)
- {{domxref("EventHandler")}} -> event handler (_It is the name of the callback, we don't create a page for it_)
- {{domxref("DataView")}} -> {{jsxref("DataView")}}
- {{domxref("Element.name", "name")}} & co (_It doesn't exists…_)
- {{DOMxRef("Uint8Array")}} -> {{jsxref("Uint8Array")}} (_I missed it previously, because fo the capitalization_)
- {{glossary("global attribute")}} -> replaced by a link.
