### PR TITLE
[Markdown] Remove figure element

### DIFF
--- a/files/en-us/web/css/flex-basis/index.html
+++ b/files/en-us/web/css/flex-basis/index.html
@@ -19,10 +19,10 @@ browser-compat: css.properties.flex-basis
 
 <p>The demo then changes the <code>flex-basis</code> on the first item. It will then grow and shrink from that flex-basis. This means that, for example, when the <code>flex-basis</code> of the first item is <code>200px</code>, it will start out at 200px but then shrink to fit the space available with the other items being at least <code>min-content</code> sized.</p>
 
-<figure>
-  <figcaption><p>The image below shows how the Firefox <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_Flexbox_layouts">Flexbox Inspector</a> helps you understand the size items become.</p></figcaption>
-  <p><img src="firefox-flex-basis.png" alt="The Firefox Flexbox Inspector showing the size of the item once it has shrunk."></p>
-</figure>
+<p>The image below shows how the Firefox <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_Flexbox_layouts">Flexbox Inspector</a> helps you understand the size items become:</p>
+
+<img src="firefox-flex-basis.png" alt="The Firefox Flexbox Inspector showing the size of the item once it has shrunk.">
+
 
 <div class="notecard note">
   <p><strong>Note:</strong> in case both <code>flex-basis</code> (other than <code>auto</code>) and <code>width</code> (or <code>height</code> in case of <code>flex-direction: column</code>) are set for an element, <code>flex-basis</code> has priority.</p>

--- a/files/en-us/web/css/forced-color-adjust/index.html
+++ b/files/en-us/web/css/forced-color-adjust/index.html
@@ -93,10 +93,11 @@ forced-color-adjust: unset;</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample("Preserving_colors", 640, 260)}}</p>
+<p>{{EmbedLiveSample("Preserving_colors", 640, 300)}}</p>
 
-<figure role="figure" aria-label="The example above in Windows High Contrast Mode"><img src="windows-high-contrast.jpg" alt="The example above in high contrast mode shows the first box with a black background the second with the grey background of the CSS.">
-<figcaption>The example above in Windows High Contrast Mode</figcaption></figure>
+<p>The following screenshot shows the image above in Windows High Contrast Mode:</p>
+
+<img src="windows-high-contrast.jpg" alt="The example above in high contrast mode shows the first box with a black background the second with the grey background of the CSS.">
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/hyphens/index.html
+++ b/files/en-us/web/css/hyphens/index.html
@@ -119,9 +119,7 @@ dd.auto {
 
 <h4 id="Result">Result</h4>
 
-<figure>
-<p>{{EmbedLiveSample("Specifying_text_hyphenation", "100%", 490)}}</p>
-</figure>
+{{EmbedLiveSample("Specifying_text_hyphenation", "100%", 490)}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/overflow-block/index.html
+++ b/files/en-us/web/css/overflow-block/index.html
@@ -106,9 +106,7 @@ overflow-block: unset;
 
 <h3 id="Result">Result</h3>
 
-<figure>
-<p>{{EmbedLiveSample("Examples", "100%", "780")}}</p>
-</figure>
+{{EmbedLiveSample("Examples", "100%", "780")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/overflow-clip-margin/index.html
+++ b/files/en-us/web/css/overflow-clip-margin/index.html
@@ -61,9 +61,7 @@ overflow-clip-margin: unset;
 
 <h3 id="Result">Result</h3>
 
-<figure>
-<p>{{EmbedLiveSample("Examples", "100%", "280")}}</p>
-</figure>
+{{EmbedLiveSample("Examples", "100%", "280")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/overflow-inline/index.html
+++ b/files/en-us/web/css/overflow-inline/index.html
@@ -104,9 +104,7 @@ overflow-inline: unset;
 
 <h4 id="Result">Result</h4>
 
-<figure>
-<p>{{EmbedLiveSample("Setting_inline_overflow_behavior", "100%", "270")}}</p>
-</figure>
+{{EmbedLiveSample("Setting_inline_overflow_behavior", "100%", "270")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/overflow-x/index.html
+++ b/files/en-us/web/css/overflow-x/index.html
@@ -104,9 +104,7 @@ overflow-x: unset;
 
 <h3 id="Result">Result</h3>
 
-<figure>
-<p>{{EmbedLiveSample("Examples", "100%", "270")}}</p>
-</figure>
+{{EmbedLiveSample("Examples", "100%", "270")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/overflow-y/index.html
+++ b/files/en-us/web/css/overflow-y/index.html
@@ -111,9 +111,7 @@ overflow-y: unset;
 
 <h4 id="Result">Result</h4>
 
-<figure>
-<p>{{EmbedLiveSample("Setting_overflow-y_behavior", "100%", "780")}}</p>
-</figure>
+{{EmbedLiveSample("Setting_overflow-y_behavior", "100%", "780")}}
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
There were 8 occurrences of the `<figure>` element in the CSS docs. While semantic markup is nice, we don't have a way to express this in GFM, so I'm removing it.
