### PR TITLE
Remove mention of custom text in beforeunload event

### DIFF
--- a/files/en-us/web/api/window/beforeunload_event/index.html
+++ b/files/en-us/web/api/window/beforeunload_event/index.html
@@ -43,8 +43,6 @@ browser-compat: api.Window.beforeunload_event
  <li>returning a string from the event handler.</li>
 </ul>
 
-<p>Some browsers used to display the returned string in the confirmation dialog, enabling the event handler to display a custom message to the user. However, this is deprecated and no longer supported in most browsers.</p>
-
 <p>To combat unwanted pop-ups, browsers may not display prompts created in <code>beforeunload</code> event handlers unless the page has been interacted with, or may even not display them at all.</p>
 
 <p>The HTML specification states that calls to {{domxref("window.alert()")}}, {{domxref("window.confirm()")}}, and {{domxref("window.prompt()")}} methods may be ignored during this event. See the <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#user-prompts">HTML specification</a> for more details.</p>


### PR DESCRIPTION
This PR removes the paragraph stating that browsers may allow for custom text in the `beforeunload` event of the Window API, to go along with the removal of the related data in BCD (see https://github.com/mdn/browser-compat-data/pull/11753).  This functionality has been dropped from all browsers over two years ago.