### PR TITLE
Correct instructions for checking Render Mode

### DIFF
--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
@@ -46,7 +46,6 @@ tags:
 
 <h2 id="How_do_I_see_which_mode_is_used">How do I see which mode is used?</h2>
 
-<p>In Firefox, select <em>Page Info</em> from the <em>Tools</em> context menu, and look for <em>Render Mode</em>.</p>
+<p>In Firefox, select <em>Page Info</em> from the <em>Tools</em> menu bar, and look for <em>Render Mode</em>.</p>
 
 <p>In Internet Explorer, press <em>F12</em>, and look for <em>Document Mode</em>.</p>
-

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
@@ -46,7 +46,7 @@ tags:
 
 <h2 id="How_do_I_see_which_mode_is_used">How do I see which mode is used?</h2>
 
-<p>In Firefox, select <em>View Page Info</em> from the context menu, and look for <em>Render Mode</em>.</p>
+<p>In Firefox, select <em>Page Info</em> from the <em>Tools</em> context menu, and look for <em>Render Mode</em>.</p>
 
 <p>In Internet Explorer, press <em>F12</em>, and look for <em>Document Mode</em>.</p>
 

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
@@ -46,6 +46,6 @@ tags:
 
 <h2 id="How_do_I_see_which_mode_is_used">How do I see which mode is used?</h2>
 
-<p>In Firefox, select <em>Page Info</em> from the <em>Tools</em> menu bar, and look for <em>Render Mode</em>.</p>
+<p>In Firefox, select <em>Page Info</em> from the <em>Tools</em> menu bar, and look for <em>Render Mode</em>. (<a href="https://support.mozilla.org/en-US/kb/firefox-page-info-window">Learn more about the Firefox Page Info window</a>)</p>
 
 <p>In Internet Explorer, press <em>F12</em>, and look for <em>Document Mode</em>.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I couldn't find "View Page Info" anywhere in the context menu for Firefox (`90.0.2 (64-bit)`, macOS). Instead I found "Page Info" under "Tools" which brings up the dialogue they're talking about here. 

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
