### PR TITLE
Replace alert() call in live sample in <template> doc

### DIFF
--- a/files/en-us/web/html/element/template/index.html
+++ b/files/en-us/web/html/element/template/index.html
@@ -152,7 +152,7 @@ table td {
 const template = document.getElementById("template");
 
 function clickHandler(event) {
-  alert("Clicked a div");
+  event.target.append(" — Clicked this div");
 }
 
 const firstClone = template.content.cloneNode(true);


### PR DESCRIPTION
Calling alert() from a cross-origin iframe no longer works in Chrome:

> A different origin subframe tried to create a JavaScript dialog. This is no longer allowed and was blocked. See https://www.chromestatus.com/feature/5148698084376576 for more details.

So this change replaces an alert() call in a live sample in the “`<template>`: The Content Template element” article with call to `event.target.append()` instead. Fixes https://github.com/mdn/content/issues/7329.