### PR TITLE
Make CSS dl elements Markdown-convertible

### DIFF
--- a/files/en-us/web/css/@page/size/index.html
+++ b/files/en-us/web/css/@page/size/index.html
@@ -55,6 +55,7 @@ size: A4 portrait;
  <dd>Any length value (see {{cssxref("&lt;length&gt;")}}). The first value corresponds to the width of the page box and the second one corresponds to its height. If only one value is provided, it is used for both width and height.</dd>
  <dt><code>&lt;page-size&gt;</code></dt>
  <dd>
+   <p>A keyword which may be any of the following values:</p>
  <dl>
   <dt>A5</dt>
   <dd>This matches the standard, ISO dimensions: 148mm x 210mm.</dd>

--- a/files/en-us/web/css/basic-shape/index.html
+++ b/files/en-us/web/css/basic-shape/index.html
@@ -32,9 +32,8 @@ browser-compat: css.types.basic-shape
 <dl>
  <dt><code>{{cssxref("basic-shape/inset()","inset()")}}</code></dt>
  <dd>
- <pre class="brush: css">inset( &lt;shape-arg&gt;{1,4} [round &lt;border-radius&gt;]? )</pre>
-
  <p>Defines an inset rectangle.</p>
+ <pre class="brush: css">inset( &lt;shape-arg&gt;{1,4} [round &lt;border-radius&gt;]? )</pre>
 
  <p>When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.</p>
 
@@ -44,6 +43,7 @@ browser-compat: css.types.basic-shape
  </dd>
  <dt><code>{{cssxref("basic-shape/circle()","circle()")}}</code></dt>
  <dd>
+ <p>Defines a circle using a radius and a position.</p>
  <pre class="brush: css">circle( [&lt;shape-radius&gt;]? [at &lt;position&gt;]? )</pre>
 
  <p>The <code>&lt;shape-radius&gt;</code> argument represents <em>r</em>, the radius of the circle. Negative values are invalid. A percentage value here is resolved from the used width and height of the reference box as <code>sqrt(width^2+height^2)/sqrt(2)</code>.</p>
@@ -52,6 +52,7 @@ browser-compat: css.types.basic-shape
  </dd>
  <dt><code>{{cssxref("basic-shape/ellipse()","ellipse()")}}</code></dt>
  <dd>
+ <p>Defines an ellipse using two radii and a position.</p>
  <pre class="brush: css">ellipse( [&lt;shape-radius&gt;{2}]? [at &lt;position&gt;]? )</pre>
 
  <p>The <code>&lt;shape-radius&gt;</code> arguments represent r<sub>x</sub> and r<sub>y</sub>, the x-axis and y-axis radii of the ellipse, in that order. Negative values for either radius are invalid. Percentage values here are resolved against the used width (for the r<sub>x</sub> value) and the used height (for the r<sub>y</sub> value) of the reference box.</p>
@@ -60,17 +61,19 @@ browser-compat: css.types.basic-shape
  </dd>
  <dt><code>{{cssxref("basic-shape/polygon()","polygon()")}}</code></dt>
  <dd>
+ <p>Defines a polygon using an SVG {{SVGAttr("fill-rule")}} and a set of vertices.</p>
  <pre class="brush: css">polygon( [&lt;fill-rule&gt;,]? [&lt;shape-arg&gt; &lt;shape-arg&gt;]# )</pre>
 
- <p><code>&lt;fill-rule&gt;</code> represents the <a href="/en-US/docs/Web/SVG/Attribute/fill-rule">filling rule</a> used to determine the interior of the polygon. Possible values are <code>nonzero</code> and <code>evenodd</code>. Default value when omitted is <code>nonzero</code>.</p>
+ <p><code>&lt;fill-rule&gt;</code> represents the {{SVGAttr("fill-rule")}} used to determine the interior of the polygon. Possible values are <code>nonzero</code> and <code>evenodd</code>. Default value when omitted is <code>nonzero</code>.</p>
 
  <p>Each pair argument in the list represents <em>x<sub>i</sub></em> and <em>y<sub>i</sub></em> - the x and y axis coordinates of the i<sup>th</sup> vertex of the polygon.</p>
  </dd>
  <dt><code>path()</code></dt>
  <dd>
+ <p>Defines a shape using an SVG {{SVGAttr("fill-rule")}} and an SVG <a href="/en-US/docs/Web/SVG/Attribute/d">path definition</a>.</p>
  <pre class="brush: css">path( [&lt;fill-rule&gt;,]? &lt;string&gt;)</pre>
 
- <p>The optional <code>&lt;fill-rule&gt;</code> represents the <a href="/en-US/docs/Web/SVG/Attribute/fill-rule">filling rule</a> used to determine the interior of the path. Possible values are <code>nonzero</code> and <code>evenodd</code>. Default value when omitted is <code>nonzero</code>.</p>
+ <p>The optional <code>&lt;fill-rule&gt;</code> represents the {{SVGAttr("fill-rule")}} used to determine the interior of the path. Possible values are <code>nonzero</code> and <code>evenodd</code>. Default value when omitted is <code>nonzero</code>.</p>
 
  <p>The required &lt;string&gt; is an <a href="/en-US/docs/Web/SVG/Attribute/d">SVG Path</a> string encompassed in quotes</p>
  </dd>

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -1146,11 +1146,13 @@ browser-compat: css.types.color
  <dd>
  <p>Text color for highlighted items in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlight</code> background color. Prior to Gecko 1.9, use <code>-moz-CellHighlightText</code>.</p>
  </dd>
- <dt>-moz-mac-accentdarkestshadow, -moz-mac-accentdarkshadow, -moz-mac-accentface, -moz-mac-accentlightesthighlight, -moz-mac-accentlightshadow, -moz-mac-accentregularhighlight, -moz-mac-accentregularshadow, -moz-mac-chrome-active</dt>
+ <dt>-moz-mac-accentdarkestshadow, -moz-mac-accentdarkshadow, -moz-mac-accentface, -moz-mac-accentlightesthighlight, -moz-mac-accentlightshadow, -moz-mac-accentregularhighlight, -moz-mac-accentregularshadow</dt>
  <dd>
+ <p>Accent colors.</p>
  </dd>
- <dt>-moz-mac-chrome-inactive</dt>
+ <dt>-moz-mac-chrome-active, -moz-mac-chrome-inactive</dt>
  <dd>
+ <p>Colors for inactive and active browser chrome.</p>
  </dd>
  <dt>-moz-mac-focusring, -moz-mac-menuselect, -moz-mac-menushadow, -moz-mac-menutextselect, -moz-MenuHover</dt>
  <dd>

--- a/files/en-us/web/css/css_fonts/index.html
+++ b/files/en-us/web/css/css_fonts/index.html
@@ -72,25 +72,10 @@ tags:
 
 <h3 id="At-rules">At-rules</h3>
 
-<dl>
- <dt>{{cssxref("@font-face")}}</dt>
- <dd>
- <div class="index">
- <ul>
-  <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
-  <li>{{cssxref("@font-face/font-feature-settings", "font-feature-settings")}}</li>
-  <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
-  <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
-  <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
-  <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
-  <li>{{cssxref("@font-face/src", "src")}}</li>
-  <li>{{cssxref("@font-face/unicode-range", "unicode-range")}}</li>
- </ul>
- </div>
- </dd>
- <dt>{{cssxref("@font-feature-values")}}</dt>
- <dd></dd>
-</dl>
+<ul>
+ <li>{{cssxref("@font-face")}}</li>
+ <li>{{cssxref("@font-feature-values")}}</li>
+</ul>
 
 <h2 id="Guides">Guides</h2>
 

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -100,43 +100,41 @@ list-style-type: unset;
  <dt><code>armenian</code></dt>
  <dd>Traditional Armenian numbering.</dd>
  <dt><code>bengali</code>, <code>-moz-bengali</code></dt>
- <dd></dd>
- <dt><code>cambodian</code> {{experimental_inline}}*</dt>
- <dd></dd>
+ <dd>Bengali numbering.</dd>
+ <dt><code>cambodian</code>/<code>khmer</code></dt>
+ <dd>Cambodian/Khmer numbering.</dd>
  <dt><code>cjk-earthly-branch</code>, <code>-moz-cjk-earthly-branch</code></dt>
- <dd></dd>
+ <dd>Han "Earthly Branch" ordinals.</dd>
  <dt><code>cjk-heavenly-stem</code>, <code>-moz-cjk-heavenly-stem</code></dt>
- <dd></dd>
+ <dd>Han "Heavenly Stem" ordinals.</dd>
  <dt><code>cjk-ideographic</code>{{experimental_inline}}</dt>
  <dd>Identical to <code>trad-chinese-informal</code>.</dd>
  <dt><code>devanagari</code>, <code>-moz-devanagari</code></dt>
- <dd></dd>
+ <dd>Devanagari numbering.</dd>
  <dt><code>ethiopic-numeric</code> {{experimental_inline}}</dt>
- <dd></dd>
+ <dd>Ethiopic numbering.</dd>
  <dt><code>georgian</code></dt>
  <dd>Traditional Georgian numbering.</dd>
  <dt><code>gujarati</code>, <code>-moz-gujarati</code></dt>
- <dd></dd>
+ <dd>Gujarati numbering.</dd>
  <dt><code>gurmukhi</code>, <code>-moz-gurmukhi</code></dt>
- <dd></dd>
+ <dd>Gurmukhi numbering.</dd>
  <dt><code>hebrew</code> {{experimental_inline}}</dt>
  <dd>Traditional Hebrew numbering</dd>
  <dt><code>hiragana</code> {{experimental_inline}}</dt>
- <dd></dd>
+ <dd>Dictionary-order hiragana lettering.</dd>
  <dt><code>hiragana-iroha</code> {{experimental_inline}}</dt>
- <dd>{{interwiki('wikipedia', 'Iroha')}} is the old japanese ordering of syllabs.</dd>
+ <dd>{{interwiki('wikipedia', 'Iroha', 'Iroha-order')}} hiragana lettering</dd>
  <dt><code>japanese-formal</code> {{experimental_inline}}</dt>
  <dd>Japanese formal numbering to be used in legal or financial documents. The kanjis are designed so that they can't be modified to look like another correct one.</dd>
  <dt><code>japanese-informal</code> {{experimental_inline}}</dt>
  <dd>Japanese informal numbering.</dd>
  <dt><code>kannada</code>, <code>-moz-kannada</code></dt>
- <dd></dd>
+ <dd>Kannada numbering.</dd>
  <dt><code>katakana</code> {{experimental_inline}}</dt>
- <dd></dd>
+ <dd>Dictionary-order katakana lettering</dd>
  <dt><code>katakana-iroha</code> {{experimental_inline}}</dt>
- <dd></dd>
- <dt><code>khmer</code>, <code>-moz-khmer</code></dt>
- <dd></dd>
+ <dd>{{interwiki('wikipedia', 'Iroha', 'Iroha-order')}} katakana lettering</dd>
  <dt><code>korean-hangul-formal</code> {{experimental_inline}}</dt>
  <dd>Korean hangul numbering.</dd>
  <dt><code>korean-hanja-formal</code> {{experimental_inline}}</dt>
@@ -144,37 +142,37 @@ list-style-type: unset;
  <dt><code>korean-hanja-informal</code> {{experimental_inline}}</dt>
  <dd>Korean hanja numbering.</dd>
  <dt><code>lao</code>, <code>-moz-lao</code></dt>
- <dd></dd>
+ <dd>Laotian numbering.</dd>
  <dt><code>lower-armenian</code> {{experimental_inline}}*</dt>
- <dd></dd>
+ <dd>Lowercase Armenian numbering.</dd>
  <dt><code>malayalam</code>, <code>-moz-malayalam</code></dt>
- <dd></dd>
+ <dd>Malayalam numbering.</dd>
  <dt><code>mongolian</code> {{experimental_inline}}</dt>
- <dd></dd>
+ <dd>Mongolian numbering.</dd>
  <dt><code>myanmar</code>, <code>-moz-myanmar</code></dt>
- <dd></dd>
+ <dd>Myanmar (Burmese) numbering.</dd>
  <dt><code>oriya</code>, <code>-moz-oriya</code></dt>
- <dd></dd>
+ <dd>Oriya numbering.</dd>
  <dt><code>persian</code> {{experimental_inline}}, <code>-moz-persian</code></dt>
- <dd></dd>
+ <dd>Persian numbering</dd>
  <dt><code>simp-chinese-formal</code> {{experimental_inline}}</dt>
  <dd>Simplified Chinese formal numbering.</dd>
  <dt><code>simp-chinese-informal</code> {{experimental_inline}}</dt>
  <dd>Simplified Chinese informal numbering.</dd>
  <dt><code>tamil</code> {{experimental_inline}}, <code>-moz-tamil</code></dt>
- <dd></dd>
+ <dd>Tamil numbering.</dd>
  <dt><code>telugu</code>, <code>-moz-telugu</code></dt>
- <dd></dd>
+ <dd>Telugu numbering.</dd>
  <dt><code>thai</code>, <code>-moz-thai</code></dt>
- <dd></dd>
+ <dd>Thai numbering.</dd>
  <dt><code>tibetan</code> {{experimental_inline}}*</dt>
- <dd></dd>
+ <dd>Tibetan numbering.</dd>
  <dt><code>trad-chinese-formal</code> {{experimental_inline}}</dt>
  <dd>Traditional Chinese formal numbering.</dd>
  <dt><code>trad-chinese-informal</code> {{experimental_inline}}</dt>
  <dd>Traditional Chinese informal numbering.</dd>
  <dt><code>upper-armenian</code> {{experimental_inline}}*</dt>
- <dd></dd>
+ <dd>Traditional uppercase Armenian numbering.</dd>
  <dt><code>disclosure-open</code> {{experimental_inline}}</dt>
  <dd>Symbol indicating that a disclosure widget such as {{HTMLElement("details")}} is opened.</dd>
  <dt><code>disclosure-closed</code> {{experimental_inline}}</dt>

--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -70,6 +70,7 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 <dl>
 	<dt><code>&lt;string&gt;</code></dt>
 	<dd>
+  <p>A string which may specify a URL or the ID of an SVG shape.</p>
 	<dl>
 		<dt>&lt;url&gt;</dt>
 		<dd>A url, which is a relative or absolute address, or pointer, to the web resource to be included, or a data uri, optionally in single or double quotes. Quotes are required if the URL includes parentheses, whitespace, or quotes, unless these characters are escaped, or if the address includes control characters above 0x7e. Double quotes cannot occur inside double quotes and single quotes cannot occur inside single quotes unless escaped. The following are all valid and equivalent:

--- a/files/en-us/web/css/visibility/index.html
+++ b/files/en-us/web/css/visibility/index.html
@@ -44,10 +44,10 @@ visibility: unset;
  <dd>The element box is invisible (not drawn), but still affects layout as normal. Descendants of the element will be visible if they have <code>visibility</code> set to <code>visible</code>. The element cannot receive focus (such as when navigating through <a href="/en-US/docs/Web/HTML/Global_attributes/tabindex">tab indexes</a>).</dd>
  <dt><code>collapse</code></dt>
  <dd>
+ <p>The <code>collapse</code> keyword has different effects for different elements:</p>
  <ul>
   <li>For {{HTMLElement("table")}} rows, columns, column groups, and row groups, the row(s) or column(s) are hidden and the space they would have occupied is removed (as if <code>{{Cssxref("display")}}: none</code> were applied to the column/row of the table). However, the size of other rows and columns is still calculated as though the cells in the collapsed row(s) or column(s) are present. This value allows for the fast removal of a row or column from a table without forcing the recalculation of widths and heights for the entire table.</li>
   <li>Collapsed flex items and ruby annotations are hidden, and the space they would have occupied is removed.</li>
-  <li>For <a href="/en-US/docs/Mozilla/Tech/XUL">XUL</a> elements, the computed size of the element is always zero, regardless of other styles that would normally affect the size, although margins still take effect.</li>
   <li>For other elements, <code>collapse</code> is treated the same as <code>hidden</code>.</li>
  </ul>
  </dd>


### PR DESCRIPTION
The HTML to Markdown converter doesn't understand certain types of `<dl>`. For details see https://github.com/mdn/yari/issues/4307 - basically it seems to be when a `<dd>` doesn't start with some text, but goes right into another list, or a code block, or something like that (or is empty).

This affects 7 `<dl>` elements in the CSS docs.

It would probably be good for the converter to be able to handle this, but all the cases I've seen it seems to improve the content to have some prose explanation at the start of the `<dd>`. So that's what this PR does.

In one page (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts#at-rules) I opted to replace the `<dl>`  with a `<ul>`, which seemed more appropriate and consistent with other pages (e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Device_Adaptation). And listing all the `@font-face` descriptors didn't seem sensible (that list is missing a lot of values).

For https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#syntax I copied descriptions out of the specification, mostly.
