### PR TITLE
Make nativeMessaging an optional permission

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
@@ -70,6 +70,7 @@ browser-compat: webextensions.manifest.optional_permissions
  <li><code>history</code></li>
  <li><code>idle</code></li>
  <li><code>management</code></li>
+ <li><code>nativeMessaging</code></li>
  <li><code>notifications</code></li>
  <li><code>pageCapture</code></li>
  <li><code>privacy</code></li>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -107,6 +107,7 @@ browser-compat: webextensions.manifest.permissions
  <li><code>management</code></li>
  <li><code>menus</code></li>
  <li><code>menus.overrideContext</code></li>
+ <li><code>nativeMessaging</code></li>
  <li><code>notifications</code></li>
  <li><code>pageCapture</code></li>
  <li><code>pkcs11</code></li>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -107,7 +107,6 @@ browser-compat: webextensions.manifest.permissions
  <li><code>management</code></li>
  <li><code>menus</code></li>
  <li><code>menus.overrideContext</code></li>
- <li><code>nativeMessaging</code></li>
  <li><code>notifications</code></li>
  <li><code>pageCapture</code></li>
  <li><code>pkcs11</code></li>

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The native application is not installed or managed by the browser. The native application is installed, using the underlying operating system's installation machinery. Create a JSON file called the "host manifest" or "app manifest". Install the JSON file in a defined location. The app manifest fill will describe how the browser can connect to the native application.</p>
 
-<p>The extension must request the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code>manifest.json</code> file. Also, the native application must grant permission for the extension by including the ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
+<p>The extension must request the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code>manifest.json</code> file. Also, the native application must grant permission for the extension by including the ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
 
 <p>After installing, the extension can exchange JSON messages with the native application. Use a set of functions in the {{WebExtAPIRef("runtime")}} API. On the native app side, messages are received using standard input (<code>stdin</code>) and sent using standard output (<code>stdout</code>).</p>
 
@@ -36,7 +36,7 @@ tags:
 <p>Extension communicating with a native application:</p>
 
 <ul>
- <li>Set the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a></code> file.</li>
+ <li>Set the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a></code> file.</li>
  <li>Specify your add-on ID explicitly. Use the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a></code> manifest key. (The app's manifest will identify the set of extensions that allow connecting to the IDs).</li>
 </ul>
 
@@ -67,13 +67,17 @@ tags:
     "default_icon": "icons/message.svg"
   },
 
-  "optional_permissions": ["nativeMessaging"]
+  "permissions": ["nativeMessaging"]
 
 }</pre>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Chrome does not support the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a> key. You will need to use another manifest without this key to install an equivalent WebExtension on Chrome. See <a href="#chrome_incompatibilities">Chrome incompatibilities below</a>.</p>
 </div>
+
+<div class="notecard note">
+<p><strong>Note:</strong> When using optional permission, check that permission has been granted and, where necessary, request permission from the user with the {{WebExtAPIRef("permissions")}} API before communicating with the native application.</p>
+</div> 
 
 <h3 id="App_manifest">App manifest</h3>
 
@@ -454,7 +458,7 @@ while True:
 <pre>"TypeError: browser.runtime.connectNative is not a function"</pre>
 
 <ul>
- <li>Check that the extension has the <code>"nativeMessaging"</code> optional permission</li>
+ <li>Check that the extension has the <code>"nativeMessaging"</code> permission.</li>
 </ul>
 
 <pre>"[object Object]       NativeMessaging.jsm:218"</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The native application is not installed or managed by the browser. The native application is installed, using the underlying operating system's installation machinery. Create a JSON file called the "host manifest" or "app manifest". Install the JSON file in a defined location. The app manifest fill will describe how the browser can connect to the native application.</p>
 
-<p>The extension must request the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> in the <code>manifest.json</code> file. Also, the native application must grant permission for the extension by including the ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
+<p>The extension must request the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code>manifest.json</code> file. Also, the native application must grant permission for the extension by including the ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
 
 <p>After installing, the extension can exchange JSON messages with the native application. Use a set of functions in the {{WebExtAPIRef("runtime")}} API. On the native app side, messages are received using standard input (<code>stdin</code>) and sent using standard output (<code>stdout</code>).</p>
 
@@ -36,7 +36,7 @@ tags:
 <p>Extension communicating with a native application:</p>
 
 <ul>
- <li>Set the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> in the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a></code> file.</li>
+ <li>Set the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a></code> file.</li>
  <li>Specify your add-on ID explicitly. Use the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a></code> manifest key. (The app's manifest will identify the set of extensions that allow connecting to the IDs).</li>
 </ul>
 
@@ -67,7 +67,7 @@ tags:
     "default_icon": "icons/message.svg"
   },
 
-  "permissions": ["nativeMessaging"]
+  "optional_permissions": ["nativeMessaging"]
 
 }</pre>
 
@@ -454,7 +454,7 @@ while True:
 <pre>"TypeError: browser.runtime.connectNative is not a function"</pre>
 
 <ul>
- <li>Check that the extension has the <code>"nativeMessaging"</code> permission</li>
+ <li>Check that the extension has the <code>"nativeMessaging"</code> optional permission</li>
 </ul>
 
 <pre>"[object Object]       NativeMessaging.jsm:218"</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.html
@@ -160,7 +160,7 @@ tags:
 
 <p>To add the file or blob you want the native application to process use <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">JSON.stringify()</a></code>.</p>
 
-<p>To use this method the extension must request the <code>"nativeMessaging"</code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in its <code>manifest.json</code> file. Reciprocally, the native application must grant permission for the extension by including its ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
+<p>To use this method the extension must request the <code>"nativeMessaging"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in its <code>manifest.json</code> file. Where optional permission is used, remember to check that permission has being granted and where necessary request permission from the user with the {{WebExtAPIRef("permissions")}} API. Reciprocally, the native application must grant permission for the extension by including its ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
 
 <p>Example: <a href="https://github.com/mdn/webextensions-examples/tree/master/native-messaging">Native Messaging</a> (illustrates simple messaging only)<br>
  Guides: <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">Native messaging</a><br>

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.html
@@ -160,7 +160,7 @@ tags:
 
 <p>To add the file or blob you want the native application to process use <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">JSON.stringify()</a></code>.</p>
 
-<p>To use this method the extension must request the <code>"nativeMessaging"</code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions"> permission</a> in its <code>manifest.json</code> file. Reciprocally, the native application must grant permission for the extension by including its ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
+<p>To use this method the extension must request the <code>"nativeMessaging"</code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> in its <code>manifest.json</code> file. Reciprocally, the native application must grant permission for the extension by including its ID in the <code>"allowed_extensions"</code> field of the app manifest.</p>
 
 <p>Example: <a href="https://github.com/mdn/webextensions-examples/tree/master/native-messaging">Native Messaging</a> (illustrates simple messaging only)<br>
  Guides: <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">Native messaging</a><br>


### PR DESCRIPTION
Removed nativeMessaging from the list of required permissions and added it to the list of optional ones. This addresses the documentation needs of [Bug 1630415](https://bugzilla.mozilla.org/show_bug.cgi?id=1630415).