### PR TITLE
Fix RTCErrorEvent and RTCError.event

### DIFF
--- a/files/en-us/web/api/rtcerror/index.html
+++ b/files/en-us/web/api/rtcerror/index.html
@@ -24,7 +24,7 @@ browser-compat: api.RTCError
 
 <dl>
  <dt>{{domxref("RTCError.RTCError", "RTCError()")}}</dt>
- <dd>Creates and returns a new <code>RTCError</code> object initialized with the properties of the provided {{domxref("RTCErrorInit")}} dictionary and, optionally, a string to use as the value of the error's {{domxref("DOMException.message", "message")}} property.</dd>
+ <dd>Creates and returns a new <code>RTCError</code> object initialized with the different parameters and, optionally, a string to use as the value of the error's {{domxref("DOMException.message", "message")}} property.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>
@@ -52,7 +52,45 @@ browser-compat: api.RTCError
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/RTCErrorEvent/error", "Examples")}}</p>
+<p>In this example, a handler is established for an {{domxref("RTCDataChannel")}}'s
+  {{domxref("RTCDataChannel.error_event", "error")}} event.</p>
+
+<pre class="brush: js">dataChannel.addEventListener("error", (event) =&gt; {
+  let error = event.error; // event.error is an RTCError
+
+  if (error.errorDetail === "sdp-syntax-error") {
+    let errLine = error.sdpLineNumber;
+    let errMessage = error.message;
+
+    let alertMessage = `A syntax error occurred interpreting line ${errLine} of the SDP: ${errMessage}`;
+    showMyAlertMessage("Data Channel Error", alertMessage);
+  } else {
+    terminateMyConnection();
+  }
+});
+</pre>
+
+<p>If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail",
+  "errorDetail")}} property being <code>sdp-syntax-error</code>—, a message string is
+  constructed to present the error message and the line number within the SDP at which the
+  error occurred. This message is then displayed using a function called
+  <code>showMyAlertMessage()</code>, which stands in for whatever output mechanism this
+  code might use.</p>
+
+<p>Any other error is treated as terminal, causing a <code>terminateMyConnection()</code>
+  function to be called.</p>
+
+<p>The above example uses {{domxref("EventTarget.addEventListener",
+  "addEventListener()")}} to add the handler for <code>error</code> events. You can also
+  use the <code>RTCDataChannel</code> object's {{domxref("RTCDataChannel.onerror",
+  "onerror")}} event handler property, like this:</p>
+
+<pre class="brush: js">dataChannel.onerror = (event) =&gt; {
+  let error = event.error;
+
+  /* and so forth */
+};
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/rtcerrorevent/error/index.html
+++ b/files/en-us/web/api/rtcerrorevent/error/index.html
@@ -2,19 +2,19 @@
 title: RTCErrorEvent.error
 slug: Web/API/RTCErrorEvent/error
 tags:
-- API
-- Audio
-- Error
-- Error Handling
-- Media
-- Property
-- RTCError
-- RTCErrorEvent
-- Reference
-- Video
-- WebRTC
-- WebRTC API
-- WebRTC Device API
+  - API
+  - Audio
+  - Error
+  - Error Handling
+  - Media
+  - Property
+  - RTCError
+  - RTCErrorEvent
+  - Reference
+  - Video
+  - WebRTC
+  - WebRTC API
+  - WebRTC Device API
 browser-compat: api.RTCErrorEvent.error
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
@@ -31,11 +31,7 @@ browser-compat: api.RTCErrorEvent.error
 <h3 id="Value">Value</h3>
 
 <p>An {{domxref("RTCError")}} object whose properties provide details about the error
-  which has occurred in the context of a {{Glossary("WebRTC")}} operation. Since
-  <code>RTCError</code> is based upon {{domxref("DOMException")}}, it includes those
-  properties. Additional properties defined by <code>RTCError</code> are:</p>
-
-<p>{{page("/en-US/docs/Web/API/RTCError", "property-list")}}</p>
+  which has occurred in the context of a {{Glossary("WebRTC")}} operation. 
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
 Fix RTCErrorEvent and RTCError.event that were including each other via `{{page}}` macros

I made both of them self contained and linking to the other for specific information.