### PR TITLE
Fix broken {{page}} by incorporating the right data.

### DIFF
--- a/files/en-us/web/api/htmlformelement/length/index.html
+++ b/files/en-us/web/api/htmlformelement/length/index.html
@@ -2,13 +2,13 @@
 title: HTMLFormElement.length
 slug: Web/API/HTMLFormElement/length
 tags:
-- API
-- HTML DOM
-- HTMLFormElement
-- NeedsSpecTable
-- Property
-- Read-only
-- Reference
+  - API
+  - HTML DOM
+  - HTMLFormElement
+  - NeedsSpecTable
+  - Property
+  - Read-only
+  - Reference
 browser-compat: api.HTMLFormElement.length
 ---
 <div>
@@ -24,8 +24,13 @@ browser-compat: api.HTMLFormElement.length
   element as well as elements that are made members of the form using their
   <code>form</code> property.</p>
 
-<p>{{page("/en-US/docs/Web/API/HTMLFormElement", "Elements that are considered form
-  controls")}}</p>
+<p>
+  Elements that are considered for this property are: {{HTMLElement("button")}},
+  {{HTMLElement("fieldset")}}, {{HTMLElement("input")}} (with the exception 
+  that any whose type is "image" are omitted for historical reasons),
+  {{HTMLElement("object")}}, {{HTMLElement("output")}}, {{HTMLElement("select")}},
+  and {{HTMLElement("textarea")}}.
+</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
I replaced the broken `{{page}}` by the content (a paragraph) it should include.

This also fixes:
- a `MacroExecutionError` (broken `page`)
- 5 `MacroBrokenLink` that were on the "paged" page (and not displayed).