### PR TITLE
Replace “namespace URI” with “namespace” in Element»getAttributeNames() doc

### DIFF
--- a/files/en-us/web/api/element/getattributenames/index.html
+++ b/files/en-us/web/api/element/getattributenames/index.html
@@ -21,7 +21,7 @@ browser-compat: api.Element.getAttributeNames
   {{domxref("Element.getAttribute","getAttribute()")}}, is a memory-efficient and
   performant alternative to accessing {{domxref("Element.attributes")}}.</p>
 
-<p>The names returned by <strong><code>getAttributeNames()</code></strong> are <em>qualified</em> attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (<em>not</em> the actual namespace URI), followed by a colon, followed by the attribute name (for example, <strong><code>xlink:href</code></strong>), while any attributes which have no namespace prefix have their names returned as-is (for example, <strong><code>href</code></strong>).</p>
+<p>The names returned by <strong><code>getAttributeNames()</code></strong> are <em>qualified</em> attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (<em>not</em> the actual namespace), followed by a colon, followed by the attribute name (for example, <strong><code>xlink:href</code></strong>), while any attributes which have no namespace prefix have their names returned as-is (for example, <strong><code>href</code></strong>).</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
See https://github.com/mdn/content/pull/5715#pullrequestreview-714767909. This is a clean-up follow-up to https://github.com/mdn/content/pull/5715.