### PR TITLE
Page macro: XRViewerPose link rather than include example

### DIFF
--- a/files/en-us/web/api/xrviewerpose/index.html
+++ b/files/en-us/web/api/xrviewerpose/index.html
@@ -21,7 +21,9 @@ browser-compat: api.XRViewerPose
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
-<p><span class="seoSummary">The WebXR Device API interface <code><strong>XRViewerPose</strong></code> represents the pose (the position and orientation) of a viewer's point of view on the scene. Each <code>XRViewerPose</code> can have multiple views to represent, for example, the slight separation between the left and right eye.</span> This view can represent anything from the point-of-view of a user's XR headset to the viewpoint represented by a player's movement of an avatar using mouse and keyboard, presented on the screen, to a virtual camera capturing the scene for a spectator.</p>
+<p>The WebXR Device API interface <code><strong>XRViewerPose</strong></code> represents the pose (the position and orientation) of a viewer's point of view on the scene. Each <code>XRViewerPose</code> can have multiple views to represent, for example, the slight separation between the left and right eye.</p>
+  
+<p>This view can represent anything from the point-of-view of a user's XR headset to the viewpoint represented by a player's movement of an avatar using mouse and keyboard, presented on the screen, to a virtual camera capturing the scene for a spectator.</p>
 
 <h2 id="Properties">Properties</h2>
 
@@ -46,7 +48,36 @@ browser-compat: api.XRViewerPose
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/XRViewerPose/views", "Examples")}}</p>
+<p>In this example—part of the code to render an {{domxref("XRFrame")}},
+  <code>getViewerPose()</code> is called to get an <code>XRViewerPose</code> using the
+  same reference space the code is using as its base reference space. If a valid pose is
+  returned, the frame is rendered by clearing the backbuffer and then rendering each of
+  the views in the pose; these are most likely the views for the left and right eyes.</p>
+
+<pre class="brush: js">let pose = frame.getViewerPose(xrReferenceSpace);
+
+if (pose) {
+  let glLayer = xrSession.renderState.baseLayer;
+
+  gl.bindFrameBuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
+  gl.clearColor(0, 0, 0, 1);
+  gl.clearDepth(1);
+  gl.clear(gl.COLOR_BUFFER_BIT, gl.DEPTH_BUFFER_BIT);
+
+  for (let view of pose.views) {
+    let viewport = glLayer.getViewport(view);
+    gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
+
+    /* render the scene for the eye view.eye */
+  }
+}
+</pre>
+
+<p>Passing each <code>view</code> to {{domxref("XRWebGLLayer.getViewport", "getViewport()")}} returns the WebGL viewport to apply in order to cause the rendered
+  output to be positioned correctly in the framebuffer for renderijng to the corresponding eye on the output device.</p>
+
+<p>This code is derived from {{SectionOnPage("/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion", "Drawing a
+  frame")}}. You can see more context and see much more on that page.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrviewerpose/views/index.html
+++ b/files/en-us/web/api/xrviewerpose/views/index.html
@@ -50,39 +50,7 @@ browser-compat: api.XRViewerPose.views
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example—part of the code to render an {{domxref("XRFrame")}},
-  <code>getViewerPose()</code> is called to get an <code>XRViewerPose</code> using the
-  same reference space the code is using as its base reference space. If a valid pose is
-  returned, the frame is rendered by clearing the backbuffer and then rendering each of
-  the views in the pose; these are most likely the views for the left and right eyes.</p>
-
-<pre class="brush: js">let pose = frame.getViewerPose(xrReferenceSpace);
-
-if (pose) {
-  let glLayer = xrSession.renderState.baseLayer;
-
-  gl.bindFrameBuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
-  gl.clearColor(0, 0, 0, 1);
-  gl.clearDepth(1);
-  gl.clear(gl.COLOR_BUFFER_BIT, gl.DEPTH_BUFFER_BIT);
-
-  for (let view of pose.views) {
-    let viewport = glLayer.getViewport(view);
-    gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
-
-    /* render the scene for the eye view.eye */
-  }
-}
-</pre>
-
-<p>Passing each <code>view</code> to {{domxref("XRWebGLLayer.getViewport",
-  "getViewport()")}} returns the WebGL viewport to apply in order to cause the rendered
-  output to be positioned correctly in the framebuffer for renderijng to the corresponding
-  eye on the output device.</p>
-
-<p>This code is derived from
-  {{SectionOnPage("/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion", "Drawing a
-  frame")}}. You can see more context and see much more on that page.</p>
+<p>See <a href="/en-US/docs/Web/API/XRViewerPose#examples"><code>XRViewerPose</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link. Note that the example was formerly in `XRViewerPose.views` and included into `XRViewerPose`. I is now present in `XRViewerPose` and linked from  `XRViewerPose.views`. My thinking was that the parent topic makes more sense for the example - if only because it is alongside the usage notes.