### PR TITLE
Update meta-docs for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,17 @@ If you choose an option other than the GitHub UI, you want to install
 
 These are some important things to keep in mind about the MDN content.
 
+- **A document's main content is written in an `index.html` or an `index.md` file** -- We're currently in the process of converting our content from HTML into Markdown. Pages that are in HTML have their content in a file called "index.html".
+ Pages that are in Markdown  have their content in a file called "index.md".
 - **Documents are folders** --  Documents are always
 represented by a folder (e.g., [`files/en-us/web/javascript`](files/en-us/web/javascript)),
 and that folder will contain the content of that specific document as an
-`index.html` file (e.g., [`files/en-us/web/javascript/index.html`](files/en-us/web/javascript/index.html)).
+`index.html` or `index.md` file (e.g., [`files/en-us/web/javascript/index.md`](files/en-us/web/javascript/index.md)).
 - **Documents are hierarchical** - A document folder may contain other folders,
-where those folders would represent child documents (e.g., [`files/en-us/web/javascript/closures/index.html`](files/en-us/web/javascript/closures/index.html)).
+where those folders would represent child documents (e.g., [`files/en-us/web/javascript/closures/index.md`](files/en-us/web/javascript/closures/index.md)).
 - **Document folders may contain image files** -- A document folder may also
 contain image files, which are referenced within that document's
-`index.html` file.
+`index.html` or `index.md` file.
 - **All redirects are specified in a single file** -- All of the redirects
 are specified within [`files/en-us/_redirects.txt`](files/en-us/_redirects.txt),
 one redirect per line. Each line specifies a `from` and `to` URI
@@ -95,15 +97,15 @@ separated by whitespace. When you move a document, you'll need to add a
 redirect to this file specifying that its old URI now redirects to its new URI.
 Both of these tasks are done using the `yarn content move` tool — see
 [Moving one or more documents](#moving-one-or-more-documents).
-**Don't edit the `_redirects.txt` file manually!**
-If both an `index.html` file and a redirect exist for a document, the
+* **Don't edit the `_redirects.txt` file manually!**
+If both an `index.html` or `index.md` file and a redirect exist for a document, the
 document takes precedence and the redirect is ignored.
-- **A document's `index.html` starts with "front-matter"** -- Each
-document's `index.html` file must begin with some [YAML](https://en.wikipedia.org/wiki/YAML)
+- **A document's `index.html` or `index.md` starts with "front-matter"** -- Each
+document's `index.html` or `index.md` file must begin with some [YAML](https://en.wikipedia.org/wiki/YAML)
 called front-matter that defines some important information about the
 document: `title`, `slug`, and [`tags`](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Tag)
 (if any). Here's an example that shows the front-matter from the
-[JavaScript landing page](files/en-us/web/javascript/index.html):
+[JavaScript landing page](files/en-us/web/javascript/index.md):
 
     ```yaml
     ---
@@ -124,7 +126,7 @@ If you just want to make a simple change to a single file, like fixing a typo,
 the GitHub UI is the simplest way to do that. For example, if you've found
 a typo within the [JavaScript landing page](https://developer.mozilla.org/en-US/docs/Web/JavaScript),
 you can sign into GitHub, go to <https://github.com/mdn/content>,
-navigate to the source file `files/en-us/web/javascript/index.html`,
+navigate to the source file `files/en-us/web/javascript/index.md`,
 and then click on the edit (pencil) button.
 
 > **Tip:** Click the **Source on GitHub** link in the footer of any MDN page
@@ -223,7 +225,7 @@ within your browser.
     ```
 
     When you preview a page you can press a button to open its associated
-    document's `index.html` file in your preferred editor. For this to work,
+    document's `index.html` or `index.md` file in your preferred editor. For this to work,
     you need to set an environment variable called `EDITOR` before starting
     the preview server. For example, if you prefer VS Code as your editor,
     you'll want to do something like this:
@@ -257,20 +259,21 @@ within your browser.
     Now, it should be set like that even after you've closed and started a new
     terminal window.
 
-1. Make your desired changes to one or more `index.html` files using
+1. Make your desired changes to one or more `index.html` or `index.md` files using
 your preferred code editor. **When thinking about your desired changes, it's
 important to keep the following in mind:**
     - **Make sure you've read the
     [MDN guidelines](https://developer.mozilla.org/en-US/docs/MDN/Guidelines),
     including the
     [Writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Writing_style_guide).**
+    - **If you're editing a Markdown file, see the [guide to writing Markdown for MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN).**
     - **Large chunks of work can be difficult to review, so try to group your
     changes into the smallest logical chunks that make sense, and create a
     separate pull request for each logical chunk.**
 
 1. Once you've made and saved your changes, open a browser, and navigate
 to the page(s) you've changed. For example, if you changed
-`files/en-us/web/javascript/index.html`, open
+`files/en-us/web/javascript/index.md`, open
 `http://localhost:5000/en-us/docs/web/javascript` in your browser.
 
 1. You might have noticed that at the top of each page that you preview,
@@ -359,21 +362,27 @@ making the change and anything else we need to know about it.
 ### Adding a new document
 
 Adding a new document is relatively straightforward, especially if you can
-start by copying the `index.html` of a similar document. There are only a
+start by copying the `index.html` or `index.md` of a similar document. There are only a
 few things to keep in mind:
 
-- Remember that a document is represented by an `index.html` file within its
+- Documents can be authored in either Markdown or HTML. However, we're converting
+  the site to Markdown one section at a time, and don't want to mix authoring
+  formats within a section. At this point we have only converted the JavaScript
+  documentation. So if you are adding a new document under
+  `files/en-us/web/javascript`, make it a Markdown file. Otherwise make it an
+  HTML file.
+- Remember that a document is represented by an `index.html` or `index.md` file within its
   own folder.
 - Determine where in the document hierarchy your document belongs. For
   example, if you're
   creating a new CSS document for a new property `foo`, you'll want to create
   a new folder
   `files/en-us/web/css/foo/` and its `files/en-us/web/css/foo/index.html` file.
-- Remember that a document's `index.html` file must start with front-matter
+- Remember that a document's `index.html` or `index.md` file must start with front-matter
   that defines the `title`, `slug`, and
   [`tags`](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Tag)
   (if any) for the document. You might find it helpful to refer
-  to the front-matter within a similar document's `index.html`.
+  to the front-matter within a similar document's `index.html` or `index.md`.
 
 As we outlined above, the step-by-step process in general would be:
 
@@ -389,7 +398,8 @@ As we outlined above, the step-by-step process in general would be:
     git checkout -b my-add
     ```
 
-1. Create one or more new document folders, each with their own `index.html` file.
+1. Create one or more new document folders, each with their own `index.html`
+or `index.md` file.
 
 1. Add and commit your new files, as well as push your new branch to your fork:
 
@@ -548,7 +558,8 @@ pushing your branch to your fork:
 
 Adding an image to a document is easy as well. All you need to do is add
 your image file within the document's folder, and then reference the image
-from within the document's `index.html` file using an `<img>` element.
+from within the document's `index.html` or `index.md` file, using an `<img>`
+or [the equivalent Markdown syntax](https://github.github.com/gfm/#images).
 It's as easy as that. Let's walk through an example:
 
 1. You should be getting used to this by now, as we've done it several

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ If you choose an option other than the GitHub UI, you want to install
 
 These are some important things to keep in mind about the MDN content.
 
-- **A document's main content is written in an `index.html` or an `index.md` file** -- We're currently in the process of converting our content from HTML into Markdown. Pages that are in HTML have their content in a file called "index.html".
- Pages that are in Markdown  have their content in a file called "index.md".
+- **A document's main content is written in an `index.html` or an `index.md`
+file** -- We're currently in the process of converting our content from HTML
+into Markdown. Pages that are in HTML have their content in a file called
+"index.html". Pages that are in Markdown  have their content in a file called
+"index.md".
 - **Documents are folders** --  Documents are always
 represented by a folder (e.g., [`files/en-us/web/javascript`](files/en-us/web/javascript)),
 and that folder will contain the content of that specific document as an
@@ -97,7 +100,7 @@ separated by whitespace. When you move a document, you'll need to add a
 redirect to this file specifying that its old URI now redirects to its new URI.
 Both of these tasks are done using the `yarn content move` tool — see
 [Moving one or more documents](#moving-one-or-more-documents).
-* **Don't edit the `_redirects.txt` file manually!**
+- **Don't edit the `_redirects.txt` file manually!**
 If both an `index.html` or `index.md` file and a redirect exist for a document, the
 document takes precedence and the redirect is ignored.
 - **A document's `index.html` or `index.md` starts with "front-matter"** -- Each
@@ -225,10 +228,10 @@ within your browser.
     ```
 
     When you preview a page you can press a button to open its associated
-    document's `index.html` or `index.md` file in your preferred editor. For this to work,
-    you need to set an environment variable called `EDITOR` before starting
-    the preview server. For example, if you prefer VS Code as your editor,
-    you'll want to do something like this:
+    document's `index.html` or `index.md` file in your preferred editor.
+    For this to work, you need to set an environment variable called `EDITOR`
+    before starting the preview server. For example, if you prefer VS Code as
+    your editor, you'll want to do something like this:
 
     ```sh
     export EDITOR=code
@@ -259,14 +262,15 @@ within your browser.
     Now, it should be set like that even after you've closed and started a new
     terminal window.
 
-1. Make your desired changes to one or more `index.html` or `index.md` files using
-your preferred code editor. **When thinking about your desired changes, it's
-important to keep the following in mind:**
+1. Make your desired changes to one or more `index.html` or `index.md` files
+using your preferred code editor. **When thinking about your desired changes,
+it's important to keep the following in mind:**
     - **Make sure you've read the
     [MDN guidelines](https://developer.mozilla.org/en-US/docs/MDN/Guidelines),
     including the
     [Writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Writing_style_guide).**
-    - **If you're editing a Markdown file, see the [guide to writing Markdown for MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN).**
+    - **If you're editing a Markdown file, see the
+    [guide to writing Markdown for MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN).**
     - **Large chunks of work can be difficult to review, so try to group your
     changes into the smallest logical chunks that make sense, and create a
     separate pull request for each logical chunk.**
@@ -297,7 +301,8 @@ and then push the branch to your fork. Remember, the default name that
     git push -u origin my-work
     ```
 
-1. You're now ready to create a [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+1. You're now ready to create a
+[pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
 1. Once you've created your pull request, sit back, relax, and wait for
 a review.
@@ -362,8 +367,8 @@ making the change and anything else we need to know about it.
 ### Adding a new document
 
 Adding a new document is relatively straightforward, especially if you can
-start by copying the `index.html` or `index.md` of a similar document. There are only a
-few things to keep in mind:
+start by copying the `index.html` or `index.md` of a similar document.
+There are only a few things to keep in mind:
 
 - Documents can be authored in either Markdown or HTML. However, we're converting
   the site to Markdown one section at a time, and don't want to mix authoring
@@ -371,15 +376,15 @@ few things to keep in mind:
   documentation. So if you are adding a new document under
   `files/en-us/web/javascript`, make it a Markdown file. Otherwise make it an
   HTML file.
-- Remember that a document is represented by an `index.html` or `index.md` file within its
-  own folder.
+- Remember that a document is represented by an `index.html` or `index.md` file
+  within its own folder.
 - Determine where in the document hierarchy your document belongs. For
   example, if you're
   creating a new CSS document for a new property `foo`, you'll want to create
   a new folder
   `files/en-us/web/css/foo/` and its `files/en-us/web/css/foo/index.html` file.
-- Remember that a document's `index.html` or `index.md` file must start with front-matter
-  that defines the `title`, `slug`, and
+- Remember that a document's `index.html` or `index.md` file must start with
+  front-matter that defines the `title`, `slug`, and
   [`tags`](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Tag)
   (if any) for the document. You might find it helpful to refer
   to the front-matter within a similar document's `index.html` or `index.md`.

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -10,9 +10,9 @@ tags:
 
 <h4>Warning</h4>
 
-<p>This document is a work-in-progress draft at the moment.</p>
+<p>We're currently in the process of converting all MDN content from HTML into Markdown. Currently you can write pages in HTML or in Markdown, but we don't want to mix formats within a section.</p>
 
-<p>It's not actually possible, yet, to write MDN documentation using Markdown, so at the moment this document is used to record the decisions we've made about how we will expect Markdown to be written, when it is supported.</p>
+<p>At the moment only the JavaScript documentation is in Markdown (pages under <a href="/en-US/docs/Web/JavaScript">https://developer.mozilla.org/en-US/docs/Web/JavaScript</a>), so this page only applies to that part of the site. For other parts of the site, write documentation in HTML.</p>
 
 </div>
 
@@ -371,12 +371,6 @@ cell 4    | cell 5    | cell 6
 <h3>Discussion reference</h3>
 
 <p>This issue was resolved in <a href="https://github.com/mdn/content/issues/4325">https://github.com/mdn/content/issues/4325</a>.</p>
-
-<h2>Heading IDs</h2>
-
-<h2>Live samples</h2>
-
-<h2>Inline styles</h2>
 
 <h2>Superscript and subscript</h2>
 

--- a/files/en-us/mdn/guidelines/css_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/css_style_guide/index.html
@@ -11,6 +11,16 @@ tags:
 ---
 <p>{{MDNSidebar}}</p>
 
+<div class="notecard warning">
+
+<h4>Warning</h4>
+
+<p>We're currently in the process of converting all MDN content from HTML into Markdown. Currently you can write pages in HTML or in Markdown, but we don't want to mix formats within a section.</p>
+
+<p>At the moment only the JavaScript documentation is in Markdown (pages under <a href="/en-US/docs/Web/JavaScript">https://developer.mozilla.org/en-US/docs/Web/JavaScript</a>). So if you're writing content in that part of the site, this page is <em>not</em> applicable, and you should instead follow the guidelines in the <a href="/en-US/docs/MDN/Contribute/Markdown_in_MDN">Markdown in MDN</a> guide.</p>
+
+</div>
+
 <p class="summary"><span class="seoSummary">MDN has many built-in global styles available for use when styling and laying out articles, and this article is a guide to the available classes and when to use them.</span></p>
 
 <p>Please keep in that these styles have been developed to cover the most common situations that arise while styling article content, and that whenever possible, you should try to use the available classes; diverging too much from the standard content look-and-feel isn't good for consistency and readability. If you feel that your page absolutely requires some kind of special custom styling, you should <a href="/en-US/docs/MDN/Contribute/Getting_started#step_4_ask_for_help">talk to us</a> about it.</p>


### PR DESCRIPTION
This makes some fairly basic updates to our contributing docs to at least acknowledge the existence of Markdown.

Since this will need to change anyway as we eventually stop using HTML, and since the README is anyway up for changes, I tried to keep the changes quite small.

I also made https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN less of a draft and added a warning to https://developer.mozilla.org/en-US/docs/MDN/Guidelines/CSS_style_guide, since it's no longer applicable when editing MD files.

@Rumyra , since we were talking about contribution docs you might want to look at this.
