### PR TITLE
Fix misstatement in MutationRecord doc

### DIFF
--- a/files/en-us/web/api/mutationrecord/index.html
+++ b/files/en-us/web/api/mutationrecord/index.html
@@ -12,7 +12,7 @@ browser-compat: api.MutationRecord
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p>A <strong><code>MutationRecord</code></strong> represents an individual DOM mutation. It is the object that is passed to {{domxref("MutationObserver")}}'s callback.</p>
+<p>A <strong><code>MutationRecord</code></strong> represents an individual DOM mutation. It is the object that is inside the array passed to {{domxref("MutationObserver")}}'s callback.</p>
 
 <h2 id="Properties">Properties</h2>
 


### PR DESCRIPTION
It is simply that the short description on the MutationRecord page seems wrong as the MutationRecord object is not what is passed to the MutationObserver callback instead it is an Array that contains one or more MutationRecords that is passed to the callback function.


This section correctly describes what happens when the  callback function is used:
https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/MutationObserver#parameters
