### PR TITLE
Description of special pseudo elements refined.

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
@@ -352,7 +352,7 @@ tags:
   </tr>
   <tr>
    <td>{{ Cssxref("::before") }}</td>
-   <td>Inserts a stylable element appearing before the originating element's actual content.</td>
+   <td>Inserts a stylable element appearing before the originating element's actual content, if used with the {{cssxref("content")}} property with a value other than <code>none</code>.</td>
   </tr>
   <tr>
    <td>{{ Cssxref("::first-letter") }}</td>

--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
@@ -348,7 +348,7 @@ tags:
  <tbody>
   <tr>
    <td>{{ Cssxref("::after") }}</td>
-   <td>Inserts a stylable element appearing after the originating element's actual content.</td>
+   <td>Inserts a stylable element appearing after the originating element's actual content, if used with the {{cssxref("content")}} property with a value other than <code>none</code>.</td>
   </tr>
   <tr>
    <td>{{ Cssxref("::before") }}</td>

--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
@@ -348,11 +348,11 @@ tags:
  <tbody>
   <tr>
    <td>{{ Cssxref("::after") }}</td>
-   <td>Matches a stylable element appearing after the originating element's actual content.</td>
+   <td>Inserts a stylable element appearing after the originating element's actual content.</td>
   </tr>
   <tr>
    <td>{{ Cssxref("::before") }}</td>
-   <td>Matches a stylable element appearing before the originating element's actual content.</td>
+   <td>Inserts a stylable element appearing before the originating element's actual content.</td>
   </tr>
   <tr>
    <td>{{ Cssxref("::first-letter") }}</td>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Since psudo-elements `::before` and `::after` _"inserts"_ content rather than _"matches"_ existing content, description changed accordingly.


