### PR TITLE
{{jsxref("Boolean")}} -> boolean value in Web/API (special cases)

### DIFF
--- a/files/en-us/web/api/abstractrange/collapsed/index.html
+++ b/files/en-us/web/api/abstractrange/collapsed/index.html
@@ -23,7 +23,7 @@ browser-compat: api.AbstractRange.collapsed
 
 <h3 id="Value">Value</h3>
 
-<p>A {{jsxref("Boolean")}} value which is <code>true</code> if the range is <strong>collapsed</strong>. A collapsed range is one in which the start and end positions are the same, resulting in a zero-character-long range..</p>
+<p>A boolean value which is <code>true</code> if the range is <strong>collapsed</strong>. A collapsed range is one in which the start and end positions are the same, resulting in a zero-character-long range..</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
@@ -51,7 +51,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInPath
 <h3 id="Return_value">Return value</h3>
 
 <dl>
-  <dt>{{jsxref("Boolean")}}</dt>
+  <dt>A boolean value</dt>
   <dd>A Boolean, which is <code>true</code> if the specified point is contained in the
     current or specified path, otherwise <code>false</code>.</dd>
 </dl>

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
@@ -37,7 +37,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInStroke
 <h3 id="Return_value">Return value</h3>
 
 <dl>
-  <dt>{{jsxref("Boolean")}}</dt>
+  <dt>A boolean value</dt>
   <dd>A Boolean, which is <code>true</code> if the point is inside the area contained by
     the stroking of a path, otherwise <code>false</code>.</dd>
 </dl>

--- a/files/en-us/web/api/cryptokey/index.html
+++ b/files/en-us/web/api/cryptokey/index.html
@@ -36,7 +36,7 @@ browser-compat: api.CryptoKey
  </dd>
  <dt><code>CryptoKey.extractable</code></dt>
  <dd>
- <p>{{jsxref("Boolean")}} indicating whether or not the key may be extracted using <a href="/en-US/docs/Web/API/SubtleCrypto/exportKey" title="The SubtleCrypto.exportKey() method exports a key: that is, it takes as input a CryptoKey object and gives you the key in an external, portable format."><code>SubtleCrypto.exportKey()</code></a> or <a href="/en-US/docs/Web/API/SubtleCrypto/wrapKey" title='The SubtleCrypto.wrapKey() method "wraps" a key. This means that it exports the key in an external, portable format, then encrypts the exported key. Wrapping a key helps protect it in untrusted environments, such as an otherwise unprotected data store or in transmission over an unprotected network.'><code>SubtleCrypto.wrapKey()</code></a>.</p>
+ <p>A boolean value indicating whether or not the key may be extracted using <a href="/en-US/docs/Web/API/SubtleCrypto/exportKey" title="The SubtleCrypto.exportKey() method exports a key: that is, it takes as input a CryptoKey object and gives you the key in an external, portable format."><code>SubtleCrypto.exportKey()</code></a> or <a href="/en-US/docs/Web/API/SubtleCrypto/wrapKey" title='The SubtleCrypto.wrapKey() method "wraps" a key. This means that it exports the key in an external, portable format, then encrypts the exported key. Wrapping a key helps protect it in untrusted environments, such as an otherwise unprotected data store or in transmission over an unprotected network.'><code>SubtleCrypto.wrapKey()</code></a>.</p>
 
  <ul>
   <li><code>true</code>: The key may be extracted.</li>

--- a/files/en-us/web/api/css/supports/index.html
+++ b/files/en-us/web/api/css/supports/index.html
@@ -12,8 +12,8 @@ browser-compat: api.CSS.supports
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p>The <code><strong>CSS.supports()</strong></code> method returns a {{jsxref("Boolean")}}
-  value indicating if the browser supports a given CSS feature, or not.</p>
+<p>The <code><strong>CSS.supports()</strong></code> method returns a boolean value
+  indicating if the browser supports a given CSS feature, or not.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/customevent/initcustomevent/index.html
+++ b/files/en-us/web/api/customevent/initcustomevent/index.html
@@ -40,10 +40,10 @@ browser-compat: api.CustomEvent.initCustomEvent
   <dt><code><em>type</em></code></dt>
   <dd>Is a {{domxref("DOMString")}} containing the name of the event.</dd>
   <dt><em><code>canBubble</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} indicating whether the event bubbles up through the DOM
+  <dd>Is a boolean value indicating whether the event bubbles up through the DOM
     or not.</dd>
   <dt><code><em>cancelable</em></code></dt>
-  <dd>Is a {{jsxref("Boolean")}} indicating whether the event is cancelable.</dd>
+  <dd>Is a boolean value indicating whether the event is cancelable.</dd>
   <dt><em><code>detail</code></em></dt>
   <dd>The data passed when initializing the event.</dd>
 </dl>

--- a/files/en-us/web/api/document/hasfocus/index.html
+++ b/files/en-us/web/api/document/hasfocus/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Document.hasFocus
 <div>{{APIRef}}</div>
 
 <p>The <code><strong>hasFocus()</strong></code> method of the {{domxref("Document")}}
-  interface returns a {{jsxref("Boolean")}} value indicating whether the document or any
+  interface returns a boolean value indicating whether the document or any
   element inside the document has focus. This method can be used to determine whether the
   active element in a document has focus.</p>
 

--- a/files/en-us/web/api/document/querycommandstate/index.html
+++ b/files/en-us/web/api/document/querycommandstate/index.html
@@ -23,7 +23,7 @@ browser-compat: api.Document.queryCommandState
 
 <h3 id="Return_value">Return value</h3>
 
-<p><code>queryCommandState()</code> can return a {{jsxref("Boolean")}} value or <code>null</code> if the state is unknown.</p>
+<p><code>queryCommandState()</code> can return a boolean value or <code>null</code> if the state is unknown.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/domstringlist/index.html
+++ b/files/en-us/web/api/domstringlist/index.html
@@ -25,7 +25,7 @@ browser-compat: api.DOMStringList
  <dt>{{domxref("DOMStringList.item()")}}</dt>
  <dd>Returns a {{domxref("DOMString")}}.</dd>
  <dt>{{domxref("DOMStringList.contains()")}}</dt>
- <dd>Returns {{jsxref("Boolean")}} indicating if the given string is in the list</dd>
+ <dd>Returns a boolean value indicating if the given string is in the list</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/element/haspointercapture/index.html
+++ b/files/en-us/web/api/element/haspointercapture/index.html
@@ -32,7 +32,7 @@ browser-compat: api.Element.hasPointerCapture
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Boolean")}} value — <code>true</code> if the element does have pointer
+<p>A boolean value — <code>true</code> if the element does have pointer
   capture, <code>false</code> if it doesn't.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/element/scrollintoview/index.html
+++ b/files/en-us/web/api/element/scrollintoview/index.html
@@ -31,7 +31,7 @@ browser-compat: api.Element.scrollIntoView
 
 <dl>
   <dt><code><var>alignToTop</var></code> {{optional_inline}}</dt>
-  <dd>Is a {{jsxref("Boolean")}} value:
+  <dd>Is a boolean value:
     <ul>
       <li>If <code>true</code>, the top of the element will be aligned to the top of the
         visible area of the scrollable ancestor. Corresponds to

--- a/files/en-us/web/api/element/scrollintoviewifneeded/index.html
+++ b/files/en-us/web/api/element/scrollintoviewifneeded/index.html
@@ -22,7 +22,7 @@ browser-compat: api.Element.scrollIntoViewIfNeeded
 
 <dl>
  <dt><em><code>opt_center</code></em></dt>
- <dd>Is an optional {{jsxref("Boolean")}} value with a default value of <code>true</code>:
+ <dd>Is an optional boolean value with a default of <code>true</code>:
  <ul>
   <li>If <code>true</code>, the element will be aligned so it is centered within the visible area of the scrollable ancestor.</li>
   <li>If <code>false</code>, the element will be aligned to the nearest edge of the visible area of the scrollable ancestor. Depending on which edge of the visible area is closest to the element, either the top of the element will be aligned to the top edge of the visible area, or the bottom edge of the element will be aligned to the bottom edge of the visible area.</li>

--- a/files/en-us/web/api/elementinternals/index.html
+++ b/files/en-us/web/api/elementinternals/index.html
@@ -24,7 +24,7 @@ browser-compat: api.ElementInternals
   <dt>{{domxref("ElementInternals.form")}}{{ReadOnlyInline}}</dt>
   <dd>Returns the {{domxref("HTMLFormElement")}} associated with this element.</dd>
   <dt>{{domxref("ElementInternals.willValidate")}}{{ReadOnlyInline}}</dt>
-  <dd> {{jsxref("Boolean")}} which returns true if the element is a submittable element that is a candidate for
+  <dd>A boolean value which returns true if the element is a submittable element that is a candidate for
     <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>.</dd>
   <dt>{{domxref("ElementInternals.validity")}}{{ReadOnlyInline}}</dt>
   <dd>Returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.</dd>

--- a/files/en-us/web/api/htmlareaelement/index.html
+++ b/files/en-us/web/api/htmlareaelement/index.html
@@ -36,7 +36,7 @@ browser-compat: api.HTMLAreaElement
  <dt>{{domxref("HTMLAreaElement.href")}}</dt>
  <dd>Is a {{domxref("USVString")}} containing that reflects the {{ htmlattrxref("href", "area") }} HTML attribute, containing a valid URL of a linked resource.</dd>
  <dt>{{domxref("HTMLAreaElement.noHref")}} {{deprecated_inline}}</dt>
- <dd>Is a boolean value flag indicating if the area is inactive (<code>true</code>) or active (<code>false</code>).</dd>
+ <dd>Is a boolean flag indicating if the area is inactive (<code>true</code>) or active (<code>false</code>).</dd>
  <dt>{{domxref("HTMLAreaElement.origin")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("USVString")}} containing the origin of the URL, that is its scheme, its domain and its port.</dd>
  <dt>{{domxref("HTMLAreaElement.password")}}</dt>

--- a/files/en-us/web/api/htmlbuttonelement/index.html
+++ b/files/en-us/web/api/htmlbuttonelement/index.html
@@ -23,9 +23,9 @@ browser-compat: api.HTMLButtonElement
  <dt>{{domxref("HTMLButtonElement.accessKey")}}</dt>
  <dd>Is a {{domxref("DOMString")}} indicating the single-character keyboard key to give access to the button.</dd>
  <dt>{{domxref("HTMLButtonElement.autofocus")}}</dt>
- <dd>Is a {{jsxref("Boolean")}} indicating whether or not the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.</dd>
+ <dd>Is a boolean value indicating whether or not the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.</dd>
  <dt>{{domxref("HTMLButtonElement.disabled")}}</dt>
- <dd>Is a {{jsxref("Boolean")}} indicating whether or not the control is disabled, meaning that it does not accept any clicks.</dd>
+ <dd>Is a boolean value indicating whether or not the control is disabled, meaning that it does not accept any clicks.</dd>
  <dt>{{domxref("HTMLButtonElement.form")}} {{readonlyInline}}</dt>
  <dd>Is a {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is the ID of that form element.<br>
  If the button is not a descendant of a form element, then the attribute can be the ID of any form element in the same document it is related to, or the <code>null</code> value if none matches.</dd>
@@ -36,7 +36,7 @@ browser-compat: api.HTMLButtonElement
  <dt>{{domxref("HTMLButtonElement.formMethod")}}</dt>
  <dd>Is a {{domxref("DOMString")}} reflecting the HTTP method that the browser uses to submit the form. If specified, this attribute overrides the {{htmlattrxref("method", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.</dd>
  <dt>{{domxref("HTMLButtonElement.formNoValidate")}}</dt>
- <dd>Is a {{jsxref("Boolean")}} indicating that the form is not to be validated when it is submitted. If specified, this attribute overrides the {{htmlattrxref("novalidate", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.</dd>
+ <dd>Is a boolean value indicating that the form is not to be validated when it is submitted. If specified, this attribute overrides the {{htmlattrxref("novalidate", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.</dd>
  <dt>{{domxref("HTMLButtonElement.formTarget")}}</dt>
  <dd>Is a {{domxref("DOMString")}} reflecting a name or keyword indicating where to display the response that is received after submitting the form. If specified, this attribute overrides the {{htmlattrxref("target", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.</dd>
  <dt>{{domxref("HTMLButtonElement.labels")}} {{readonlyInline}}</dt>
@@ -57,7 +57,7 @@ browser-compat: api.HTMLButtonElement
  </ul>
  </dd>
  <dt>{{domxref("HTMLButtonElement.willValidate")}} {{readonlyInline}}</dt>
- <dd>Is a {{jsxref("Boolean")}} indicating whether the button is a candidate for constraint validation. It is <code>false</code> if any conditions bar it from constraint validation, including: its <code>type</code> property is <code>reset</code> or <code>button</code>; it has a {{HTMLElement("datalist")}} ancestor; or the <code>disabled</code> property is set to <code>true</code>.</dd>
+ <dd>Is a boolean value indicating whether the button is a candidate for constraint validation. It is <code>false</code> if any conditions bar it from constraint validation, including: its <code>type</code> property is <code>reset</code> or <code>button</code>; it has a {{HTMLElement("datalist")}} ancestor; or the <code>disabled</code> property is set to <code>true</code>.</dd>
  <dt>{{domxref("HTMLButtonElement.validationMessage")}} {{readonlyInline}}</dt>
  <dd>Is a {{domxref("DOMString")}} representing the localized message that describes the validation constraints that the control does not satisfy (if any). This attribute is the empty string if the control is not a candidate for constraint validation (<code>willValidate</code> is <code>false</code>), or it satisfies its constraints.</dd>
  <dt>{{domxref("HTMLButtonElement.validity")}} {{readonlyInline}}</dt>
@@ -81,12 +81,12 @@ browser-compat: api.HTMLButtonElement
  <tbody>
   <tr>
    <td><code>checkValidity()</code></td>
-   <td>{{jsxref("Boolean")}}</td>
+   <td>A boolean value</td>
    <td>Not supported for reset or button elements.</td>
   </tr>
   <tr>
    <td><code>reportValidity()</code></td>
-   <td>{{jsxref("Boolean")}}</td>
+   <td>A boolean value</td>
    <td>Not supported for reset or button elements.</td>
   </tr>
   <tr>

--- a/files/en-us/web/api/htmlelement/contenteditable/index.html
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HTMLElement.contentEditable
 </ul>
 
 <p>You can use the {{domxref("HTMLElement.isContentEditable")}} property to test the
-  computed {{jsxref("Boolean")}} value of this property.</p>
+  computed boolean value of this property.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -42,7 +42,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>formNoValidate</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("formnovalidate", "input") }} attribute, indicating that the form is not to be validated when it is submitted. This overrides the {{ htmlattrxref("novalidate", "form") }} attribute of the parent form.</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("formnovalidate", "input") }} attribute, indicating that the form is not to be validated when it is submitted. This overrides the {{ htmlattrxref("novalidate", "form") }} attribute of the parent form.</td>
   </tr>
   <tr>
    <td><code>formTarget</code></td>
@@ -64,15 +64,15 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>disabled</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("disabled", "input") }} attribute, indicating that the control is not available for interaction. The input values will not be submitted with the form. See also {{ htmlattrxref("readOnly", "input") }}</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("disabled", "input") }} attribute, indicating that the control is not available for interaction. The input values will not be submitted with the form. See also {{ htmlattrxref("readOnly", "input") }}</td>
   </tr>
   <tr>
    <td><code>autofocus</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("autofocus", "input") }} attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the {{htmlattrxref("autofocus","input")}} attribute. It cannot be applied if the {{htmlattrxref("type","input")}} attribute is set to <code>hidden</code> (that is, you cannot automatically set focus to a hidden control).</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("autofocus", "input") }} attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the {{htmlattrxref("autofocus","input")}} attribute. It cannot be applied if the {{htmlattrxref("type","input")}} attribute is set to <code>hidden</code> (that is, you cannot automatically set focus to a hidden control).</td>
   </tr>
   <tr>
    <td><code>required</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("required", "input") }} attribute, indicating that the user must fill in a value before submitting a form.</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("required", "input") }} attribute, indicating that the user must fill in a value before submitting a form.</td>
   </tr>
   <tr>
    <td><code>value</code></td>
@@ -90,7 +90,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>willValidate</code> {{readonlyInline}}</td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns</strong> whether the element is a candidate for constraint validation. It is <code>false</code> if any conditions bar it from constraint validation, including: its <code>type</code> is <code>hidden</code>, <code>reset</code>, or <code>button</code>; it has a {{HTMLElement("datalist")}} ancestor; its <code>disabled</code> property is <code>true</code>.</td>
+   <td><em>A boolean value:</em> <strong>Returns</strong> whether the element is a candidate for constraint validation. It is <code>false</code> if any conditions bar it from constraint validation, including: its <code>type</code> is <code>hidden</code>, <code>reset</code>, or <code>button</code>; it has a {{HTMLElement("datalist")}} ancestor; its <code>disabled</code> property is <code>true</code>.</td>
   </tr>
  </tbody>
 </table>
@@ -100,15 +100,15 @@ browser-compat: api.HTMLInputElement
  <tbody>
   <tr>
    <td><code>checked</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the current state of the element when {{htmlattrxref("type","input")}} is <code>checkbox</code> or <code>radio</code>.</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the current state of the element when {{htmlattrxref("type","input")}} is <code>checkbox</code> or <code>radio</code>.</td>
   </tr>
   <tr>
    <td><code>defaultChecked</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the default state of a radio button or checkbox as originally specified in HTML that created this object.</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the default state of a radio button or checkbox as originally specified in HTML that created this object.</td>
   </tr>
   <tr>
    <td><code id="indeterminate">indeterminate</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns</strong> whether the checkbox or radio button is in indeterminate state. For checkboxes, the effect is that the appearance of the checkbox is obscured/greyed in some way as to indicate its state is indeterminate (not checked but not unchecked). Does not affect the value of the <code>checked</code> attribute, and clicking the checkbox will set the value to false.</td>
+   <td><em>A boolean value:</em> <strong>Returns</strong> whether the checkbox or radio button is in indeterminate state. For checkboxes, the effect is that the appearance of the checkbox is obscured/greyed in some way as to indicate its state is indeterminate (not checked but not unchecked). Does not affect the value of the <code>checked</code> attribute, and clicking the checkbox will set the value to false.</td>
   </tr>
  </tbody>
 </table>
@@ -144,7 +144,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>allowdirs</code> {{non-standard_inline}}</td>
-   <td><em>{{jsxref("Boolean")}}:</em> Part of the non-standard Directory Upload API; <strong>indicates</strong> whether or not to allow directories and files both to be selected in the file list. Implemented only in Firefox and is hidden behind a preference.</td>
+   <td><em>A boolean value:</em> Part of the non-standard Directory Upload API; <strong>indicates</strong> whether or not to allow directories and files both to be selected in the file list. Implemented only in Firefox and is hidden behind a preference.</td>
   </tr>
   <tr>
    <td><code id="files_prop">files</code></td>
@@ -152,7 +152,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td>{{domxref("HTMLInputElement.webkitdirectory", "webkitdirectory")}} {{Non-standard_inline}}</td>
-   <td><em>{{jsxref("Boolean")}}:</em><strong> Returns</strong> the {{htmlattrxref("webkitdirectory", "input")}} attribute; if true, the file system picker interface only accepts directories instead of files.</td>
+   <td><em>A boolean value:</em><strong> Returns</strong> the {{htmlattrxref("webkitdirectory", "input")}} attribute; if true, the file system picker interface only accepts directories instead of files.</td>
   </tr>
   <tr>
    <td>{{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} {{Non-standard_inline}}</td>
@@ -242,7 +242,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>multiple</code></td>
-   <td><em>{{jsxref("Boolean")}}:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("multiple", "input") }} attribute, indicating whether more than one value is possible (e.g., multiple files).</td>
+   <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("multiple", "input") }} attribute, indicating whether more than one value is possible (e.g., multiple files).</td>
   </tr>
   <tr>
    <td><code>files</code></td>
@@ -322,7 +322,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>checkValidity()</code></td>
-   <td>Returns a {{jsxref("Boolean")}} that is <code>false</code> if the element is a candidate for constraint validation, and it does not satisfy its constraints. In this case, it also fires an {{event("invalid")}} event at the element. It returns <code>true</code> if the element is not a candidate for constraint validation, or if it satisfies its constraints.</td>
+   <td>Returns a boolean value that is <code>false</code> if the element is a candidate for constraint validation, and it does not satisfy its constraints. In this case, it also fires an {{event("invalid")}} event at the element. It returns <code>true</code> if the element is not a candidate for constraint validation, or if it satisfies its constraints.</td>
   </tr>
   <tr>
    <td><code>reportValidity()</code></td>

--- a/files/en-us/web/api/inputevent/iscomposing/index.html
+++ b/files/en-us/web/api/inputevent/iscomposing/index.html
@@ -12,7 +12,7 @@ browser-compat: api.InputEvent.isComposing
 <div>{{APIRef("DOM Events")}}</div>
 
 <p>The <code><strong>InputEvent.isComposing</strong></code> read-only property returns a
-  {{jsxref("Boolean")}} value indicating if the event is fired after
+  boolean value indicating if the event is fired after
   {{event("compositionstart")}} and before {{event("compositionend")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/keyboardevent/altkey/index.html
+++ b/files/en-us/web/api/keyboardevent/altkey/index.html
@@ -13,7 +13,7 @@ browser-compat: api.KeyboardEvent.altKey
 <div>{{APIRef("DOM Events")}}</div>
 
 <p>The <strong><code>KeyboardEvent.altKey</code></strong> read-only property is a
-  {{jsxref("Boolean")}} that indicates if the <kbd>alt</kbd> key (<kbd>Option</kbd> or
+  boolean value that indicates if the <kbd>alt</kbd> key (<kbd>Option</kbd> or
   <kbd>⌥</kbd> on OS X) was pressed (<code>true</code>) or not (<code>false</code>) when
   the event occurred.</p>
 
@@ -24,7 +24,7 @@ browser-compat: api.KeyboardEvent.altKey
 
 <h3 id="Return_value">Return value</h3>
 
-<p>{{jsxref("Boolean")}}</p>
+<p>A boolean value</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.html
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.html
@@ -44,24 +44,24 @@ tags:
   <dt><em><code>type</code></em></dt>
   <dd>Is a {{domxref("DOMString")}} representing the type of event.</dd>
   <dt><em><code>bubbles</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} indicating whether the event should bubble up through the
+  <dd>Is a boolean value indicating whether the event should bubble up through the
     event chain or not (see <a href="/en-US/docs/Web/API/Event/bubbles">bubbles</a>).</dd>
   <dt><em><code>cancelable</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} i indicating whether the event can be canceled (see <a
+  <dd>Is a boolean value indicating whether the event can be canceled (see <a
       href="/en-US/docs/Web/API/Event/cancelable">cancelable</a>).</dd>
   <dt><em><code>viewArg</code></em></dt>
   <dd>Specifies the {{domxref("UIEvent.view")}}; this value may be <code>null</code>.</dd>
   <dt><em><code>ctrlKeyArg</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} that is <code>true</code> if the virtual key to be
+  <dd>Is a boolean value that is <code>true</code> if the virtual key to be
     generated is a combination of keys containing the <kbd>Ctrl</kbd> key.</dd>
   <dt><em><code>altKeyArg</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} that is <code>true</code> if the virtual key to be
+  <dd>Is a boolean value that is <code>true</code> if the virtual key to be
     generated is a combination of keys containing the <kbd>Alt</kbd> key.</dd>
   <dt><em><code>shiftKeyArg</code></em></dt>
-  <dd>A {{jsxref("Boolean")}} that is <code>true</code> if the virtual key to be generated
+  <dd>A boolean value that is <code>true</code> if the virtual key to be generated
     is a combination of keys containing the <kbd>Shift</kbd> key.</dd>
   <dt><em><code>metaKeyArg</code></em></dt>
-  <dd>Is a {{jsxref("Boolean")}} that is <code>true</code> if the virtual key to be
+  <dd>Is a boolean value that is <code>true</code> if the virtual key to be
     generated is a combination of keys containing the <kbd>Meta</kbd> key.</dd>
   <dt><em><code>keyCodeArg</code></em></dt>
   <dd>Is a <code>unsigned long</code> representing the virtual key code value of the key

--- a/files/en-us/web/api/keyboardevent/iscomposing/index.html
+++ b/files/en-us/web/api/keyboardevent/iscomposing/index.html
@@ -13,7 +13,7 @@ browser-compat: api.KeyboardEvent.isComposing
 <p>{{APIRef("DOM Events")}}</p>
 
 <p>The <code><strong>KeyboardEvent.isComposing</strong></code> read-only property returns
-  a boolean value value indicating if the event is fired within a composition
+  a boolean value indicating if the event is fired within a composition
   session, i.e. after {{domxref("Element/compositionstart_event", "compositionstart")}}
   and before {{domxref("Element/compositionend_event", "compositionend")}}.</p>
 

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.html
@@ -28,42 +28,54 @@ browser-compat: api.KeyboardEvent.KeyboardEvent
 	<dd>Is a <code>KeyboardEventInit</code> dictionary, having the following fields:
 
 		<ul>
-			<li><code>"key"</code>, optional and defaulting to <code>""</code>, of type
-				{{domxref("DOMString")}}, that sets the value of
-				{{domxref("KeyboardEvent.key")}}.</li>
-			<li><code>"code"</code>, optional and defaulting to <code>""</code>, of type
-				{{domxref("DOMString")}}, that sets the value of
-				{{domxref("KeyboardEvent.code")}}.</li>
-			<li><code>"location"</code>, optional and defaulting to <code>0</code>, of
-				type <code>unsigned long</code>, that sets the value of
-				{{domxref("KeyboardEvent.location")}}.</li>
-			<li><code>"ctrlKey"</code>, optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.ctrlKey")}}.</li>
-			<li><code>"shiftKey"</code>, optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.shiftKey")}}.</li>
-			<li><code>"altKey"</code>, optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.altKey")}}.</li>
-			<li><code>"metaKey"</code>, optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.metaKey")}}.</li>
-			<li><code>"repeat"</code>, optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.repeat")}}.</li>
-			<li><code>"isComposing"</code>, optional and defaulting to <code>false</code>,
-				of type {{jsxref("Boolean")}}, that sets the value of
-				{{domxref("KeyboardEvent.isComposing")}}.</li>
-			<li><code>"charCode"</code>, optional and defaulting to <code>0</code>, of
-				type <code>unsigned long</code>, that sets the value of the deprecated
-				{{domxref("KeyboardEvent.charCode")}}.</li>
-			<li><code>"keyCode"</code>, optional and defaulting to <code>0</code>, of type
-				<code>unsigned long</code>, that sets the value of the deprecated
-				{{domxref("KeyboardEvent.keyCode")}}.</li>
-			<li><code>"which"</code>, optional and defaulting to <code>0</code>, of type
-				<code>unsigned long</code>, that sets the value of the deprecated
-				{{domxref("KeyboardEvent.which")}}.</li>
+			<li>
+        <code>"key"</code>, optional {{domxref("DOMString")}}, defaulting to <code>""</code>,
+        that sets the value of {{domxref("KeyboardEvent.key")}}.
+      </li>
+			<li>
+        <code>"code"</code>, optional {{domxref("DOMString")}}, defaulting to <code>""</code>,
+        that sets the value of {{domxref("KeyboardEvent.code")}}.
+      </li>
+			<li>
+        <code>"location"</code>, optional <code>unsigned long</code>, defaulting to <code>0</code>,
+        that sets the value of {{domxref("KeyboardEvent.location")}}.
+      </li>
+			<li>
+        <code>"ctrlKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.ctrlKey")}}.
+      </li>
+			<li>
+        <code>"shiftKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.shiftKey")}}.
+      </li>
+			<li>
+        <code>"altKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.altKey")}}.
+      </li>
+			<li>
+        <code>"metaKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.metaKey")}}.<
+          /li>
+			<li>
+        <code>"repeat"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.repeat")}}.
+      </li>
+			<li>
+        <code>"isComposing"</code>, optional boolean value, defaulting to <code>false</code>,
+        that sets the value of {{domxref("KeyboardEvent.isComposing")}}.
+      </li>
+			<li>
+        <code>"charCode"</code>, optional <code>unsigned long</code>, defaulting to <code>0</code>,
+        that sets the value of the deprecated {{domxref("KeyboardEvent.charCode")}}.
+      </li>
+			<li>
+        <code>"keyCode"</code>, optional <code>unsigned long</code>, defaulting to <code>0</code>,
+        that sets the value of the deprecated {{domxref("KeyboardEvent.keyCode")}}.
+      </li>
+			<li>
+        <code>"which"</code>, optional <code>unsigned long</code>, defaulting to <code>0</code>,
+        that sets the value of the deprecated {{domxref("KeyboardEvent.which")}}.
+      </li>
 		</ul>
 
 		<div class="note">

--- a/files/en-us/web/api/keyboardevent/repeat/index.html
+++ b/files/en-us/web/api/keyboardevent/repeat/index.html
@@ -13,7 +13,7 @@ browser-compat: api.KeyboardEvent.repeat
 <div>{{APIRef("DOM Events")}}</div>
 
 <p>The <code><strong>repeat</strong></code> read-only property of the
-  {{domxref("KeyboardEvent")}} interface returns a {{jsxref("Boolean")}} that is
+  {{domxref("KeyboardEvent")}} interface returns a boolean value that is
   <code>true</code> if the given key is being held down such that it is automatically
   repeating.</p>
 
@@ -24,7 +24,7 @@ browser-compat: api.KeyboardEvent.repeat
 
 <h3 id="Return_value">Return value</h3>
 
-<p>{{jsxref("Boolean")}}</p>
+<p>A boolean value</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediasource/istypesupported/index.html
+++ b/files/en-us/web/api/mediasource/istypesupported/index.html
@@ -20,7 +20,7 @@ browser-compat: api.MediaSource.isTypeSupported
 
 <p><span class="seoSummary">The
     <code><strong>MediaSource.isTypeSupported()</strong></code> static method returns a
-    {{jsxref("Boolean")}} value which is <code>true</code> if the given MIME type is
+    boolean value which is <code>true</code> if the given MIME type is
     <em>likely</em> to be supported by the current {{Glossary("user agent")}}.</span> That
   is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME
   type. If the returned value is <code>false</code>, then the user agent is certain that
@@ -42,7 +42,7 @@ browser-compat: api.MediaSource.isTypeSupported
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Boolean")}} which is <code>true</code> if the browser feels that it can
+<p>A boolean value which is <code>true</code> if the browser feels that it can
   <em>probably</em> play media of the specified type. This is <em>not</em> a guarantee,
   however, and your code must be prepared for the possibility that the media will not play
   correctly if at all. A value of <code>false</code> is a guarantee that media of the

--- a/files/en-us/web/api/mediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/audio/index.html
@@ -39,8 +39,8 @@ browser-compat: api.MediaStreamConstraints.audio
 </p>
 
 <dl>
-  <dt>{{jsxref("Boolean")}}</dt>
-  <dd>If a Boolean value is specified, it indicates whether or not an audio track should
+  <dt>A boolean value</dt>
+  <dd>If specified, it indicates whether or not an audio track should
     be included in the returned stream; if it's <code>true</code>, an audio track is
     included; if no audio source is available or if permission is not given to use the
     audio source, the call to <code>getUserMedia()</code> will fail. If
@@ -69,7 +69,7 @@ browser-compat: api.MediaStreamConstraints.audio
 
   <pre class="brush: html">&lt;p&gt;Click the start button below to begin the demonstration.&lt;/p&gt;
 &lt;div id="startButton" class="button"&gt;
-  Start
+  Start
 &lt;/div&gt;
 &lt;audio id="audio" autoplay controls&gt;&lt;/audio&gt;&lt;br&gt;
 &lt;div id="log"&gt;&lt;/div&gt;</pre>
@@ -135,7 +135,7 @@ function log(msg) {
 
   <pre class="brush: html">&lt;p&gt;Click the start button below to begin the demonstration.&lt;/p&gt;
 &lt;div id="startButton" class="button"&gt;
-  Start
+  Start
 &lt;/div&gt;
 &lt;audio id="audio" autoplay controls&gt;&lt;/audio&gt;&lt;br&gt;
 &lt;div id="log"&gt;&lt;/div&gt;</pre>
@@ -179,8 +179,8 @@ function log(msg) {
   navigator.mediaDevices.getUserMedia({
     audio: {
       sampleSize: 8,
-      echoCancellation: true
-    }
+      echoCancellation: true
+    }
   }).then(stream =&gt; audioElement.srcObject = stream)
     .catch(err =&gt; log(err.name + ": " + err.message));
 }, false);</pre>

--- a/files/en-us/web/api/mediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/video/index.html
@@ -38,8 +38,8 @@ browser-compat: api.MediaStreamConstraints.video
 </p>
 
 <dl>
-  <dt>{{jsxref("Boolean")}}</dt>
-  <dd>If a Boolean value is specified, it indicates whether or not a video track should be
+  <dt>A boolean value</dt>
+  <dd>If specified, it indicates whether or not a video track should be
     included in the returned stream; if it's <code>true</code>, a video track is included;
     if no video source is available or if permission is not given to use the video source,
     the call to <code>getUserMedia()</code> will fail. If <code>false</code>, no video
@@ -63,7 +63,7 @@ browser-compat: api.MediaStreamConstraints.video
 
   <pre class="brush: html">&lt;p&gt;Click the start button below to begin the demonstration.&lt;/p&gt;
 &lt;div id="startButton" class="button"&gt;
-  Start
+  Start
 &lt;/div&gt;
 &lt;video id="video" width="160" height="120" autoplay&gt;&lt;/video&gt;&lt;br&gt;
 &lt;div id="log"&gt;&lt;/div&gt;</pre>
@@ -128,7 +128,7 @@ function log(msg) {
 
   <pre class="brush: html">&lt;p&gt;Click the start button below to begin the demonstration.&lt;/p&gt;
 &lt;div id="startButton" class="button"&gt;
-  Start
+  Start
 &lt;/div&gt;
 &lt;video id="video" width="160" height="120" autoplay&gt;&lt;/video&gt;&lt;br&gt;
 &lt;div id="log"&gt;&lt;/div&gt;</pre>

--- a/files/en-us/web/api/mouseevent/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.html
@@ -29,35 +29,47 @@ browser-compat: api.MouseEvent.MouseEvent
   <dd>Is a <code>MouseEventInit</code> dictionary, having the following fields:
 
     <ul>
-      <li><code>"screenX"</code>, optional and defaulting to <code>0</code>, of type
-        <code>long</code>, that is the horizontal position of the mouse event on the
-        user's screen; setting this value doesn't move the mouse pointer.</li>
-      <li><code>"screenY"</code>, optional and defaulting to <code>0</code>, of type
-        <code>long</code>, that is the vertical position of the mouse event on the user's
-        screen; setting this value doesn't move the mouse pointer.</li>
-      <li><code>"clientX"</code>, optional and defaulting to <code>0</code>, of type
-        <code>long</code>, that is the horizontal position of the mouse event on the
-        client window of user's screen; setting this value doesn't move the mouse pointer.
+      <li>
+        <code>"screenX"</code>, optional <code>long</code>, defaulting to <code>0</code>,
+        that is the horizontal position of the mouse event on the user's screen;
+        setting this value doesn't move the mouse pointer.
       </li>
-      <li><code>"clientY"</code>, optional and defaulting to <code>0</code>, of type
-        <code>long</code>, that is the vertical position of the mouse event on the client
-        window of the user's screen; setting this value doesn't move the mouse pointer.
+      <li>
+        <code>"screenY"</code>, optional <code>long</code>, defaulting to <code>0</code>,
+        that is the vertical position of the mouse event on the user's screen;
+        setting this value doesn't move the mouse pointer.
       </li>
-      <li><code>"ctrlKey"</code>, optional and defaulting to <code>false</code>, of type
-        {{jsxref("Boolean")}}, that indicates if the <kbd>ctrl</kbd> key was
-        simultaneously pressed.</li>
-      <li><code>"shiftKey"</code>, optional and defaulting to <code>false</code>, of type
-        {{jsxref("Boolean")}}, that indicates if the <kbd>shift</kbd> key was
-        simultaneously pressed.</li>
-      <li><code>"altKey"</code>, optional and defaulting to <code>false</code>, of type
-        {{jsxref("Boolean")}}, that indicates if the <kbd>alt</kbd> key was simultaneously
-        pressed.</li>
-      <li><code>"metaKey"</code>, optional and defaulting to <code>false</code>, of type
-        {{jsxref("Boolean")}}, that indicates if the <kbd>meta</kbd> key was
-        simultaneously pressed.</li>
-      <li><code>"button"</code>, optional and defaulting to <code>0</code>, of type
-        <code>short</code>, that describes which button is pressed during events related
-        to the press or release of a button:
+      <li>
+        <code>"clientX"</code>, optional <code>long</code>, defaulting to <code>0</code>,
+        that is the horizontal position of the mouse event on the client window of user's screen;
+        setting this value doesn't move the mouse pointer.
+      </li>
+      <li>
+        <code>"clientY"</code>, optional <code>long</code>, defaulting to <code>0</code>,
+        that is the vertical position of the mouse event
+        on the client window of the user's screen;
+        setting this value doesn't move the mouse pointer.
+      </li>
+      <li>
+        <code>"ctrlKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that indicates if the <kbd>ctrl</kbd> key was simultaneously pressed.
+      </li>
+      <li>
+        <code>"shiftKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that indicates if the <kbd>shift</kbd> key was simultaneously pressed.
+      </li>
+      <li>
+        <code>"altKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that indicates if the <kbd>alt</kbd> key was simultaneously pressed.
+      </li>
+      <li>
+        <code>"metaKey"</code>, optional boolean value, defaulting to <code>false</code>,
+        that indicates if the <kbd>meta</kbd> key was simultaneously pressed.
+      </li>
+      <li>
+        <code>"button"</code>, optional <code>short</code>, defaulting to <code>0</code>,
+        that describes which button is pressed
+        during events related to the press or release of a button:
         <table class="standard-table">
           <thead>
             <tr>
@@ -81,9 +93,10 @@ browser-compat: api.MouseEvent.MouseEvent
           </tbody>
         </table>
       </li>
-      <li><code>"buttons"</code>, optional and defaulting to <code>0</code>, of type
-        <code>unsigned short</code>, that describes which buttons are pressed when the
-        event is launched:
+      <li>
+        <code>"buttons"</code>, optional <code>unsigned short</code>, defaulting to <code>0</code>,
+        that describes which buttons are pressed
+        when the event is launched:
         <table class="standard-table">
           <thead>
             <tr>
@@ -111,14 +124,17 @@ browser-compat: api.MouseEvent.MouseEvent
           </tbody>
         </table>
       </li>
-      <li><code>"relatedTarget"</code>, optional and defaulting to <code>null</code>, of
-        type {{domxref("EventTarget")}}, that is the element just left (in case of  a
-        {{event("mouseenter")}} or {{event("mouseover")}}) or is entering (in case of a
-        {{event("mouseout")}} or {{event("mouseleave")}}).</li>
-      <li><code>"region"</code>, optional and defaulting to <code>null</code>, of type
-        {{domxref("DOMString")}}, is the id of the hit region affected by the event. The
-        absence of any hit region is affected, is represented by the <code>null</code>
-        value.</li>
+      <li>
+        <code>"relatedTarget"</code>, optional {{domxref("EventTarget")}}, defaulting to <code>null</code>
+        that is the element just left
+        (in case of a {{event("mouseenter")}} or {{event("mouseover")}})
+        or is entering (in case of a {{event("mouseout")}} or {{event("mouseleave")}}).
+      </li>
+      <li>
+        <code>"region"</code>, optional {{domxref("DOMString")}}, defaulting to <code>null</code>,
+        that is the ID of the hit region affected by the event.
+        The absence of any affected hit region is represented with the <code>null</code> value.
+      </li>
     </ul>
 
     <p>In some implementations, passing anything other than a number for the screen and

--- a/files/en-us/web/api/node/index.html
+++ b/files/en-us/web/api/node/index.html
@@ -191,7 +191,7 @@ browser-compat: api.Node
   <dd>Returns a boolean value which indicates whether or not two nodes are of the
     same type and all their defining data points match.</dd>
   <dt>{{DOMxRef("Node.isSameNode()")}}</dt>
-  <dd>Returns a boolean value value indicating whether or not the two nodes are
+  <dd>Returns a boolean value indicating whether or not the two nodes are
     the same (that is, they reference the same object).</dd>
   <dt>{{DOMxRef("Node.lookupPrefix()")}}</dt>
   <dd>Returns a {{DOMxRef("DOMString")}} containing the prefix for a given namespace URI,

--- a/files/en-us/web/api/node/isdefaultnamespace/index.html
+++ b/files/en-us/web/api/node/isdefaultnamespace/index.html
@@ -13,8 +13,8 @@ browser-compat: api.Node.isDefaultNamespace
 <div>{{APIRef("DOM")}}</div>
 
 <p>The <strong><code>Node.isDefaultNamespace()</code></strong> method accepts a namespace
-  URI as an argument and returns a {{jsxref("Boolean")}} with a value of <code>true</code>
-  if the namespace is the default namespace on the given node or <code>false</code> if
+  URI as an argument and returns a boolean value that is <code>true</code>
+  if the namespace is the default namespace on the given node and <code>false</code> if
   not.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -29,7 +29,7 @@ browser-compat: api.Node.isDefaultNamespace
 
 <h3 id="Return_value">Return value</h3>
 
-<p><code>result</code> is a {{jsxref("Boolean")}} that holds the return value
+<p><code>result</code> is a boolean value that holds the return value
   <code>true</code> or <code>false</code>.</p>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/performanceobserver/observe/index.html
+++ b/files/en-us/web/api/performanceobserver/observe/index.html
@@ -36,13 +36,13 @@ browser-compat: api.PerformanceObserver.observe
     members:
     <ul>
       <li><code>entryTypes</code>: An array of {{domxref("DOMString")}} objects, each
-        specifying one performance entry type to observe.  May not be used together with
+        specifying one performance entry type to observe. May not be used together with
         the "<code>type</code>" or "<code>buffered</code>" options.</li>
-      <li><code>type</code>: A single {{domxref("DOMString")}} specifying exactly one
-        performance entry type to observe.  May not be used together with the
+      <li><code>type</code>: A single {{domxref("DOMString")}} specifying exactly one
+        performance entry type to observe. May not be used together with the
         <code>entryTypes</code> option.</li>
-      <li><code>buffered</code>: A {{jsxref("Boolean")}} flag to indicate whether buffered
-        entries should be queued into the observer's buffer.  Must be used only with the
+      <li><code>buffered</code>: A boolean flag to indicate whether buffered
+        entries should be queued into the observer's buffer. Must be used only with the
         "<code>type</code>" option.</li>
     </ul>
 

--- a/files/en-us/web/api/pointerevent/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.html
@@ -29,36 +29,46 @@ browser-compat: api.PointerEvent.PointerEvent
 	<dd>Is a <code>PointerEventInit</code> dictionary, having the following fields:
 
 		<ul>
-			<li><code>pointerId</code> — optional and defaulting to <code>0</code>, of
-				type <code>long</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.pointerId")}}.</li>
-			<li><code>width</code> — optional and defaulting to <code>1</code>, of type
-				<code>double</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.width")}}.</li>
-			<li><code>height</code> — optional and defaulting to <code>1</code>, of type
-				<code>double</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.height")}}.</li>
-			<li><code>pressure</code> — optional and defaulting to <code>0</code>, of type
-				<code>float</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.pressure")}}.</li>
-			<li><code>tangentialPressure</code> — optional and defaulting to
-				<code>0</code>, of type <code>float</code>, that sets the value of the
-				instance's {{domxref("PointerEvent.tangentialPressure")}}.</li>
-			<li><code>tiltX</code> — optional and defaulting to <code>0</code>, of type
-				<code>long</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.tiltX")}}.</li>
-			<li><code>tiltY</code> — optional and defaulting to <code>0</code>, of type
-				<code>long</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.tiltY")}}.</li>
-			<li><code>twist</code> — optional and defaulting to <code>0</code>, of type
-				<code>long</code>, that sets the value of the instance's
-				{{domxref("PointerEvent.twist")}}.</li>
-			<li><code>pointerType</code> — optional and defaulting to <code>""</code>, of
-				type {{domxref("DOMString")}}, that sets the value of the instance's
-				{{domxref("PointerEvent.pointerType")}}.</li>
-			<li><code>isPrimary</code> — optional and defaulting to <code>false</code>, of
-				type {{jsxref("Boolean")}}, that sets the value of the instance's
-				{{domxref("PointerEvent.isPrimary")}}.</li>
+      <li>
+        <code>pointerId</code> — optional <code>long</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.pointerId")}}.
+      </li>
+      <li>
+        <code>width</code> — optional <code>double</code>, defaulting to <code>1</code>,
+        sets the value of the instance'sc{{domxref("PointerEvent.width")}}.
+      </li>
+      <li>
+        <code>height</code> — optional <code>double</code>, defaulting to <code>1</code>,
+        sets the value of the instance's {{domxref("PointerEvent.height")}}.
+      </li>
+      <li>
+        <code>pressure</code> — optional <code>float</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.pressure")}}.
+      </li>
+      <li>
+        <code>tangentialPressure</code> — optional <code>float</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.tangentialPressure")}}.
+      </li>
+      <li>
+        <code>tiltX</code> — optional <code>long</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.tiltX")}}.
+      </li>
+      <li>
+        <code>tiltY</code> — optional <code>long</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.tiltY")}}.
+      </li>
+      <li>
+        <code>twist</code> — optional <code>long</code>, defaulting to <code>0</code>,
+        sets the value of the instance's {{domxref("PointerEvent.twist")}}.
+      </li>
+      <li>
+        <code>pointerType</code> — optional {{domxref("DOMString")}}, defaulting to <code>""</code>
+        sets the value of the instance's {{domxref("PointerEvent.pointerType")}}.
+      </li>
+      <li>
+        <code>isPrimary</code> — optional boolean value, defaulting to <code>false</code>
+        sets the value of the instance's {{domxref("PointerEvent.isPrimary")}}.
+      </li>
 		</ul>
 
 		<div class="note">

--- a/files/en-us/web/api/range/collapse/index.html
+++ b/files/en-us/web/api/range/collapse/index.html
@@ -26,7 +26,7 @@ browser-compat: api.Range.collapse
 
 <dl>
   <dt><code>toStart</code> {{optional_inline}}</dt>
-  <dd>A boolean value value: <code>true</code> collapses the {{domxref("Range")}}
+  <dd>A boolean value: <code>true</code> collapses the {{domxref("Range")}}
     to its start, <code>false</code> to its end. If omitted, it defaults to
     <code>false</code> {{experimental_inline}}.</dd>
 </dl>

--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -27,7 +27,7 @@ browser-compat: api.RTCDataChannel.ordered
 <pre class="brush: js">var <em>ordered</em> = <em>aDataChannel</em>.ordered;
 </pre>
 
-<p>A {{jsxref("Boolean")}} value which is <code>true</code> if in-order delivery is
+<p>A boolean value which is <code>true</code> if in-order delivery is
   guaranteed and is otherwise <code>false</code>.</p>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/staticrange/collapsed/index.html
+++ b/files/en-us/web/api/staticrange/collapsed/index.html
@@ -27,7 +27,7 @@ browser-compat: api.StaticRange.collapsed
 
 <h3 id="Value">Value</h3>
 
-<p>A {{jsxref("Boolean")}} value which is <code>true</code> if the range
+<p>A boolean value which is <code>true</code> if the range
   is <strong>collapsed</strong>. A collapsed range is one in which the start and end
   positions are the same, resulting in a zero-character-long range..</p>
 

--- a/files/en-us/web/api/subtlecrypto/index.html
+++ b/files/en-us/web/api/subtlecrypto/index.html
@@ -42,7 +42,7 @@ browser-compat: api.SubtleCrypto
  <dt>{{domxref("SubtleCrypto.sign()")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that fulfills with the signature corresponding to the text, algorithm, and key given as parameters.</dd>
  <dt>{{domxref("SubtleCrypto.verify()")}}</dt>
- <dd>Returns a {{jsxref("Promise")}} that fulfills with a {{jsxref("Boolean")}} value indicating if the signature given as a parameter matches the text, algorithm, and key that are also given as parameters.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that fulfills with a boolean value indicating if the signature given as a parameter matches the text, algorithm, and key that are also given as parameters.</dd>
  <dt>{{domxref("SubtleCrypto.digest()")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that fulfills with a digest generated from the algorithm and text given as parameters.</dd>
  <dt>{{domxref("SubtleCrypto.generateKey()")}}</dt>

--- a/files/en-us/web/api/subtlecrypto/verify/index.html
+++ b/files/en-us/web/api/subtlecrypto/verify/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SubtleCrypto.verify
 
 <p>It takes as its arguments a {{glossary("key")}} to verify the signature with, some
   algorithm-specific parameters, the signature, and the original signed data. It returns a
-  {{jsxref("Promise")}} which will be fulfilled with a {{jsxref("Boolean")}} value
+  {{jsxref("Promise")}} which will be fulfilled with a boolean value
   indicating whether the signature is valid.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -60,7 +60,7 @@ browser-compat: api.SubtleCrypto.verify
 
 <ul>
   <li><code><em>result</em></code> is a {{jsxref("Promise")}} that fulfills with a
-    {{jsxref("Boolean")}}: <code>true</code> if the signature is valid, <code>false</code>
+    boolean value: <code>true</code> if the signature is valid, <code>false</code>
     otherwise.</li>
 </ul>
 

--- a/files/en-us/web/api/svgevent/index.html
+++ b/files/en-us/web/api/svgevent/index.html
@@ -35,12 +35,12 @@ tags:
   </tr>
   <tr>
    <td><code>bubbles</code> {{readonlyInline}}</td>
-   <td>{{jsxref("Boolean")}}</td>
+   <td>A boolean value</td>
    <td>Whether the event normally bubbles or not.</td>
   </tr>
   <tr>
    <td><code>cancelable</code> {{readonlyInline}}</td>
-   <td>{{jsxref("Boolean")}}</td>
+   <td>A boolean value</td>
    <td>Whether the event is cancellable or not.</td>
   </tr>
  </tbody>

--- a/files/en-us/web/api/touchevent/altkey/index.html
+++ b/files/en-us/web/api/touchevent/altkey/index.html
@@ -14,7 +14,7 @@ browser-compat: api.TouchEvent.altKey
 
 <h2 id="Summary">Summary</h2>
 
-<p>A {{jsxref("Boolean")}} value indicating whether or not the <kbd>alt</kbd> (Alternate) key is enabled when the touch event is created. If the <kbd>alt</kbd> key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
+<p>A boolean value indicating whether or not the <kbd>alt</kbd> (Alternate) key is enabled when the touch event is created. If the <kbd>alt</kbd> key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
 
 <p>This property is {{readonlyInline}}.</p>
 

--- a/files/en-us/web/api/touchevent/ctrlkey/index.html
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.html
@@ -14,7 +14,7 @@ browser-compat: api.TouchEvent.ctrlKey
 
 <h2 id="Summary">Summary</h2>
 
-<p>A {{jsxref("Boolean")}} value indicating whether the <kbd>control</kbd> (Control) key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
+<p>A boolean value indicating whether the <kbd>control</kbd> (Control) key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
 
 <p>This property is {{readonlyInline}}.</p>
 

--- a/files/en-us/web/api/touchevent/metakey/index.html
+++ b/files/en-us/web/api/touchevent/metakey/index.html
@@ -14,7 +14,7 @@ browser-compat: api.TouchEvent.metaKey
 
 <h2 id="Summary">Summary</h2>
 
-<p>A {{jsxref("Boolean")}} value indicating whether or not the <kbd>Meta</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
+<p>A boolean value indicating whether or not the <kbd>Meta</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
 
 <p>This property is {{readonlyInline}}.</p>
 

--- a/files/en-us/web/api/touchevent/shiftkey/index.html
+++ b/files/en-us/web/api/touchevent/shiftkey/index.html
@@ -14,7 +14,7 @@ browser-compat: api.TouchEvent.shiftKey
 
 <h2 id="Summary">Summary</h2>
 
-<p>A {{jsxref("Boolean")}} value indicating whether or not the <kbd>shift</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
+<p>A boolean value indicating whether or not the <kbd>shift</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is <code>true</code>. Otherwise, it is <code>false</code>.</p>
 
 <p>This property is {{readonlyInline}}.</p>
 

--- a/files/en-us/web/api/touchevent/touchevent/index.html
+++ b/files/en-us/web/api/touchevent/touchevent/index.html
@@ -27,13 +27,13 @@ browser-compat: api.TouchEvent.TouchEvent
 	<dd>Is a Touch<code>EventInit</code> dictionary, having the following fields:
 
 	<ul>
-		<li><code>"touches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact currently touching the surface.</li>
-		<li><code>"targetTouches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact that is touching the surface <em>and</em> started on the element that is the target of the current event.</li>
-		<li><code>"changedTouches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact which contributed to the event.</li>
-		<li><code>"ctrlKey"</code>, optional and defaulting to <code>false</code>, of type {{jsxref("Boolean")}}, that indicates if the <kbd>ctrl</kbd> key was simultaneously pressed.</li>
-		<li><code>"shiftKey"</code>, optional and defaulting to <code>false</code>, of type {{jsxref("Boolean")}}, that indicates if the <kbd>shift</kbd> key was simultaneously pressed.</li>
-		<li><code>"altKey"</code>, optional and defaulting to <code>false</code>, of type {{jsxref("Boolean")}}, that indicates if the <kbd>alt</kbd> key was simultaneously pressed.</li>
-		<li><code>"metaKey"</code>, optional and defaulting to <code>false</code>, of type {{jsxref("Boolean")}}, that indicates if the <kbd>meta</kbd> key was simultaneously pressed.</li>
+		<li><code>"touches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact currently touching the surface.</li>
+		<li><code>"targetTouches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact that is touching the surface <em>and</em> started on the element that is the target of the current event.</li>
+		<li><code>"changedTouches"</code>, optional and defaulting to <code>[]</code>, of type <code>Touch[]</code>, that is a list of objects for every point of contact which contributed to the event.</li>
+		<li><code>"ctrlKey"</code>, optional and defaulting to <code>false</code>, a boolean value that indicates if the <kbd>ctrl</kbd> key was simultaneously pressed.</li>
+		<li><code>"shiftKey"</code>, optional and defaulting to <code>false</code>, a boolean value that indicates if the <kbd>shift</kbd> key was simultaneously pressed.</li>
+		<li><code>"altKey"</code>, optional and defaulting to <code>false</code>, a boolean value that indicates if the <kbd>alt</kbd> key was simultaneously pressed.</li>
+		<li><code>"metaKey"</code>, optional and defaulting to <code>false</code>, a boolean value that indicates if the <kbd>meta</kbd> key was simultaneously pressed.</li>
 	</ul>
 
 	<p><em>The Touch<code>EventInit</code> dictionary also accepts fields from {{domxref("UIEvent.UIEvent", "UIEventInit")}} and from {{domxref("Event.Event", "EventInit")}} dictionaries.</em></p>

--- a/files/en-us/web/api/wakelocksentinel/released/index.html
+++ b/files/en-us/web/api/wakelocksentinel/released/index.html
@@ -21,7 +21,7 @@ browser-compat: api.WakeLockSentinel.released
 
 <h3 id="Value">Value</h3>
 
-<p>A {{jsxref("Boolean")}}. Its value is <code>false</code> until the
+<p>A boolean value, that is <code>false</code> until the
 	{{domxref("WakeLockSentinel")}} has been released (either through a call to
 	{{domxref("WakeLockSentinel.release()")}} or because the lock has been released
 	automatically) and the {{domxref("WakeLockSentinel.onrelease")}} event has been

--- a/files/en-us/web/api/window/find/index.html
+++ b/files/en-us/web/api/window/find/index.html
@@ -31,16 +31,16 @@ browser-compat: api.Window.find
   <dt><code>aString</code></dt>
   <dd>The text string for which to search.</dd>
   <dt><code>aCaseSensitive</code></dt>
-  <dd>{{jsxref("Boolean")}}. If <code>true</code>, specifies a case-sensitive search.</dd>
+  <dd>A boolean value. If <code>true</code>, specifies a case-sensitive search.</dd>
   <dt><code>aBackwards</code></dt>
-  <dd>{{jsxref("Boolean")}}. If <code>true</code>, specifies a backward search.</dd>
+  <dd>A boolean value. If <code>true</code>, specifies a backward search.</dd>
   <dt><code>aWrapAround</code></dt>
-  <dd>{{jsxref("Boolean")}}. If <code>true</code>, specifies a wrap around search.</dd>
+  <dd>A boolean value. If <code>true</code>, specifies a wrap around search.</dd>
   <dt><code>aWholeWord</code> {{Unimplemented_Inline}}</dt>
-  <dd>{{jsxref("Boolean")}}. If <code>true</code>, specifies a whole word search. This is
+  <dd>A boolean value. If <code>true</code>, specifies a whole word search. This is
     not implemented; see {{bug(481513)}}.</dd>
   <dt><code>aSearchInFrames</code></dt>
-  <dd>{{jsxref("Boolean")}}. If <code>true</code>, specifies a search in frames.</dd>
+  <dd>A boolean value. If <code>true</code>, specifies a search in frames.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>


### PR DESCRIPTION
Most `{{jsxref("Boolean")}}` are wrong in `Web/API`: no Boolean objects are returned, only a boolean value.

This fixes all cases that weren't simple find and replace operations.

The replacement of erroneous mentions of Boolean objects in `Web/API` is done after this PR.