### PR TITLE
Removed links in headings

### DIFF
--- a/files/en-us/learn/forms/your_first_form/index.html
+++ b/files/en-us/learn/forms/your_first_form/index.html
@@ -60,7 +60,7 @@ tags:
 
 <p>Before you go any further, make a local copy of our <a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/getting-started/index.html">simple HTML template</a> — you'll enter your form HTML into here.</p>
 
-<h3 id="The_HTMLelementform_element">The {{HTMLelement("form")}} element</h3>
+<h3 id="The_HTMLelementform_element">The <code>&lt;form&gt;</code> element</h3>
 
 <p>All forms start with a {{HTMLelement("form")}} element, like this:</p>
 
@@ -81,7 +81,7 @@ tags:
 
 <p>For now, add the above {{htmlelement("form")}} element into your HTML {{htmlelement("body")}}.</p>
 
-<h3 id="The_HTMLelementlabel_HTMLelementinput_and_HTMLelementtextarea_elements">The {{HTMLelement("label")}}, {{HTMLelement("input")}}, and {{HTMLelement("textarea")}} elements</h3>
+<h3 id="The_HTMLelementlabel_HTMLelementinput_and_HTMLelementtextarea_elements">The <code>&lt;label&gt;</code>, <code>&lt;input&gt;</code>, and <code>&lt;textarea&gt;</code> elements</h3>
 
 <p>Our contact form is not complex: the data entry portion contains three text fields, each with a corresponding {{HTMLelement("label")}}:</p>
 
@@ -133,7 +133,7 @@ tags:
 by default this element is filled with this text
 &lt;/textarea&gt;</pre>
 
-<h3 id="The_HTMLelementbutton_element">The {{HTMLelement("button")}} element</h3>
+<h3 id="The_HTMLelementbutton_element">The <code>&lt;button&gt;</code> element</h3>
 
 <p>The markup for our form is almost complete; we just need to add a button to allow the user to send, or "submit", their data once they have filled out the form. This is done by using the {{HTMLelement("button")}} element; add the following just above the closing <code>&lt;/ul&gt;</code> tag:</p>
 

--- a/files/en-us/web/guide/ajax/index.html
+++ b/files/en-us/web/guide/ajax/index.html
@@ -9,9 +9,9 @@ tags:
   - References
   - XMLHttpRequest
 ---
-<h2><a href="/en-US/docs/Web/Guide/AJAX/Getting_Started">Getting Started</a></h2>
+<h2>Getting Started</h2>
 
-<p><span class="seoSummary"><strong><u>A</u>synchronous <u>J</u>avaScript <u>a</u>nd <u>X</u>ML</strong>, while not a technology in itself, is a term coined in 2005 by Jesse James Garrett, that describes a "new" approach to using a number of existing technologies together</span>, including <a href="/en-US/docs/Web/HTML">HTML</a> or <a href="/en-US/docs/Glossary/XHTML">XHTML</a>, <a href="/en-US/docs/Web/CSS">CSS</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/XSLT">XSLT</a>, and most importantly the {{domxref("XMLHttpRequest")}} object.<br>
+<p><strong><u>A</u>synchronous <u>J</u>avaScript <u>a</u>nd <u>X</u>ML</strong>, while not a technology in itself, is a term coined in 2005 by Jesse James Garrett, that describes a "new" approach to using a number of existing technologies together, including <a href="/en-US/docs/Web/HTML">HTML</a> or <a href="/en-US/docs/Glossary/XHTML">XHTML</a>, <a href="/en-US/docs/Web/CSS">CSS</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/XSLT">XSLT</a>, and most importantly the {{domxref("XMLHttpRequest")}} object.<br>
  When these technologies are combined in the Ajax model, web applications are able to make quick, incremental updates to the user interface without reloading the entire browser page. This makes the application faster and more responsive to user actions.</p>
 
 <p>Although X in Ajax stands for XML, {{glossary("JSON")}} is used more than XML nowadays because of its many advantages such as being lighter and a part of JavaScript. Both JSON and XML are used for packaging information in the Ajax model.</p>

--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -11,7 +11,8 @@ tags:
 
 This page provides an overall cheat sheet of all the capabilities of `RegExp` syntax by aggregating the content of the articles in the `RegExp` guide. If you need more information on a specific topic, please follow the link on the corresponding heading to access the full article or head to [the guide](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
 
-## [Character classes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes)
+## Character classes
+[Character classes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes) distinguish kinds of characters such as, for example, distinguishing between letters and digits.
 
 <table class="standard-table">
   <thead>
@@ -248,7 +249,8 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` s
   </tbody>
 </table>
 
-## [Assertions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions)
+## Assertions
+[Assertions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions) include boundaries, which indicate the beginnings and endings of lines and words, and other patterns indicating in some way that a match is possible (including look-ahead, look-behind, and conditional expressions).
 
 ### Boundary-type assertions
 
@@ -414,7 +416,8 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` s
   </tbody>
 </table>
 
-## [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)
+## Groups and ranges
+[Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges) indicate groups and ranges of expression characters.
 
 <table class="standard-table">
   <thead>
@@ -597,7 +600,8 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` s
   </tbody>
 </table>
 
-## [Quantifiers](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers)
+## Quantifiers
+[Quantifiers](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers) indicate numbers of characters or expressions to match.
 
 > **Note:** In the following, *item* refers not only to singular characters, but also includes [character classes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes), [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), [groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges).
 
@@ -725,7 +729,8 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` s
   </tbody>
 </table>
 
-## [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes)
+## Unicode property escapes
+[Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) allow for matching characters based on their Unicode properties.
 
 ```js
 // Non-binary values

--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
@@ -44,7 +44,7 @@ for (const [index, element] of a.entries())
 // 2 'c'
 ```
 
-### Using a [for…of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop
+### Using a `for…of` loop
 
 ```js
 var a = ['a', 'b', 'c'];

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.statements.for_of
 {{jsSidebar("Statements")}}
 
 The **`for...of` statement** creates a loop iterating over [iterable
-objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol), including: built-in {{jsxref("String")}}, {{jsxref("Array")}}, array-like
+objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), including: built-in {{jsxref("String")}}, {{jsxref("Array")}}, array-like
 objects (e.g., {{jsxref("Functions/arguments", "arguments")}}
 or {{domxref("NodeList")}}), {{jsxref("TypedArray")}}, {{jsxref("Map")}},
 {{jsxref("Set")}}, and user-defined iterables. It invokes a custom iteration hook with
@@ -38,7 +38,7 @@ for (variable of iterable) {
 
 ## Examples
 
-### Iterating over an {{jsxref("Array")}}
+### Iterating over an `Array`
 
 ```js
 const iterable = [10, 20, 30];
@@ -66,7 +66,7 @@ for (let value of iterable) {
 // 31
 ```
 
-### Iterating over a {{jsxref("String")}}
+### Iterating over a `String`
 
 ```js
 const iterable = 'boo';
@@ -79,7 +79,7 @@ for (const value of iterable) {
 // "o"
 ```
 
-### Iterating over a {{jsxref("TypedArray")}}
+### Iterating over a `TypedArray`
 
 ```js
 const iterable = new Uint8Array([0x00, 0xff]);
@@ -91,7 +91,7 @@ for (const value of iterable) {
 // 255
 ```
 
-### Iterating over a {{jsxref("Map")}}
+### Iterating over a `Map`
 
 ```js
 const iterable = new Map([['a', 1], ['b', 2], ['c', 3]]);
@@ -111,7 +111,7 @@ for (const [key, value] of iterable) {
 // 3
 ```
 
-### Iterating over a {{jsxref("Set")}}
+### Iterating over a `Set`
 
 ```js
 const iterable = new Set([1, 1, 2, 2, 3, 3]);
@@ -261,7 +261,7 @@ The {{jsxref("Statements/for...in", "for...in")}} statement iterates over the [e
 properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object, in an arbitrary order.
 
 The `for...of` statement iterates over values that the [iterable
-object](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Iterables) defines to be iterated over.
+object](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#iterables) defines to be iterated over.
 
 The following example shows the difference between a `for...of` loop and a
 `for...in` loop when used with an {{jsxref("Array")}}.
@@ -300,8 +300,8 @@ iterable.foo = 'hello';
 
 Every object will inherit the `objCustom` property and every object that is
 an {{jsxref("Array")}} will inherit the `arrCustom` property since these
-properties have been added to {{jsxref("Object.prototype")}} and
-{{jsxref("Array.prototype")}}, respectively. The object `iterable` inherits
+properties have been added to {{jsxref("Object", "Object.prototype")}} and
+{{jsxref("Array", "Array.prototype")}}, respectively. The object `iterable` inherits
 the properties `objCustom` and `arrCustom` because of [inheritance and
 the prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).
 
@@ -345,7 +345,7 @@ for (const i of iterable) {
 
 This loop iterates and logs **values** that `iterable`, as an
 [iterable
-object](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Iterables), defines to be iterated over. The object's **elements**
+object](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#iterables), defines to be iterated over. The object's **elements**
 `3`, `5`, `7` are shown, but none of the object's
 **properties**.
 

--- a/files/en-us/web/media/formats/webrtc_codecs/index.html
+++ b/files/en-us/web/media/formats/webrtc_codecs/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Containerless_media">Containerless media</h2>
 
-<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711">G.711</a>'s PCMA and PCMU formats.</p>
+<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711</a>'s PCMA and PCMU formats.</p>
 
 <p>These two RFCs also lay out options that must be supported for each codec, as well as specific user comfort features such as echo cancelation. This guide reviews the codecs that browsers are required to implement as well as other codecs that some or all browsers support for WebRTC.</p>
 
@@ -100,7 +100,7 @@ tags:
 
 <p>The network payload format for sharing VP8 using {{Glossary("RTP")}} (such as when using WebRTC) is described in {{RFC(7741, "RTP Payload Format for VP8 Video")}}.</p>
 
-<h3 id="AVC_H.264"><a id="AVC">AVC / H.264</a></h3>
+<h3 id="AVC">AVC / H.264</h3>
 
 <p>Support for AVC's Constrained Baseline (CB) profile is required in all fully-compliant WebRTC implementations. CB is a subset of the main profile, and is specifically designed for low-complexity, low-delay applications such as mobile video and videoconferencing, as well as for platforms with lower performing video processing capabilities.</p>
 
@@ -177,11 +177,11 @@ tags:
    <td>Chrome, Edge, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711">G.711 PCM (A-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (A-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711">G.711 PCM (µ-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (µ-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
  </tbody>


### PR DESCRIPTION
Links in headings are flaws (and inaccessible)

This PR removes some of them:
- altogether if useless, obvious, or immediately linked
- adds a intro paragraph if the link was useful.

Also fixes a few other flaws.