### PR TITLE
Change 'semantic' to 'semantics' on JavaScript main page in docs

### DIFF
--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -16,7 +16,7 @@ This section is dedicated to the JavaScript language itself, and not the parts t
 
 The standards for JavaScript are the [ECMAScript Language Specification](https://tc39.es/ecma262/) (ECMA-262) and the [ECMAScript Internationalization API specification](https://tc39.es/ecma402/) (ECMA-402). The JavaScript documentation throughout MDN is based on the latest draft versions of ECMA-262 and ECMA-402. And in cases where some [proposals for new ECMAScript features](https://github.com/tc39/proposals) have already been implemented in browsers, documentation and examples in MDN articles may use some of those new features.
 
-Do not confuse JavaScript with the [Java programming language](<https://en.wikipedia.org/wiki/Java_(programming_language)>). Both "Java" and "JavaScript" are trademarks or registered trademarks of Oracle in the U.S. and other countries. However, the two programming languages have very different syntax, semantic, and use.
+Do not confuse JavaScript with the [Java programming language](<https://en.wikipedia.org/wiki/Java_(programming_language)>). Both "Java" and "JavaScript" are trademarks or registered trademarks of Oracle in the U.S. and other countries. However, the two programming languages have very different syntax, semantics, and use.
 
 > **Callout:** **Looking to become a front-end web developer?**
 >


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Fixes #7400 

Although semantic is defined as: "relating to meaning in language or logic". Typically when discussing the language/linguistics of something in programming, I've read & heard "semantics".


> Issue number (if there is an associated issue)
[#7400](https://github.com/mdn/content/issues/7400#issue-955220955) in `mdn/yari` 
