### PR TITLE
Improve the readability of the “Continuous Media” glossary entry

### DIFF
--- a/files/en-us/glossary/continuous_media/index.html
+++ b/files/en-us/glossary/continuous_media/index.html
@@ -7,6 +7,6 @@ tags:
 ---
 <p><span class="seoSummary">Continuous media is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.</span></p>
 
-<p>CSS can be used in a variety of contexts, including print media and some CSS, in particular, that used for layout behaves differently depending on the context it is in.</p>
+<p>CSS can be used in a variety of contexts, including print media. And some CSS, particularly those that are used for layout, behave differently depending on the context they are in.</p>
 
-<p>Continuous Media, therefore, identifies a context where the content is not broken up, it flows continuously. Web content displayed on a screen is continuous media, as is spoken content.</p>
+<p>Continuous Media, therefore, identifies a context where the content is not broken up. It flows continuously. Web content displayed on a screen is continuous media, as is spoken content.</p>


### PR DESCRIPTION
2nd `<p>` was just really difficult to understand.
3rd `<p>` seems to have a grammatical error.

> Anything else that could help us review it
I just tried to simply better the style of the writing, and not touch the content.

But I was wondering whether it might be better to get rid of the second `<p>`

Since CSS does not apply to all continuous media (such as voice recording), and only to web content on screen, maybe it is better to focus solely on the description of what continuous media is.

```html
<p>Continuous media is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.</p>

<p>Continuous Media identifies a context where the content is not broken up, it flows continuously. Web content displayed on a screen is continuous media, as is spoken content.</p>
```

I thought maybe above could be better.

Just my thought. 
Thanks for all the great work you guys are doing.
