### PR TITLE
Remove self-link on How the Web works

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -121,5 +121,5 @@ tags:
 	<li id="CSS_basics"><a href="/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics">CSS basics</a></li>
 	<li id="JavaScript_basics"><a href="/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics">JavaScript basics</a></li>
 	<li id="Publishing_your_website"><a href="/en-US/docs/Learn/Getting_started_with_the_web/Publishing_your_website">Publishing your website</a></li>
-	<li id="How_the_web_works"><a href="/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works">How the web works</a></li>
+	<li>How the web works</li>
 </ul>


### PR DESCRIPTION
This fixes the flaw "Link points to the page it's already on"