### PR TITLE
Removed unnecessary punctation in “Basic Concepts of grid layout” doc

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h3 id="Control_of_overlapping_content">Control of overlapping content</h3>
 
-<p>More than one item can be placed into a grid cell or area and, they can partially overlap each other. This layering may then be controlled with the {{cssxref("z-index")}} property.</p>
+<p>More than one item can be placed into a grid cell or area and they can partially overlap each other. This layering may then be controlled with the {{cssxref("z-index")}} property.</p>
 
 <p>Grid is a powerful specification that, when combined with other parts of CSS such as <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">flexbox</a>, can help you create layouts that were previously impossible to build in CSS. It all starts by creating a grid in your <strong>grid container</strong>.</p>
 


### PR DESCRIPTION
Removed unnecessary comma after `and` in the section `Control of overlapping content`

<!-- Please provide the following information to help us review this PR: -->

> Issue number to be fixed (ie 'Fixes #123', if there is an associated issue)



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
