### PR TITLE
Add page summary to markdown guide

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -386,6 +386,17 @@ cell 4    | cell 5    | cell 6
 
 <p>This issue was resolved in <a href="https://github.com/mdn/content/issues/4578">https://github.com/mdn/content/issues/4578</a>.</p>
 
+<h2>Page summary</h2>
+
+<p>The <em>page summary</em> is the first "content" paragraph in a page—the first text that appears after the page front matter and any <a href="#kumascript">sidebar or page banner macros</a>.</p>
+
+<p>This summary is used for search engine optimisation (SEO) and also automatically included alongside page listings by some macros.
+  The first paragraph should therefore be both succinct and informative.</p>
+
+<h3>Discussion reference</h3>
+
+<p>This issue was resolved in <a href="https://github.com/mdn/content/issues/3923">https://github.com/mdn/content/issues/3923</a>.</p>
+
 <h2>KumaScript</h2>
 
 <p>Writers will be able to include KumaScript macro calls in prose content:</p>


### PR DESCRIPTION
The page summary is the first content paragraph in the page. It should therefore be succinct and useful. This adds a note to that effect. As discussed in https://github.com/mdn/content/pull/7441#issuecomment-890284655

