### PR TITLE
Remove css ids, final part

### DIFF
--- a/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.html
+++ b/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.html
@@ -26,7 +26,7 @@ browser-compat: css.at-rules.media.-webkit-device-pixel-ratio
 
 <dl>
  <dt>{{cssxref("&lt;number&gt;")}}</dt>
- <dd>The number of device pixels used to represent each CSS <a href="/en-US/docs/Web/CSS/length#absolute_length_units"><code>px</code></a>. Although the value is a <code>&lt;number&gt;</code>, and thus doesn't syntactically allow units, its implicit unit is <a href="/en-US/docs/Web/CSS/resolution#dppx"><code>dppx</code></a>.</dd>
+ <dd>The number of device pixels used to represent each CSS <a href="/en-US/docs/Web/CSS/length#absolute_length_units"><code>px</code></a>. Although the value is a <code>&lt;number&gt;</code>, and thus doesn't syntactically allow units, its implicit unit is <a href="/en-US/docs/Web/CSS/resolution#units"><code>dppx</code></a>.</dd>
 </dl>
 
 <h2 id="Implementation">Implementation</h2>

--- a/files/en-us/web/css/resolution/index.html
+++ b/files/en-us/web/css/resolution/index.html
@@ -23,13 +23,13 @@ browser-compat: css.types.resolution
 <h3 id="Units">Units</h3>
 
 <dl>
- <dt id="dpi"><code>dpi</code></dt>
+ <dt><code>dpi</code></dt>
  <dd>Represents the number of <a href="https://en.wikipedia.org/wiki/Dots_per_inch">dots per inch</a>. Screens typically contains 72 or 96 dots per inch, but the dpi for printed documents is usually much greater. As 1 inch is 2.54 cm, <code>1dpi ≈ 0.39dpcm</code>.</dd>
- <dt id="dpcm"><code>dpcm</code></dt>
+ <dt><code>dpcm</code></dt>
  <dd>Represents the number of <a href="https://en.wikipedia.org/wiki/Dots_per_inch">dots per centimeter</a>. As 1 inch is 2.54 cm, <code>1dpcm ≈ 2.54dpi</code>.</dd>
- <dt id="dppx"><code>dppx</code></dt>
+ <dt><code>dppx</code></dt>
  <dd>Represents the number of dots per <code><a href="/en-US/docs/Web/CSS/length#px">px</a></code> unit. Due to the 1:96 fixed ratio of CSS <code class="css">in</code> to CSS <code class="css">px</code>, <code class="css">1dppx</code> is equivalent to <code class="css">96dpi</code>, which corresponds to the default resolution of images displayed in CSS as defined by {{cssxref("image-resolution")}}.</dd>
- <dt id="x"><code>x</code></dt>
+ <dt><code>x</code></dt>
  <dd>Alias for <code>dppx</code>.</dd>
 </dl>
 

--- a/files/en-us/web/css/right/index.html
+++ b/files/en-us/web/css/right/index.html
@@ -91,7 +91,6 @@ right: unset;
 
 <h4 id="CSS">CSS</h4>
 
-<div id="example1">
 <pre class="brush: css">#relative {
   width: 100px;
   height: 100px;
@@ -115,7 +114,6 @@ right: unset;
 <h4 id="Result">Result</h4>
 
 <p>{{ EmbedLiveSample('Absolute_and_relative_positioning_using_right', 500, 220) }}</p>
-</div>
 
 <h3 id="Declaring_both_left_and_right">Declaring both left and right</h3>
 
@@ -130,7 +128,6 @@ right: unset;
 
 <h4 id="CSS_2">CSS</h4>
 
-<div id="example2">
 <pre class="brush: css;">div {
   outline: 1px solid #CCCCCC;
 }
@@ -158,7 +155,6 @@ right: unset;
 <h4 id="Result_2">Result</h4>
 
 <p>{{ EmbedLiveSample('Declaring_both_left_and_right', 500, 220) }}</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/text-align/index.html
+++ b/files/en-us/web/css/text-align/index.html
@@ -45,31 +45,31 @@ text-align: unset;
 <p>The <code>text-align</code> property is specified in one of the following ways:</p>
 
 <ul>
- <li>Using the keyword values <code><a href="#start">start</a></code>, <code><a href="#end">end</a></code>, <code><a href="#left">left</a></code>, <code><a href="#right">right</a></code>, <code><a href="#center">center</a></code>, <code><a href="#justify">justify</a></code>, <code><a href="#justify-all">justify-all</a></code>, or <code><a href="#match-parent">match-parent</a></code>.</li>
- <li>Using a <code><a href="#string">&lt;string&gt;</a></code> value only, in which case the other value defaults to <code><a href="#right">right</a></code>.</li>
+ <li>Using the keyword values <code>start</code>, <code>end</code>, <code>left</code>, <code>right</code>, <code>center</code>, <code>justify</code>, <code>justify-all</code>, or <code>match-parent</code>.</li>
+ <li>Using a <code>&lt;string&gt;</code> value only, in which case the other value defaults to <code>right</code>.</li>
  <li>Using both a keyword value and a <code><a href="#string">&lt;string&gt;</a></code> value.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="start"><code>start</code></dt>
+ <dt><code>start</code></dt>
  <dd>The same as <code>left</code> if direction is left-to-right and <code>right</code> if direction is right-to-left.</dd>
- <dt id="end"><code>end</code></dt>
+ <dt><code>end</code></dt>
  <dd>The same as <code>right</code> if direction is left-to-right and <code>left</code> if direction is right-to-left.</dd>
- <dt id="left"><code>left</code></dt>
+ <dt><code>left</code></dt>
  <dd>The inline contents are aligned to the left edge of the line box.</dd>
- <dt id="right"><code>right</code></dt>
+ <dt><code>right</code></dt>
  <dd>The inline contents are aligned to the right edge of the line box.</dd>
- <dt id="center"><code>center</code></dt>
+ <dt><code>center</code></dt>
  <dd>The inline contents are centered within the line box.</dd>
- <dt id="justify"><code>justify</code></dt>
+ <dt><code>justify</code></dt>
  <dd>The inline contents are justified. Text should be spaced to line up its left and right edges to the left and right edges of the line box, except for the last line.</dd>
- <dt id="justify-all"><code>justify-all</code> {{experimental_inline}}</dt>
+ <dt><code>justify-all</code> {{experimental_inline}}</dt>
  <dd>Same as <code>justify</code>, but also forces the last line to be justified.</dd>
- <dt id="match-parent"><code>match-parent</code></dt>
+ <dt><code>match-parent</code></dt>
  <dd>Similar to <code>inherit</code>, but the values <code>start</code> and <code>end</code> are calculated according to the parent's {{cssxref("direction")}} and are replaced by the appropriate <code>left</code> or <code>right</code> value.</dd>
- <dt id="string">{{cssxref("&lt;string&gt;")}} {{experimental_inline}}</dt>
+ <dt>{{cssxref("&lt;string&gt;")}} {{experimental_inline}}</dt>
  <dd>When applied to a table cell, specifies the alignment character around which the cell's contents will align.</dd>
 </dl>
 

--- a/files/en-us/web/css/text-decoration/index.html
+++ b/files/en-us/web/css/text-decoration/index.html
@@ -40,9 +40,9 @@ text-decoration: initial;
 text-decoration: revert;
 text-decoration: unset;</pre>
 
-<p id="Values">The <code>text-decoration</code> property is specified as one or more space-separated values representing the various longhand text-decoration properties.</p>
+<p>The <code>text-decoration</code> property is specified as one or more space-separated values representing the various longhand text-decoration properties.</p>
 
-<h3 id="Values_2">Values</h3>
+<h3 id="values">Values</h3>
 
 <dl>
 	<dt>{{cssxref("text-decoration-line")}}</dt>

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -14,7 +14,6 @@ browser-compat: css.properties.text-overflow
 
 <div>{{EmbedInteractiveExample("pages/css/text-overflow.html")}}</div>
 
-
 <p>The <code>text-overflow</code> property doesn't force an overflow to occur. To make text overflow its container you have to set other CSS properties: {{cssxref("overflow")}} and {{cssxref("white-space")}}. For example:</p>
 
 <pre class="brush: css no-line-numbers">overflow: hidden;
@@ -37,23 +36,23 @@ text-overflow: revert;
 text-overflow: unset;</pre>
 
 <ul>
- <li>one of the keyword values: <code><a href="#clip">clip</a></code>, <code><a href="#ellipsis">ellipsis</a></code>, <code><a href="#fade">fade</a></code></li>
- <li>the function <code><a href="#fade_length_percentage">fade()</a></code>, which is passed a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} to control the fade distance</li>
- <li>a <code><a href="#string">&lt;string&gt;</a></code>.</li>
+ <li>one of the keyword values: <code>clip</code>, <code>ellipsis</code>, <code>fade</code></li>
+ <li>the function <code>fade()</code>, which is passed a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} to control the fade distance</li>
+ <li>a <code>&lt;string&gt;</code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="clip"><code>clip</code></dt>
+ <dt><code>clip</code></dt>
  <dd>The default for this property. This keyword value will truncate the text at the limit of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, therefore the truncation can happen in the middle of a character. To clip at the transition between characters you can specify <code>text-overflow</code> as an empty string, if that is supported in your target browsers: <code>text-overflow: '';</code>.</dd>
- <dt id="ellipsis"><code>ellipsis</code></dt>
+ <dt><code>ellipsis</code></dt>
  <dd>This keyword value will display an ellipsis (<code>'…'</code>, <code>U+2026 HORIZONTAL ELLIPSIS</code>) to represent clipped text. The ellipsis is displayed inside the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, decreasing the amount of text displayed. If there is not enough space to display the ellipsis, it is clipped.</dd>
- <dt id="string"><code>&lt;string&gt;</code> {{experimental_inline}}</dt>
+ <dt><code>&lt;string&gt;</code> {{experimental_inline}}</dt>
  <dd>The {{cssxref("&lt;string&gt;")}} to be used to represent clipped text. The string is displayed inside the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, shortening the size of the displayed text. If there is not enough space to display the string itself, it is clipped.</dd>
- <dt id="fade"><code>fade</code> {{experimental_inline}}</dt>
+ <dt><code>fade</code> {{experimental_inline}}</dt>
  <dd>This keyword clips the overflowing inline content and applies a fade-out effect near the edge of the line box with complete transparency at the edge.</dd>
- <dt id="fade_length_percentage"><code>fade( &lt;length&gt; | &lt;percentage&gt; )</code> {{experimental_inline}}</dt>
+ <dt><code>fade( &lt;length&gt; | &lt;percentage&gt; )</code> {{experimental_inline}}</dt>
  <dd>
    <p>This function clips the overflowing inline content and applies a fade-out effect near the edge of the line box with complete transparency at the edge.</p>
    <p>The argument determines the distance over which the fade effect is applied. The {{cssxref("&lt;percentage&gt;")}} is resolved against the width of the line box. Values lower than <code>0</code> are clipped to <code>0</code>. Values greater than the width of the line box are clipped to the width of the line box.</p>

--- a/files/en-us/web/css/text-size-adjust/index.html
+++ b/files/en-us/web/css/text-size-adjust/index.html
@@ -35,16 +35,16 @@ text-size-adjust: unset;
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>text-size-adjust</code> property is specified as <code><a href="#none">none</a></code>, <code><a href="#auto">auto</a></code>, or a <code><a href="#percentage">&lt;percentage&gt;</a></code>.</p>
+<p>The <code>text-size-adjust</code> property is specified as <code>none</code>, <code>auto</code>, or a <code>&lt;percentage&gt;</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Disables the browser's inflation algorithm.</dd>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd>Enables the browser's inflation algorithm. This value is used to cancel a <code>none</code> value previously set with CSS.</dd>
- <dt id="percentage"><code>&lt;percentage&gt;</code></dt>
+ <dt><code>&lt;percentage&gt;</code></dt>
  <dd>Enables the browser's inflation algorithm, specifying a percentage value with which to increase the font size.</dd>
 </dl>
 

--- a/files/en-us/web/css/time/index.html
+++ b/files/en-us/web/css/time/index.html
@@ -25,9 +25,9 @@ browser-compat: css.types.time
 <h3 id="Units">Units</h3>
 
 <dl>
-	<dt><strong><code id="s">s</code></strong></dt>
+	<dt><strong><code>s</code></strong></dt>
 	<dd>Represents a time in seconds. Examples: <code>0s</code>, <code>1.5s</code>, <code>-60s</code>.</dd>
-	<dt><strong><code id="ms">ms</code></strong></dt>
+	<dt><strong><code>ms</code></strong></dt>
 	<dd>Represents a time in milliseconds. Examples: <code>0ms</code>, <code>150.25ms</code>, <code>-60000ms</code>.</dd>
 </dl>
 

--- a/files/en-us/web/css/touch-action/index.html
+++ b/files/en-us/web/css/touch-action/index.html
@@ -45,26 +45,26 @@ touch-action: unset;
 <p>The <code>touch-action</code> property may be specified as either:</p>
 
 <ul>
- <li>One of the keywords <code><a href="#auto">auto</a></code>, <code><a href="#none">none</a></code>, <code><a href="#manipulation">manipulation</a></code>, <em>or</em></li>
- <li>One of the keywords <code><a href="#pan-x">pan-x</a></code>, <code><a href="#pan-keywords">pan-left</a></code>, <code><a href="#pan-keywords">pan-right</a></code>, and/or one of the keywords <code><a href="#pan-y">pan-y</a></code>, <code><a href="#pan-keywords">pan-up</a></code>, <code><a href="#pan-keywords">pan-down</a></code>, plus optionally the keyword <code><a href="#pinch-zoom">pinch-zoom</a></code>.</li>
+ <li>One of the keywords <code>auto</code>, <code>none</code>, <code><a href="#manipulation">manipulation</a></code>, <em>or</em></li>
+ <li>One of the keywords <code>pan-x</code>, <code>pan-left</code>, <code>pan-right</code>, and/or one of the keywords <code>pan-y</code>, <code>pan-up</code>, <code>pan-down</code>, plus optionally the keyword <code>pinch-zoom</code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd>Enable browser handling of all panning and zooming gestures.</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Disable browser handling of all panning and zooming gestures.</dd>
- <dt id="pan-x"><code>pan-x</code></dt>
+ <dt><code>pan-x</code></dt>
  <dd>Enable single-finger horizontal panning gestures. May be combined with <strong>pan-y</strong>, <strong>pan-up</strong>, <strong>pan-down</strong> and/or <strong>pinch-zoom</strong>.</dd>
- <dt id="pan-y"><code>pan-y</code></dt>
+ <dt><code>pan-y</code></dt>
  <dd>Enable single-finger vertical panning gestures. May be combined with <strong>pan-x</strong>, <strong>pan-left</strong>, <strong>pan-right</strong> and/or <strong>pinch-zoom</strong>.</dd>
- <dt id="manipulation"><code>manipulation</code></dt>
+ <dt><code>manipulation</code></dt>
  <dd>Enable panning and pinch zoom gestures, but disable additional non-standard gestures such as double-tap to zoom. Disabling double-tap to zoom removes the need for browsers to delay the generation of <strong>click</strong> events when the user taps the screen. This is an alias for "<strong>pan-x pan-y pinch-zoom</strong>" (which, for compatibility, is itself still valid).</dd>
- <dt id="pan-keywords"><code>pan-left</code>, <code>pan-right</code>, <code>pan-up</code>, <code>pan-down</code> {{experimental_inline}}</dt>
+ <dt><code>pan-left</code>, <code>pan-right</code>, <code>pan-up</code>, <code>pan-down</code> {{experimental_inline}}</dt>
  <dd>Enable single-finger gestures that begin by scrolling in the given direction(s). Once scrolling has started, the direction may still be reversed. Note that scrolling "up" (<strong>pan-up</strong>) means that the user is dragging their finger downward on the screen surface, and likewise <strong>pan-left</strong> means the user is dragging their finger to the right. Multiple directions may be combined except when there is a simpler representation (for example, <strong>"pan-left pan-right</strong>" is invalid since "<strong>pan-x</strong>" is simpler, but "<strong>pan-left pan-down</strong>" is valid).</dd>
- <dt id="pinch-zoom"><code>pinch-zoom</code></dt>
+ <dt><code>pinch-zoom</code></dt>
  <dd>Enable multi-finger panning and zooming of the page. This may be combined with any of the <strong>pan-</strong> values.</dd>
 </dl>
 

--- a/files/en-us/web/css/transform/index.html
+++ b/files/en-us/web/css/transform/index.html
@@ -60,16 +60,16 @@ transform: revert;
 transform: unset;
 </pre>
 
-<p>The <code>transform</code> property may be specified as either the keyword value <code><a href="#none">none</a></code> or as one or more <code><a href="#transform-function">&lt;transform-function&gt;</a></code> values.</p>
+<p>The <code>transform</code> property may be specified as either the keyword value <code>none</code> or as one or more <code>&lt;transform-function&gt;</code> values.</p>
 
 <p>If {{cssxref("transform-function/perspective", "perspective()")}} is one of multiple function values, it must be listed first.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="transform-function">{{cssxref("&lt;transform-function&gt;")}}</dt>
+ <dt)}}</dt>
  <dd>One or more of the <a href="/en-US/docs/Web/CSS/transform-function">CSS transform functions</a> to be applied. The transform functions are multiplied in order from left to right, meaning that composite transforms are effectively applied in order from right to left.</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Specifies that no transform should be applied.</dd>
 </dl>
 

--- a/files/en-us/web/css/translate/index.html
+++ b/files/en-us/web/css/translate/index.html
@@ -44,7 +44,7 @@ translate: unset;</pre>
  <dd>Two {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} that specify the X and Y axis translation values (respectively) of a 2D translation. Equivalent to a <code>translate()</code> (2D translation) function with two values specified.</dd>
  <dt>Three values</dt>
  <dd>Two {{cssxref("&lt;length-percentage&gt;")}} and single {{cssxref("&lt;length&gt;")}} values that specify the X, Y, and Z axis translation values (respectively) of a 3D translation. Equivalent to a <code>translate3d()</code> (3D translation) function.</dd>
- <dt id="none"><code>none</code></dt>
+ <dt><code>none</code></dt>
  <dd>Specifies that no translation should be applied.</dd>
 </dl>
 

--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -129,7 +129,6 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 
 <h3 id="Using_a_data-uri">Using a data-uri</h3>
 
-<div id="color-value">
 <h4 id="HTML_2">HTML</h4>
 
 <pre class="brush: html">&lt;div class="background"&gt;&lt;/div&gt;</pre>
@@ -144,7 +143,6 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
   background: yellow;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='90' height='45'%3E%3Cpath d='M10 10h60' stroke='%2300F' stroke-width='5'/%3E%3Cpath d='M10 20h60' stroke='%230F0' stroke-width='5'/%3E%3Cpath d='M10 30h60' stroke='red' stroke-width='5'/%3E%3C/svg%3E");
 }</pre>
-</div>
 
 <p>{{EmbedLiveSample("Using_a_data-uri", "100%", 50)}}</p>
 

--- a/files/en-us/web/css/using_css_custom_properties/index.html
+++ b/files/en-us/web/css/using_css_custom_properties/index.html
@@ -101,7 +101,6 @@ tags:
 <h2 id="Using_the_root_pseudo-class">Using the :root pseudo-class</h2>
 
 <p>Notice the repetitive CSS in the example above. The background color is set to <code>brown</code> in several places. For some CSS declarations, it is possible to declare this higher in the cascade and let CSS inheritance solve this problem naturally. For non-trivial projects, this is not always possible. By declaring a custom property on the {{cssxref(":root")}} pseudo-class and using it where needed throughout the document, a CSS author can reduce the need for repetition:</p>
-</div>
 
 <pre class="brush:css; highlight:[2, 7, 24,30,36]">:root {
   --main-bg-color: brown;

--- a/files/en-us/web/css/using_css_custom_properties/index.html
+++ b/files/en-us/web/css/using_css_custom_properties/index.html
@@ -49,7 +49,6 @@ tags:
 
 <p>Let's start with this simple CSS that applies the same color to elements of different classes:</p>
 
-<div id="sample1">
 <pre class="brush:css; highlight:[3,20,26,32]">.one {
   color: white;
   background-color: brown;
@@ -99,10 +98,11 @@ tags:
 
 <p>{{EmbedLiveSample("First_steps_with_custom_properties",600,180)}}</p>
 
-<p>Notice the repetition in the CSS. The background color is set to <code>brown</code> in several places. For some CSS declarations, it is possible to declare this higher in the cascade and let CSS inheritance solve this problem naturally. For non-trivial projects, this is not always possible. By declaring a custom property on the {{cssxref(":root")}} pseudo-class and using it where needed throughout the document, a CSS author can reduce the need for repetition:</p>
+<h2 id="Using_the_root_pseudo-class">Using the :root pseudo-class</h2>
+
+<p>Notice the repetitive CSS in the example above. The background color is set to <code>brown</code> in several places. For some CSS declarations, it is possible to declare this higher in the cascade and let CSS inheritance solve this problem naturally. For non-trivial projects, this is not always possible. By declaring a custom property on the {{cssxref(":root")}} pseudo-class and using it where needed throughout the document, a CSS author can reduce the need for repetition:</p>
 </div>
 
-<div id="sample2">
 <pre class="brush:css; highlight:[2, 7, 24,30,36]">:root {
   --main-bg-color: brown;
 }
@@ -149,8 +149,6 @@ tags:
     &lt;textarea class="four"&gt;Lorem Ipsum&lt;/textarea&gt;
 &lt;/div&gt;
 </pre>
-
-</div>
 
 <p>This leads to the same result as the previous example, yet allows for one canonical declaration of the desired property value; very useful if you want to change the value across the entire page later.</p>
 

--- a/files/en-us/web/css/will-change/index.html
+++ b/files/en-us/web/css/will-change/index.html
@@ -38,7 +38,7 @@ will-change: unset;
 
 <ul>
  <li>
-  <p id="Don't_apply_will-change_to_too_many_elements"><em>Don't apply will-change to too many elements.</em> The browser already tries as hard as it can to optimize everything. Some of the stronger optimizations that are likely to be tied to <code>will-change</code> end up using a lot of a machine’s resources, and when overused like this can cause the page to slow down or consume a lot of resources.</p>
+  <p><em>Don't apply will-change to too many elements.</em> The browser already tries as hard as it can to optimize everything. Some of the stronger optimizations that are likely to be tied to <code>will-change</code> end up using a lot of a machine’s resources, and when overused like this can cause the page to slow down or consume a lot of resources.</p>
  </li>
  <li>
   <p><em>Use sparingly.</em> The normal behavior for optimizations that the browser make is to remove the optimizations as soon as it can and revert back to normal. But adding <code>will-change</code> directly in a stylesheet implies that the targeted elements are always a few moments away from changing and the browser will keep the optimizations for much longer time than it would have otherwise. So it is a good practice to switch <code>will-change</code> on and off using script code before and after the change occurs.</p>
@@ -47,7 +47,7 @@ will-change: unset;
   <p><em>Don't apply will-change to elements to perform premature optimization</em>. If your page is performing well, don't add the <code>will-change</code> property to elements just to wring out a little more speed. <code>will-change</code> is intended to be used as something of a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems. Excessive use of <code>will-change</code> will result in excessive memory use and will cause more complex rendering to occur as the browser attempts to prepare for the possible change. This will lead to worse performance.</p>
  </li>
  <li>
-  <p id="Give_it_sufficient_time_to_work"><em>Give it sufficient time to work</em>. This property is intended as a method for authors to let the user-agent know about properties that are likely to change ahead of time. Then the browser can choose to apply any ahead-of-time optimizations required for the property change before the property change actually happens. So it is important to give the browser some time to actually do the optimizations. Find some way to predict at least slightly ahead of time that something will change, and set <code>will-change</code> then.</p>
+  <p><em>Give it sufficient time to work</em>. This property is intended as a method for authors to let the user-agent know about properties that are likely to change ahead of time. Then the browser can choose to apply any ahead-of-time optimizations required for the property change before the property change actually happens. So it is important to give the browser some time to actually do the optimizations. Find some way to predict at least slightly ahead of time that something will change, and set <code>will-change</code> then.</p>
  </li>
  <li>
   <p><em>Be aware, that will-change may actually influence the visual appearance of elements</em>, when used with property values, that create a <a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context">stacking context</a> (e.g. will-change: opacity), as the stacking context is created up front.</p>

--- a/files/en-us/web/css/z-index/index.html
+++ b/files/en-us/web/css/z-index/index.html
@@ -40,14 +40,14 @@ z-index: revert;
 z-index: unset;
 </pre>
 
-<p>The <code>z-index</code> property is specified as either the keyword <code><a href="#auto">auto</a></code> or an <code><a href="#integer">&lt;integer&gt;</a></code>.</p>
+<p>The <code>z-index</code> property is specified as either the keyword <code>auto</code> or an <code>&lt;integer&gt;</code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="auto"><code>auto</code></a></dt>
+ <dt><a><code>auto</code></a></dt>
  <dd>The box does not establish a new local stacking context. The stack level of the generated box in the current stacking context is <code>0</code>.</dd>
- <dt><a id="integer"><code>&lt;integer&gt;</code></a></dt>
+ <dt><a><code>&lt;integer&gt;</code></a></dt>
  <dd>This {{cssxref("&lt;integer&gt;")}} is the stack level of the generated box in the current stacking context. The box also establishes a local stacking context. This means that the z-indexes of descendants are not compared to the z-indexes of elements outside this element.</dd>
 </dl>
 


### PR DESCRIPTION
Following on from https://github.com/mdn/content/pull/5923, https://github.com/mdn/content/pull/7479, and https://github.com/mdn/content/pull/7467, this removes the last batch of IDs from the CSS docs.

As before I've tried to ensure that any internal links still go somewhere reasonably sensible.

After this change there are still 5 pages that use IDs. These are the pages that used `EmbedLiveSample` to implement complete web apps:

https://developer.mozilla.org/en-US/docs/Web/CSS/css_background_and_borders/border-image_generator
https://developer.mozilla.org/en-US/docs/Web/CSS/css_background_and_borders/border-radius_generator
https://developer.mozilla.org/en-US/docs/Web/CSS/css_background_and_borders/box-shadow_generator
https://developer.mozilla.org/en-US/docs/Web/CSS/css_colors/color_picker_tool
https://developer.mozilla.org/en-US/docs/Web/CSS/tools/linear-gradient_generator (though we should delete this one)

They use `<div id=` as a referent for `EmbedLiveSample`. They can't naturally use a heading because the only natural heading is the title of the page, which isn't in content.

Implementing quite complex tools like this using `EmbedLiveSample` makes them  very hard to maintain anyway, and converting them to Markdown wouldn't help that much. In a sensible system these tools would be a part of the platform.

That said, I do think 4/5 of these are useful tools as they are.
