### PR TITLE
Pagemacro removal - XR examples

### DIFF
--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
@@ -25,24 +25,20 @@ browser-compat: api.XRInputSourcesChangeEvent.removed
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The read-only {{domxref("XRInputSourcesChangeEvent")}}
-    property {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} is an array of
-    zero or more {{domxref("XRInputSource")}} objects representing the input sources which
-    have been removed from the {{domxref("XRSession")}}.</span></p>
+<p>The read-only {{domxref("XRInputSourcesChangeEvent")}} property {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} is an array of
+    zero or more {{domxref("XRInputSource")}} objects representing the input sources that have been removed from the {{domxref("XRSession")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><em>removedInputs</em> = <em>xrInputSourcesChangeEvent</em>.removed;</pre>
+<pre class="brush: js"><em>removedInputs</em> = <em>xrInputSourcesChangeEvent</em>.removed;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>An {{jsxref("Array")}} of zero or more {{domxref("XRInputSource")}} objects, each
-  representing one input device removed from the XR system.</p>
+<p>An {{jsxref("Array")}} of zero or more {{domxref("XRInputSource")}} objects, each representing one input device removed from the XR system.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRInputSourcesChangeEvent/added", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/XRInputSourcesChangeEvent/added#examples"><code>XRInputSourcesChangeEvent.added</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
@@ -24,7 +24,9 @@ browser-compat: api.XRSession.inputsourceschange_event
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The <strong><code>inputsourceschange</code></strong> event is sent to an {{domxref("XRSession")}} when the set of available WebXR input devices changes.</span> The received event, of type {{domxref("XRInputSourcesChangeEvent")}}, contains a list of any newly {{domxref("XRInputSourcesChangeEvent.added", "added")}} and/or {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} input devices.</p>
+<p>The <strong><code>inputsourceschange</code></strong> event is sent to an {{domxref("XRSession")}} when the set of available WebXR input devices changes.</p>
+
+<p>The received event, of type {{domxref("XRInputSourcesChangeEvent")}}, contains a list of any newly {{domxref("XRInputSourcesChangeEvent.added", "added")}} and/or {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} input devices.</p>
 
 <table class="properties">
  <tbody>
@@ -51,7 +53,7 @@ browser-compat: api.XRSession.inputsourceschange_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRInputSourcesChangeEvent", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/XRInputSourcesChangeEvent#examples"><code>XRInputSourcesChangeEvent</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.html
+++ b/files/en-us/web/api/xrsession/selectend_event/index.html
@@ -24,7 +24,9 @@ browser-compat: api.XRSession.selectend_event
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The WebXR event <code><strong>selectend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</span> Primary actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
+<p>The WebXR event <code><strong>selectend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</p>
+
+<p>Primary actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 
 <table class="properties">
  <tbody>
@@ -51,7 +53,7 @@ browser-compat: api.XRSession.selectend_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRSession/selectstart_event", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/XRSession/selectstart_event#examples"><code>selectstart_event</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.html
@@ -25,7 +25,9 @@ browser-compat: api.XRSession.squeezeend_event
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The WebXR event <code><strong>squeezeend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_squeeze_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</span> Primary squeeze actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
+<p>The WebXR event <code><strong>squeezeend</strong></code> is sent to an {{domxref("XRSession")}} when one of its input sources ends its <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions">primary action</a> or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.</p>
+
+<p>Primary squeeze actions include things like users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.</p>
 
 <table class="properties">
  <tbody>
@@ -52,7 +54,7 @@ browser-compat: api.XRSession.squeezeend_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRSession/squeezestart_event", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/XRSession/squeezestart_event#examples"><code>squeezestart_event</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.html
@@ -26,7 +26,9 @@ browser-compat: api.XRSession.squeezestart_event
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a> event <code><strong>squeezestart</strong></code> is sent to an {{domxref("XRSession")}} when the user begins a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#Primary_squeeze_actions">primary squeeze action</a> on one of its input sources.</span> Primary squeeze actions are actions which are meant to represent gripping or squeezing using your hands, and may be simulated using triggers on hand controllers.</p>
+<p>The <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a> event <code><strong>squeezestart</strong></code> is sent to an {{domxref("XRSession")}} when the user begins a <a href="/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions">primary squeeze action</a> on one of its input sources.</p>
+
+<p>Primary squeeze actions are actions which are meant to represent gripping or squeezing using your hands, and may be simulated using triggers on hand controllers.</p>
 
 <table class="properties">
  <tbody>
@@ -53,7 +55,7 @@ browser-compat: api.XRSession.squeezestart_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to establish handlers for the squeezeion events: {{domxref("XRSession.squeezestart_event", "squeezestart")}}, {{domxref("XRSession.squeezeend_event", "squeezeend")}}, and {{domxref("XRSession.squeeze_event", "squeeze")}}. This snippet is the core of an event handler to allow the user to grab objects in the scene and move them around.</p>
+<p>The following example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to establish handlers for the squeeze events: {{domxref("XRSession.squeezestart_event", "squeezestart")}}, {{domxref("XRSession.squeezeend_event", "squeezeend")}}, and {{domxref("XRSession.squeeze_event", "squeeze")}}. This snippet is the core of an event handler to allow the user to grab objects in the scene and move them around.</p>
 
 <p>In this case, a single function is used to handle all three events, allowing them to share certain code that's the same regardless of which of the three events is received. Only after completing those tasks does the <code>onSqueezeEvent()</code> function below dispatch the action out to a specialized function to handle things.</p>
 

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
@@ -36,8 +36,7 @@ browser-compat: api.XRSessionEvent.XRSessionEvent
 <dl>
   <dt><code>type</code></dt>
   <dd>A {{domxref("DOMString")}} indicating which of the events represented by objects of
-    type <code>XRSessionEvent</code> this particular object represents. See {{anch("Event
-    types")}} for a list of the permitted values.</dd>
+    type <code>XRSessionEvent</code> this particular object represents. See <a href="/en-US/docs/Web/API/XRSessionEvent#session_event_types"><code>XRSessionEvent &gt; Session event types</code></a> for a list of the permitted values.</dd>
   <dt><code>eventInitDict</code></dt>
   <dd>
     <p>An object with the following values:</p>
@@ -50,16 +49,11 @@ browser-compat: api.XRSessionEvent.XRSessionEvent
 <h3 id="Return_value">Return value</h3>
 
 <p>A newly-created {{domxref("XRSessionEvent")}} object representing an object of the
-  specfied type and configured as described by the <code>eventInitDict</code> parameter.
-</p>
-
-<h2 id="Event_types">Event types</h2>
-
-<p>{{page("/en-US/docs/Web/API/XRSessionEvent", "Session event types")}}</p>
+  specfied type and configured as described by the <code>eventInitDict</code> parameter.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRSessionEvent", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/XRSessionEvent#examples"><code>XRSessionEvent</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link (for a small bunch of cases).  Also removed a few seosummary spans.