### PR TITLE
Clean up some code examples

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.html
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.html
@@ -57,7 +57,10 @@ fetch('./tortoise.png')
 // Retrieve its body as ReadableStream
 .then(response =&gt; response.body)
 .then(body =&gt; {
-  const reader = body.getReader();</pre>
+  const reader = body.getReader();
+  // ...
+  });
+</pre>
 
 <p>Invoking this method creates a reader and locks it to the stream — no other reader may read this stream until this reader is released, e.g. by invoking {{domxref("ReadableStreamDefaultReader.releaseLock()")}}.</p>
 
@@ -67,7 +70,10 @@ fetch('./tortoise.png')
   fetch('./tortoise.png')
   // Retrieve its body as ReadableStream
   .then(response =&gt; {
-    const reader = response.body.getReader();</pre>
+    const reader = response.body.getReader();
+    // ...
+  });
+</pre>
 
 <h3 id="Reading_the_stream">Reading the stream</h3>
 


### PR DESCRIPTION
This pr fixes the code in the examples for attaching a reader. Previously the code was not complete useable code, which may confuse inexperienced users who try and copy-paste this code and run it. 
I'm not sure if this is the source code or auto-generated from markdown or something, and I'd be glad to make a pr on the source if someone can tell me where it is.