### PR TITLE
Fix misstatement in “Arrow function expressions” doc

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -24,9 +24,7 @@ expression](/en-US/docs/Web/JavaScript/Reference/Operators/function), but is lim
   and should not be used as
   [`methods`](/en-US/docs/Glossary/Method).
 - Does not have
-  [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments),
-  or
-  [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keywords.
+  [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keyword.
 - Not suitable for
   [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call),
   [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)


### PR DESCRIPTION
Update Javascript documentation for arrow functions; arrow functions can indeed have arguments, as the documentation shows.

<!-- Please provide the following information to help us review this PR: -->

> Issue number to be fixed (ie 'Fixes #123', if there is an associated issue)

I'm not aware of an issue number.


> What was wrong/why is this fix needed? (quick summary only)

Arrow functions can indeed take arguments. They'd be almost useless without them.

> Anything else that could help us review it

If this is a semantic issue (arguments vs parameters) I'll be happy to add that clarification, but afaik, they're two
words for the same thing.
