### PR TITLE
Replace offensive words in CORS documentation

### DIFF
--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -395,7 +395,7 @@ Vary: Origin</pre>
 
 <h3 id="Access-Control-Expose-Headers">Access-Control-Expose-Headers</h3>
 
-<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header lets a server allowlist headers that Javascript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers are allowed to access.</p>
+<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header adds the specified headers to the allowlist that Javascript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers is allowed to access.</p>
 
 <pre class="brush: none">Access-Control-Expose-Headers: &lt;header-name&gt;[, &lt;header-name&gt;]*
 </pre>

--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -391,11 +391,11 @@ Content-Type: text/plain
 <pre class="brush: none">Access-Control-Allow-Origin: https://mozilla.org
 Vary: Origin</pre>
 
-<p>If the server specifies a single origin (that may dynamically change based on the requesting origin as part of a white-list) rather than the "<code>*</code>" wildcard, then the server should also include <code>Origin</code> in the {{HTTPHeader("Vary")}} response header — to indicate to clients that server responses will differ based on the value of the {{HTTPHeader("Origin")}} request header.</p>
+<p>If the server specifies a single origin (that may dynamically change based on the requesting origin as part of a allow-list) rather than the "<code>*</code>" wildcard, then the server should also include <code>Origin</code> in the {{HTTPHeader("Vary")}} response header — to indicate to clients that server responses will differ based on the value of the {{HTTPHeader("Origin")}} request header.</p>
 
 <h3 id="Access-Control-Expose-Headers">Access-Control-Expose-Headers</h3>
 
-<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header lets a server whitelist headers that Javascript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers are allowed to access.</p>
+<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header lets a server allowlist headers that Javascript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers are allowed to access.</p>
 
 <pre class="brush: none">Access-Control-Expose-Headers: &lt;header-name&gt;[, &lt;header-name&gt;]*
 </pre>

--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -395,7 +395,7 @@ Vary: Origin</pre>
 
 <h3 id="Access-Control-Expose-Headers">Access-Control-Expose-Headers</h3>
 
-<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header adds the specified headers to the allowlist that Javascript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers is allowed to access.</p>
+<p>The {{HTTPHeader("Access-Control-Expose-Headers")}} header adds the specified headers to the allowlist that JavaScript (such as {{domxref("XMLHttpRequest.getResponseHeader()","getResponseHeader()")}}) in browsers is allowed to access.</p>
 
 <pre class="brush: none">Access-Control-Expose-Headers: &lt;header-name&gt;[, &lt;header-name&gt;]*
 </pre>

--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -391,7 +391,7 @@ Content-Type: text/plain
 <pre class="brush: none">Access-Control-Allow-Origin: https://mozilla.org
 Vary: Origin</pre>
 
-<p>If the server specifies a single origin (that may dynamically change based on the requesting origin as part of a allow-list) rather than the "<code>*</code>" wildcard, then the server should also include <code>Origin</code> in the {{HTTPHeader("Vary")}} response header — to indicate to clients that server responses will differ based on the value of the {{HTTPHeader("Origin")}} request header.</p>
+<p>If the server specifies a single origin (that may dynamically change based on the requesting origin as part of a allowlist) rather than the "<code>*</code>" wildcard, then the server should also include <code>Origin</code> in the {{HTTPHeader("Vary")}} response header — to indicate to clients that server responses will differ based on the value of the {{HTTPHeader("Origin")}} request header.</p>
 
 <h3 id="Access-Control-Expose-Headers">Access-Control-Expose-Headers</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

*whitelist* and *blacklist* are offensive words.
The one occurrence of *blacklist* was not replaced because it's the title of an external resource.