### PR TITLE
Add missing 'a' in “Using server-sent events” doc

### DIFF
--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.html
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.html
@@ -14,7 +14,7 @@ tags:
 <p>{{DefaultAPISidebar("Server Sent Events")}}</p>
 
 <div class="summary">
-<p>Developing a web application that uses <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> is straightforward. You'll need a bit of code on the server to stream events to the front-end, but the client side code works almost identically to <a href="/en-US/docs/Web/API/WebSockets_API">websockets</a> in part of handling incoming events. This is one-way connection, so you can't send events from a client to a server.</p>
+<p>Developing a web application that uses <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> is straightforward. You'll need a bit of code on the server to stream events to the front-end, but the client side code works almost identically to <a href="/en-US/docs/Web/API/WebSockets_API">websockets</a> in part of handling incoming events. This is a one-way connection, so you can't send events from a client to a server.</p>
 </div>
 
 <h2 id="Receiving_events_from_the_server">Receiving events from the server</h2>


### PR DESCRIPTION
I found a small grammatical mistake in the [Using server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#receiving_events_from_the_server). This PR fixes it.