### PR TITLE
Clarify WebGLContext.drawElements' count parameter

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
@@ -42,7 +42,14 @@ browser-compat: api.WebGLRenderingContext.drawElements
     </ul>
   </dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of elements to be rendered.</dd>
+  <dd>A {{domxref("GLsizei")}} specifying the number of elements of the bound element array
+    buffer to be rendered. For example, to draw a wireframe triangle with <code>gl.LINES</code>
+    the count should be 2 endpoints per line &times; 3 lines = 6 elements. However to draw the
+    same wireframe triangle with <code>gl.LINE_STRIP</code> the element array buffer does not
+    repeat the indices for the end of the first line/start of the second line, and end of the
+    second line/start of the third line, so <code>count</code> will be four. To draw the same
+    triangle with <code>gl.LINE_LOOP</code> the element array buffer does not repeat the
+    first/last vertex either so <code>count</code> will be three.</dd>
   <dt>type</dt>
   <dd>A {{domxref("GLenum")}} specifying the type of the values in the element array
     buffer. Possible values are:


### PR DESCRIPTION
drawElements' `count` parameter is confusing because "count" used casually could refer to the number of things (points, lines, triangles) being drawn, the number of elements used in the element array buffer, or at a stretch the number of items in the vertex array buffer like drawArrays does.

This clarifies that `count` refers to the number of items in the element array buffer and adds a brief example explaining how the same geometry can have different counts depending on how it is drawn.

> What was wrong/why is this fix needed? (quick summary only)

It isn't clear if "elements" refers to what's being drawn or the elements array buffer.

> Issue number (if there is an associated issue)

Issue #813

> Anything else that could help us review it

Here's a fiddle which demonstrates the difference with LINE_LOOP/LINE_STRIP https://jsfiddle.net/fztq2b8p/30/