### PR TITLE
Fix flaws + missing end tags

### DIFF
--- a/files/en-us/web/api/mediatrackconstraints/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/index.html
@@ -60,9 +60,9 @@ browser-compat: api.MediaTrackConstraints
 
 <dl>
   <dt><code>exact</code></dt>
-  <dd>A {{domxref("DOMString")}}, or an array of <code>DOMString<code>s, one of which must be the value of the property. If the property can't be set to one of the listed values, matching will fail.</dd>
+  <dd>A {{domxref("DOMString")}}, or an array of <code>DOMString</code>s, one of which must be the value of the property. If the property can't be set to one of the listed values, matching will fail.</dd>
   <dt><code>ideal</code></dt>
-  <dd>A {{domxref("DOMString")}}, or an array of <code>DOMString<code>s, specifying ideal values for the property. If possible, one of the listed values will be used, but if it's not possible, the user agent will use the closest possible match.</dd>
+  <dd>A {{domxref("DOMString")}}, or an array of <code>DOMString</code>s, specifying ideal values for the property. If possible, one of the listed values will be used, but if it's not possible, the user agent will use the closest possible match.</dd>
 </dl>
 
 <h3 id="ConstrainULong">ConstrainULong</h3>
@@ -88,30 +88,30 @@ browser-compat: api.MediaTrackConstraints
 
 <dl>
  <dt>{{domxref("MediaTrackConstraints.deviceId", "deviceId")}}</dt>
- <dd>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> object specifying a device ID or an array of device IDs which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> object specifying a device ID or an array of device IDs which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.groupId", "groupId")}}</dt>
- <dd>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> object specifying a group ID or an array of group IDs which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> object specifying a group ID or an array of group IDs which are acceptable and/or required.</dd>
 </dl>
 
 <h3 id="Properties_of_audio_tracks">Properties of audio tracks</h3>
 
 <dl>
  <dt>{{domxref("MediaTrackConstraints.autoGainControl", "autoGainControl")}}</dt>
- <dd>A <a href="#ConstrainBoolean"><code>ConstrainBoolean</code></a> object which specifies whether automatic gain control is preferred and/or required.</dd>
+ <dd>A <a href="#constrainboolean"><code>ConstrainBoolean</code></a> object which specifies whether automatic gain control is preferred and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.channelCount", "channelCount")}}</dt>
- <dd>A <a href="#ConstrainULong"><code>ConstrainULong</code></a> specifying the channel count or range of channel counts which are acceptable and/or required.</dd>
+ <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the channel count or range of channel counts which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.echoCancellation", "echoCancellation")}}</dt>
- <dd>A <a href="#ConstrainBoolean"><code>ConstrainBoolean</code></a> object specifying whether or not echo cancellation is preferred and/or required.</dd>
+ <dd>A <a href="#constrainboolean"><code>ConstrainBoolean</code></a> object specifying whether or not echo cancellation is preferred and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.latency", "latency")}}</dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> specifying the latency or range of latencies which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> specifying the latency or range of latencies which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.noiseSuppression", "noiseSuppression")}}</dt>
- <dd>A <a href="#ConstrainBoolean"><code>ConstrainBoolean</code></a> which specifies whether noise suppression is preferred and/or required.</dd>
+ <dd>A <a href="#constrainboolean"><code>ConstrainBoolean</code></a> which specifies whether noise suppression is preferred and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.sampleRate", "sampleRate")}}</dt>
- <dd>A <a href="#ConstrainULong"><code>ConstrainULong</code></a> specifying the sample rate or range of sample rates which are acceptable and/or required.</dd>
+ <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the sample rate or range of sample rates which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.sampleSize", "sampleSize")}}</dt>
- <dd>A <a href="#ConstrainULong"><code>ConstrainULong</code></a> specifying the sample size or range of sample sizes which are acceptable and/or required.</dd>
+ <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the sample size or range of sample sizes which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.volume", "volume")}}</dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> specifying the volume or range of volumes which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> specifying the volume or range of volumes which are acceptable and/or required.</dd>
 </dl>
 
 <h3 id="Properties_of_image_tracks">Properties of image tracks</h3>
@@ -126,23 +126,23 @@ browser-compat: api.MediaTrackConstraints
  <dt><span id="pointsofinterest">pointsOfInterest</span></dt>
  <dd>The pixel coordinates on the sensor of one or more points of interest. This is either an object in the form { x:<em>value</em>, y:<em>value</em> } or an array of such objects, where <em>value</em> is a double-precision integer.</dd>
  <dt><span id="exposurecompensation">exposureCompensation</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying f-stop adjustment by up to ±3. </dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying f-stop adjustment by up to ±3. </dd>
  <dt><span id="colortemperature">colorTemperature</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired color temperature in degrees kelvin.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired color temperature in degrees kelvin.</dd>
  <dt><span id="iso">iso</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired iso setting.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired iso setting.</dd>
  <dt><span id="brightness">brightness</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired brightness setting.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired brightness setting.</dd>
  <dt><span id="contrast">contrast</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of difference between light and dark.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of difference between light and dark.</dd>
  <dt><span id="saturation">saturation</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of color intensity.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of color intensity.</dd>
  <dt><span id="sharpness">sharpness</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the intensity of edges.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the intensity of edges.</dd>
  <dt><span id="focusdistance">focusDistance</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying distance to a focused object.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying distance to a focused object.</dd>
  <dt><span id="zoom">zoom</span></dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the desired focal length.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the desired focal length.</dd>
  <dt><span id="torch">torch</span></dt>
  <dd>A boolean value defining whether the fill light is continuously connected, meaning it stays on as long as the track is active.</dd>
 </dl>
@@ -151,17 +151,17 @@ browser-compat: api.MediaTrackConstraints
 
 <dl>
  <dt>{{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}}</dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> specifying the video aspect ratio or range of aspect ratios which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> specifying the video aspect ratio or range of aspect ratios which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.facingMode", "facingMode")}}</dt>
- <dd>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> object specifying a facing or an array of facings which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> object specifying a facing or an array of facings which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.frameRate", "frameRate")}}</dt>
- <dd>A <a href="#ConstrainDouble"><code>ConstrainDouble</code></a> specifying the frame rate or range of frame rates which are acceptable and/or required.</dd>
+ <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> specifying the frame rate or range of frame rates which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.height", "height")}}</dt>
- <dd>A <a href="#ConstrainULong"><code>ConstrainULong</code></a> specifying the video height or range of heights which are acceptable and/or required.</dd>
+ <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the video height or range of heights which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.width", "width")}}</dt>
- <dd>A <a href="#ConstrainULong"><code>ConstrainULong</code></a> specifying the video width or range of widths which are acceptable and/or required.</dd>
+ <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the video width or range of widths which are acceptable and/or required.</dd>
  <dt><span id="resizemode">resizeMode</span></dt>
- <dd>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> object specifying a mode or an array of modes the UA can use to derive the resolution of a video track. Allowed values are <code>none</code> and <code>crop-and-scale</code>. <code>none</code> means that the user agent uses the resolution provided by the camera, its driver or the OS. <code>crop-and-scale</code> means that the user agent can use cropping and downscaling on the camera output  in order to satisfy other constraints that affect the resolution.</dd>
+ <dd>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> object specifying a mode or an array of modes the UA can use to derive the resolution of a video track. Allowed values are <code>none</code> and <code>crop-and-scale</code>. <code>none</code> means that the user agent uses the resolution provided by the camera, its driver or the OS. <code>crop-and-scale</code> means that the user agent can use cropping and downscaling on the camera output  in order to satisfy other constraints that affect the resolution.</dd>
 </dl>
 
 <h3 id="Properties_of_shared_screen_tracks">Properties of shared screen tracks</h3>
@@ -171,7 +171,7 @@ browser-compat: api.MediaTrackConstraints
 <dl>
  <dt>{{domxref("MediaTrackConstraints.cursor", "cursor")}}</dt>
  <dd>
- <p>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> which specifies whether or not to include the mouse cursor in the generated track, and if so, whether or not to hide it while not moving. The value may be a single one of the following strings, or an array of them to allow the browser flexibility in deciding what to do about the cursor.</p>
+ <p>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> which specifies whether or not to include the mouse cursor in the generated track, and if so, whether or not to hide it while not moving. The value may be a single one of the following strings, or an array of them to allow the browser flexibility in deciding what to do about the cursor.</p>
 
  <dl>
   <dt><code>always</code></dt>
@@ -184,7 +184,7 @@ browser-compat: api.MediaTrackConstraints
  </dd>
  <dt>{{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}}</dt>
  <dd>
- <p>A <a href="#ConstrainDOMString"><code>ConstrainDOMString</code></a> which specifies the types of display surface that may be selected by the user. This may be a single one of the following strings, or a list of them to allow multiple source surfaces:</p>
+ <p>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> which specifies the types of display surface that may be selected by the user. This may be a single one of the following strings, or a list of them to allow multiple source surfaces:</p>
 
  <dl>
   <dt><code>application</code></dt>
@@ -198,7 +198,7 @@ browser-compat: api.MediaTrackConstraints
  </dl>
  </dd>
  <dt>{{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}}</dt>
- <dd>A <a href="#ConstrainBoolean"><code>ConstrainBoolean</code></a> value which may contain a single Boolean value or a set of them, indicating whether or not to allow the user to choose source surfaces which do not directly correspond to display areas. These may include backing buffers for windows to allow capture of window contents that are hidden by other windows in front of them, or buffers containing larger documents that need to be scrolled through to see the entire contents in their windows.</dd>
+ <dd>A <a href="#constrainboolean"><code>ConstrainBoolean</code></a> value which may contain a single Boolean value or a set of them, indicating whether or not to allow the user to choose source surfaces which do not directly correspond to display areas. These may include backing buffers for windows to allow capture of window contents that are hidden by other windows in front of them, or buffers containing larger documents that need to be scrolled through to see the entire contents in their windows.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Fix flaws:
- uncapitalization of fragments
- two closing  `<code>` were missing, breaking sectioning and making yari panic and display headers in the wrong order.