### PR TITLE
Fix broken link on outline-offset page which was causing a flaw

### DIFF
--- a/files/en-us/web/api/domparser/index.html
+++ b/files/en-us/web/api/domparser/index.html
@@ -30,6 +30,13 @@ browser-compat: api.DOMParser
   from a URL-addressable resource, returning a <code>Document</code> in its
   {{domxref("XMLHttpRequest.response", "response")}} property.</p>
 
+<div class="note notecard">
+  <p>
+    <strong>Note:</strong> Be aware that <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level elements</a>
+    like <code>&lt;p&gt;</code> will be automatically closed if another 
+    block-level element is nested inside and therefore parsed before the closing <code>&lt;/p&gt;</code> tag.</p>
+</div>
+
 <h2 id="Constructor">Constructor</h2>
 
 <dl>

--- a/files/en-us/web/css/outline-offset/index.html
+++ b/files/en-us/web/css/outline-offset/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.outline-offset
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>outline-offset</code></strong> CSS property sets the amount of space between an <a href="/docs/Web/CSS/outline">outline</a> and the edge or border of an element.</p>
+<p>The <strong><code>outline-offset</code></strong> CSS property sets the amount of space between an <a href="/en-US/docs/Web/CSS/outline">outline</a> and the edge or border of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/outline-offset.html")}}</div>
 


### PR DESCRIPTION
Didn't make an issue, as it was just a fixable flaw that I saw while working on something else.



> What was wrong/why is this fix needed? (quick summary only)

The link was `docs/...` and was missing the `/en-US/` prefix at the beginning.


