### PR TITLE
Refine “Browser storage limits and eviction criteria” doc

### DIFF
--- a/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.html
+++ b/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.html
@@ -89,7 +89,7 @@ tags:
 
 <p>The maximum browser storage space is dynamic — it is based on your hard drive size. The <strong>global limit</strong> is calculated as 50% of free disk space. In Firefox, an internal browser tool called the Quota Manager keeps track of how much disk space each origin is using up, and deletes data if necessary.</p>
 
-<p>So if your hard drive is 500 GB, then the total storage for a browser is 250 GB. If this is exceeded, a process called <strong>origin eviction</strong> comes into play, deleting an entire origin's worth of data until the storage amount goes under the limit again. There is no trimming effect put in place to delete parts of origins — deleting one database of an origin could cause problems with inconsistency.</p>
+<p>So if the free space on your hard drive is 500 GB, then the total storage for a browser is 250 GB. If this is exceeded, a process called <strong>origin eviction</strong> comes into play, deleting an entire origin's worth of data until the storage amount goes under the limit again. There is no trimming effect put in place to delete parts of origins — deleting one database of an origin could cause problems with inconsistency.</p>
 
 <p>There's also another limit called <strong>group limit</strong> — this is defined as 20% of the global limit, but it has a minimum of 10 MB and a maximum of 2 GB. Each origin is part of a group (group of origins). There's one group for each eTLD+1 domain. For example:</p>
 


### PR DESCRIPTION
Made - 50% of available - explicit. Tried confirming using `navigator.storage.estimate().then(console.log)` but that gives about a fifth of free space on one Ubuntu system and about a tenth on a Windows system. But that could also be because the function returning per origin quota.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #3181'



> What was wrong/why is this fix needed? (quick summary only)
The example was not in line with the preceding description. Updated to match description


> Anything else that could help us review it
