### PR TITLE
Remove IDs from CSS docs, part 3

### DIFF
--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.html
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <a href="/en-US/docs/Web/CSS/margin-top">top</a> and <a href="/en-US/docs/Web/CSS/margin-bottom">bottom</a> margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as <strong>margin collapsing</strong>. Note that the margins of <a href="/en-US/docs/Web/CSS/float">floating</a> and <a href="/en-US/docs/Web/CSS/position#absolute">absolutely positioned</a> elements never collapse.</p>
+<p>The <a href="/en-US/docs/Web/CSS/margin-top">top</a> and <a href="/en-US/docs/Web/CSS/margin-bottom">bottom</a> margins of blocks are sometimes combined (collapsed) into a single margin whose size is the largest of the individual margins (or just one of them, if they are equal), a behavior known as <strong>margin collapsing</strong>. Note that the margins of <a href="/en-US/docs/Web/CSS/float">floating</a> and <a href="/en-US/docs/Web/CSS/position#types_of_positioning">absolutely positioned</a> elements never collapse.</p>
 
 <p>Margin collapsing occurs in three basic cases:</p>
 

--- a/files/en-us/web/css/css_flow_layout/intro_to_formatting_contexts/index.html
+++ b/files/en-us/web/css/css_flow_layout/intro_to_formatting_contexts/index.html
@@ -29,7 +29,7 @@ tags:
 
 <ul>
  <li>elements made to float using {{cssxref("float")}}</li>
- <li>absolutely positioned elements (including {{cssxref("position", "position: fixed", "#fixed")}} or {{cssxref("position", "position: sticky", "#sticky")}})</li>
+ <li><a href="/en-US/docs/Web/CSS/position#types_of_positioning">absolutely positioned</a> elements</li>
  <li>elements with {{cssxref("display", "display: inline-block", "#inline-block")}}</li>
  <li>table cells or elements with <code>display: table-cell</code>, including anonymous table cells created when using the <code>display: table-*</code> properties</li>
  <li>table captions or elements with <code>display: table-caption</code></li>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.html
@@ -15,19 +15,21 @@ tags:
 
 <ol>
  <li>The background and borders of the root element</li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#static">non-positioned</a> blocks, in order of appearance in the HTML</li>
+ <li>Descendant non-positioned blocks, in order of appearance in the HTML</li>
  <li><em>Floating blocks</em></li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#types_of_positioning">positioned</a> elements, in order of appearance in the HTML</li>
+ <li>Descendant positioned elements, in order of appearance in the HTML</li>
 </ol>
+
+<p>See <a href="/en-US/docs/Web/CSS/position#types_of_positioning">types of positioning</a> for an explanation of positioned and non-positioned elements.</p>
 
 <p>Actually, as you can see in the example below, the background and border of the non-positioned block (DIV #4) is completely unaffected by floating blocks, but the content is affected. This happens according to standard float behavior. This behavior can be shown with an added rule to the above list:</p>
 
 <ol>
  <li>The background and borders of the root element</li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#static">non-positioned</a> blocks, in order of appearance in the HTML</li>
+ <li>Descendant non-positioned blocks, in order of appearance in the HTML</li>
  <li>Floating blocks</li>
- <li><em>Descendant <a href="/en-US/docs/Web/CSS/position#static">non-positioned</a> inline elements</em></li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#types_of_positioning">positioned</a> elements, in order of appearance in the HTML</li>
+ <li><em>Descendant non-positioned inline elements</em></li>
+ <li>Descendant positioned elements, in order of appearance in the HTML</li>
 </ol>
 
 <p>{{EmbedLiveSample("Source_code_for_the_example", 600, 250)}}</p>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
@@ -15,9 +15,11 @@ tags:
 
 <ol>
  <li>The background and borders of the root element</li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#static">non-positioned</a> blocks, in order of appearance in the HTML</li>
- <li>Descendant <a href="/en-US/docs/Web/CSS/position#Types_of_positioning">positioned</a> elements, in order of appearance in the HTML</li>
+ <li>Descendant non-positioned blocks, in order of appearance in the HTML</li>
+ <li>Descendant positioned elements, in order of appearance in the HTML</li>
 </ol>
+
+<p>See <a href="/en-US/docs/Web/CSS/position#types_of_positioning">types of positioning</a> for an explanation of positioned and non-positioned elements.</p>
 
 <p>Keep in mind, when the {{cssxref("order")}} property alters rendering from the "order of appearance in the HTML" within {{cssxref("flex")}} containers, it similarly affects the order for stacking context.</p>
 

--- a/files/en-us/web/css/gradient/conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/conic-gradient()/index.html
@@ -62,7 +62,7 @@ background: conic-gradient(
 
 <h2 id="Description">Description</h2>
 
-<p>As with any gradient, a conic gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to, or size of the <code>&lt;image&gt;</code> is set to something other than the element size.</p>
+<p>As with any gradient, a conic gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to, or size of the <code>&lt;image&gt;</code> is set to something other than the element size.</p>
 
 <p>To create a conic gradient that repeats so as to fill a 360 degree rotation, use the {{CSSxRef("gradient/repeating-conic-gradient()")}} function instead.</p>
 

--- a/files/en-us/web/css/gradient/index.html
+++ b/files/en-us/web/css/gradient/index.html
@@ -18,7 +18,7 @@ browser-compat: css.types.image.gradient
 <div>{{EmbedInteractiveExample("pages/css/type-gradient.html")}}</div>
 
 
-<p>A CSS gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element to which it applies.</p>
+<p>A CSS gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element to which it applies.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/gradient/linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/linear-gradient()/index.html
@@ -70,7 +70,7 @@ linear-gradient(45deg, red 0 50%, blue 50% 100%);</pre>
 
 <h2 id="Description">Description</h2>
 
-<p>As with any gradient, a linear gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
+<p>As with any gradient, a linear gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
 <p>To create a linear gradient that repeats so as to fill its container, use the {{CSSxRef("gradient/repeating-linear-gradient()")}} function instead.</p>
 

--- a/files/en-us/web/css/gradient/radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/radial-gradient()/index.html
@@ -78,7 +78,7 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <h2 id="Description">Description</h2>
 
-<p>As with any gradient, a radial gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
+<p>As with any gradient, a radial gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
 <p>To create a radial gradient that repeats so as to fill its container, use the {{cssxref("gradient/repeating-radial-gradient()")}} function instead.</p>
 

--- a/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
@@ -52,7 +52,7 @@ background: repeating-conic-gradient(
 
 <p>If neither the first nor the last color stops include a color stop angle greater than 0deg or less than 360 degrees respectively, the conic-gradient will not repeat.</p>
 
-<p>As with any gradient, a repeating-conic gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to, or the size the <code>&lt;image&gt;</code> is set to if it's set to something other than the element's size.</p>
+<p>As with any gradient, a repeating-conic gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to, or the size the <code>&lt;image&gt;</code> is set to if it's set to something other than the element's size.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>repeating-conic-gradient()</code> won't work on {{CSSxRef("background-color")}} and other properties that use the {{CSSxRef("&lt;color&gt;")}} data type.</p>
 

--- a/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
@@ -22,7 +22,7 @@ browser-compat: css.types.image.gradient.repeating-linear-gradient
 
 <p>The length of the gradient that repeats is the distance between the first and last color stop. If the first color does not have a color-stop-length, the color-stop-length defaults to 0. With each repetition, the positions of the color stops are shifted by a multiple of the length of the basic linear gradient. Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition. This can be altered with repeating the first color again as the last color.</p>
 
-<p>As with any gradient, a repeating linear gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
+<p>As with any gradient, a repeating linear gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>repeating-linear-gradient()</code> won't work on {{Cssxref("background-color")}} and other properties that use the {{cssxref("&lt;color&gt;")}} data type.</p>
 

--- a/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
@@ -22,7 +22,7 @@ browser-compat: css.types.image.gradient.repeating-radial-gradient
 
 <p>With each repetition, the positions of the color stops are shifted by a multiple of the dimensions of the basic radial gradient (the distance between the last color stop and the first). Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition, which can be mitigated by repeating the first color as the last color.</p>
 
-<p>As with any gradient, a repeating radial gradient has <a href="/en-US/docs/Web/CSS/image#no_intrinsic">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
+<p>As with any gradient, a repeating radial gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>repeating-radial-gradient()</code> won't work on {{cssxref("background-color")}} and other properties that use the {{cssxref("&lt;color&gt;")}} data type.</p>
 

--- a/files/en-us/web/css/image/image-set()/index.html
+++ b/files/en-us/web/css/image/image-set()/index.html
@@ -42,7 +42,7 @@ where &lt;image-set-option&gt; = [ &lt;image&gt; | &lt;string&gt; ] &lt;resoluti
 
 <h3 id="Using_image-set_to_provide_alternative_background-image_options">Using image-set() to provide alternative background-image options</h3>
 
-<p>This example shows how to use <code><a class="css" href="https://drafts.csswg.org/css-images-4/#funcdef-image-set" id="ref-for-funcdef-image-set⑨">image-set()</a></code> to provide two alternative {{cssxref("background-image")}} options, chosen depending on the resolution needed: a normal version and a high-resolution version.</p>
+<p>This example shows how to use <code><a class="css" href="https://drafts.csswg.org/css-images-4/#funcdef-image-set">image-set()</a></code> to provide two alternative {{cssxref("background-image")}} options, chosen depending on the resolution needed: a normal version and a high-resolution version.</p>
 
 <p>{{EmbedGHLiveSample("css-examples/images/image-set.html", '100%', 600)}}</p>
 

--- a/files/en-us/web/css/image/index.html
+++ b/files/en-us/web/css/image/index.html
@@ -37,7 +37,7 @@ browser-compat: css.types.image
 	<li>Images with <em>intrinsic dimensions</em> (a natural size), like a JPEG, PNG, or other <a href="https://en.wikipedia.org/wiki/Raster_graphics">raster format</a>.</li>
 	<li>Images with <em>multiple intrinsic dimensions</em>, existing in multiple versions inside a single file, like some .ico formats. (In this case, the intrinsic dimensions will be those of the image largest in area and the aspect ratio most similar to the containing box.)</li>
 	<li>Images with no intrinsic dimensions but with <em>an intrinsic aspect ratio</em> between its width and height, like an SVG or other <a href="https://en.wikipedia.org/wiki/Vector_graphics">vector format</a>.</li>
-	<li id="no_intrinsic">Images with <em>neither intrinsic dimensions, nor an intrinsic aspect ratio</em>, like a CSS gradient.</li>
+	<li>Images with <em>neither intrinsic dimensions, nor an intrinsic aspect ratio</em>, like a CSS gradient.</li>
 </ul>
 
 <p>CSS determines an object's <em>concrete size</em> using (1) its <em>intrinsic dimensions</em>; (2) its <em>specified size</em>, defined by CSS properties like {{CSSxRef("width")}}, {{CSSxRef("height")}}, or {{CSSxRef("background-size")}}; and (3) its <em>default size</em>, determined by the kind of property the image is used with:</p>

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.html
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.html
@@ -26,7 +26,7 @@ tags:
 
 <h2 id="Choices_made">Choices made</h2>
 
-<p id="docs-internal-guid-30ae4ecd-7fff-36c2-da7d-0fbb6ec4feae">This recipe uses the CSS Grid {{cssxref("minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width we can set a minimum value of 0 or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using a numeric unit (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using percentage values or viewport units will mean this wrapper grows or shrinks in response to its context.</p>
+<p>This recipe uses the CSS Grid {{cssxref("minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width we can set a minimum value of 0 or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using a numeric unit (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using percentage values or viewport units will mean this wrapper grows or shrinks in response to its context.</p>
 
 <p>The outer two columns have a maximum size of <code>1fr</code>, meaning that they will each expand to fill the remaining available space in the grid container.</p>
 
@@ -75,7 +75,7 @@ tags:
 
 <ul>
  <li>{{Cssxref("grid-template-columns")}}</li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout" id="docs-internal-guid-ae8eafc9-7fff-65b9-8d8c-bb5f1e3c874c">CSS Grid Layout on MDN</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout on MDN</a></li>
  <li>Article:<a href="https://css-irl.info/more-flexibility-with-minmax/"> CSS Grid: More flexibility with minmax()</a></li>
  <li>Article: <a href="https://rachelandrew.co.uk/archives/2017/06/01/breaking-out-with-css-grid-explained/">Breaking Out with CSS Grid</a></li>
 </ul>

--- a/files/en-us/web/css/length/index.html
+++ b/files/en-us/web/css/length/index.html
@@ -42,23 +42,23 @@ browser-compat: css.types.length
 </div>
 
 <dl>
- <dt><code id="cap">cap</code> {{experimental_inline}}</dt>
+ <dt><code>cap</code> {{experimental_inline}}</dt>
  <dd>Represents the "cap height" (nominal height of capital letters) of the element’s {{Cssxref("font")}}.</dd>
- <dt><code id="ch">ch</code></dt>
+ <dt><code>ch</code></dt>
  <dd>Represents the width, or more precisely the advance measure, of the glyph "0" (zero, the Unicode character U+0030) in the element's {{Cssxref("font")}}.<br>
  <br>
  In the cases where it is impossible or impractical to determine the measure of the “0” glyph, it must be assumed to be 0.5em wide by 1em tall.</dd>
- <dt><code id="em">em</code></dt>
+ <dt><code>em</code></dt>
  <dd>Represents the calculated {{Cssxref("font-size")}} of the element. If used on the {{Cssxref("font-size")}} property itself, it represents the <em>inherited</em> font-size of the element.</dd>
- <dt><code id="ex">ex</code></dt>
+ <dt><code>ex</code></dt>
  <dd>Represents the <a href="https://en.wikipedia.org/wiki/X-height">x-height</a> of the element's {{Cssxref("font")}}. On fonts with the "x" letter, this is generally the height of lowercase letters in the font; <code>1ex ≈ 0.5em</code> in many fonts.</dd>
- <dt><code id="ic">ic</code> {{experimental_inline}}</dt>
+ <dt><code>ic</code> {{experimental_inline}}</dt>
  <dd>Equal to the used advance measure of the "水" glyph (CJK water ideograph, U+6C34), found in the font used to render it.</dd>
- <dt><code id="lh">lh</code> {{experimental_inline}}</dt>
+ <dt><code>lh</code> {{experimental_inline}}</dt>
  <dd>Equal to the computed value of the {{Cssxref("line-height")}} property of the element on which it is used, converted to an absolute length.</dd>
- <dt><code id="rem">rem</code></dt>
+ <dt><code>rem</code></dt>
  <dd>Represents the {{Cssxref("font-size")}} of the root element (typically {{HTMLElement("html")}}). When used within the root element {{Cssxref("font-size")}}, it represents its initial value (a common browser default is <code>16px</code>, but user-defined preferences may modify this).</dd>
- <dt><code id="rlh">rlh</code> {{experimental_inline}}</dt>
+ <dt><code>rlh</code> {{experimental_inline}}</dt>
  <dd>Equal to the computed value of the {{Cssxref("line-height")}} property on the root element (typically {{HTMLElement("html")}}), converted to an absolute length. When used on the {{Cssxref("font-size")}} or {{Cssxref("line-height")}} properties of the root element, it refers to the properties' initial value.</dd>
 </dl>
 
@@ -67,17 +67,17 @@ browser-compat: css.types.length
 <p>Viewport-percentage lengths define the <code>&lt;length&gt;</code> value relative to the size of the {{glossary("viewport")}}, i.e., the visible portion of the document. Viewport lengths are invalid in {{cssxref("@page")}} declaration blocks.</p>
 
 <dl>
- <dt><code id="vh">vh</code></dt>
+ <dt><code>vh</code></dt>
  <dd>Equal to 1% of the height of the viewport's initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>.</dd>
- <dt><code id="vw">vw</code></dt>
+ <dt><code>vw</code></dt>
  <dd>Equal to 1% of the width of the viewport's initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>.</dd>
- <dt><code id="vi">vi</code> {{experimental_inline}}</dt>
+ <dt><code>vi</code> {{experimental_inline}}</dt>
  <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline">inline axis</a>.</dd>
- <dt><code id="vb">vb</code> {{experimental_inline}}</dt>
+ <dt><code>vb</code> {{experimental_inline}}</dt>
  <dd>Equal to 1% of the size of the initial <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a>, in the direction of the root element’s <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline">block axis</a>.</dd>
- <dt><code id="vmin">vmin</code></dt>
+ <dt><code>vmin">vmin</code></dt>
  <dd>Equal to the smaller of <code>vw</code> and <code>vh</code>.</dd>
- <dt><code id="vmax">vmax</code></dt>
+ <dt><code>vmax</code></dt>
  <dd>Equal to the larger of <code>vw</code> and <code>vh</code>.</dd>
 </dl>
 
@@ -94,22 +94,20 @@ browser-compat: css.types.length
 </div>
 
 <dl>
- <dt><code id="px">px</code></dt>
+ <dt><code>px</code></dt>
  <dd>One pixel. For screen displays, it traditionally represents one device pixel (dot). However, for <em>printers</em> and <em>high-resolution screens</em>, one CSS pixel implies multiple device pixels. <code>1px</code> = 1/96th of <code>1in</code>.</dd>
- <dt><code id="cm">cm</code></dt>
+ <dt><code>cm</code></dt>
  <dd>One centimeter. <code>1cm</code> = <code>96px/2.54</code>.</dd>
- <dt><code id="mm">mm</code></dt>
+ <dt><code>mm</code></dt>
  <dd>One millimeter. <code>1mm</code> = 1/10th of <code>1cm</code>.</dd>
- <dt><code id="q">Q</code> {{experimental_inline}}</dt>
+ <dt><code>Q</code> {{experimental_inline}}</dt>
  <dd>One quarter of a millimeter. <code>1Q</code> = 1/40th of <code>1cm</code>.</dd>
- <dt><code id="in">in</code></dt>
+ <dt><code>in</code></dt>
  <dd>One inch. <code>1in</code> = <code>2.54cm</code> = <code>96px</code>.</dd>
- <dt><code id="pc">pc</code></dt>
+ <dt><code>pc</code></dt>
  <dd>One pica. <code>1pc</code> = <code>12pt</code> = 1/6th of <code>1in</code>.</dd>
- <dt><code id="pt">pt</code></dt>
+ <dt><code>pt</code></dt>
  <dd>One point. <code>1pt</code> = 1/72nd of <code>1in</code>.</dd>
- <dt><code id="mozmm">mozmm</code> {{non-standard_inline}}, removed in Firefox 59</dt>
- <dd>An experimental unit that attempts to render at exactly one millimeter regardless of the size or resolution of the display. This is rarely actually what you want, but may be useful in particular for mobile devices.</dd>
 </dl>
 
 <h2 id="Interpolation">Interpolation</h2>

--- a/files/en-us/web/css/line-height-step/index.html
+++ b/files/en-us/web/css/line-height-step/index.html
@@ -27,13 +27,13 @@ line-height-step: unset;</pre>
 <p>The <code>line-height-step</code> property is specified as any one of the following:</p>
 
 <ul>
- <li>a <code><a href="#length">&lt;length&gt;</a></code>.</li>
+ <li>a <code>&lt;length&gt;</code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="length"><code>&lt;length&gt;</code></a></dt>
+ <dt><code>&lt;length&gt;</code></dt>
  <dd>The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height step.</dd>
 </dl>
 
@@ -49,7 +49,7 @@ line-height-step: unset;</pre>
 
 <h3 id="Setting_step_unit_for_line_box_height">Setting step unit for line box height</h3>
 
-<p id="sect1">In the following example, the height of line box in each paragraph is rounded up to the step unit. The line box in <code>&lt;h1&gt;</code> does not fit into one step unit and thus occupies two, but it is still centered within the two step unit.</p>
+<p>In the following example, the height of line box in each paragraph is rounded up to the step unit. The line box in <code>&lt;h1&gt;</code> does not fit into one step unit and thus occupies two, but it is still centered within the two step unit.</p>
 
 <pre class="brush: css">:root {
   font-size: 12pt;

--- a/files/en-us/web/css/line-height/index.html
+++ b/files/en-us/web/css/line-height/index.html
@@ -46,24 +46,24 @@ line-height: unset;
 <p>The <code>line-height</code> property is specified as any one of the following:</p>
 
 <ul>
- <li>a <code><a href="#number">&lt;number&gt;</a></code></li>
- <li>a <code><a href="#length">&lt;length&gt;</a></code></li>
- <li>a <code><a href="#percentage">&lt;percentage&gt;</a></code></li>
- <li>the keyword <code><a href="#normal">normal</a></code>.</li>
+ <li>a <code>&lt;number&gt;</code></li>
+ <li>a <code>&lt;length&gt;</code></li>
+ <li>a <code>&lt;percentage&gt;</code></li>
+ <li>the keyword <code>normal</code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="normal">normal</code></dt>
+ <dt><code>normal</code></dt>
  <dd>Depends on the user agent. Desktop browsers (including Firefox) use a default value of roughly <strong><code>1.2</code></strong>, depending on the element's <code>font-family</code>.</dd>
- <dt><code id="number">&lt;number&gt;</code> (unitless)</dt>
+ <dt><code>&lt;number&gt;</code> (unitless)</dt>
  <dd>The used value is this unitless {{cssxref("&lt;number&gt;")}} multiplied by the element's own font size. The computed value is the same as the specified <code>&lt;number&gt;</code>. In most cases, <strong>this is the preferred way</strong> to set <code>line-height</code> and avoid unexpected results due to inheritance.</dd>
- <dt><code id="length">&lt;length&gt;</code></dt>
+ <dt><code>&lt;length&gt;</code></dt>
  <dd>The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height. Values given in <strong>em</strong> units may produce unexpected results (see example below).</dd>
- <dt><code id="percentage">&lt;percentage&gt;</code></dt>
+ <dt><code>&lt;percentage&gt;</code></dt>
  <dd>Relative to the font size of the element itself. The computed value is this {{cssxref("&lt;percentage&gt;")}} multiplied by the element's computed font size. <strong>Percentage</strong> values may produce unexpected results (see the second example below).</dd>
- <dt><code id="-moz-block-height">-moz-block-height</code> {{non-standard_inline}}</dt>
+ <dt><code>-moz-block-height</code> {{non-standard_inline}}</dt>
  <dd>Sets the line height to the content height of the current block.</dd>
 </dl>
 

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -49,10 +49,10 @@ list-style-type: unset;
 <p>The list-style-type property may be defined as any one of:</p>
 
 <ul>
- <li>a <code><a href="#custom-ident">&lt;custom-ident&gt;</a></code> value</li>
- <li>a <code><a href="#symbols()">symbols()</a></code> value</li>
- <li>a <code><a href="#string">&lt;string&gt;</a></code> value</li>
- <li>the keyword <code><a href="#none">none</a></code>.</li>
+ <li>a <code>&lt;custom-ident&gt;</code> value</li>
+ <li>a <code>symbols()</code> value</li>
+ <li>a <code>>&lt;string&gt;</code> value</li>
+ <li>the keyword <code>none</code>.</li>
 </ul>
 
 <p>Note that:</p>
@@ -65,13 +65,13 @@ list-style-type: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="custom-ident">{{cssxref("custom-ident", "&lt;custom-ident&gt;")}}</a></dt>
+ <dt>{{cssxref("custom-ident", "&lt;custom-ident&gt;")}}</dt>
  <dd>A identifier matching the value of a {{cssxref("@counter-style")}} or one of the predefined styles:</dd>
- <dt><a id="symbols()">{{cssxref("symbols()")}}</a></dt>
+ <dt>{{cssxref("symbols()")}}</dt>
  <dd>Defines an anonymous style of the list.</dd>
- <dt><a id="string">{{cssxref("&lt;string&gt;")}}</a></dt>
+ <dt>{{cssxref("&lt;string&gt;")}}</dt>
  <dd>The specified string will be used as the item's marker.</dd>
- <dt><a id="none"><code>none</code></a></dt>
+ <dt><code>none</code></dt>
  <dd>No item marker is shown.</dd>
  <dt><code>disc</code></dt>
  <dd>A filled circle (default value).</dd>

--- a/files/en-us/web/css/mask-border-slice/index.html
+++ b/files/en-us/web/css/mask-border-slice/index.html
@@ -71,9 +71,9 @@ mask-border-slice: unset;
 <p>The above diagram illustrates the location of each region.</p>
 
 <ul>
- <li>Zones 1-4 are <a id="corner-regions">corner regions</a>. Each one is used a single time to form the corners of the final border image.</li>
- <li>Zones 5-8 are <a id="edge-regions">edge regions</a>. These are <a href="/en-US/docs/Web/CSS/mask-border-repeat">repeated, scaled, or otherwise modified</a> in the final border image to match the dimensions of the element.</li>
- <li>Zone 9 is the <a id="middle-region">middle region</a>. It is discarded by default, but is used like a background image if the keyword <code>fill</code> is set.</li>
+ <li>Zones 1-4 are corner regions. Each one is used a single time to form the corners of the final border image.</li>
+ <li>Zones 5-8 are edge regions. These are <a href="/en-US/docs/Web/CSS/mask-border-repeat">repeated, scaled, or otherwise modified</a> in the final border image to match the dimensions of the element.</li>
+ <li>Zone 9 is the middle region. It is discarded by default, but is used like a background image if the keyword <code>fill</code> is set.</li>
 </ul>
 
 <p>The {{cssxref("mask-border-repeat")}}, {{cssxref("mask-border-width")}}, and {{cssxref("mask-border-outset")}} properties determine how these regions are used to form the final mask border.</p>

--- a/files/en-us/web/css/mask-size/index.html
+++ b/files/en-us/web/css/mask-size/index.html
@@ -68,20 +68,20 @@ mask-size: unset;
  <li>If two values are given, the first sets width and the second sets height.</li>
 </ul>
 
-<p>Each value can be a <code><a href="#length">&lt;length&gt;</a></code>, a <code><a href="#percentage">&lt;percentage&gt;</a></code>, or <code><a href="#auto">auto</a></code>.</p>
+<p>Each value can be a <code>&lt;length&gt;</code>, a <code>&lt;percentage&gt;</code>, or <code>auto</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="length">&lt;length&gt;</code></dt>
+ <dt><code>&lt;length&gt;</code></dt>
  <dd>A <code>{{cssxref("&lt;length&gt;")}}</code> value scales the mask image to the specified length in the corresponding dimension. Negative lengths are not allowed.</dd>
- <dt><code id="percentage">&lt;percentage&gt;</code></dt>
+ <dt><code>&lt;percentage&gt;</code></dt>
  <dd>A {{cssxref("&lt;percentage&gt;")}} value scales the mask image in the corresponding dimension to the specified percentage of the mask positioning area, which is determined by the value of {{cssxref("mask-origin")}}. The mask positioning area is, by default, the area containing the content of the box and its padding; the area may also be changed to just the content or to the area containing borders, padding and content. Negative percentages are not allowed.</dd>
- <dt><a id="auto"><code>auto</code></a></dt>
+ <dt><code>auto</code></dt>
  <dd>A keyword that scales the mask image in the corresponding directions in order to maintain its intrinsic proportion.</dd>
- <dt><a id="contain"><code>contain</code></a></dt>
+ <dt><code>contain</code></dt>
  <dd>A keyword that scales the image as large as possible and maintains image aspect ratio (image doesn't get squished). The image is <em>letterboxed</em> within the container. The image is automatically centered unless over-ridden by another property such as {{cssxref("mask-position")}}.</dd>
- <dt><a id="cover"><code>cover</code></a></dt>
+ <dt><code>cover</code></dt>
  <dd>A keyword that is the inverse of <code>contain</code>. Scales the image as large as possible and maintains image aspect ratio (image doesn't get squished). The image "covers" the entire width or height of the container. When the image and container have different dimensions, <em>the image is clipped</em> either on left/right or at top/bottom.</dd>
 </dl>
 

--- a/files/en-us/web/css/max-width/index.html
+++ b/files/en-us/web/css/max-width/index.html
@@ -87,7 +87,6 @@ max-width: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<div id="basic-max-width-demo">
 <pre class="brush: html">&lt;div id="parent"&gt;
   &lt;div id="child"&gt;
     Fusce pulvinar vestibulum eros, sed luctus ex lobortis quis.
@@ -110,7 +109,6 @@ max-width: unset;
 </pre>
 
 <h4 id="Result">Result</h4>
-</div>
 
 <p>{{EmbedLiveSample("Setting_max_width_in_pixels", 350, 100)}}</p>
 

--- a/files/en-us/web/css/media_queries/using_media_queries/index.html
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.html
@@ -41,13 +41,13 @@ tags:
 <p><em>Media types</em> describe the general category of a device. Except when using the <code>not</code> or <code>only</code> logical operators, the media type is optional and the <code>all</code> type will be implied.</p>
 
 <dl>
- <dt><a id="all"><code>all</code></a></dt>
+ <dt><code>all</code></dt>
  <dd>Suitable for all devices.</dd>
- <dt><a id="print"><code>print</code></a></dt>
+ <dt><code>print</code></dt>
  <dd>Intended for paged material and documents viewed on a screen in print preview mode. (Please see <a href="/en-US/docs/Web/CSS/Paged_Media">paged media</a> for information about formatting issues that are specific to these formats.)</dd>
- <dt><a id="screen"><code>screen</code></a></dt>
+ <dt><code>screen</code></dt>
  <dd>Intended primarily for screens.</dd>
- <dt><a id="speech"><code>speech</code></a></dt>
+ <dt><code>speech</code></dt>
  <dd>Intended for speech synthesizers.</dd>
 </dl>
 

--- a/files/en-us/web/css/mix-blend-mode/index.html
+++ b/files/en-us/web/css/mix-blend-mode/index.html
@@ -62,7 +62,6 @@ mix-blend-mode: unset;
 
 <h3 id="Effect_of_different_mix-blend-mode_values">Effect of different mix-blend-mode values</h3>
 
-<div id="mix-blend-mode">
 <pre class="brush: html hidden">&lt;div class="grid"&gt;
   &lt;div class="col"&gt;
     &lt;div class="note"&gt;Blending in isolation (no blending with the background)&lt;/div&gt;
@@ -566,7 +565,6 @@ mix-blend-mode: unset;
 .saturation .item  { mix-blend-mode: saturation; }
 .color .item       { mix-blend-mode: color; }
 .luminosity .item  { mix-blend-mode: luminosity; }</pre>
-</div>
 
 <div>{{EmbedLiveSample("Effect_of_different_mix-blend-mode_values", "100%", 1600, "", "", "example-outcome-frame")}}</div>
 

--- a/files/en-us/web/css/offset-position/index.html
+++ b/files/en-us/web/css/offset-position/index.html
@@ -51,7 +51,7 @@ offset-position: unset;
 <dl>
  <dt><code>auto</code></dt>
  <dd>The initial position is the position of the box specified by the {{cssxref("position")}} property.</dd>
- <dt id="&lt;position&gt;"><code>&lt;position&gt;</code></dt>
+ <dt><code>&lt;position&gt;</code></dt>
  <dd>A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be <code>center</code>. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.</dd>
 </dl>
 

--- a/files/en-us/web/css/offset-rotate/index.html
+++ b/files/en-us/web/css/offset-rotate/index.html
@@ -51,7 +51,7 @@ offset-rotate: unset;</pre>
  </dd>
  <dt><code><dfn>auto &lt;angle&gt;</dfn></code></dt>
  <dd>
- <p>If <code>auto</code> is followed by an {{cssxref("&lt;angle&gt;")}}, the computed value of <span class="production" id="ref-for-angle-value①③" title="Expands to: turn | rad | grad | deg">the angle</span> is added to the computed value of <code>auto</code>.</p>
+ <p>If <code>auto</code> is followed by an {{cssxref("&lt;angle&gt;")}}, the computed value of the angle is added to the computed value of <code>auto</code>.</p>
  </dd>
  <dt><code><dfn>reverse</dfn></code></dt>
  <dd>

--- a/files/en-us/web/css/overflow/index.html
+++ b/files/en-us/web/css/overflow/index.html
@@ -67,17 +67,17 @@ overflow: unset;
 <h4 id="Mozilla_extensions">Mozilla extensions</h4>
 
 <dl>
- <dt><code>-moz-scrollbars-none</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
+ <dt><code>-moz-scrollbars-none</code> {{deprecated_inline}}</dt>
  <dd>Use <code>overflow: hidden</code> instead.</dd>
- <dt><code>-moz-scrollbars-horizontal</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
+ <dt><code>-moz-scrollbars-horizontal</code> {{deprecated_inline}}</dt>
  <dd>Use <code>{{Cssxref("overflow-x")}}: scroll</code> and <code>{{Cssxref("overflow-y")}}: hidden</code>, or <code>overflow: scroll hidden</code> instead.</dd>
- <dt><code>-moz-scrollbars-vertical</code> {{deprecated_inline}}<a href="#deprecated">[1]</a></dt>
+ <dt><code>-moz-scrollbars-vertical</code> {{deprecated_inline}}</dt>
  <dd>Use <code>{{Cssxref("overflow-x")}}: hidden</code> and <code>{{Cssxref("overflow-y")}}: scroll</code>, or <code>overflow: hidden scroll</code> instead.</dd>
  <dt><code>-moz-hidden-unscrollable</code> {{deprecated_inline}}</dt>
  <dd>Use <code>overflow: clip</code> instead.</dd>
 </dl>
 
-<p id="Deprecated">[1] As of Firefox 63, this feature is behind a feature preference setting. In about:config, set <code>layout.css.overflow.moz-scrollbars.enabled</code> to <code>true</code></p>
+<p>As of Firefox 63, <code>-moz-scrollbars-none</code>, <code>-moz-scrollbars-horizontal</code>, and <code>-moz-scrollbars-vertical</code> are behind a feature preference setting. In about:config, set <code>layout.css.overflow.moz-scrollbars.enabled</code> to <code>true</code>.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/css/position/index.html
+++ b/files/en-us/web/css/position/index.html
@@ -33,24 +33,24 @@ position: unset;</pre>
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="static"><code>static</code></dt>
+ <dt><code>static</code></dt>
  <dd>The element is positioned according to the normal flow of the document. The {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("z-index")}} properties have <em>no effect</em>. This is the default value.</dd>
- <dt id="relative"><code>relative</code></dt>
+ <dt><code>relative</code></dt>
  <dd>
    <p>The element is positioned according to the normal flow of the document, and then offset <em>relative to itself</em> based on the values of <code>top</code>, <code>right</code>, <code>bottom</code>, and <code>left</code>. The offset does not affect the position of any other elements; thus, the space given for the element in the page layout is the same as if position were <code>static</code>.</p>
    <p>This value creates a new <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context">stacking context</a> when the value of <code>z-index</code> is not <code>auto</code>. Its effect on <code>table-*-group</code>, <code>table-row</code>, <code>table-column</code>, <code>table-cell</code>, and <code>table-caption</code> elements is undefined.</p>
  </dd>
- <dt id="absolute"><code>absolute</code></dt>
+ <dt><code>absolute</code></dt>
  <dd>
    <p>The element is removed from the normal document flow, and no space is created for the element in the page layout. It is positioned relative to its closest positioned ancestor, if any; otherwise, it is placed relative to the initial <a href="/en-US/docs/Web/CSS/Containing_block">containing block</a>. Its final position is determined by the values of <code>top</code>, <code>right</code>, <code>bottom</code>, and <code>left</code>.</p>
    <p>This value creates a new <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context">stacking context</a> when the value of <code>z-index</code> is not <code>auto</code>. The margins of absolutely positioned boxes do not <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">collapse</a> with other margins.</p>
  </dd>
- <dt id="fixed"><code>fixed</code></dt>
+ <dt><code>fixed</code></dt>
  <dd>
    <p>The element is removed from the normal document flow, and no space is created for the element in the page layout. It is positioned relative to the initial <a href="/en-US/docs/Web/CSS/Containing_block">containing block</a> established by the {{glossary("viewport")}}, except when one of its ancestors has a <code>transform</code>, <code>perspective</code>, or <code>filter</code> property set to something other than <code>none</code> (see the <a href="https://www.w3.org/TR/css-transforms-1/#propdef-transform">CSS Transforms Spec</a>), in which case that ancestor behaves as the containing block. (Note that there are browser inconsistencies with <code>perspective</code> and <code>filter</code> contributing to containing block formation.) Its final position is determined by the values of <code>top</code>, <code>right</code>, <code>bottom</code>, and <code>left</code>.</p>
    <p>This value always creates a new <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context">stacking context</a>. In printed documents, the element is placed in the same position on <em>every page</em>.</p>
  </dd>
- <dt id="sticky"><code>sticky</code></dt>
+ <dt><code>sticky</code></dt>
  <dd>
    <p>The element is positioned according to the normal flow of the document, and then offset relative to its <em>nearest scrolling ancestor</em> and <a href="/en-US/docs/Web/CSS/Containing_block">containing block</a> (nearest block-level ancestor), including table-related elements, based on the values of <code>top</code>, <code>right</code>, <code>bottom</code>, and <code>left</code>. The offset does not affect the position of any other elements.</p>
    <p>This value always creates a new <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context">stacking context</a>. Note that a sticky element "sticks" to its nearest ancestor that has a "scrolling mechanism" (created when <code>overflow</code> is <code>hidden</code>, <code>scroll</code>, <code>auto</code>, or <code>overlay</code>), even if that ancestor isn't the nearest actually scrolling ancestor. This effectively inhibits any "sticky" behavior (see the <a href="https://github.com/w3c/csswg-drafts/issues/865">GitHub issue on W3C CSSWG</a>).</p>

--- a/files/en-us/web/css/pseudo-classes/index.html
+++ b/files/en-us/web/css/pseudo-classes/index.html
@@ -182,7 +182,7 @@ button:hover {
 
 <p>Pseudo-classes defined by a set of CSS specifications include the following:</p>
 
-<div id="index"><span>A</span>
+<span>A</span>
 
 <ul>
  <li>{{CSSxRef(":active")}}</li>
@@ -318,7 +318,6 @@ button:hover {
 <ul>
  <li>{{CSSxRef(":where", ":where()")}}</li>
 </ul>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/pseudo-elements/index.html
+++ b/files/en-us/web/css/pseudo-elements/index.html
@@ -39,7 +39,7 @@ p::first-line {
 
 <p>Pseudo-elements defined by a set of CSS specifications include the following:</p>
 
-<div id="index"><span>A</span>
+<span>A</span>
 
 <ul>
  <li>{{CSSxRef("::after", "::after (:after)")}}</li>
@@ -92,7 +92,6 @@ p::first-line {
 <ul>
  <li>{{CSSxRef("::target-text")}} {{Experimental_Inline}}</li>
 </ul>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/resize/index.html
+++ b/files/en-us/web/css/resize/index.html
@@ -69,7 +69,7 @@ resize: unset;  </pre>
 
 <h3 id="Disabling_resizability_of_textareas">Disabling resizability of textareas</h3>
 
-<p id="CSS">In many browsers, {{HTMLElement("textarea")}} elements are resizable by default. You may override this behavior with the <code>resize</code> property.</p>
+<p>In many browsers, {{HTMLElement("textarea")}} elements are resizable by default. You may override this behavior with the <code>resize</code> property.</p>
 
 <h4 id="HTML">HTML</h4>
 

--- a/files/en-us/web/css/rotate/index.html
+++ b/files/en-us/web/css/rotate/index.html
@@ -49,7 +49,7 @@ rotate: unset;</pre>
  <dd>The name of the axis you want to rotate the affected element around (<code>"x"</code>, "<code>y</code>", or "<code>z"</code>), plus an {{CSSxRef("&lt;angle&gt;")}} specifying the angle to rotate the element through. Equivalent to a <code>rotateX()</code>/<code>rotateY()</code>/<code>rotateZ()</code> (3D rotation) function.</dd>
  <dt>vector plus angle value</dt>
  <dd>Three {{CSSxRef("&lt;number&gt;")}}s representing an origin-centered vector that defines a line around which you want to rotate the element, plus an {{CSSxRef("&lt;angle&gt;")}} specifying the angle to rotate the element through. Equivalent to a <code>rotate3d()</code> (3D rotation) function.</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Specifies that no rotation should be applied.</dd>
 </dl>
 

--- a/files/en-us/web/css/scale/index.html
+++ b/files/en-us/web/css/scale/index.html
@@ -45,7 +45,7 @@ scale: unset;</pre>
  <dd>Two {{CSSxRef("&lt;number&gt;")}}s that specify the X and Y axis scaling values (respectively) of a 2D scale. Equivalent to a <code>scale()</code> (2D scaling) function with two values specified.</dd>
  <dt>Three length/percentage values</dt>
  <dd>Three {{CSSxRef("&lt;number&gt;")}}s that specify the X, Y, and Z axis scaling values (respectively) of a 3D scale. Equivalent to a <code>scale3d()</code> (3D scaling) function.</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Specifies that no scaling should be applied.</dd>
 </dl>
 

--- a/files/en-us/web/css/shape/index.html
+++ b/files/en-us/web/css/shape/index.html
@@ -24,7 +24,7 @@ browser-compat: css.types.shape
 
 <p>The <code>&lt;shape&gt;</code> data type is specified using the <code>rect()</code> function, which produces a region in the form of a rectangle.</p>
 
-<p><code><a id="rect()">rect()</a></code></p>
+<p><code>rect()</code></p>
 
 <pre class="brush: css">rect(<em>top</em>, <em>right</em>, <em>bottom</em>, <em>left</em>)</pre>
 

--- a/files/en-us/web/css/syntax/index.html
+++ b/files/en-us/web/css/syntax/index.html
@@ -76,7 +76,9 @@ tags:
 
 <p>Any statement which isn't a ruleset or an at-rule is invalid and ignored.</p>
 
-<p id="nested_statements">There is another group of statements – the <strong>nested statements</strong>. These are statements that can be used in a specific subset of at-rules – the <em>conditional group rules</em>. These statements only apply if a specific condition is matched: the <code>@media</code> at-rule content is applied only if the device on which the browser runs matches the expressed condition; the <code>@document</code> at-rule content is applied only if the current page matches some conditions, and so on. In CSS1 and CSS2.1, only <em>rulesets</em> could be used inside conditional group rules. That was very restrictive and this restriction was lifted in <a href="/en-US/docs/Web/CSS/CSS3#Conditionals"><em>CSS Conditionals Level 3</em></a>. Now, though still experimental and not supported by every browser, conditional group rules can contain a wider range of content: rulesets but also some, but not all, at-rules.</p>
+<h3>Nested statements</h3>
+
+<p>There is another group of statements – the <strong>nested statements</strong>. These are statements that can be used in a specific subset of at-rules – the <em>conditional group rules</em>. These statements only apply if a specific condition is matched: the <code>@media</code> at-rule content is applied only if the device on which the browser runs matches the expressed condition; the <code>@document</code> at-rule content is applied only if the current page matches some conditions, and so on. In CSS1 and CSS2.1, only <em>rulesets</em> could be used inside conditional group rules. That was very restrictive and this restriction was lifted in <a href="/en-US/docs/Web/CSS/CSS3#Conditionals"><em>CSS Conditionals Level 3</em></a>. Now, though still experimental and not supported by every browser, conditional group rules can contain a wider range of content: rulesets but also some, but not all, at-rules.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Following on from https://github.com/mdn/content/pull/5923 and https://github.com/mdn/content/pull/7467, this removes the next batch of IDs from the CSS docs.

As before I've tried to ensure that any internal links still go somewhere reasonably sensible.
