### PR TITLE
Add notecard on DOMParser page about tags that will automatically close when parsed

### DIFF
--- a/files/en-us/web/api/domparser/index.html
+++ b/files/en-us/web/api/domparser/index.html
@@ -30,6 +30,13 @@ browser-compat: api.DOMParser
   from a URL-addressable resource, returning a <code>Document</code> in its
   {{domxref("XMLHttpRequest.response", "response")}} property.</p>
 
+<div class="note notecard">
+  <p>
+    <strong>Note:</strong> Be aware that <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level elements</a>
+    like <code>&lt;p&gt;</code> will be automatically closed if another 
+    block-level element is nested inside and therefore parsed before the closing <code>&lt;/p&gt;</code> tag.</p>
+</div>
+
 <h2 id="Constructor">Constructor</h2>
 
 <dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Fixes #7421 

Adds notecard highlighting that `<p>` tags in particular will be automatically closed when parsed. The language could maybe be better but this was my first iteration before review.

<img width="978" alt="Screen Shot 2021-08-01 at 10 47 02 PM" src="https://user-images.githubusercontent.com/48612525/127810840-ac733ad7-8e4b-4963-9072-7000fc2e34db.png">

cc @sideshowbarker 