### PR TITLE
FF91 visualViewport API updates 

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1207,45 +1207,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Visual_Viewport_API">Visual Viewport API</h3>
-
-<p>The <a href="/en-US/docs/Web/API/Visual_Viewport_API">Visual Viewport API</a> provides access to information describing the position of the {{Glossary("visual viewport")}} relative to the document as well as to the window's content area. It also supports events to monitor changes to this information. See {{bug(1550390)}} for more details. There in now a plan to ship this on desktop, you can track the state of that in {{bug(1551302)}}.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>63</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>63</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>63</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>63</td>
-   <td>Starting in Firefox 68, on Android only</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>dom.visualviewport.enabled</code></th>
-  </tr>
- </tbody>
-</table>
 
 <h3 id="Constructable_stylesheets">Constructable stylesheets</h3>
 

--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -63,6 +63,9 @@ tags:
     and the {{event("gamepadconnected")}} and {{event("gamepaddisconnected")}} events will not fire.
     The default <code>allowlist</code> is <code>*</code>; This default will be updated to <code>self</code> in a future release in order to match the specification. ({{bug(1704005)}}).</li>
   <li><code>Window.clientInformation</code> has been added as an alias for {{domxref("Window.navigator")}}, in order to match recent specification updates and improve compatibility with other major browsers ({{bug(1717072)}}).</li>
+  <li>The <a href="/en-US/docs/Web/API/Visual_Viewport_API">Visual Viewport API</a> is now enabled by default on Firefox desktop releases (it has been enabled on Firefox for Android since version 68).
+    The API provides access to information describing the position of the {{Glossary("visual viewport")}} relative to the document as well as to the window's content area.
+    It also provides events that allow changes to the viewport to be monitored. ({{bug(1551302)}}).</li>
 </ul>
 
 

--- a/files/en-us/web/api/visual_viewport_api/index.html
+++ b/files/en-us/web/api/visual_viewport_api/index.html
@@ -12,9 +12,9 @@ tags:
   - visual
   - visual viewport
 ---
-<p>{{DefaultAPISidebar("Visual Viewport")}}{{draft}}</p>
+<p>{{DefaultAPISidebar("Visual Viewport")}}</p>
 
-<p class="summary">The <strong>Visual Viewport API</strong> provides an explicit mechanism for querying and modifying the properties of the window's {{Glossary("visual viewport")}}. The visual viewport is the visual portion of a screen excluding on-screen keyboards, areas outside of a pinch-zoom area, or any other on-screen artifact that doesn't scale with the dimensions of a page.</p>
+<p>The <strong>Visual Viewport API</strong> provides an explicit mechanism for querying and modifying the properties of the window's {{Glossary("visual viewport")}}. The visual viewport is the visual portion of a screen excluding on-screen keyboards, areas outside of a pinch-zoom area, or any other on-screen artifact that doesn't scale with the dimensions of a page.</p>
 
 <h2 id="Visual_Viewport_concepts_and_usage">Visual Viewport concepts and usage</h2>
 
@@ -76,20 +76,7 @@ window.visualViewport.addEventListener('resize', viewportHandler);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Visual Viewport','#the-visualviewport-interface','VisualViewport')}}</td>
-   <td>{{Spec2('Visual Viewport')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.VisualViewport")}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/visualviewport/height/index.html
+++ b/files/en-us/web/api/visualviewport/height/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.height
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>height</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the height of the visual viewport, in
@@ -19,8 +19,7 @@ browser-compat: api.VisualViewport.height
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>height</em> = VisualViewport.height</pre>
+<pre class="brush: js">var <em>height</em> = VisualViewport.height</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/visualviewport/index.html
+++ b/files/en-us/web/api/visualviewport/index.html
@@ -3,7 +3,6 @@ title: VisualViewport
 slug: Web/API/VisualViewport
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Visual Viewport API
@@ -11,7 +10,7 @@ tags:
   - viewport
 browser-compat: api.VisualViewport
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>VisualViewport</code></strong> interface of the <a href="/en-US/docs/Web/API/Visual_Viewport_API">Visual Viewport API</a> represents the visual viewport for a given window. For a page containing iframes, each iframe, as well as the containing page, will have a unique window object. Each window on a page will have a unique <code>VisualViewport</code> representing the properties associated with that window.</p>
 

--- a/files/en-us/web/api/visualviewport/offsetleft/index.html
+++ b/files/en-us/web/api/visualviewport/offsetleft/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.offsetLeft
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>offsetLeft</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the offset of the left edge of the
@@ -19,8 +19,7 @@ browser-compat: api.VisualViewport.offsetLeft
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>offsetLeft</em> = VisualViewport.offsetLeft</pre>
+<pre class="brush: js">var <em>offsetLeft</em> = VisualViewport.offsetLeft</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/visualviewport/offsettop/index.html
+++ b/files/en-us/web/api/visualviewport/offsettop/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.offsetTop
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>offsetTop</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the offset of the top edge of the visual
@@ -19,8 +19,7 @@ browser-compat: api.VisualViewport.offsetTop
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>offsetTop</em> = VisualViewport.offsetTop</pre>
+<pre class="brush: js">var <em>offsetTop</em> = VisualViewport.offsetTop</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/visualviewport/pageleft/index.html
+++ b/files/en-us/web/api/visualviewport/pageleft/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.pageLeft
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>pageLeft</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the x coordinate of the left edge of the
@@ -19,8 +19,7 @@ browser-compat: api.VisualViewport.pageLeft
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>pageLeft</em> = VisualViewport.pageLeft</pre>
+<pre class="brush: js">var <em>pageLeft</em> = VisualViewport.pageLeft</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/visualviewport/pagetop/index.html
+++ b/files/en-us/web/api/visualviewport/pagetop/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.pageTop
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>pageTop</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the y coordinate of the top edge of the
@@ -19,8 +19,7 @@ browser-compat: api.VisualViewport.pageTop
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>pageTop</em> = VisualViewport.pageTop</pre>
+<pre class="brush: js">var <em>pageTop</em> = VisualViewport.pageTop</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/visualviewport/resize_event/index.html
+++ b/files/en-us/web/api/visualviewport/resize_event/index.html
@@ -3,14 +3,13 @@ title: 'VisualViewport: resize event'
 slug: Web/API/VisualViewport/resize_event
 tags:
   - API
-  - Experimental
   - Reference
   - VisualViewport
   - events
   - resize
 browser-compat: api.VisualViewport.resize_event
 ---
-<div>{{APIRef("Window")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("Window")}}</div>
 
 <p>The <strong><code>resize</code></strong> event of the <code><a href="/en-US/docs/Web/API/VisualViewport">VisualViewport</a></code> interface is fired when the visual viewport is resized.</p>
 

--- a/files/en-us/web/api/visualviewport/scale/index.html
+++ b/files/en-us/web/api/visualviewport/scale/index.html
@@ -11,7 +11,7 @@ tags:
 - viewport
 browser-compat: api.VisualViewport.scale
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>scale</code></strong> read-only property of the
 	{{domxref("VisualViewport")}} interface returns the pinch-zoom scaling factor applied

--- a/files/en-us/web/api/visualviewport/scroll_event/index.html
+++ b/files/en-us/web/api/visualviewport/scroll_event/index.html
@@ -3,14 +3,13 @@ title: 'VisualViewport: scroll event'
 slug: Web/API/VisualViewport/scroll_event
 tags:
   - API
-  - Experimental
   - Reference
   - Scroll
   - VisualViewport
   - events
 browser-compat: api.VisualViewport.scroll_event
 ---
-<div>{{APIRef("Window")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("Window")}}</div>
 
 <p>The <code><strong>scroll</strong></code> event of the <code><a href="/en-US/docs/Web/API/VisualViewport">VisualViewport</a></code> interface is fired when the visual viewport is scrolled.</p>
 

--- a/files/en-us/web/api/visualviewport/width/index.html
+++ b/files/en-us/web/api/visualviewport/width/index.html
@@ -11,7 +11,7 @@ tags:
 - width
 browser-compat: api.VisualViewport.width
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>width</code></strong> read-only property of the
   {{domxref("VisualViewport")}} interface returns the width of the visual viewport, in CSS

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -166,7 +166,7 @@ browser-compat: api.Window
  <dd>Returns the toolbar object, whose visibility can be toggled in the window.</dd>
  <dt>{{domxref("Window.top")}} {{readOnlyInline}}</dt>
  <dd>Returns a reference to the topmost window in the window hierarchy. This property is read only.</dd>
- <dt>{{domxref("Window.visualViewport")}} {{readOnlyInline}} {{experimental_inline}}</dt>
+ <dt>{{domxref("Window.visualViewport")}} {{readOnlyInline}}</dt>
  <dd>Returns a {{domxref("VisualViewport")}} object which represents the visual viewport for a given window.</dd>
  <dt>{{domxref("Window.window")}} {{ReadOnlyInline}}</dt>
  <dd>Returns a reference to the current window.</dd>

--- a/files/en-us/web/api/window/visualviewport/index.html
+++ b/files/en-us/web/api/window/visualviewport/index.html
@@ -3,7 +3,6 @@ title: Window.visualViewport
 slug: Web/API/Window/visualViewport
 tags:
 - API
-- Experimental
 - Property
 - Reference
 - Visual Viewport API
@@ -11,7 +10,7 @@ tags:
 - Window
 browser-compat: api.Window.visualViewport
 ---
-<p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
+<p>{{APIRef("Visual Viewport")}}</p>
 
 <p>The <strong><code>visualViewport</code></strong> read-only property of the
   {{domxref("Window")}} interface returns a {{domxref("VisualViewport")}} object
@@ -19,8 +18,7 @@ browser-compat: api.Window.visualViewport
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>visualViewport</em> = Window.visualViewport</pre>
+<pre class="brush: js">var <em>visualViewport</em> = Window.visualViewport</pre>
 
 <h3 id="Value">Value</h3>
 


### PR DESCRIPTION
visual viewport API is now enabled by default on FF91. This fixes up the docs as needed, 
- removal of "experimental" tagging on the API pages ( SeeCompatTable macro and Experimental tag)
- remove preference from Experimental features page
- add release note update
- Removed "Draft" banner from the visual viewport API page. Also fixed up specifications table. Note, page/docs might not be complete, but this draft is now how we track that stuff now days. It is not partial, but there might be more to add.
- 
Docs tracking for this https://github.com/mdn/content/issues/6713