### PR TITLE
List WebXR specifications

### DIFF
--- a/files/en-us/web/api/webxr_device_api/index.html
+++ b/files/en-us/web/api/webxr_device_api/index.html
@@ -178,20 +178,18 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("WebXR")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li><a href="https://immersive-web.github.io/webxr/"><strong>WebXR Device API</strong></a> (<a href="https://github.com/immersive-web/webxr">Source</a>, <a href="https://github.com/immersive-web/webxr/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/anchors/"><strong>WebXR Anchors Module</strong></a> (<a href="https://github.com/immersive-web/anchors">Source</a>, <a href="https://github.com/immersive-web/anchors/issues">Issues</a>, <a href="https://github.com/immersive-web/anchors/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/webxr-ar-module/"><strong>WebXR Augmented Reality Module</strong></a> (<a href="https://github.com/immersive-web/webxr-ar-module">Source</a>, <a href="https://github.com/immersive-web/webxr-ar-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-ar-module/blob/master/ar-module-explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/depth-sensing/"><strong>WebXR Depth Sensing Module</strong></a> (<a href="https://github.com/immersive-web/depth-sensing">Source</a>, <a href="https://github.com/immersive-web/depth-sensing/issues">Issues</a>, <a href="https://github.com/immersive-web/depth-sensing/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/dom-overlays"><strong>WebXR DOM Overlays Module</strong></a> (<a href="https://github.com/immersive-web/dom-overlays">Source</a>, <a href="https://github.com/immersive-web/dom-overlays/issues">Issues</a>, <a href="https://github.com/immersive-web/dom-overlays/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/webxr-gamepads-module/"><strong>WebXR Gamepads Module</strong></a> (<a href="https://github.com/immersive-web/webxr-gamepads-module">Source</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/blob/master/gamepads-module-explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/webxr-hand-input/"><strong>WebXR Hand Input Module</strong></a> (<a href="https://github.com/immersive-web/webxr-hand-input">Source</a>, <a href="https://github.com/immersive-web/webxr-hand-input/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-hand-input/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/hit-test"><strong>WebXR Hit Test Module</strong></a> (<a href="https://github.com/immersive-web/hit-test">Source</a>, <a href="https://github.com/immersive-web/hit-test/issues">Issues</a>, <a href="https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/layers/"><strong>WebXR Layers API</strong></a> (<a href="https://github.com/immersive-web/layers">Source</a>, <a href="https://github.com/immersive-web/layers/issues">Issues</a>, <a href="https://github.com/immersive-web/layers/blob/master/explainer.md">Explainer</a>)</li>
+  <li><a href="https://immersive-web.github.io/lighting-estimation/"><strong>WebXR Lighting Estimation API</strong></a> (<a href="https://github.com/immersive-web/lighting-estimation">Source</a>, <a href="https://github.com/immersive-web/lighting-estimation/issues">Issues</a>, <a href="https://github.com/immersive-web/lighting-estimation/blob/master/lighting-estimation-explainer.md">Explainer</a>)</li>
+</ul>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/webxr_device_api/index.html
+++ b/files/en-us/web/api/webxr_device_api/index.html
@@ -178,18 +178,45 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<ul>
-  <li><a href="https://immersive-web.github.io/webxr/"><strong>WebXR Device API</strong></a> (<a href="https://github.com/immersive-web/webxr">Source</a>, <a href="https://github.com/immersive-web/webxr/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/anchors/"><strong>WebXR Anchors Module</strong></a> (<a href="https://github.com/immersive-web/anchors">Source</a>, <a href="https://github.com/immersive-web/anchors/issues">Issues</a>, <a href="https://github.com/immersive-web/anchors/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/webxr-ar-module/"><strong>WebXR Augmented Reality Module</strong></a> (<a href="https://github.com/immersive-web/webxr-ar-module">Source</a>, <a href="https://github.com/immersive-web/webxr-ar-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-ar-module/blob/master/ar-module-explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/depth-sensing/"><strong>WebXR Depth Sensing Module</strong></a> (<a href="https://github.com/immersive-web/depth-sensing">Source</a>, <a href="https://github.com/immersive-web/depth-sensing/issues">Issues</a>, <a href="https://github.com/immersive-web/depth-sensing/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/dom-overlays"><strong>WebXR DOM Overlays Module</strong></a> (<a href="https://github.com/immersive-web/dom-overlays">Source</a>, <a href="https://github.com/immersive-web/dom-overlays/issues">Issues</a>, <a href="https://github.com/immersive-web/dom-overlays/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/webxr-gamepads-module/"><strong>WebXR Gamepads Module</strong></a> (<a href="https://github.com/immersive-web/webxr-gamepads-module">Source</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/blob/master/gamepads-module-explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/webxr-hand-input/"><strong>WebXR Hand Input Module</strong></a> (<a href="https://github.com/immersive-web/webxr-hand-input">Source</a>, <a href="https://github.com/immersive-web/webxr-hand-input/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-hand-input/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/hit-test"><strong>WebXR Hit Test Module</strong></a> (<a href="https://github.com/immersive-web/hit-test">Source</a>, <a href="https://github.com/immersive-web/hit-test/issues">Issues</a>, <a href="https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/layers/"><strong>WebXR Layers API</strong></a> (<a href="https://github.com/immersive-web/layers">Source</a>, <a href="https://github.com/immersive-web/layers/issues">Issues</a>, <a href="https://github.com/immersive-web/layers/blob/master/explainer.md">Explainer</a>)</li>
-  <li><a href="https://immersive-web.github.io/lighting-estimation/"><strong>WebXR Lighting Estimation API</strong></a> (<a href="https://github.com/immersive-web/lighting-estimation">Source</a>, <a href="https://github.com/immersive-web/lighting-estimation/issues">Issues</a>, <a href="https://github.com/immersive-web/lighting-estimation/blob/master/lighting-estimation-explainer.md">Explainer</a>)</li>
-</ul>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://immersive-web.github.io/webxr/"><strong>WebXR Device API</strong></a> (<a href="https://github.com/immersive-web/webxr">Source</a>, <a href="https://github.com/immersive-web/webxr/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/anchors/"><strong>WebXR Anchors Module</strong></a> (<a href="https://github.com/immersive-web/anchors">Source</a>, <a href="https://github.com/immersive-web/anchors/issues">Issues</a>, <a href="https://github.com/immersive-web/anchors/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/webxr-ar-module/"><strong>WebXR Augmented Reality Module</strong></a> (<a href="https://github.com/immersive-web/webxr-ar-module">Source</a>, <a href="https://github.com/immersive-web/webxr-ar-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-ar-module/blob/master/ar-module-explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/depth-sensing/"><strong>WebXR Depth Sensing Module</strong></a> (<a href="https://github.com/immersive-web/depth-sensing">Source</a>, <a href="https://github.com/immersive-web/depth-sensing/issues">Issues</a>, <a href="https://github.com/immersive-web/depth-sensing/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/dom-overlays"><strong>WebXR DOM Overlays Module</strong></a> (<a href="https://github.com/immersive-web/dom-overlays">Source</a>, <a href="https://github.com/immersive-web/dom-overlays/issues">Issues</a>, <a href="https://github.com/immersive-web/dom-overlays/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/webxr-gamepads-module/"><strong>WebXR Gamepads Module</strong></a> (<a href="https://github.com/immersive-web/webxr-gamepads-module">Source</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-gamepads-module/blob/master/gamepads-module-explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/webxr-hand-input/"><strong>WebXR Hand Input Module</strong></a> (<a href="https://github.com/immersive-web/webxr-hand-input">Source</a>, <a href="https://github.com/immersive-web/webxr-hand-input/issues">Issues</a>, <a href="https://github.com/immersive-web/webxr-hand-input/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/hit-test"><strong>WebXR Hit Test Module</strong></a> (<a href="https://github.com/immersive-web/hit-test">Source</a>, <a href="https://github.com/immersive-web/hit-test/issues">Issues</a>, <a href="https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/layers/"><strong>WebXR Layers API</strong></a> (<a href="https://github.com/immersive-web/layers">Source</a>, <a href="https://github.com/immersive-web/layers/issues">Issues</a>, <a href="https://github.com/immersive-web/layers/blob/master/explainer.md">Explainer</a>)</td>
+    </tr>
+    <tr>
+      <td><a href="https://immersive-web.github.io/lighting-estimation/"><strong>WebXR Lighting Estimation API</strong></a> (<a href="https://github.com/immersive-web/lighting-estimation">Source</a>, <a href="https://github.com/immersive-web/lighting-estimation/issues">Issues</a>, <a href="https://github.com/immersive-web/lighting-estimation/blob/master/lighting-estimation-explainer.md">Explainer</a>)</td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
The {{Specifications}} macro doesn't allow us to list all specs of a group of features but there is no reason to not do this manually. I'm listing all WebXR specs I found in https://github.com/w3c/browser-specs. They should all be relevant given the project's [spec selection criteria](https://github.com/w3c/browser-specs#spec-selection-criteria).