### PR TITLE
Update Range.cloneContents()

### DIFF
--- a/files/en-us/web/api/range/clonecontents/index.html
+++ b/files/en-us/web/api/range/clonecontents/index.html
@@ -24,7 +24,7 @@ browser-compat: api.Range.cloneContents
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>documentFragment </em>= <em>range</em>.cloneContents();
+<pre class="brush: js"><var>documentFragment</var> = <var>range</var>.cloneContents();
 </pre>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/range/clonecontents/index.html
+++ b/files/en-us/web/api/range/clonecontents/index.html
@@ -14,8 +14,9 @@ browser-compat: api.Range.cloneContents
   domxref("DocumentFragment") }} copying the objects of type {{ domxref("Node") }}
   included in the {{ domxref("Range") }}.</p>
 
-<p>Event Listeners added using DOM Events are not copied during cloning. HTML attribute
-  events are duplicated as they are for the DOM Core cloneNode method. HTML id attributes
+<p>Event listeners added using {{domxref("EventTarget.addEventListener()", "addEventListener()")}}
+  are not copied during cloning. HTML attribute events are duplicated as they are
+  for the {{ domxref("Node.cloneNode()") }} method. HTML <code>id</code> attributes
   are also cloned, which can lead to an invalid document through cloning.</p>
 
 <p>Partially selected nodes include the parent tags necessary to make the document

--- a/files/en-us/web/api/range/clonecontents/index.html
+++ b/files/en-us/web/api/range/clonecontents/index.html
@@ -24,7 +24,7 @@ browser-compat: api.Range.cloneContents
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>documentFragment</var> = <var>range</var>.cloneContents();
+<pre class="brush: js">documentFragment = range.cloneContents();
 </pre>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
* adds xref to the `cloneNode()` method
* clarify "using DOM Events" by xrefing to the `addEventListener()`
* wrap "id" using `<code></code>` in "HTML id attributes"
* remove`em` in the syntax section

> Issue number to be fixed (ie 'Fixes #123', if there is an associated issue)

none.


> What was wrong/why is this fix needed? (quick summary only)

for xref updates, I felt it is helpful to have those links.


> Anything else that could help us review it
