### PR TITLE
Removing sub and sup from CSS docs for markdowning

### DIFF
--- a/files/en-us/web/css/basic-shape/index.html
+++ b/files/en-us/web/css/basic-shape/index.html
@@ -55,7 +55,7 @@ browser-compat: css.types.basic-shape
  <p>Defines an ellipse using two radii and a position.</p>
  <pre class="brush: css">ellipse( [&lt;shape-radius&gt;{2}]? [at &lt;position&gt;]? )</pre>
 
- <p>The <code>&lt;shape-radius&gt;</code> arguments represent r<sub>x</sub> and r<sub>y</sub>, the x-axis and y-axis radii of the ellipse, in that order. Negative values for either radius are invalid. Percentage values here are resolved against the used width (for the r<sub>x</sub> value) and the used height (for the r<sub>y</sub> value) of the reference box.</p>
+ <p>The <code>&lt;shape-radius&gt;</code> arguments represent rx and ry, the x-axis and y-axis radii of the ellipse, in that order. Negative values for either radius are invalid. Percentage values here are resolved against the used width (for the rx value) and the used height (for the ry value) of the reference box.</p>
 
  <p>The position argument defines the center of the ellipse. This defaults to center if omitted.</p>
  </dd>
@@ -66,7 +66,7 @@ browser-compat: css.types.basic-shape
 
  <p><code>&lt;fill-rule&gt;</code> represents the {{SVGAttr("fill-rule")}} used to determine the interior of the polygon. Possible values are <code>nonzero</code> and <code>evenodd</code>. Default value when omitted is <code>nonzero</code>.</p>
 
- <p>Each pair argument in the list represents <em>x<sub>i</sub></em> and <em>y<sub>i</sub></em> - the x and y axis coordinates of the i<sup>th</sup> vertex of the polygon.</p>
+ <p>Each pair argument in the list represents <em>xi</em> and <em>yi</em> - the x and y axis coordinates of the vertex of the polygon at position i.</p>
  </dd>
  <dt><code>path()</code></dt>
  <dd>

--- a/files/en-us/web/css/easing-function/index.html
+++ b/files/en-us/web/css/easing-function/index.html
@@ -50,24 +50,24 @@ tags:
 
 <p>The <code>cubic-bezier()</code> functional notation defines a <a href="https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves">cubic Bézier curve</a>. As these curves are continuous, they are often used to smooth down the start and end of the interpolation and are therefore sometimes called <em>easing functions</em>.</p>
 
-<p>A cubic Bézier curve is defined by four points P<sub>0</sub>, P<sub>1</sub>, P<sub>2</sub>, and P<sub>3</sub>. P<sub>0</sub> and P<sub>3</sub> are the start and the end of the curve and, in CSS these points are fixed as the coordinates are ratios (the abscissa the ratio of time, the ordinate the ratio of the output range). P<sub>0</sub> is <code>(0, 0)</code> and represents the initial time or position and the initial state, P<sub>3</sub> is <code>(1, 1)</code> and represents the final time or position and the final state.</p>
+<p>A cubic Bézier curve is defined by four points P0, P1, P2, and P3. P0 and P3 are the start and the end of the curve and, in CSS these points are fixed as the coordinates are ratios (the abscissa the ratio of time, the ordinate the ratio of the output range). P0 is <code>(0, 0)</code> and represents the initial time or position and the initial state, P3 is <code>(1, 1)</code> and represents the final time or position and the final state.</p>
 
-<p>Not all cubic Bézier curves are suitable as easing functions as not all are <a href="https://en.wikipedia.org/wiki/Function_%28mathematics%29">mathematical functions</a>; i.e., curves that for a given abscissa have zero or one value. With P<sub>0</sub> and P<sub>3</sub> fixed as defined by CSS, a cubic Bézier curve is a function, and is therefore valid, if and only if the abscissas of P<sub>1</sub> and P<sub>2</sub> are both in the <code>[0, 1]</code> range.</p>
+<p>Not all cubic Bézier curves are suitable as easing functions as not all are <a href="https://en.wikipedia.org/wiki/Function_%28mathematics%29">mathematical functions</a>; i.e., curves that for a given abscissa have zero or one value. With P0 and P3 fixed as defined by CSS, a cubic Bézier curve is a function, and is therefore valid, if and only if the abscissas of P1 and P2 are both in the <code>[0, 1]</code> range.</p>
 
-<p>Cubic Bézier curves with the P<sub>1</sub> or P<sub>2</sub> ordinate outside the <code>[0, 1]</code> range may generate <em>bouncing</em> effects.</p>
+<p>Cubic Bézier curves with the P1 or P2 ordinate outside the <code>[0, 1]</code> range may generate <em>bouncing</em> effects.</p>
 
 <p>When you specify an invalid <code>cubic-bezier</code> curve, CSS ignores the whole property.</p>
 
 <h5 id="Syntax_2">Syntax</h5>
 
-<pre class="brush: css">cubic-bezier(<var>x<sub>1</sub></var>, <var>y<sub>1</sub></var>, <var>x<sub>2</sub></var>, <var>y<sub>2</sub></var>)
+<pre class="brush: css">cubic-bezier(x1, y1, x2, y2)
 </pre>
 
 <p>where:</p>
 
 <dl>
- <dt><strong><var>x<sub>1</sub></var>, <var>y<sub>1</sub></var>, <var>x<sub>2</sub></var>, <var>y<sub>2</sub></var></strong></dt>
- <dd>Are {{cssxref("&lt;number&gt;")}} values representing the abscissas, and ordinates of the P<sub>1</sub> and P<sub>2</sub> points defining the cubic Bézier curve. x<sub>1</sub> and x<sub>2</sub> must be in the range [0, 1] or the value is invalid.</dd>
+ <dt><strong>x1, y1, x2, y2</strong></dt>
+ <dd>Are {{cssxref("&lt;number&gt;")}} values representing the abscissas, and ordinates of the P1 and P2 points defining the cubic Bézier curve. x1 and x2 must be in the range [0, 1] or the value is invalid.</dd>
 </dl>
 
 <h4 id="Keywords_for_common_cubic-bezier_easing_functions">Keywords for common cubic-bezier easing functions</h4>

--- a/files/en-us/web/css/font-variant-numeric/index.html
+++ b/files/en-us/web/css/font-variant-numeric/index.html
@@ -48,7 +48,7 @@ font-variant-numeric: unset;
  <dt><code>normal</code></dt>
  <dd>This keyword leads to the deactivation of the use of such alternate glyphs.</dd>
  <dt><code>ordinal</code></dt>
- <dd>This keyword forces the use of special glyphs for the ordinal markers, like 1<sup>st</sup>, 2<sup>nd</sup>, 3<sup>rd</sup>, 4<sup>th</sup> in English or a 1<sup>a</sup> in Italian. It corresponds to the OpenType values <code>ordn</code>.</dd>
+ <dd>This keyword forces the use of special glyphs for the ordinal markers, like 1st, 2nd, 3rd, 4th in English or a 1a in Italian. It corresponds to the OpenType values <code>ordn</code>.</dd>
  <dt><code>slashed-zero</code></dt>
  <dd>This keyword forces the use of a 0 with a slash; this is useful when a clear distinction between O and 0 is needed. It corresponds to the OpenType values <code>zero</code>.</dd>
  <dt><em>&lt;numeric-figure-values</em>&gt;</dt>

--- a/files/en-us/web/css/integer/index.html
+++ b/files/en-us/web/css/integer/index.html
@@ -18,7 +18,7 @@ browser-compat: css.types.integer
 <p>The <code>&lt;integer&gt;</code> data type consists of one or several decimal digits, 0 through 9 inclusive, optionally preceded by a single <code>+</code> or <code>-</code> sign. There is no unit associated with integers.</p>
 
 <div class="note">
-  <p><strong>Note:</strong> There is no official range of valid <code>&lt;integer&gt;</code> values. Opera 12.1 supports values up to 2<sup>15</sup>-1, IE up to 2<sup>20</sup>-1, and other browsers even higher. During the CSS3 Values cycle there was a lot of discussion about setting a minimum range to support: the latest decision, <a href="http://lists.w3.org/Archives/Public/www-style/2012Apr/0633.html">in April 2012 during the LC phase</a>, was [-2<sup>27</sup>-1; 2<sup>27</sup>-1], but other values like 2<sup>24</sup>-1 and 2<sup>30</sup>-1 <a href="http://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html">were also proposed</a>. However, the latest spec doesn't specify a range anymore.</p>
+  <p><strong>Note:</strong> There is no official range of valid <code>&lt;integer&gt;</code> values. Opera 12.1 supports values up to 2^15 - 1, IE up to 2^20 - 1, and other browsers even higher. During the CSS3 Values cycle there was a lot of discussion about setting a minimum range to support: the latest decision, <a href="http://lists.w3.org/Archives/Public/www-style/2012Apr/0633.html">in April 2012 during the LC phase</a>, was [-2^27 - 1; 2^27 - 1], but other values like 2^24 - 1 and 2^30 - 1 <a href="http://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html">were also proposed</a>. However, the latest spec doesn't specify a range anymore.</p>
 </div>
 
 <h2 id="Interpolation">Interpolation</h2>

--- a/files/en-us/web/css/ratio/index.html
+++ b/files/en-us/web/css/ratio/index.html
@@ -40,7 +40,7 @@ browser-compat: css.types.ratio
   <tr>
    <td><img class="default internal" src="ratio4_3.png"></td>
    <td><code>4/3</code></td>
-   <td>Traditional TV format in the 20<sup>th</sup> century.</td>
+   <td>Traditional TV format in the twentieth century.</td>
   </tr>
   <tr>
    <td><img src="ratio16_9.png"></td>

--- a/files/en-us/web/css/transform-function/matrix()/index.html
+++ b/files/en-us/web/css/transform-function/matrix()/index.html
@@ -41,10 +41,10 @@ browser-compat: css.types.transform-function.matrix
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/matrix3d()/index.html
+++ b/files/en-us/web/css/transform-function/matrix3d()/index.html
@@ -35,10 +35,10 @@ browser-compat: css.types.transform-function.matrix3d
 <table class="standard-table">
 	<thead>
 		<tr>
-			<th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-			<th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-			<th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-			<th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+			<th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/files/en-us/web/css/transform-function/perspective()/index.html
+++ b/files/en-us/web/css/transform-function/perspective()/index.html
@@ -43,10 +43,10 @@ browser-compat: css.types.transform-function.perspective
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
@@ -54,7 +54,7 @@ browser-compat: css.types.transform-function.perspective
       <td colspan="2">
         <p>This transformation applies to the 3D space and can't be represented on the plane.</p>
       </td>
-      <td>This transformation is not a linear transformation in ℝ<sup>3</sup>, and can't be represented
+      <td>This transformation is not a linear transformation in ℝ^3, and can't be represented
         using a Cartesian-coordinate matrix.</td>
       <td><math>
           <mfenced>

--- a/files/en-us/web/css/transform-function/rotate()/index.html
+++ b/files/en-us/web/css/transform-function/rotate()/index.html
@@ -40,10 +40,10 @@ browser-compat: css.types.transform-function.rotate
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/rotate3d()/index.html
+++ b/files/en-us/web/css/transform-function/rotate3d()/index.html
@@ -59,14 +59,14 @@ browser-compat: css.types.transform-function.rotate3d
 <table class="standard-table">
   <tbody>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
       <td rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
     </tr>
     <tr>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
     </tr>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
       <td><a href="/en-US/docs/Web/CSS/transform-function/rotate3d()/transform-functions-rotate3d_cart.png"><img
             src="transform-functions-rotate3d_cart.png"></a><math>
           <mfenced>
@@ -267,7 +267,7 @@ browser-compat: css.types.transform-function.rotate3d
         </math></td>
     </tr>
     <tr>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
       <td><a href="/en-US/docs/Web/CSS/transform-function/rotate3d()/transform-functions-rotate3d_hom4.png"><img
             src="transform-functions-rotate3d_hom4.png"></a></td>
     </tr>

--- a/files/en-us/web/css/transform-function/rotatex()/index.html
+++ b/files/en-us/web/css/transform-function/rotatex()/index.html
@@ -50,10 +50,10 @@ browser-compat: css.types.transform-function.rotateX
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/rotatey()/index.html
+++ b/files/en-us/web/css/transform-function/rotatey()/index.html
@@ -50,10 +50,10 @@ browser-compat: css.types.transform-function.rotateY
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/rotatez()/index.html
+++ b/files/en-us/web/css/transform-function/rotatez()/index.html
@@ -50,10 +50,10 @@ browser-compat: css.types.transform-function.rotateZ
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/scale()/index.html
+++ b/files/en-us/web/css/transform-function/scale()/index.html
@@ -55,10 +55,10 @@ scale(<var>sx</var>, <var>sy</var>)
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/scale3d()/index.html
+++ b/files/en-us/web/css/transform-function/scale3d()/index.html
@@ -49,10 +49,10 @@ browser-compat: css.types.transform-function.scale3d
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/scalex()/index.html
+++ b/files/en-us/web/css/transform-function/scalex()/index.html
@@ -47,10 +47,10 @@ browser-compat: css.types.transform-function.scaleX
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/scaley()/index.html
+++ b/files/en-us/web/css/transform-function/scaley()/index.html
@@ -49,10 +49,10 @@ browser-compat: css.types.transform-function.scaleY
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/scalez()/index.html
+++ b/files/en-us/web/css/transform-function/scalez()/index.html
@@ -49,10 +49,10 @@ browser-compat: css.types.transform-function.scaleZ
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/skew()/index.html
+++ b/files/en-us/web/css/transform-function/skew()/index.html
@@ -49,10 +49,10 @@ skew(<var>ax</var>, <var>ay</var>)
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/skewx()/index.html
+++ b/files/en-us/web/css/transform-function/skewx()/index.html
@@ -43,10 +43,10 @@ browser-compat: css.types.transform-function.skewX
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/skewy()/index.html
+++ b/files/en-us/web/css/transform-function/skewy()/index.html
@@ -37,10 +37,10 @@ browser-compat: css.types.transform-function.skewY
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/css/transform-function/translate()/index.html
+++ b/files/en-us/web/css/transform-function/translate()/index.html
@@ -53,16 +53,16 @@ transform: translate(30%, 50%);
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td rowspan="2">
-        <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a
+        <p>A translation is not a linear transformation in ℝ^2 and can't be represented using a
           Cartesian-coordinate matrix.</p>
       </td>
       <td><math>

--- a/files/en-us/web/css/transform-function/translate3d()/index.html
+++ b/files/en-us/web/css/transform-function/translate3d()/index.html
@@ -43,10 +43,10 @@ browser-compat: css.types.transform-function.translate3d
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
@@ -54,7 +54,7 @@ browser-compat: css.types.transform-function.translate3d
       <td colspan="2">
         <p>This transformation applies to the 3D space and can't be represented on the plane.</p>
       </td>
-      <td>A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a
+      <td>A translation is not a linear transformation in ℝ^3 and can't be represented using a
         Cartesian-coordinate matrix.</td>
       <td><math>
           <mfenced>

--- a/files/en-us/web/css/transform-function/translatex()/index.html
+++ b/files/en-us/web/css/transform-function/translatex()/index.html
@@ -43,16 +43,16 @@ transform: translateX(50%);
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td rowspan="2">
-        <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a
+        <p>A translation is not a linear transformation in ℝ^2 and can't be represented using a
           Cartesian-coordinate matrix.</p>
       </td>
       <td><math>

--- a/files/en-us/web/css/transform-function/translatey()/index.html
+++ b/files/en-us/web/css/transform-function/translatey()/index.html
@@ -43,16 +43,16 @@ transform: translateY(50%);
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td rowspan="2">
-        <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a
+        <p>A translation is not a linear transformation in ℝ^2 and can't be represented using a
           Cartesian-coordinate matrix.</p>
       </td>
       <td><math>

--- a/files/en-us/web/css/transform-function/translatez()/index.html
+++ b/files/en-us/web/css/transform-function/translatez()/index.html
@@ -48,17 +48,17 @@ browser-compat: css.types.transform-function.translateZ
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Cartesian coordinates on ℝ<sup>2</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>2</sup></th>
-      <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-      <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
+      <th scope="col">Cartesian coordinates on ℝ^2</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^2</th>
+      <th scope="col">Cartesian coordinates on ℝ^3</th>
+      <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td colspan="2">This transformation applies to the 3D space and can't be represented on the plane.
       </td>
-      <td>A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a
+      <td>A translation is not a linear transformation in ℝ^3 and can't be represented using a
         Cartesian-coordinate matrix.</td>
       <td><math>
           <mfenced>


### PR DESCRIPTION
Fixes #7267 

I followed the lead of the JS/* and API/* updates. 