### PR TITLE
adds a note to the hyphens property

### DIFF
--- a/files/en-us/web/css/hyphens/index.html
+++ b/files/en-us/web/css/hyphens/index.html
@@ -15,6 +15,9 @@ browser-compat: css.properties.hyphens
 
 <div>{{EmbedInteractiveExample("pages/css/hyphens.html")}}</div>
 
+<div class="notecard note">
+<p>In the above demo, the string "An extra­ordinarily long English word!" contains the hidden <code>&amp;shy;</code> character: <code>An extra&amp;shy;­ordinarily long English word!</code>. This character is used to indicate a potential place to insert a hyphen when <code>hyphens: manual;</code> is specified.</p>
+</div>
 
 <p>Hyphenation rules are language-specific. In HTML, the language is determined by the <code><a href="/en-US/docs/Web/HTML/Global_attributes/lang">lang</a></code> attribute, and browsers will hyphenate only if this attribute is present and the appropriate hyphenation dictionary is available. In XML, the <code><a href="/en-US/docs/Web/SVG/Attribute/xml:lang">xml:lang</a></code> attribute must be used.</p>
 


### PR DESCRIPTION
Fixes #6307 by adding a clarifying note to explain the hidden character used in the demo.