### PR TITLE
cache $HOME/.local for faster poetry installation

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -67,6 +67,13 @@ jobs:
         with:
           python-version: "3.8"
 
+      # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
+      - name: Load cached ~/.local
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.local
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-review-companion.yml') }}
+
       - name: Install Python poetry
         uses: snok/install-poetry@v1.1.6
         with:


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

If you look at https://github.com/mdn/content/actions/workflows/pr-review-companion.yml and you click into each one, you'll often see things like this:
<img width="1087" alt="Screen Shot 2021-07-27 at 11 55 35 AM" src="https://user-images.githubusercontent.com/26739/127186741-d7a3fe74-3880-47cb-b481-07edc57b4256.png">

The single thing that slows down the arrival of the preview URLs PR comment is the installation of `poetry`. 
After [much research](https://www.peterbe.com/plog/install-python-poetry-github-actions-faster) I've come up with a solution. 



> Anything else that could help us review it

Lots of context for the curious here: https://github.com/mdn/yari/pull/4328
