### PR TITLE
docs: correct the class name of a code block

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.html
@@ -127,7 +127,7 @@ myAudio.buffered.end(1);   // returns 19</pre>
 
 <p>So let's build this. The HTML for our player looks like this:</p>
 
-<pre class="brush: css">&lt;audio id="my-audio" preload controls&gt;
+<pre class="brush: html">&lt;audio id="my-audio" preload controls&gt;
   &lt;source src="music.mp3" type="audio/mpeg"&gt;
 &lt;/audio&gt;
 &lt;div class="buffered"&gt;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

An HTML code block on the [Media buffering, seeking, and time ranges article](https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/buffering_seeking_time_ranges#creating_our_own_buffering_feedback) is given the `css` class, which makes the syntax highlighting not correctly apply.

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Screenshots

| Before | After |
| --- | --- |
| <img width="1030" alt="Screen Shot 2021-07-28 at 20 51 49" src="https://user-images.githubusercontent.com/25715018/127335304-703b12b1-eb87-4d9c-a880-b9d37d6a2110.png"> | <img width="1031" alt="Screen Shot 2021-07-28 at 20 51 42" src="https://user-images.githubusercontent.com/25715018/127335417-550f9231-25b2-4e0b-89de-0e845d8df90a.png"> |
