### PR TITLE
Fix a line in Array.Prototype.includes documentation.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
@@ -91,8 +91,8 @@ arr.includes('c', 100)  // false
 
 If `fromIndex` is negative, the computed index is calculated to
 be used as a position in the array at which to begin searching for
-`searchElement`. If the computed index is less or equal than
-`-1 * arr.length`, the entire array will be searched.
+`searchElement`. If the computed index is less than or equal to
+`0`, the entire array will be searched.
 
 ```js
 // array length is 3


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

![image](https://user-images.githubusercontent.com/58631762/127271884-6bad9c82-beb1-46d1-bd43-b836f56fdb40.png)

It was given that the entire array will be searched if the computed index is less than or equal to `-1 * arr.length`. But it should be `0` instead of the expression `-1 * arr.length`. 

Let's consider an array `[1, 2, 3, 4, 0]`. If I do `array.includes(2, -7)`, the computed index will be `5 - 7 = -2` which is `≤0`. I'll get `true` because the entire array will be searched.