### PR TITLE
Document xrCompatible

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
@@ -105,6 +105,12 @@ var <em>ctx</em> = <em>canvas</em>.getContext(<em>contextType</em>, <em>contextA
       <li><code><strong>failIfMajorPerformanceCaveat</strong></code>: Boolean that
         indicates if a context will be created if the system performance is low or if no
         hardware GPU is available.</li>
+      <li><code><strong>xrCompatible</strong></code>: Boolean that hints to the user agent
+         to use a compatible graphics adapter for an
+         <a href="/en-US/docs/Web/API/WebXR_Device_API">immersive XR device</a>. Setting this
+         synchronous flag at context creation is discouraged; rather call the asynchronous
+         {{domxref("WebGLRenderingContext.makeXRCompatible()")}} method the moment you
+         intend to start an XR session.</li>
       <li><code><strong>powerPreference</strong></code>: A hint to the user agent
         indicating what configuration of GPU is suitable for the WebGL context. Possible
         values are:

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
@@ -105,12 +105,6 @@ var <em>ctx</em> = <em>canvas</em>.getContext(<em>contextType</em>, <em>contextA
       <li><code><strong>failIfMajorPerformanceCaveat</strong></code>: Boolean that
         indicates if a context will be created if the system performance is low or if no
         hardware GPU is available.</li>
-      <li><code><strong>xrCompatible</strong></code>: Boolean that hints to the user agent
-         to use a compatible graphics adapter for an
-         <a href="/en-US/docs/Web/API/WebXR_Device_API">immersive XR device</a>. Setting this
-         synchronous flag at context creation is discouraged; rather call the asynchronous
-         {{domxref("WebGLRenderingContext.makeXRCompatible()")}} method the moment you
-         intend to start an XR session.</li>
       <li><code><strong>powerPreference</strong></code>: A hint to the user agent
         indicating what configuration of GPU is suitable for the WebGL context. Possible
         values are:
@@ -131,6 +125,12 @@ var <em>ctx</em> = <em>canvas</em>.getContext(<em>contextType</em>, <em>contextA
         overwritten by the author.</li>
       <li><strong><code>stencil</code></strong>: Boolean that indicates that the drawing
         buffer has a stencil buffer of at least 8 bits.</li>
+      <li><code><strong>xrCompatible</strong></code>: Boolean that hints to the user agent
+        to use a compatible graphics adapter for an
+        <a href="/en-US/docs/Web/API/WebXR_Device_API">immersive XR device</a>. Setting this
+        synchronous flag at context creation is discouraged; rather call the asynchronous
+        {{domxref("WebGLRenderingContext.makeXRCompatible()")}} method the moment you
+        intend to start an XR session.</li>
     </ul>
   </dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.html
@@ -21,6 +21,7 @@ tags:
 - XRWebGLLayer
 - augmented
 - makeXRCompatible
+- Method
 browser-compat: api.WebGLRenderingContext.makeXRCompatible
 ---
 <p>{{APIRef("WebGL")}}</p>

--- a/files/en-us/web/api/webxr_device_api/index.html
+++ b/files/en-us/web/api/webxr_device_api/index.html
@@ -105,8 +105,8 @@ tags:
 <p>The WebGL API is extended by the WebXR specification to augment the WebGL context to allow it to be used to render views for display by a WebXR device.</p>
 
 <dl>
- <dt>{{domxref("WebGLRenderingContextBase.makeXRCompatibile","WebGLRenderingContextBase.makeXRCompatibile()")}}</dt>
- <dd>Configures the WebGL context to be compatible with WebXR. If the context was not initially created with the {{domxref("WebGLContextAttributes.xrCompatible", "xrCompatible")}} property set to <code>true</code>, you must call <code>makeXRCompatible()</code> prior to attempting to use the WebGL context for WebXR rendering. Returns a {{jsxref("Promise")}} which resolves once the context has been prepared, or is rejected if the context cannot be configured for use by WebXR.</dd>
+ <dt>{{domxref("WebGLRenderingContext.makeXRCompatible()")}}</dt>
+ <dd>Configures the WebGL context to be compatible with WebXR. If the context was not initially created with the {{domxref("HTMLCanvasElement.getContext", "xrCompatible")}} property set to <code>true</code>, you must call <code>makeXRCompatible()</code> prior to attempting to use the WebGL context for WebXR rendering. Returns a {{jsxref("Promise")}} which resolves once the context has been prepared, or is rejected if the context cannot be configured for use by WebXR.</dd>
 </dl>
 
 <h2 id="Guides_and_tutorials">Guides and tutorials</h2>


### PR DESCRIPTION
Adding `xrCompatbile` to `HTMLCanvasElement.getContext` and talk about how you should rather use `WebGLRenderingContext.makeXRCompatible()`.

Spec: https://immersive-web.github.io/webxr/#contextcompatibility