### PR TITLE
Remove useless links in headings

### DIFF
--- a/files/en-us/learn/performance/css/index.html
+++ b/files/en-us/learn/performance/css/index.html
@@ -31,7 +31,7 @@ tags:
 
 <pre class="brush: css">will-change: opacity, transform;</pre>
 
-<h3 id="The_cssxreffont-display_property">The {{cssxref('font-display')}} property</h3>
+<h3 id="The_cssxreffont-display_property">The <code>font-display</code> property</h3>
 
 <p>Applied to the <a href="/en-US/docs/Web/CSS/@font-face">@font-face</a> rule, the <a href="/en-US/docs/Web/CSS/@font-face/font-display">font-display</a> property defines how font files are loaded and displayed by the browser, allowing text to appear with a fallback font while a font loads, or fails to load. This improves performance by making the text visible instead of having a blank screen, with a trade-off being a flash of unstyled text.</p>
 
@@ -43,7 +43,7 @@ tags:
   font-display: fallback;
 }</pre>
 
-<h3 id="The_cssxrefcontain_property">The {{cssxref('contain')}} property</h3>
+<h3 id="The_cssxrefcontain_property">The <code>contain</code> property</h3>
 
 <p>The {{cssxref('contain')}} CSS property allows an author to indicate that an element and its contents are, as much as possible, <em>independent</em> of the rest of the document tree. This allows the browser to recalculate layout, style, paint, size, or any combination of them for a limited area of the DOM and not the entire page.</p>
 


### PR DESCRIPTION
There were 2 useless links in headings (the link was again in the first sentence right after)