### PR TITLE
Fix broken link on outline-offset page which created a flaw

### DIFF
--- a/files/en-us/web/css/outline-offset/index.html
+++ b/files/en-us/web/css/outline-offset/index.html
@@ -11,7 +11,7 @@ browser-compat: css.properties.outline-offset
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>outline-offset</code></strong> CSS property sets the amount of space between an <a href="/docs/Web/CSS/outline">outline</a> and the edge or border of an element.</p>
+<p>The <strong><code>outline-offset</code></strong> CSS property sets the amount of space between an <a href="/en-US/docs/Web/CSS/outline">outline</a> and the edge or border of an element.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/outline-offset.html")}}</div>
 


### PR DESCRIPTION
Didn't make an issue, as it was just a fixable flaw that I saw while working on something else.

> What was wrong/why is this fix needed? (quick summary only)

Broken link which was missing the `/en-US/` prefix at the beginning of URL

