### PR TITLE
 Slice Method returns a Deep copy for non nested Objects

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Array.slice
 ---
 {{JSRef}}
 
-The **`slice()`** method returns a shallow copy of a portion of
+The **`slice()`** method returns a Deep copy of a portion of
 an array into a new array object selected from `start` to `end`
 (`end` not included) where `start` and `end` represent
 the index of items in that array. The original array will not be modified.
@@ -65,13 +65,13 @@ A new array containing the extracted elements.
 
 ## Description
 
-`slice` does not alter the original array. It returns a shallow copy of
+`slice` does not alter the original array. It returns a Deep copy of
 elements from the original array. Elements of the original array are copied into the
 returned array as follows:
 
 - For object `slice` copies object references into the new array. Both the
-  original and new array refer to the same object. If an object changes, the changes are
-  visible to both the new and original arrays.
+  original and new array refer to objects with different memory Address. If an object changes, the changes are
+  not visible to the other Object.
 - For strings, numbers and booleans (not {{jsxref("String")}}, {{jsxref("Number")}}
   and {{jsxref("Boolean")}} objects), `slice` copies the values into the new
   array. Changes to the string, number, or boolean in one array do not affect the other


### PR DESCRIPTION
There is an correction in line 14, 68 and 73 as Slice method returns a Deep Copy until and unless there are not any nested object in the Object which we are slicing, It will return a new object which will point to a different memory location in heap and hence any changes in the copied new object will not affect the older object from which it is copied.


You can Check my contribution by running this code on terminal

arr1 = [1, 2, 'John', 'Peterson', 7]
arr2 = arr1.slice(1)
arr2[2] = 'Raddison'
console.log(arr1)
console.log(arr2)

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)



> Issue number (if there is an associated issue)



> Anything else that could help us review it
