### PR TITLE
Hardcode spec tables for 3 overview pages (Feedback welcome!)

### DIFF
--- a/files/en-us/web/api/background_fetch_api/index.html
+++ b/files/en-us/web/api/background_fetch_api/index.html
@@ -65,7 +65,18 @@ returns a promise that resolves with a {{domxref("BackgroundFetchRegistration")}
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications("api.BackgroundFetchManager")}}
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://wicg.github.io/background-fetch/">Background Fetch</a></td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -156,7 +156,18 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications("api.BarcodeDetector")}}
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://wicg.github.io/shape-detection-api/#barcode-detection-api">Accelerated Shape Detection in Images<br/><small># barcode-detection-api</small></a></td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -129,31 +129,28 @@ tags:
       <td><a href="https://drafts.csswg.org/cssom-view/">CSSOM View Module</a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-fonts-3/#object-model">CSS Fonts Module Level 3<br/><small># object-model</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-fonts/#object-model">CSS Fonts Module<br/><small># object-model</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-animations-1/#interface-dom">CSS Animations Level 1<br/><small># interface-dom</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-animations/#interface-dom">CSS Animations<br/><small># interface-dom</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-fonts-3/#object-model">CSS Fonts Module Level 3<br/><small># object-model</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-conditional/#apis">CSS Conditional Rules Module<br/><small># apis</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-conditional-3/#apis">CSS Conditional Rules Module Level 3<br/><small># apis</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-variables/#apis">CSS Custom Properties for Cascading Variables Module<br/><small># apis</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-variables/#apis">CSS Custom Properties for Cascading Variables Module Level 1<br/><small># apis</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-counter-styles/#apis">CSS Counter Styles<br/><small># apis</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-counter-styles-3/#apis">CSS Counter Styles Level 3<br/><small># apis</small></a></td>
+      <td><a href="https://drafts.csswg.org/css-device-adapt/#cssom">CSS Device Adaptation Module<br/><small># cssom</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.csswg.org/css-device-adapt/#cssom">CSS Device Adaptation Module Level 1<br/><small># cssom</small></a></td>
+      <td><a href="https://drafts.css-houdini.org/css-paint-api/#paint-worklet">CSS Painting API<br/><small># paint-worklet</small></a></td>
     </tr>
     <tr>
-      <td><a href="https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet">CSS Painting API Level 1<br/><small># paint-worklet</small></a></td>
-    </tr>
-    <tr>
-      <td><a href="https://drafts.css-houdini.org/css-typed-om-1/">CSS Typed OM Level 1</a></td>
+      <td><a href="https://drafts.css-houdini.org/css-typed-om/">CSS Typed OM</a></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -116,78 +116,46 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Typed OM")}}</td>
-   <td>{{Spec2("CSS Typed OM")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Painting API")}}</td>
-   <td>{{Spec2("CSS Painting API")}}</td>
-   <td>Extended the {{DOMxRef("CSS")}} interface with the {{DOMxRef("CSS.paintWorklet","paintWorklet")}} static property.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM View")}}</td>
-   <td>{{Spec2("CSSOM View")}}</td>
-   <td>Defined the {{DOMxRef("Screen")}} and {{DOMxRef("MediaQueryList")}} interfaces and the {{DOMxRef("MediaQueryListEvent")}} event and {{DOMxRef("MediaQueryList")}} event listener.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSSOM")}}</td>
-   <td>{{Spec2("CSSOM")}}</td>
-   <td>Extended the {{DOMxRef("CSS")}} interface and provides the base for the modern CSSOM specification.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Screen Orientation")}}</td>
-   <td>{{Spec2("Screen Orientation")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Fonts")}}</td>
-   <td>{{Spec2("CSS3 Fonts")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Animations")}}</td>
-   <td>{{Spec2("CSS3 Animations")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Transitions")}}</td>
-   <td>{{Spec2("CSS3 Transitions")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Variables")}}</td>
-   <td>{{Spec2("CSS3 Variables")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Conditional")}}</td>
-   <td>{{Spec2("CSS3 Conditional")}}</td>
-   <td>Defined the {{DOMxRef("CSS")}} interface.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Device")}}</td>
-   <td>{{Spec2("CSS3 Device")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Counter Styles")}}</td>
-   <td>{{Spec2("CSS3 Counter Styles")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 Style")}}</td>
-   <td>{{Spec2("DOM2 Style")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://drafts.csswg.org/cssom/">CSS Object Model (CSSOM)</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/cssom-view/">CSSOM View Module</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-fonts-3/#object-model">CSS Fonts Module Level 3<br/><small># object-model</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-animations-1/#interface-dom">CSS Animations Level 1<br/><small># interface-dom</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-fonts-3/#object-model">CSS Fonts Module Level 3<br/><small># object-model</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-conditional-3/#apis">CSS Conditional Rules Module Level 3<br/><small># apis</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-variables/#apis">CSS Custom Properties for Cascading Variables Module Level 1<br/><small># apis</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-counter-styles-3/#apis">CSS Counter Styles Level 3<br/><small># apis</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.csswg.org/css-device-adapt/#cssom">CSS Device Adaptation Module Level 1<br/><small># cssom</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet">CSS Painting API Level 1<br/><small># paint-worklet</small></a></td>
+    </tr>
+    <tr>
+      <td><a href="https://drafts.css-houdini.org/css-typed-om-1/">CSS Typed OM Level 1</a></td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>


### PR DESCRIPTION

Background: We are replacing old specification tables with `{{Specification}}` macros, but this don't work out of the box for Overview pages that doesn't have, most of the time, an adequate entry in mdn/browser-compat-data.

@elchi3 has started experimented with a look and fill for these tables in #7338.

This PR contains an alternative way of displaying these specifications (on Overview pages). I did three examples.

### Background Fetch API
This is a case where the overview page covers an API that has its own specification. This is very common. Previously we were doing a deeplink to one object of that spec, which is not optimal.

Before:
<img width="1049" alt="Screenshot 2021-07-28 at 10 17 19" src="https://user-images.githubusercontent.com/1466293/127321624-9adc7546-78cc-4214-95a1-c7f1865aeb60.png">

In this PR:
<img width="1073" alt="Screenshot 2021-07-28 at 10 17 39" src="https://user-images.githubusercontent.com/1466293/127321650-dc596e9c-d5bc-4b78-9781-b79e6e7f4b29.png">

### Barcode Detection API
In this case, the overview page covers a significant section of a specification, but far from all of it. This is less common, but the _Canvas API_ is another example.

Note that the link we had before (coming out of mdn/browser-compat-data) was already good, but this is not always the case, often it is too deep in the hierarchy.

Before:
<img width="1109" alt="Screenshot 2021-07-28 at 10 22 10" src="https://user-images.githubusercontent.com/1466293/127322198-c2260458-effb-4fae-bdd6-2e946f1b9882.png">

In this PR:
<img width="1049" alt="Screenshot 2021-07-28 at 10 18 52" src="https://user-images.githubusercontent.com/1466293/127322181-1682343e-a7dd-4b44-b186-6b2c7ab3b3ef.png">

### CSSOM
This is a case where the API is spread over several specificatiions. 

**Note:** I've cleaned the original list that had obsolete documents, as well as unrelated specifications (some that didn't expand the CSS Object Model.

Before:
<img width="966" alt="Screenshot 2021-07-28 at 10 28 13" src="https://user-images.githubusercontent.com/1466293/127323408-89f2f030-0e8c-49c6-92c0-9e7c00ee433b.png">

In this PR:
<img width="1000" alt="Screenshot 2021-07-28 at 14 00 51" src="https://user-images.githubusercontent.com/1466293/127323441-5f4ea52f-d65b-44c9-9a7e-65e5f4fe78f4.png">

Notice that some links lead to a whole document, while some links lead only to a section of a specification.

### Evaluation
Positive points:
- Same look than generated specification tables
- Get rid of the outdated `SpecName` and `Spec2` macros
- Apply same rule as mdn/browser-compat-table: obsolete specs are no more listed

Negative point:
- No extra information like links to the issue trackers, or the github version of the specs.

Negative points (linke dot the fact that they are still hardcoded):
- Keeping them updated is still a manual process, not tight to w3c/browser-spec or mdn/browser-compat-data
- If the look of spec table change, we have to update these.

I do think that once we have more experience with spec on overview page, and maybe more experience on how and what to store in a data format for API overview page, we could in the future maybe design a macro, but this can be separate from the discussion here.