### PR TITLE
Remove rotationRate from WebGL 2D example

### DIFF
--- a/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.html
+++ b/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.html
@@ -147,7 +147,6 @@ function startup() {
   vertexCount = vertexArray.length/vertexNumComponents;
 
   currentAngle = 0.0;
-  rotationRate = 6;
 
   animateScene();
 }</pre>


### PR DESCRIPTION
The variable `rotationRate` is not used in the demo. This variable is obsolete and probably was substituted by  `degreesPerSecond`

I've found no other mention of this variable in the WebGL section of this repo: https://github.com/mdn/content/search?q=rotationRate
I also tested the code without the variable and it ran correctly.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The variable `rotationRate` is not used anywhere in the demo

> Anything else that could help us review it
This can be easily tested with the [Live Samples](https://developer.mozilla.org/en-US/docs/MDN/Structures/Live_samples)