### PR TITLE
Duplicated text from description can be removed.

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.html
@@ -90,7 +90,7 @@ tags:
   <tr>
    <td><code>[<em>attr</em>^=<em>value</em>]</code></td>
    <td><code>li[class^="box-"]</code></td>
-   <td>Matches elements with an <em>attr</em> attribute (whose name is the value in square brackets), whose value begins with <em>value</em>.</td>
+   <td>Matches elements with an <em>attr</em> attribute, whose value begins with <em>value</em>.</td>
   </tr>
   <tr>
    <td><code>[<em>attr</em>$=<em>value</em>]</code></td>


### PR DESCRIPTION

> What was wrong/why is this fix needed? (quick summary only)

The description _"whose name is the value in square brackets"_ seems to be an unintentional duplication from previous table. i.e description of example `a[title] `


If not relevant to current example, can we please remove it?
