### PR TITLE
FF91 relnote, specify the gamepad feature default allowlist is off spec

### DIFF
--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -36,7 +36,6 @@ tags:
 
 <ul>
   <li>{{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}} and {{jsxref("Intl/DateTimeFormat/formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}} are now supported in release builds. The <code>formatRange()</code> method returns a localized and formatted string for the range between two {{jsxref("Date")}} objects (e.g. "1/05/21 – 1/10/21"). The <code>formatRangeToParts()</code> method returns an array containing the locale-specific <em>parts</em> of a formatted date range ({{bug(1653024)}}).</li>
-
   <li>The {{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat() constructor")}} allows four new <code>timeZoneName</code> options for formatting how the timezone is displayed. These include the localized GMT formats <code>shortOffset</code> and <code>longOffset</code>, and the generic non-location formats <code>shortGeneric</code> and <code>longGeneric</code> ({{bug(1653024)}}).</li>
  </ul>
 
@@ -59,7 +58,10 @@ tags:
 <h4 id="DOM">DOM</h4>
 
 <ul>
-  <li>The <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a> is now protected by {{httpheader('Feature-Policy/gamepad','Feature-Policy: gamepad')}}. If disallowed by the <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a>, calls to {{domxref('Navigator.getGamepads()')}} will throw a <code>SecurityError</code> {{domxref('DOMException')}}, and the {{event("gamepadconnected")}} and {{event("gamepaddisconnected")}} events will not fire ({{bug(1704005)}}).</li>
+  <li>The <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a> is now protected by {{httpheader('Feature-Policy/gamepad','Feature-Policy: gamepad')}}.
+    If disallowed by the <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a>, calls to {{domxref('Navigator.getGamepads()')}} will throw a <code>SecurityError</code> {{domxref('DOMException')}},
+    and the {{event("gamepadconnected")}} and {{event("gamepaddisconnected")}} events will not fire.
+    The default <code>allowlist</code> is <code>*</code>; This default will be updated to <code>self</code> in a future release in order to match the specification. ({{bug(1704005)}}).</li>
   <li><code>Window.clientInformation</code> has been added as an alias for {{domxref("Window.navigator")}}, in order to match recent specification updates and improve compatibility with other major browsers ({{bug(1717072)}}).</li>
 </ul>
 


### PR DESCRIPTION
The implementation temporarily set the default allow list to `*` while the spec says `self` (in order to overcome a bug). I originally was going to defer this to just be in BCD, but it seems relevant to the release notes as well, which are specific to FF versions. 