### PR TITLE
User-agent client hints API overview, and extensions to Navigator

### DIFF
--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -72,6 +72,8 @@ browser-compat: api.Navigator
  <dd>Returns the singleton {{domxref('StorageManager')}} object used for managing persistence permissions and estimating available storage on a site-by-site/app-by-app basis.</dd>
  <dt>{{domxref("Navigator.userAgent")}} {{readonlyInline}}</dt>
  <dd>Returns the user agent string for the current browser.</dd>
+ <dt>{{domxref("Navigator.userAgentData")}} {{readonlyInline}}</dt>
+ <dd>Returns a {{domxref("NavigatorUAData")}} object, which gives access to information about the browser and operating system of the user.</dd>
  <dt>{{domxref("Navigator.vendor")}} {{readonlyInline}}</dt>
  <dd>Returns the vendor name of the current browser (e.g., "Netscape6").</dd>
  <dt>{{domxref("Navigator.webdriver")}} {{readonlyInline}} {{experimental_inline}}</dt>

--- a/files/en-us/web/api/navigator/useragentdata/index.html
+++ b/files/en-us/web/api/navigator/useragentdata/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Navigator.userAgentData
 ---
 <div>{{APIRef("User-Agent Client Hints API")}}</div>
 
-<p>The <code><strong>userAgentData</strong></code> read-only property of the {{domxref("Navigator")}} interface returns an {{domxref("NavigatorUAData")}} object
+<p>The <code><strong>userAgentData</strong></code> read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("NavigatorUAData")}} object
 which can be used to access the {{domxref("User-Agent Client Hints API")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigator/useragentdata/index.html
+++ b/files/en-us/web/api/navigator/useragentdata/index.html
@@ -1,0 +1,43 @@
+---
+title: Navigator.userAgentData
+slug: Web/API/Navigator/userAgentData
+tags:
+- API
+- Navigator
+- Property
+- Reference
+- NavigatorUAData
+browser-compat: api.Navigator.userAgentData
+---
+<div>{{APIRef("User-Agent Client Hints API")}}</div>
+
+<p>The <code><strong>userAgentData</strong></code> read-only property of the {{domxref("Navigator")}} interface returns an {{domxref("NavigatorUAData")}} object
+which can be used to access the {{domxref("User-Agent Client Hints API")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let userAgentData = navigator.userAgentData</pre>
+
+<h3 id="Value">Value</h3>
+
+<p>A {{domxref("NavigatorUAData")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints the value of {{domxref("NavigatorUAData.brands")}} to the console.</p>
+
+<pre class="brush:js">console.log(navigator.userAgentData.brands);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/user-agent-client-hints/">Improving user privacy and developer experience with User-Agent Client Hints</a></li>
+</ul>

--- a/files/en-us/web/api/user-agent_client_hints_api/index.html
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.html
@@ -1,0 +1,78 @@
+---
+title: User-Agent Client Hints API
+slug: Web/API/User-Agent_Client_Hints_API
+tags:
+  - API
+  - User-Agent Client Hints API
+  - Overview
+  - Reference
+browser-compat: api.NavigatorUAData
+---
+<div>{{DefaultAPISidebar("User-Agent Client Hints API")}}</div>
+
+<p class="summary">The User-Agent Client Hints API extends <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.</p>
+
+<h2> Concepts and Usage</h2>
+
+<p>Parsing the User-Agent string has historically been the way to get information about the user's browser or device. A typical User-Agent string looks like the following example, identifying Chrome 92 on Windows:</p>
+
+<pre class="brush:html">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36</pre>
+
+<p>User-Agent Client Hints aims to provide this information in a more privacy-preserving way by enforcing a model where the server requests a set of information. The browser decides what to return. This approach means that a user-agent could provide settings that allow a user to hide some of the information that could fingerprint them from such requests.</p>
+
+<h3>Use cases for User-Agent Client Hints</h3>
+
+<p>The <a href="">User-Agent Client Hints Explainer</a> details some potential use cases for the API. These include:</p>
+
+<ul>
+  <li>Providing custom-tailored polyfills to users on identifying that their browser lacked some web platform feature.</li>
+  <li>Working around browser bugs.</li>
+  <li>Recording browser analytics.</li>
+  <li>Adapting content based on user-agent information. Includes serving different content to mobile devices, in particular devices identified as low-powered. It might also include adapting the design to tailor the interfaces to the user's OS, or providing links to OS-specific ones.</li>
+  <li>Providing a notification when a user logs in from a different browser or device, as a security feature.</li>
+  <li>Providing the correct binary executable, on a site offering a download.</li>
+  <li>Collecting information about the browser and device to identify application errors.</li>
+  <li>Blocking spammers, bots, and crawlers.</li>
+</ul>
+
+<h2 id="Interfaces"> Interfaces</h2>
+
+<dl>
+  <dt>{{domxref("NavigatorUAData")}}</dt>
+  <dd>Provides properties and methods to access data about the user's browser and operating system.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Getting the brands</h3>
+
+<p>The following example prints the value of {{domxref("NavigatorUAData.brands")}} to the console.</p>
+
+<pre class="brush:js">console.log(navigator.userAgentData.brands);</pre>
+
+<h3>Returning high entropy values</h3>
+
+<p>In the following value a number of hints are requested using the {{domxref("NavigatorUAData.getHighEntropyValues()")}} method. When the promise resolves, this information is printed to the console.</p>
+
+<pre class="brush:js">navigator.userAgentData.getHighEntropyValues(
+  ["architecture",
+  "model",
+  "platform",
+  "platformVersion",
+  "uaFullVersion"])
+  .then(ua => { console.log(ua) });</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/user-agent-client-hints/">Improving user privacy and developer experience with User-Agent Client Hints</a></li>
+  <li><a href="https://web.dev/migrate-to-ua-ch/">Migrate to User-Agent Client Hints</a></li>
+</ul>

--- a/files/en-us/web/api/user-agent_client_hints_api/index.html
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.html
@@ -14,21 +14,21 @@ browser-compat: api.NavigatorUAData
 
 <h2> Concepts and Usage</h2>
 
-<p>Parsing the User-Agent string has historically been the way to get information about the user's browser or device. A typical User-Agent string looks like the following example, identifying Chrome 92 on Windows:</p>
+<p>Parsing the User-Agent string has historically been the way to get information about the user's browser or device. A typical user agent string looks like the following example, identifying Chrome 92 on Windows:</p>
 
 <pre class="brush:html">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36</pre>
 
-<p>User-Agent Client Hints aims to provide this information in a more privacy-preserving way by enforcing a model where the server requests a set of information. The browser decides what to return. This approach means that a user-agent could provide settings that allow a user to hide some of the information that could fingerprint them from such requests.</p>
+<p>User agent Client Hints aims to provide this information in a more privacy-preserving way by enforcing a model where the server requests a set of information. The browser decides what to return. This approach means that a user-agent could provide settings that allow a user to hide some of the information that could fingerprint them from such requests.</p>
 
 <h3>Use cases for User-Agent Client Hints</h3>
 
-<p>The <a href="">User-Agent Client Hints Explainer</a> details some potential use cases for the API. These include:</p>
+<p>The <a href="">User-Agent Client Hints Explainer</a> explains some potential use cases for the API. These include:</p>
 
 <ul>
   <li>Providing custom-tailored polyfills to users on identifying that their browser lacked some web platform feature.</li>
   <li>Working around browser bugs.</li>
   <li>Recording browser analytics.</li>
-  <li>Adapting content based on user-agent information. Includes serving different content to mobile devices, in particular devices identified as low-powered. It might also include adapting the design to tailor the interfaces to the user's OS, or providing links to OS-specific ones.</li>
+  <li>Adapting content based on user-agent information. This includes serving different content to mobile devices, in particular devices identified as low-powered. It might also include adapting the design to tailor the interfaces to the user's OS, or providing links to OS-specific ones.</li>
   <li>Providing a notification when a user logs in from a different browser or device, as a security feature.</li>
   <li>Providing the correct binary executable, on a site offering a download.</li>
   <li>Collecting information about the browser and device to identify application errors.</li>
@@ -52,7 +52,7 @@ browser-compat: api.NavigatorUAData
 
 <h3>Returning high entropy values</h3>
 
-<p>In the following value a number of hints are requested using the {{domxref("NavigatorUAData.getHighEntropyValues()")}} method. When the promise resolves, this information is printed to the console.</p>
+<p>In the following example a number of hints are requested using the {{domxref("NavigatorUAData.getHighEntropyValues()")}} method. When the promise resolves, this information is printed to the console.</p>
 
 <pre class="brush:js">navigator.userAgentData.getHighEntropyValues(
   ["architecture",

--- a/files/en-us/web/api/user-agent_client_hints_api/index.html
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.html
@@ -20,6 +20,8 @@ browser-compat: api.NavigatorUAData
 
 <p>User agent Client Hints aims to provide this information in a more privacy-preserving way by enforcing a model where the server requests a set of information. The browser decides what to return. This approach means that a user-agent could provide settings that allow a user to hide some of the information that could fingerprint them from such requests.</p>
 
+<p>In order to decide what to return, the information accessed via this API is split into two groups—<strong>low entropy</strong> and <strong>high entropy</strong> hints. Low entropy hints are those that do not give away much information, the API makes these easily accessible with every request. High entropy hints have the potential to give away more information and therefore are gated in such a way that the browser can make a decision as to whether to provide them. This decision could potentially be based on user preferences, or behind a permission request.</p>
+
 <h3>Use cases for User-Agent Client Hints</h3>
 
 <p>The <a href="">User-Agent Client Hints Explainer</a> explains some potential use cases for the API. These include:</p>

--- a/files/en-us/web/api/workernavigator/index.html
+++ b/files/en-us/web/api/workernavigator/index.html
@@ -50,6 +50,8 @@ browser-compat: api.WorkerNavigator
  <dd>Returns a {{DOMxRef('StorageManager')}} interface for managing persistance permissions and estimating available storage.</dd>
  <dt>{{DOMxRef("WorkerNavigator.userAgent")}}{{ReadOnlyInline}}</dt>
  <dd>Returns the user agent string for the current browser.</dd>
+ <dt>{{domxref("WorkerNavigator.userAgentData")}} {{readonlyInline}}</dt>
+ <dd>Returns a {{domxref("NavigatorUAData")}} object, which gives access to information about the browser and operating system of the user.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/workernavigator/useragentdata/index.html
+++ b/files/en-us/web/api/workernavigator/useragentdata/index.html
@@ -1,0 +1,44 @@
+---
+title: WorkerNavigator.userAgentData
+slug: Web/API/WorkerNavigator/userAgentData
+tags:
+- API
+- Navigator
+- Property
+- Reference
+- NavigatorUAData
+browser-compat: api.WorkerNavigator.userAgentData
+---
+<div>{{APIRef("User-Agent Client Hints API")}}</div>
+
+<p>The <code><strong>userAgentData</strong></code> read-only property of the {{domxref("WorkerNavigator")}} interface returns an {{domxref("NavigatorUAData")}} object
+which can be used to access the {{domxref("User-Agent Client Hints API")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let userAgentData = navigator.userAgentData</pre>
+
+<h3 id="Value">Value</h3>
+
+<p>A {{domxref("NavigatorUAData")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example prints the value of {{domxref("NavigatorUAData.brands")}} to the console.</p>
+
+<pre class="brush:js">console.log(navigator.userAgentData.brands);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/user-agent-client-hints/">Improving user privacy and developer experience with User-Agent Client Hints</a></li>
+</ul>
+


### PR DESCRIPTION
Adds an API Overview page for the User-Agent Client Hints API. Also adds the property pages for Navigator and WorkerNavigator.

Reviewer: @jpmedley 