### PR TITLE
Fix explanation of two-digit year handling in JS date methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -173,19 +173,27 @@ const [month, day, year]       = [date.getMonth(), date.getDate(), date.getFullY
 const [hour, minutes, seconds] = [date.getHours(), date.getMinutes(), date.getSeconds()];
 ```
 
-### Two digit years map to 1900 – 1999
+### Interpretation of two-digit years
 
-Values from `0` to `99` map to the years `1900` to `1999`. All other values are the actual year .
-
-In order to create and get dates between the years `0` and `99` the {{jsxref("Date.prototype.setFullYear()")}} and {{jsxref("Date.prototype.getFullYear()")}} methods should be used.
+`new Date()` exhibits legacy undesirable, inconsistent behavior with two-digit year values; specifically, when a `new Date()` call is given a two-digit year value, that year value does not get treated as a literal year and used as-is but instead gets interpreted as a relative offset — in some cases as an offset from the year `1900`, but in other cases, as an offset from the year `2000`.
 
 ```js
-let date = new Date(98, 1)  // Sun Feb 01 1998 00:00:00 GMT+0000 (GMT)
+let date = new Date(98, 1)         // Sun Feb 01 1998 00:00:00 GMT+0000 (GMT)
+let date = new Date(22, 1)         // Wed Feb 01 1922 00:00:00 GMT+0000 (GMT)
+let date = new Date("2/1/22")      // Tue Feb 01 2022 00:00:00 GMT+0000 (GMT)
 
-// Deprecated method; 98 maps to 1998 here as well
-date.setYear(98)            // Sun Feb 01 1998 00:00:00 GMT+0000 (GMT)
+// Legacy method; always interprets two-digit year values as relative to 1900
+date.setYear(98); date.toString()  // Sun Feb 01 1998 00:00:00 GMT+0000 (GMT)
+date.setYear(22); date.toString()  // Wed Feb 01 1922 00:00:00 GMT+0000 (GMT)
+```
 
-date.setFullYear(98)        // Sat Feb 01 0098 00:00:00 GMT+0000 (BST)
+So, to create and get dates between the years `0` and `99`, instead use the preferred {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} and {{jsxref("Date.prototype.getFullYear()", "getFullYear()")}} methods:.
+
+```js
+// Preferred method; never interprets any value as being a relative offset,
+// but instead uses the year value as-is
+date.setFullYear(98); date.getFullYear()  // 98 (not 1998)
+date.setFullYear(22); date.getFullYear()  // 22 (not 1922, not 2022)
 ```
 
 ### Calculating elapsed time

--- a/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
@@ -12,10 +12,15 @@ browser-compat: javascript.builtins.Date.setYear
 ---
 {{JSRef}} {{deprecated_header}}
 
-The **`setYear()`** method sets the year for a specified date
-according to local time. Because `setYear()` does not set full years ("year
-2000 problem"), it is no longer used and has been replaced by the
-{{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} method.
+The legacy **`setYear()`** method sets the year for a specified date according to local time.
+
+However, the way the legacy `setYear()` method sets year values is different from how the preferred {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} method sets year values — and in some cases, also different from how `new Date()` and {{jsxref("Date.parse()")}} set year values. Specifically, given two-digit numbers, such as `22` and `61`:
+
+* `setYear()` interprets any two-digit number as an offset to `1900`; so `date.setYear(22)` results in the year value being set to `1922`, and `date.setYear(61)` results in the year value being set to `1961`. (In contrast, while `new Date(61, 1)` also results in the year value being set to `1961`, `new Date(22, 1)` results in the year value being set to `2022`; and similarly for {{jsxref("Date.parse()")}}).
+
+* {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} does no special interpretation but instead uses the literal two-digit value as-is to set the year; so `date.setFullYear(61)` results in the year value being set to `0061`, and `date.setFullYear(22)` results in the year value being set to `0022`.
+
+Because of those differences in behavior, you should no longer use the legacy `setYear()` method, but should instead use the preferred {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
@@ -16,7 +16,7 @@ The legacy **`setYear()`** method sets the year for a specified date according t
 
 However, the way the legacy `setYear()` method sets year values is different from how the preferred {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} method sets year values — and in some cases, also different from how `new Date()` and {{jsxref("Date.parse()")}} set year values. Specifically, given two-digit numbers, such as `22` and `61`:
 
-* `setYear()` interprets any two-digit number as an offset to `1900`; so `date.setYear(22)` results in the year value being set to `1922`, and `date.setYear(61)` results in the year value being set to `1961`. (In contrast, while `new Date(61, 1)` also results in the year value being set to `1961`, `new Date(22, 1)` results in the year value being set to `2022`; and similarly for {{jsxref("Date.parse()")}}).
+* `setYear()` interprets any two-digit number as an offset to `1900`; so `date.setYear(22)` results in the year value being set to `1922`, and `date.setYear(61)` results in the year value being set to `1961`. (In contrast, while `new Date(61, 1)` also results in the year value being set to `1961`, `new Date("2/1/22")` results in the year value being set to `2022`; and similarly for {{jsxref("Date.parse()")}}).
 
 * {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}} does no special interpretation but instead uses the literal two-digit value as-is to set the year; so `date.setFullYear(61)` results in the year value being set to `0061`, and `date.setFullYear(22)` results in the year value being set to `0022`.
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/1461