### PR TITLE
Updated insertdtmf doc

### DIFF
--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
@@ -29,7 +29,7 @@ browser-compat: api.RTCDTMFSender.insertDTMF
   <code>insertDTMF()</code> replaces any already-pending tones from the <code>toneBuffer</code>. 
   You can abort sending queued tones by specifying an empty string (<code>""</code>) as the set of tones to play.
   Since <code>insertDTMF()</code> replaces the tone buffer, in order to add to the DTMF tones being played, it is necessary to call 
-  insertDTMF with a string containing both the remaining tones (stored in the <code>toneBuffer</code>) and the new tones appended together.</p>
+  <code>insertDTMF</code> with a string containing both the remaining tones (stored in the <code>toneBuffer</code>) and the new tones appended together.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
@@ -26,8 +26,10 @@ browser-compat: api.RTCDTMFSender.insertDTMF
     a tone starts or ends.</span></p>
 
 <p>As long as the connection is active, you can send tones at any time. Calling
-  <code>insertDTMF()</code> will append the specified tones to the end of the current tone
-  buffer, so that those tones play after the previously-enqueued tones.</p>
+  <code>insertDTMF()</code> replaces any already-pending tones from the <code>toneBuffer</code>. 
+  You can abort sending queued tones by specifying an empty string (<code>""</code>) as the set of tones to play.
+  Since <code>insertDTMF()</code> replaces the tone buffer, in order to add to the DTMF tones being played, it is necessary to call 
+  insertDTMF with a string containing both the remaining tones (stored in the <code>toneBuffer</code>) and the new tones appended together.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
insertDTMF overwrites existing toneBuffer, current doc is wrong
https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Using_DTMF here you can find info that "Calling insertDTMF() replaces any already-pending tones from the toneBuffer."

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
