### PR TITLE
Remove broken links from Glossary

### DIFF
--- a/files/en-us/glossary/index.html
+++ b/files/en-us/glossary/index.html
@@ -25,18 +25,7 @@ tags:
 
 <h2 id="Contribute_to_the_glossary">Contribute to the glossary</h2>
 
-<p>This glossary is a never-ending work in progress. You can help improve it by <a href="/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary">writing new entries</a> or by making the existing ones better. The easiest way to start is to hit the following link or to pick one of the suggested terms below.</p>
-
-<p><strong><a href="/en-US/docs/new?parent=4391">Add a new entry to the glossary</a></strong></p>
-
-<p>{{GlossaryList({"terms":["at-rule", "Attack", "Byte-Order Mark", "client", "cryptosystem", "debug", "digital signature", "execution", "flex-direction", "GLSL", "Interface", "Library", "Memory management", "Self-Executing Anonymous Function", "Vector image"], "filter": "notdefined", "css": "multiColumnList"})}}</p>
-
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="/en-US/docs/MDN/Community">Join the MDN community</a></li>
-</ul>
-
+<p>This glossary is a never-ending work in progress. You can help improve it by <a href="/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary">writing new entries</a> or by making the existing ones better.</p>
 
 <section id="Quick_links">
 <!-- section is rendered in sidebar -->


### PR DESCRIPTION
These broken links were call for actions. This doesn't work as easily since we contribute via Github.

I removed them.