### PR TITLE
Replace Text object description with clear example

### DIFF
--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -10,13 +10,28 @@ browser-compat: api.Text
 ---
 <div>{{ApiRef("DOM")}}</div>
 
-<p><span class="seoSummary">The <strong><code>Text</code></strong> interface represents the textual content of {{domxref("Element")}} or {{domxref("Attr")}}. </span></p>
-
-<p>If an element has no markup within its content, it has a single child implementing <code>Text</code> that contains the element's text. However, if the element contains markup, it is parsed into information items and <code>Text</code> nodes that form its children.</p>
-
-<p>New documents have a single <code>Text</code> node for each block of text. Over time, more <code>Text</code> nodes may be created as the document's content changes. The {{domxref("Node.normalize()")}} method merges adjacent <code>Text</code> objects back into a single node for each block of text.</p>
+<p>The <strong><code>Text</code></strong> interface represents a text {{domxref("Node", "node")}} in a DOM tree.</p>
 
 <p>{{InheritanceDiagram}}</p>
+
+<p>To understand what a text node is, consider the following document:</p>
+
+<pre class="brush: html">
+&lt;html class="e"&gt;&lt;head&gt;&lt;title&gt;Aliens?&lt;/title&gt;&lt;/head&gt;
+ &lt;body&gt;Why yes.
+&lt;/body&gt;&lt;/html&gt;
+</pre>
+
+<p>In that document, there are three text nodes, with the following contents:</p>
+
+<ul>
+  <li>"<code>Aliens?</code>" (the contents of the <code>title</code> element)</li>
+  <li>"<code>\n </code>" (after the <code>&lt;/head&gt;</code> end tag, a newline followed by a space)</li>
+  <li>"<code>Why yes.\n</code>" (the contents of the <code>body</code> element)</li>
+</ul>
+
+<p>Each of those text nodes is an object that has the properties and methods documented in this article.</p>
+
 
 <h2 id="Methods">Constructor</h2>
 


### PR DESCRIPTION
In https://developer.mozilla.org/en-US/docs/Web/API/Text the current summary/description of the `Text` interface was copied verbatim from https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-1312295772.  And that description is really not actually clear or useful to developers.

So, this change replaces that description with an example that makes clear what a text node is. Fixes https://github.com/mdn/content/issues/5487.