### PR TITLE
Remove more CSS ids

### DIFF
--- a/files/en-us/web/css/@media/aspect-ratio/index.html
+++ b/files/en-us/web/css/@media/aspect-ratio/index.html
@@ -54,7 +54,8 @@ browser-compat: css.at-rules.media.aspect-ratio
 }
 </pre>
 
-<div id="_Example">
+<h3 id="Result">Result</h3>
+
 
 <pre class="brush: html hidden">&lt;label id="wf" for="w"&gt;width:165&lt;/label&gt;
 &lt;input id="w" name="w" type="range" min="100" max="250" step="5" value="165"&gt;
@@ -66,15 +67,11 @@ browser-compat: css.at-rules.media.aspect-ratio
 &lt;/iframe&gt;
 </pre>
 
-<h3 id="CSS_2">CSS</h3>
-
-<pre class="brush: css">iframe{
+<pre class="brush: css hidden">iframe{
   display:block;
 }</pre>
 
-<h3 id="JavaScript">JavaScript</h3>
-
-<pre class="brush: js">outer.style.width=outer.style.height="165px"
+<pre class="brush: js hidden">outer.style.width=outer.style.height="165px"
 
 w.onchange=w.oninput=function(){
   outer.style.width=w.value+"px"
@@ -84,11 +81,8 @@ h.onchange=h.oninput=function(){
   outer.style.height=h.value+"px"
   hf.textContent="height:"+h.value
 }</pre>
-</div>
 
-<h3 id="Result">Result</h3>
-
-<div>{{ EmbedLiveSample('_Example', '300px', '350px') }}</div>
+<div>{{ EmbedLiveSample('Result', '300px', '350px') }}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/clear/index.html
+++ b/files/en-us/web/css/clear/index.html
@@ -15,7 +15,7 @@ browser-compat: css.properties.clear
 
 <div>{{EmbedInteractiveExample("pages/css/clear.html")}}</div>
 
-<p>When applied to non-floating blocks, it moves the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border-area">border edge</a> of the element down until it is below the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#margin-area">margin edge</a> of all relevant floats. The non-floated block's top margin collapses.</p>
+<p>When applied to non-floating blocks, it moves the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border_area">border edge</a> of the element down until it is below the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#margin_area">margin edge</a> of all relevant floats. The non-floated block's top margin collapses.</p>
 
 <p>Vertical margins between two floated elements on the other hand will not collapse. When applied to floating elements, the margin edge of the bottom element is moved below the margin edge of all relevant floats. This affects the position of later floats, since later floats cannot be positioned higher than earlier ones.</p>
 

--- a/files/en-us/web/css/clip-path/index.html
+++ b/files/en-us/web/css/clip-path/index.html
@@ -100,7 +100,7 @@ clip-path: unset;
 
 <h3 id="Comparison_of_HTML_and_SVG">Comparison of HTML and SVG</h3>
 
-<pre id="clip-path" class="brush: html hidden">&lt;svg class="defs"&gt;
+<pre class="brush: html hidden">&lt;svg class="defs"&gt;
   &lt;defs&gt;
     &lt;clipPath id="myPath" clipPathUnits="objectBoundingBox"&gt;
       &lt;path d="M0.5,1 C0.5,1,0,0.7,0,0.3 A0.25,0.25,1,1,1,0.5,0.3 A0.25,0.25,1,1,1,1,0.3 C1,0.7,0.5,1,0.5,1 Z" /&gt;

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -87,7 +87,7 @@ browser-compat: css.types.color
 </ul>
 </div>
 
-<table id="colors_table">
+<table>
  <thead>
   <tr>
    <th scope="col">Specification</th>
@@ -846,7 +846,7 @@ browser-compat: css.types.color
  </tbody>
 </table>
 
-<h3 id="transparent_keyword"><code id="transparent">transparent</code> keyword</h3>
+<h3 id="transparent_keyword"><code>transparent</code> keyword</h3>
 
 <p>The <code>transparent</code> keyword represents a fully transparent color. This makes the background behind the colored item completely visible. Technically, <code>transparent</code> is a shortcut for <code>rgba(0,0,0,0)</code>.</p>
 
@@ -858,7 +858,7 @@ browser-compat: css.types.color
 <p><strong>Note:</strong> <code>transparent</code> wasn't a true color in CSS Level 2 (Revision 1). It was a special keyword that could be used instead of a regular <code>&lt;color&gt;</code> value on two CSS properties: {{Cssxref("background")}} and {{Cssxref("border")}}. It was essentially added to allow developers to override an inherited solid color. With the advent of alpha channels in CSS Colors Level 3, <code>transparent</code> was redefined as a true color. It can now be used wherever a <code>&lt;color&gt;</code> value can be used.</p>
 </div>
 
-<h3 id="currentcolor_keyword"><code id="currentColor">currentColor</code> keyword</h3>
+<h3 id="currentcolor_keyword"><code>currentColor</code> keyword</h3>
 
 <p>The <code>currentColor</code> keyword represents the value of an element's {{Cssxref("color")}} property. This lets you use the <code>color</code> value on properties that do not receive it by default.</p>
 
@@ -880,7 +880,7 @@ browser-compat: css.types.color
 
 <h4 id="Syntax_2">Syntax</h4>
 
-<p>RGB colors can be expressed through both hexadecimal (prefixed with <code>#</code>) and functional (<code id="rgb()">rgb()</code>, <code id="rgba()">rgba()</code>) notations.</p>
+<p>RGB colors can be expressed through both hexadecimal (prefixed with <code>#</code>) and functional (<code>rgb()</code>, <code>rgba()</code>) notations.</p>
 
 <div class="note">
 <p><strong>Note:</strong> As of CSS Colors Level 4, <code>rgba()</code> is an alias for <code>rgb()</code>. In browsers that implement the Level 4 standard, they accept the same parameters and behave the same way.</p>
@@ -907,7 +907,7 @@ browser-compat: css.types.color
 
 <h4 id="Syntax_3">Syntax</h4>
 
-<p>HSL colors are expressed through the functional <code id="hsl()">hsl()</code> and <code id="hsla()">hsla()</code> notations.</p>
+<p>HSL colors are expressed through the functional <code">hsl()</code> and <code>hsla()</code> notations.</p>
 
 <div class="note">
 <p><strong>Note:</strong> As of CSS Colors Level 4, <code>hsla()</code> is an alias for <code>hsl()</code>. In browsers that implement the Level 4 standard, they accept the same parameters and behave the same way.</p>

--- a/files/en-us/web/css/containing_block/index.html
+++ b/files/en-us/web/css/containing_block/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The size and position of an element are often impacted by its <strong>containing block</strong>. Most often, the containing block is the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content-area">content area</a> of an element's nearest <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level</a> ancestor, but this is not always the case. In this article, we examine the factors that determine an element's containing block.</span></p>
+<p>The size and position of an element are often impacted by its <strong>containing block</strong>. Most often, the containing block is the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content_area">content area</a> of an element's nearest <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level</a> ancestor, but this is not always the case. In this article, we examine the factors that determine an element's containing block.</span></p>
 
 <p>When a user agent (such as your browser) lays out a document, it generates a box for every element. Each box is divided into four areas:</p>
 

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.html
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.html
@@ -15,19 +15,27 @@ tags:
 
 <p><img alt="CSS Box model" src="boxmodel-(3).png"></p>
 
-<p id="content-area">The <strong>content area</strong>, bounded by the content edge, contains the "real" content of the element, such as text, an image, or a video player. Its dimensions are the <em>content width</em> (or <em>content-box width</em>) and the <em>content height</em> (or <em>content-box height</em>). It often has a background color or background image.</p>
+<h2>Content area</h2>
+
+<p>The <strong>content area</strong>, bounded by the content edge, contains the "real" content of the element, such as text, an image, or a video player. Its dimensions are the <em>content width</em> (or <em>content-box width</em>) and the <em>content height</em> (or <em>content-box height</em>). It often has a background color or background image.</p>
 
 <p>If the {{cssxref("box-sizing")}} property is set to <code>content-box</code> (default) and if the element is a block element, the content area's size can be explicitly defined with the {{cssxref("width")}}, {{cssxref("min-width")}}, {{cssxref("max-width")}}, {{ cssxref("height") }}, {{cssxref("min-height")}}, and {{cssxref("max-height")}} properties.</p>
 
-<p id="padding-area">The <strong>padding area</strong>, bounded by the padding edge, extends the content area to include the element's padding. Its dimensions are the <em>padding-box width</em> and the <em>padding-box height</em>.</p>
+<h2>Padding area</h2>
+
+<p>The <strong>padding area</strong>, bounded by the padding edge, extends the content area to include the element's padding. Its dimensions are the <em>padding-box width</em> and the <em>padding-box height</em>.</p>
 
 <p>The thickness of the padding is determined by the {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}, and shorthand {{cssxref("padding")}} properties.</p>
 
-<p id="border-area">The <strong>border area</strong>, bounded by the border edge, extends the padding area to include the element's borders. Its dimensions are the <em>border-box width</em> and the <em>border-box height</em>.</p>
+<h2>Border area</h2>
+
+<p>The <strong>border area</strong>, bounded by the border edge, extends the padding area to include the element's borders. Its dimensions are the <em>border-box width</em> and the <em>border-box height</em>.</p>
 
 <p>The thickness of the borders are determined by the {{cssxref("border-width")}} and shorthand {{cssxref("border")}} properties. If the {{cssxref("box-sizing")}} property is set to <code>border-box</code>, the border area's size can be explicitly defined with the {{cssxref("width")}}, {{cssxref("min-width")}}, {{cssxref("max-width")}}, {{ cssxref("height") }}, {{cssxref("min-height")}}, and {{cssxref("max-height")}} properties. When there is a background ({{cssxref("background-color")}} or {{cssxref("background-image")}}) set on a box, it extends to the outer edge of the border (i.e. extends underneath the border in z-ordering). This default behavior can be altered with the {{cssxref("background-clip")}} css property.</p>
 
-<p id="margin-area">The <strong>margin area</strong>, bounded by the margin edge, extends the border area to include an empty area used to separate the element from its neighbors. Its dimensions are the <em>margin-box width</em> and the <em>margin-box height</em>.</p>
+<h2>Margin area</h2>
+
+<p>The <strong>margin area</strong>, bounded by the margin edge, extends the border area to include an empty area used to separate the element from its neighbors. Its dimensions are the <em>margin-box width</em> and the <em>margin-box height</em>.</p>
 
 <p>The size of the margin area is determined by the {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, {{cssxref("margin-left")}}, and shorthand {{cssxref("margin")}} properties. When <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">margin collapsing</a> occurs, the margin area is not clearly defined since margins are shared between boxes.</p>
 

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
@@ -6,6 +6,8 @@ tags:
   - CSS Grids
   - Guide
 ---
+<div>{{CSSRef}}</div>
+
 <p>In the <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">article covering the basic concepts of grid layout</a>, we started to look at how to position items on a grid using line numbers. In this article we will fully explore how this fundamental feature of the specification works.</p>
 
 <p>Starting your exploration of grid with numbered lines is the most logical place to begin, as when you use grid layout you always have numbered lines. The lines are numbered for columns and rows, and are indexed from 1. Note that grid is indexed according to the writing mode of the document. In a left to right language such as English line 1 is on the left-hand side of the grid. If you are working in a right-to-left language then line 1 will be the far right of the grid. We will learn more about the interaction between writing modes and grids in a later guide.</p>
@@ -581,66 +583,3 @@ tags:
 <p>To become familiar with line based positioning in grid try to build a few common layouts by placing items onto grids with varying numbers of columns. Remember that if you do not place all of the items, any leftover items will be placed according to auto-placement rules. This may result in the layout you want, but if something is appearing somewhere unexpected, check that you have set a position for it.</p>
 
 <p>Also, remember that items on the grid can overlap each other when you place them explicitly like this. That can create some nice effects, however you can also end up with things overlapping incorrectly if you specify the wrong start or end line. The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts">Firefox Grid Highlighter</a> can be very useful as you learn, especially if your grid is quite complicated.</p>
-
-<section id="Quick_links">
-<ol>
- <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
- <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
- <li data-default-state="open"><a href="#"><strong>Guides</strong></a>
-  <ol>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basics concepts of grid layout</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relationship to other layout methods</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Line-based placement</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Auto-placement in grid layout</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in grid layout</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout and Accessibility</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout and Progressive Enhancement</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Realizing common layouts using grids</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid">Subgrid</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout">Masonry layout</a></li>
-  </ol>
- </li>
- <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
-  <ol>
-   <li><code><a href="/en-US/docs/Web/CSS/align-tracks">align-tracks</a></code>{{Experimental_Inline}}</li>
-   <li><code><a href="/en-US/docs/Web/CSS/column-gap">column-gap</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/gap">gap</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid">grid</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-area">grid-area</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-column">grid-column</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-column-end">grid-column-end</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-column-start">grid-column-start</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-row">grid-row</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-row-end">grid-row-end</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-row-start">grid-row-start</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-template">grid-template</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-template-areas">grid-template-areas</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-template-columns">grid-template-columns</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/grid-template-rows">grid-template-rows</a></code></li>
-   <li><code><a href="/en-US/docs/Web/CSS/justify-tracks">justify-tracks</a></code>{{Experimental_Inline}}</li>
-   <li><code><a href="/en-US/docs/Web/CSS/masonry-auto-flow">masonry-auto-flow</a></code>{{Experimental_Inline}}</li>
-   <li><code><a href="/en-US/docs/Web/CSS/row-gap">row-gap</a></code></li>
-  </ol>
- </li>
- <li data-default-state="open"><a href="#"><strong>Glossary</strong></a>
-  <ol>
-   <li><a href="/en-US/docs/Glossary/Grid">Grid</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_lines">Grid lines</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_tracks">Grid tracks</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_cell">Grid cell</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_areas">Grid areas</a></li>
-   <li><a href="/en-US/docs/Glossary/Gutters">Gutters</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_Axis">Grid Axis</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_rows">Grid row</a></li>
-   <li><a href="/en-US/docs/Glossary/Grid_column">Grid column</a></li>
-  </ol>
- </li>
-</ol>
-</section>

--- a/files/en-us/web/css/css_logical_properties/index.html
+++ b/files/en-us/web/css/css_logical_properties/index.html
@@ -15,14 +15,14 @@ tags:
 
 <p>The module also defines logical properties and values for properties previously defined in <abbr title="Cascading Stylesheets">CSS</abbr> 2.1. Logical properties define direction‐relative equivalents of their corresponding physical properties.</p>
 
-<h3 id="Block_vs._inline">Block vs. inline</h3>
+<h3 id="block_vs._inline">Block vs. inline</h3>
 
 <p>Logical properties and values use the abstract terms <em>block</em> and <em>inline</em> to describe the direction in which they flow. The physical meaning of these terms depends on the <a href="/en-US/docs/Web/CSS/CSS_Writing_Modes">writing mode</a>.</p>
 
 <dl>
- <dt id="block-dimension">Block dimension</dt>
+ <dt>Block dimension</dt>
  <dd>The dimension perpendicular to the flow of text within a line, i.e., the vertical dimension in horizontal writing modes, and the horizontal dimension in vertical writing modes. For standard English text, it is the vertical dimension.</dd>
- <dt id="inline-dimension">Inline dimension</dt>
+ <dt>Inline dimension</dt>
  <dd>The dimension parallel to the flow of text within a line, i.e., the horizontal dimension in horizontal writing modes, and the vertical dimension in vertical writing modes. For standard English text, it is the horizontal dimension.</dd>
 </dl>
 

--- a/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.html
+++ b/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.html
@@ -35,7 +35,6 @@ tags:
 
 <p>In the following example, there are five links that point to elements in the same document. Selecting the "First" link, for example, will cause <code>&lt;h1 id="one"&gt;</code> to become the target element. Note that the document may jump to a new scroll position, since target elements are placed on the top of the browser window if possible.</p>
 
-<div id="example">
 <pre class="brush: html">&lt;h4 id="one"&gt;...&lt;/h4&gt; &lt;p id="two"&gt;...&lt;/p&gt;
 &lt;div id="three"&gt;...&lt;/div&gt; &lt;a id="four"&gt;...&lt;/a&gt; &lt;em id="five"&gt;...&lt;/em&gt;
 
@@ -44,7 +43,6 @@ tags:
 &lt;a href="#three"&gt;Third&lt;/a&gt;
 &lt;a href="#four"&gt;Fourth&lt;/a&gt;
 &lt;a href="#five"&gt;Fifth&lt;/a&gt;</pre>
-</div>
 
 <h2 id="Conclusion">Conclusion</h2>
 

--- a/files/en-us/web/css/cursor/index.html
+++ b/files/en-us/web/css/cursor/index.html
@@ -41,9 +41,9 @@ cursor: revert;
 cursor: unset;
 </pre>
 
-<p>The <code>cursor</code> property is specified as zero or more <code><a href="#url">&lt;url&gt;</a></code> values, separated by commas, followed by a single mandatory <a href="#keyword_values">keyword value</a>. Each <code>&lt;url&gt;</code> should point to an image file. The browser will try to load the first image specified, falling back to the next if it can't, and falling back to the keyword value if no images could be loaded (or if none were specified).</p>
+<p>The <code>cursor</code> property is specified as zero or more <code>&lt;url&gt;</code> values, separated by commas, followed by a single mandatory keyword value. Each <code>&lt;url&gt;</code> should point to an image file. The browser will try to load the first image specified, falling back to the next if it can't, and falling back to the keyword value if no images could be loaded (or if none were specified).</p>
 
-<p>Each <code>&lt;url&gt;</code> may be optionally followed by a pair of space-separated numbers, which represent <code><a href="#x_y">&lt;x&gt;&lt;y&gt;</a></code> coordinates. These will set the cursor's hotspot, relative to the top-left corner of the image.</p>
+<p>Each <code>&lt;url&gt;</code> may be optionally followed by a pair of space-separated numbers, which represent <code>&lt;x&gt;&lt;y&gt;</code> coordinates. These will set the cursor's hotspot, relative to the top-left corner of the image.</p>
 
 <p>For example, this specifies two images using <code>&lt;url&gt;</code> values, providing <code>&lt;x&gt;&lt;y&gt;</code> coordinates for the second one, and falling back to the <code>progress</code> keyword value if neither image can be loaded:</p>
 
@@ -52,11 +52,11 @@ cursor: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="url">&lt;url&gt;</code></dt>
+ <dt><code>&lt;url&gt;</code></dt>
  <dd>A <code>url(…)</code> or a comma separated list <code>url(…), url(…), …</code>, pointing to an image file. More than one {{cssxref("url()")}} may be provided as fallbacks, in case some cursor image types are not supported. A non-URL fallback (one or more of the keyword values) <em>must</em> be at the end of the fallback list. See <a href="/en-US/docs/Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property">Using URL values for the cursor property</a> for more details.</dd>
- <dt><code id="x_y">&lt;x&gt;</code> <code>&lt;y&gt;</code> {{experimental_inline}}</dt>
+ <dt><code>&lt;x&gt;</code> <code>&lt;y&gt;</code> {{experimental_inline}}</dt>
  <dd>Optional x- and y-coordinates. Two unitless nonnegative numbers less than 32.</dd>
- <dt><span id="Keyword_values">Keyword values</span></dt>
+ <dt>Keyword values</dt>
  <dd>
  <p><em>Move your mouse over values to see their live appearance in your browser:</em></p>
 
@@ -160,7 +160,7 @@ cursor: unset;
     <td><img alt="not-allowed.gif" src="not-allowed.gif"></td>
     <td>The requested action will not be carried out.</td>
    </tr>
-   <tr id="grab" style="cursor: grab;">
+   <tr style="cursor: grab;">
     <td><code>grab</code></td>
     <td><img class="default" src="grab.gif"></td>
     <td>Something can be grabbed (dragged to be moved).</td>

--- a/files/en-us/web/css/display-legacy/index.html
+++ b/files/en-us/web/css/display-legacy/index.html
@@ -40,7 +40,6 @@ tags:
 
 <p>In the below example, we are creating an inline flex container with the legacy keyword inline-flex.</p>
 
-<div id="Example">
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;div class="container"&gt;
@@ -61,7 +60,6 @@ Not a flex item
 <h3 id="Result">Result</h3>
 
 <p>{{EmbedLiveSample("Examples", 300, 150)}}</p>
-</div>
 
 <p>In the new syntax the inline flex container would be created using two values, inline for the outer display type, and flex for the inner display type.</p>
 

--- a/files/en-us/web/css/env()/index.html
+++ b/files/en-us/web/css/env()/index.html
@@ -41,7 +41,7 @@ env(safe-area-inset-left, 1.4rem);
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="safe-area-inset-top">safe-area-inset-top</code>, <code id="safe-area-inset-right">safe-area-inset-right</code>, <code id="safe-area-inset-bottom">safe-area-inset-bottom</code>, <code id="safe-area-inset-left">safe-area-inset-left</code></dt>
+ <dt><code>safe-area-inset-top</code>, <code>safe-area-inset-right</code>, <code>safe-area-inset-bottom</code>, <code>safe-area-inset-left</code></dt>
  <dd>The <code>safe-area-inset-*</code> variables are four environment variables that define a rectangle by its top, right, bottom, and left insets from the edge of the viewport, which is safe to put content into without risking it being cut off by the shape of a non‑rectangular display. For rectangular viewports, like your average laptop monitor, their value is equal to zero. For non-rectangular displays — like a round watch face — the four values set by the user agent form a rectangle such that all content inside the rectangle is visible.</dd>
 </dl>
 

--- a/files/en-us/web/css/fit-content()/index.html
+++ b/files/en-us/web/css/fit-content()/index.html
@@ -17,9 +17,11 @@ tags:
 <div>{{EmbedInteractiveExample("pages/css/function-fit-content.html")}}</div>
 
 
-<p>The function can be used as a track size in <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid</a> properties, where the maximum size is defined by <code><a href="/en-US/docs/Web/CSS/grid-template-columns#max-content">max-content</a></code> and the minimum size by <code><a href="/en-US/docs/Web/CSS/grid-template-columns#auto">auto</a></code>, which is calculated similar to <code>auto</code> (i.e., <code><a href="/en-US/docs/Web/CSS/minmax()">minmax(auto, max-content)</a></code>), except that the track size is clamped at <var>argument</var> if it is greater than the <code>auto</code> minimum.</p>
+<p>The function can be used as a track size in <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid</a> properties, where the maximum size is defined by <code>max-content</code> and the minimum size by <code>auto</code>, which is calculated similar to <code>auto</code> (i.e., <code><a href="/en-US/docs/Web/CSS/minmax()">minmax(auto, max-content)</a></code>), except that the track size is clamped at <var>argument</var> if it is greater than the <code>auto</code> minimum.</p>
 
-<p>The function can also be used as laid out box size for {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} and {{cssxref("max-height")}}, where the maximum and minimum sizes refer to the content size.</p>
+<p>See the {{cssxref("grid-template-columns")}} page for more information on the <code>max-content</code> and <code>auto</code> keywords.
+
+<p>The <code>fit-content()</code> function can also be used as laid out box size for {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} and {{cssxref("max-height")}}, where the maximum and minimum sizes refer to the content size.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/flex-basis/index.html
+++ b/files/en-us/web/css/flex-basis/index.html
@@ -51,14 +51,14 @@ flex-basis: revert;
 flex-basis: unset;
 </pre>
 
-<p>The <code>flex-basis</code> property is specified as either the keyword <code><a href="#content">content</a></code> or a <code><a href="#width">&lt;'width'&gt;</a></code>.</p>
+<p>The <code>flex-basis</code> property is specified as either the keyword <code>content</code> or a <code>&lt;'width'&gt;</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="width">&lt;'width'&gt;</code></dt>
+ <dt><code>&lt;'width'&gt;</code></dt>
  <dd>An absolute {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}} of the parent flex container's main size property, or the keyword <code>auto</code>. Negative values are invalid. Defaults to <code>auto</code>.</dd>
- <dt><code id="content">content</code></dt>
+ <dt><code>content</code></dt>
  <dd>
   <p>Indicates automatic sizing, based on the flex item’s content.</p>
   <div class="note">

--- a/files/en-us/web/css/flex-grow/index.html
+++ b/files/en-us/web/css/flex-grow/index.html
@@ -29,12 +29,12 @@ flex-grow: revert;
 flex-grow: unset;
 </pre>
 
-<p>The <code>flex-grow</code> property is specified as a single <code><a href="#number">&lt;number&gt;</a></code>.</p>
+<p>The <code>flex-grow</code> property is specified as a single <code>&lt;number&gt;</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="number"><code>&lt;number&gt;</code></a></dt>
+ <dt><code>&lt;number&gt;</code></dt>
  <dd>See {{cssxref("&lt;number&gt;")}}. Negative values are invalid. Defaults to 0.</dd>
 </dl>
 
@@ -62,7 +62,6 @@ flex-grow: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<div id="Live_Sample">
 <pre class="brush: html">&lt;h4&gt;This is a Flex-Grow&lt;/h4&gt;
 &lt;h5&gt;A,B,C and F are flex-grow:1 . D and E are flex-grow:2 .&lt;/h5&gt;
 &lt;div id="content"&gt;
@@ -95,7 +94,6 @@ flex-grow: unset;
   border: 3px solid rgba(0,0,0,.2);
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/flex-shrink/index.html
+++ b/files/en-us/web/css/flex-shrink/index.html
@@ -18,7 +18,6 @@ browser-compat: css.properties.flex-shrink
 
 <div>{{EmbedInteractiveExample("pages/css/flex-shrink.html")}}</div>
 
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush:css no-line-numbers">/* &lt;number&gt; values */
@@ -32,12 +31,12 @@ flex-shrink: revert;
 flex-shrink: unset;
 </pre>
 
-<p>The <code>flex-shrink</code> property is specified as a single <code><a href="#number">&lt;number&gt;</a></code>.</p>
+<p>The <code>flex-shrink</code> property is specified as a single <code>&lt;number&gt;</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="number">&lt;number&gt;</code></dt>
+ <dt><code>&lt;number&gt;</code></dt>
  <dd>See {{cssxref("&lt;number&gt;")}}. Negative values are invalid. Defaults to 1.</dd>
 </dl>
 
@@ -55,7 +54,6 @@ flex-shrink: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<div id="Live_Sample">
 <pre class="brush: html">&lt;p&gt;The width of content is 500px; the flex-basis of the flex items is 120px.&lt;/p&gt;
 &lt;p&gt;A, B, C have flex-shrink:1 set. D and E have flex-shrink:2 set&lt;/p&gt;
 &lt;p&gt;The width of D and E is less than the others.&lt;/p&gt;
@@ -88,7 +86,6 @@ flex-shrink: unset;
   flex-shrink: 2;
 }
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/css/flex-wrap/index.html
+++ b/files/en-us/web/css/flex-wrap/index.html
@@ -59,7 +59,6 @@ flex-wrap: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<div id="Live_Sample">
 <pre class="brush: html">&lt;h4&gt;This is an example for flex-wrap:wrap &lt;/h4&gt;
 &lt;div class="content"&gt;
   &lt;div class="red"&gt;1&lt;/div&gt;
@@ -123,7 +122,6 @@ flex-wrap: unset;
 }
 
 </pre>
-</div>
 
 <h4 id="Results">Results</h4>
 

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -65,29 +65,29 @@ flex: unset;
 
   <ul>
    <li>a <code>&lt;number&gt;</code>: In this case it is interpreted as <code>flex: &lt;number&gt; 1 0</code>; the <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code> value is assumed to be 1 and the <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code> value is assumed to be <code>0</code>.</li>
-   <li>one of the keywords: <code><a href="#none">none</a></code>, <code><a href="#auto">auto</a></code>, or <code>initial</code>.</li>
+   <li>one of the keywords: <code>none</code>, <code>auto</code>, or <code>initial</code>.</li>
   </ul>
  </li>
  <li><strong>Two-value syntax:</strong>
   <ul>
    <li>The first value must be:
     <ul>
-     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code><a href="#flex-grow">&lt;flex-grow&gt;</a></code>.</li>
+     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code>&lt;flex-grow&gt;</code>.</li>
     </ul>
    </li>
    <li>The second value must be one of:
     <ul>
-     <li>a {{cssxref("&lt;number&gt;")}}: then it is interpreted as <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
-     <li>a valid value for {{cssxref("width")}}: then it is interpreted as <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code>.</li>
+     <li>a {{cssxref("&lt;number&gt;")}}: then it is interpreted as <code>&lt;flex-shrink&gt;</code>.</li>
+     <li>a valid value for {{cssxref("width")}}: then it is interpreted as <code>&lt;flex-basis&gt;</code>.</li>
     </ul>
    </li>
   </ul>
  </li>
  <li><strong>Three-value syntax:</strong> the values must be in the following order:
   <ol>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#flex-grow">&lt;flex-grow&gt;</a></code>.</li>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
-   <li>a valid value for {{cssxref("width")}} for <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code>&lt;flex-grow&gt;</code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code>&lt;flex-shrink&gt;</code>.</li>
+   <li>a valid value for {{cssxref("width")}} for <code>&lt;flex-basis&gt;</code>.</li>
   </ol>
  </li>
 </ul>
@@ -97,15 +97,15 @@ flex: unset;
 <dl>
  <dt><code>initial</code></dt>
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties. It shrinks to its minimum size to fit the container, but does not grow to absorb any extra free space in the flex container. This is equivalent to setting "<code>flex: 0 1 auto</code>".</dd>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties, but grows to absorb any extra free space in the flex container, and shrinks to its minimum size to fit the container. This is equivalent to setting "<code>flex: 1 1 auto</code>".</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties. It is fully inflexible: it neither shrinks nor grows in relation to the flex container. This is equivalent to setting "<code>flex: 0 0 auto</code>".</dd>
- <dt id="flex-grow"><code>&lt;'flex-grow'&gt;</code></dt>
+ <dt><code>&lt;'flex-grow'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-grow")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>0</code>)</dd>
- <dt id="flex-shrink"><code>&lt;'flex-shrink'&gt;</code></dt>
+ <dt><code>&lt;'flex-shrink'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-shrink")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>1</code>)</dd>
- <dt id="flex-basis"><code>&lt;'flex-basis'&gt;</code></dt>
+ <dt><code>&lt;'flex-basis'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-basis")}} of the flex item. A preferred size of <code>0</code> must have a unit to avoid being interpreted as a flexibility. Defaults to <code>0</code> when omitted. (initial is <code>auto</code>)</dd>
 </dl>
 

--- a/files/en-us/web/css/flex_value/index.html
+++ b/files/en-us/web/css/flex_value/index.html
@@ -16,7 +16,7 @@ browser-compat: css.types.flex
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>&lt;flex&gt;</code> data type is specified as a {{cssxref("&lt;number&gt;")}} followed by the unit <a id="fr"><code>fr</code></a>. The <code>fr</code> unit represents a fraction of the leftover space in the grid container. As with all CSS dimensions, there is no space between the unit and the number.</p>
+<p>The <code>&lt;flex&gt;</code> data type is specified as a {{cssxref("&lt;number&gt;")}} followed by the unit <code>fr</code>. The <code>fr</code> unit represents a fraction of the leftover space in the grid container. As with all CSS dimensions, there is no space between the unit and the number.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/css/font-family/index.html
+++ b/files/en-us/web/css/font-family/index.html
@@ -51,7 +51,7 @@ font-family: revert;
 font-family: unset;
 </pre>
 
-<p>The <code>font-family</code> property lists one or more font families, separated by commas. Each font family is specified as either a <code><a href="#family-name">&lt;family-name&gt;</a></code> or a <code><a href="#generic-name">&lt;generic-name&gt;</a></code> value.</p>
+<p>The <code>font-family</code> property lists one or more font families, separated by commas. Each font family is specified as either a <code>&lt;family-name&gt;</code> or a <code>&lt;generic-name&gt;</code> value.</p>
 
 <p>The example below lists two font families, the first with a <code>&lt;family-name&gt;</code> and the second with a <code>&lt;generic-name&gt;</code>:</p>
 
@@ -60,9 +60,9 @@ font-family: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="family-name"><code>&lt;family-name&gt;</code></a></dt>
+ <dt><code>&lt;family-name&gt;</code></dt>
  <dd>The name of a font family. For example, "Times" and "Helvetica" are font families. Font family names containing whitespace should be quoted. For example: "Comic Sans MS".</dd>
- <dt><a id="generic-name"><code>&lt;generic-name&gt;</code></a></dt>
+ <dt><code>&lt;generic-name&gt;</code></dt>
  <dd>
  <p>Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:</p>
  <dl>

--- a/files/en-us/web/css/font-size/index.html
+++ b/files/en-us/web/css/font-size/index.html
@@ -48,24 +48,24 @@ font-size: unset;
 <p>The <code>font-size</code> property is specified in one of the following ways:</p>
 
 <ul>
- <li>As one of the <a href="#absolute-size">absolute-size</a> or <a href="#relative-size">relative-size</a> keywords</li>
+ <li>As one of the absolute-size or relative-size keywords</li>
  <li>As a <code>&lt;length&gt;</code> or a <code>&lt;percentage&gt;</code>, relative to the element's font size.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="absolute-size"><code>xx-small</code>, <code>x-small</code>, <code>small</code>, <code>medium</code>, <code>large</code>, <code>x-large</code>, <code>xx-large</code>, <code>xxx-large</code></dt>
+ <dt><code>xx-small</code>, <code>x-small</code>, <code>small</code>, <code>medium</code>, <code>large</code>, <code>x-large</code>, <code>xx-large</code>, <code>xxx-large</code></dt>
  <dd>Absolute-size keywords, based on the user's default font size (which is <code>medium</code>).</dd>
- <dt id="relative-size"><code>larger</code>, <code>smaller</code></dt>
+ <dt><code>larger</code>, <code>smaller</code></dt>
  <dd>Relative-size keywords. The font will be larger or smaller relative to the parent element's font size, roughly by the ratio used to separate the absolute-size keywords above.</dd>
- <dt id="&lt;length&gt;">{{cssxref("&lt;length&gt;")}}</dt>
+ <dt>{{cssxref("&lt;length&gt;")}}</dt>
  <dd>
  <p>A positive {{cssxref("&lt;length&gt;")}} value. For most font-relative units (such as <code>em</code> and <code>ex</code>), the font size is relative to the parent element's font size.</p>
 
  <p>For font-relative units that are root-based (such as <code>rem</code>), the font size is relative to the size of the font used by the {{HTMLElement("html")}} (root) element.</p>
  </dd>
- <dt id="&lt;percentage&gt;">{{cssxref("&lt;percentage&gt;")}}</dt>
+ <dt>{{cssxref("&lt;percentage&gt;")}}</dt>
  <dd>
  <p>A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.</p>
  </dd>

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -36,7 +36,7 @@ browser-compat: css.properties.font
 
 <p>The <code>font</code> property may be specified as either a single keyword, which will select a system font, or as a shorthand for various font-related properties.</p>
 
-<p>If <code>font</code> is specified as a system keyword, it must be one of: <code><a href="#caption">caption</a></code>, <code><a href="#icon">icon</a></code>, <code><a href="#menu">menu</a></code>, <code><a href="#message-box">message-box</a></code>, <code><a href="#small-caption">small-caption</a></code>, <code><a href="#status-bar">status-bar</a></code>.</p>
+<p>If <code>font</code> is specified as a system keyword, it must be one of: <code>caption</code>, <code>icon</code>, <code>menu</code>, <code>>message-box</code>, <code>small-caption</code>, <code>status-bar</code>.</p>
 
 <p>If <code>font</code> is specified as a shorthand for several font-related properties, then:</p>
 
@@ -66,36 +66,36 @@ browser-compat: css.properties.font
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="font-style"><code>&lt;'font-style'&gt;</code></dt>
+ <dt><code>&lt;'font-style'&gt;</code></dt>
  <dd>See the {{cssxref("font-style")}} CSS property.</dd>
- <dt id="font-variant"><code>&lt;'font-variant'&gt;</code></dt>
+ <dt><code>&lt;'font-variant'&gt;</code></dt>
  <dd>See the {{cssxref("font-variant")}} CSS property.</dd>
- <dt id="font-weight"><code>&lt;'font-weight'&gt;</code></dt>
+ <dt><code>&lt;'font-weight'&gt;</code></dt>
  <dd>See the {{cssxref("font-weight")}} CSS property.</dd>
- <dt id="font-stretch"><code>&lt;'font-stretch'&gt;</code></dt>
+ <dt><code>&lt;'font-stretch'&gt;</code></dt>
  <dd>See the {{cssxref("font-stretch")}} CSS property.</dd>
- <dt id="font-size"><code>&lt;'font-size'&gt;</code></dt>
+ <dt><code>&lt;'font-size'&gt;</code></dt>
  <dd>See the {{cssxref("font-size")}} CSS property.</dd>
- <dt id="line-height"><code>&lt;'line-height'&gt;</code></dt>
+ <dt><code>&lt;'line-height'&gt;</code></dt>
  <dd>See the {{cssxref("line-height")}} CSS property.</dd>
- <dt id="font-family"><code>&lt;'font-family'&gt;</code></dt>
+ <dt><code>&lt;'font-family'&gt;</code></dt>
  <dd>See the {{cssxref("font-family")}} CSS property.</dd>
 </dl>
 
 <h4 id="System_font_values">System font values</h4>
 
 <dl>
- <dt id="caption"><code>caption</code></dt>
+ <dt><code>caption</code></dt>
  <dd>The system font used for captioned controls (e.g., buttons, drop-downs, etc.).</dd>
- <dt id="icon"><code>icon</code></dt>
+ <dt><code>icon</code></dt>
  <dd>The system font used to label icons.</dd>
- <dt id="menu"><code>menu</code></dt>
+ <dt><code>menu</code></dt>
  <dd>The system font used in menus (e.g., dropdown menus and menu lists).</dd>
- <dt id="message-box"><code>message-box</code></dt>
+ <dt><code>message-box</code></dt>
  <dd>The system font used in dialog boxes.</dd>
- <dt id="small-caption"><code>small-caption</code></dt>
+ <dt><code>small-caption</code></dt>
  <dd>The system font used for labeling small controls.</dd>
- <dt id="status-bar"><code>status-bar</code></dt>
+ <dt><code>status-bar</code></dt>
  <dd>The system font used in window status bars.</dd>
  <dt>Prefixed system font keywords</dt>
  <dd>Browsers often implement several more, prefixed, keywords: Gecko implements <code>-moz-window</code>, <code>-moz-document</code>, <code>-moz-desktop</code>, <code>-moz-info</code>, <code>-moz-dialog</code>, <code>-moz-button</code>, <code>-moz-pull-down-menu</code>, <code>-moz-list</code>, and <code>-moz-field</code>.</dd>

--- a/files/en-us/web/css/frequency/index.html
+++ b/files/en-us/web/css/frequency/index.html
@@ -20,9 +20,9 @@ browser-compat: css.types.frequency
 <h3 id="Units">Units</h3>
 
 <dl>
- <dt><code><a id="Hz">Hz</a></code></dt>
+ <dt><code>Hz</code></dt>
  <dd>Represents a frequency in hertz. Examples: <code>0Hz</code>, <code>1500Hz</code>, <code>10000Hz</code>.</dd>
- <dt><code><a id="kHz">kHz</a></code></dt>
+ <dt><code>kHz</code></dt>
  <dd>Represents a frequency in kilohertz. Examples: <code>0kHz</code>, <code>1.5kHz</code>, <code>10kHz</code>.</dd>
 </dl>
 

--- a/files/en-us/web/css/gradient/conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/conic-gradient()/index.html
@@ -22,7 +22,7 @@ browser-compat: css.types.image.gradient.conic-gradient
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="language-css" id="css">/* A conic gradient rotated 45 degrees,
+<pre class="brush: css">/* A conic gradient rotated 45 degrees,
    starting blue and finishing red */
 conic-gradient(from 45deg, blue, red);
 

--- a/files/en-us/web/css/gradient/index.html
+++ b/files/en-us/web/css/gradient/index.html
@@ -24,29 +24,21 @@ browser-compat: css.types.image.gradient
 
 <p>The <code>&lt;gradient&gt;</code> data type is defined with one of the function types listed below.</p>
 
-<div id="linear-gradient">
 <h4 id="Linear_gradient">Linear gradient</h4>
 
 <p>Linear gradients transition colors progressively along an imaginary line. They are generated with the {{cssxref("gradient/linear-gradient()", "linear-gradient()")}} function.</p>
-</div>
 
-<div id="radial-gradient">
 <h4 id="Radial_gradient">Radial gradient</h4>
 
 <p>Radial gradients transition colors progressively from a center point (origin). They are generated with the {{cssxref("gradient/radial-gradient()", "radial-gradient()")}} function.</p>
-</div>
 
-<div id="repeating-gradient">
 <h4 id="Repeating_gradient">Repeating gradient</h4>
 
 <p>Repeating gradients duplicate a gradient as much as necessary to fill a given area. They are generated with the {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}} and {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}} functions.</p>
-</div>
 
-<div id="conic-gradient">
 <h4 id="Conic_gradient">Conic gradient</h4>
 
 <p>Conic gradients transition colors progressively around a circle. They are generated with the {{cssxref("gradient/conic-gradient()", "conic-gradient()")}} function.</p>
-</div>
 
 <h2 id="Interpolation">Interpolation</h2>
 

--- a/files/en-us/web/css/gradient/linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/linear-gradient()/index.html
@@ -22,7 +22,7 @@ browser-compat: css.types.image.gradient.linear-gradient
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="language-css" id="css">/* A gradient tilted 45 degrees,
+<pre class="brush: css">/* A gradient tilted 45 degrees,
    starting blue and finishing red */
 linear-gradient(45deg, blue, red);
 

--- a/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
@@ -19,7 +19,7 @@ browser-compat: css.types.image.gradient.repeating-conic-gradient
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: css language-css" id="css">/* Starburst: a blue on blue starburst: the gradient
+<pre class="brush: css">/* Starburst: a blue on blue starburst: the gradient
    is a starburst of lighter and darker blue,
    centered in the upper left quadrant,
    offset by 3degrees so there is no up/down straight line */

--- a/files/en-us/web/css/grid-template-columns/index.html
+++ b/files/en-us/web/css/grid-template-columns/index.html
@@ -63,13 +63,13 @@ grid-template-columns: unset;
  <dd>Is a non-negative dimension with the unit <code>fr</code> specifying the track’s flex factor. Each <code>&lt;flex&gt;</code>-sized track takes a share of the remaining space in proportion to its flex factor.
  <p>When appearing outside a <code>minmax()</code> notation, it implies an automatic minimum (i.e. <code>minmax(auto, &lt;flex&gt;)</code>).</p>
  </dd>
- <dt id="max-content">{{cssxref("max-content")}}</dt>
+ <dt>{{cssxref("max-content")}}</dt>
  <dd>Is a keyword representing the largest maximal content contribution of the grid items occupying the grid track.</dd>
  <dt>{{cssxref("min-content")}}</dt>
  <dd>Is a keyword representing the largest minimal content contribution of the grid items occupying the grid track.</dd>
  <dt>{{cssxref("minmax()", "minmax(min, max)")}}</dt>
  <dd>Is a functional notation that defines a size range greater than or equal to <em>min</em> and less than or equal to <em>max</em>. If <em>max</em> is smaller than <em>min</em>, then <em>max</em> is ignored and the function is treated as <em>min</em>. As a maximum, a <code>&lt;flex&gt;</code> value sets the track’s flex factor. It is invalid as a minimum.</dd>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd><p>As a maximum represents the largest {{cssxref("max-content")}} size of the items in that track.</p>
   <p>As a minimum represents the largest minimum size of items in that track (specified by the {{cssxref("min-width")}}/{{cssxref("min-height")}} of the items). This is often, though not always, the {{cssxref("min-content")}} size.</p>
   <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maximum described above. This behaves similarly to <code>minmax(min-content,max-content)</code> in most cases.</p>
@@ -78,7 +78,7 @@ grid-template-columns: unset;
    <p><strong>Note:</strong> <code>auto</code> track sizes (and only <code>auto</code> track sizes) can be stretched by the {{cssxref("align-content")}} and {{cssxref("justify-content")}} properties. Therefore by default, an <code>auto</code> sized track will take up any remaining space in the grid container.</p>
  </div>
  </dd>
- <dt id="fit-content()"><code>{{cssxref("fit-content()", "fit-content( [ &lt;length&gt; | &lt;percentage&gt; ] )")}}</code></dt>
+ <dt><code>{{cssxref("fit-content()", "fit-content( [ &lt;length&gt; | &lt;percentage&gt; ] )")}}</code></dt>
  <dd>Represents the formula <code>min(max-content, max(auto, <var>argument</var>))</code>, which is calculated similar to <code>auto</code> (i.e. <code>minmax(auto, max-content)</code>), except that the track size is clamped at <var>argument</var> if it is greater than the <code>auto</code> minimum.</dd>
  <dt>{{cssxref("repeat()", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}</dt>
  <dd>Represents a repeated fragment of the track list, allowing a large number of columns that exhibit a recurring pattern to be written in a more compact form.</dd>

--- a/files/en-us/web/css/height/index.html
+++ b/files/en-us/web/css/height/index.html
@@ -15,7 +15,7 @@ browser-compat: css.properties.height
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>height</code></strong> CSS property specifies the height of an element. By default, the property defines the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content-area">content area</a>. If {{cssxref("box-sizing")}} is set to <code>border-box</code>, however, it instead determines the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border-area">border area</a>.</p>
+<p>The <strong><code>height</code></strong> CSS property specifies the height of an element. By default, the property defines the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content_area">content area</a>. If {{cssxref("box-sizing")}} is set to <code>border-box</code>, however, it instead determines the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border_area">border area</a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/height.html")}}</div>
 

--- a/files/en-us/web/css/length/index.html
+++ b/files/en-us/web/css/length/index.html
@@ -72,9 +72,9 @@ browser-compat: css.types.length
  <dt><code id="vw">vw</code></dt>
  <dd>Equal to 1% of the width of the viewport's initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>.</dd>
  <dt><code id="vi">vi</code> {{experimental_inline}}</dt>
- <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#inline-dimension">inline axis</a>.</dd>
+ <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline">inline axis</a>.</dd>
  <dt><code id="vb">vb</code> {{experimental_inline}}</dt>
- <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#block-dimension">block axis</a>.</dd>
+ <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline">block axis</a>.</dd>
  <dt><code id="vmin">vmin</code></dt>
  <dd>Equal to the smaller of <code>vw</code> and <code>vh</code>.</dd>
  <dt><code id="vmax">vmax</code></dt>

--- a/files/en-us/web/css/padding-bottom/index.html
+++ b/files/en-us/web/css/padding-bottom/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.padding-bottom
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>padding-bottom</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding-area">padding area</a> on the bottom of an element.</p>
+<p>The <strong><code>padding-bottom</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area">padding area</a> on the bottom of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/padding-bottom.html")}}</div>
 

--- a/files/en-us/web/css/padding-left/index.html
+++ b/files/en-us/web/css/padding-left/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.padding-left
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>padding-left</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding-area">padding area</a> to the left of an element.</p>
+<p>The <strong><code>padding-left</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area">padding area</a> to the left of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/padding-left.html")}}</div>
 

--- a/files/en-us/web/css/padding-right/index.html
+++ b/files/en-us/web/css/padding-right/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.padding-right
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>padding-right</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding-area">padding area</a> on the right of an element.</p>
+<p>The <strong><code>padding-right</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area">padding area</a> on the right of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/padding-right.html")}}</div>
 

--- a/files/en-us/web/css/padding-top/index.html
+++ b/files/en-us/web/css/padding-top/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.padding-top
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>padding-top</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding-area">padding area</a> on the top of an element.</p>
+<p>The <strong><code>padding-top</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the height of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area">padding area</a> on the top of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/padding-top.html")}}</div>
 

--- a/files/en-us/web/css/padding/index.html
+++ b/files/en-us/web/css/padding/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.padding
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>padding</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> sets the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding-area">padding area</a> on all four sides of an element at once.</p>
+<p>The <strong><code>padding</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> sets the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area">padding area</a> on all four sides of an element at once.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/padding.html")}}</div>
 

--- a/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.html
+++ b/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.html
@@ -38,7 +38,7 @@ tags:
  <li>The color parts of the {{SVGAttr("fill")}} and {{SVGAttr("stroke")}} attributes</li>
 </ul>
 
-<p>In addition, even for the above styles, you won't be able to change the transparency between unvisited and visited links, as you otherwise would be able to using <code><a href="/en-US/docs/Web/CSS/color_value#rgba()">rgba()</a></code>, <code><a href="/en-US/docs/Web/CSS/color_value#hsla()">hsla()</a></code>, or the <code><a href="/en-US/docs/Web/CSS/color_value#transparent">transparent</a></code> keyword.</p>
+<p>In addition, even for the above styles, you won't be able to change the transparency between unvisited and visited links, as you otherwise would be able to using <code><a href="/en-US/docs/Web/CSS/color_value#rgba()">rgba()</a></code>, <code><a href="/en-US/docs/Web/CSS/color_value#hsla()">hsla()</a></code>, or the <code><a href="/en-US/docs/Web/CSS/color_value#transparent_keyword">transparent</a></code> keyword.</p>
 
 <p>Here is an example of how to use styles with the aforementioned restrictions:</p>
 

--- a/files/en-us/web/css/width/index.html
+++ b/files/en-us/web/css/width/index.html
@@ -14,7 +14,7 @@ browser-compat: css.properties.width
 ---
 <p>{{CSSRef}}</p>
 
-<p>The <strong><code>width</code></strong> CSS property sets an element's width. By default, it sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content-area">content area</a>, but if {{cssxref("box-sizing")}} is set to <code>border-box</code>, it sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border-area">border area</a>.</p>
+<p>The <strong><code>width</code></strong> CSS property sets an element's width. By default, it sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#content_area">content area</a>, but if {{cssxref("box-sizing")}} is set to <code>border-box</code>, it sets the width of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#border_area">border area</a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/width.html")}}</div>
 


### PR DESCRIPTION
This is the next batch of changes to remove ID attributes from the CSS documentation. These changes are a bit intricate sometimes.

I've done my best to ensure that any internal links still work reasonably well. Probably the most common usage is adding `id` attributes to the `dt` elements for a property's values, so they can be linked by the preceding paragraph (for example, see https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#syntax, where it says:

> The line-height property is specified as any one of the following:
>
> *   a \<number>
> *   a \<length>
> *   a \<percentage>
> *   the keyword normal.

...and the names of the values link to the "values" list. This is quite nice but it doesn't seem especially useful, as the values are right underneath anyway.
