### PR TITLE
Fixing incorrect comment on one of the examples

### DIFF
--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -210,8 +210,8 @@ function parseProtocol(url) {
     return false;
   }
   console.log(parsedURL);
-  // ["https://developer.mozilla.org/en-US/docs/Web/JavaScript",
-      "https", "developer.mozilla.org", "en-US/docs/Web/JavaScript"]
+  // ["https://developer.mozilla.org/en-US/docs/Web/JavaScript", 
+  // "https", "developer.mozilla.org", "en-US/docs/Web/JavaScript"]
 
   const [, protocol, fullhost, fullpath] = parsedURL;
   return protocol;


### PR DESCRIPTION
Fixing incorrect comment on one of the examples. 
Due to the line break, the array comment was not ended correctly.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
Fixing incorrect comment on one of the examples. 
Due to the line break, the array comment was not ended correctly.


> Anything else that could help us review it
