### PR TITLE
Page macro: VR Api  examples link rather than include

### DIFF
--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplay/getEyeParameters
 tags:
   - API
   - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -23,8 +24,7 @@ browser-compat: api.VRDisplay.getEyeParameters
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var myEyeParameters = vrDisplayInstance.getEyeParameters(<em>whichEye</em>);
-</pre>
+<pre class="brush: js">getEyeParameters(whichEye)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -39,7 +39,7 @@ browser-compat: api.VRDisplay.getEyeParameters
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VREyeParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VREyeParameters#examples"><code>VREyeParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplay/getLayers
 tags:
   - API
   - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -23,8 +24,7 @@ browser-compat: api.VRDisplay.getLayers
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var myLayers = vrDisplayInstance.getLayers();
-</pre>
+<pre class="brush: js">var myLayers = vrDisplayInstance.getLayers();</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -36,7 +36,7 @@ browser-compat: api.VRDisplay.getLayers
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRLayerInit", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRLayerInit#examples"><code>VRLayerInit</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplay/stageParameters
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -23,8 +24,7 @@ browser-compat: api.VRDisplay.stageParameters
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var myStageParameters = vrDisplayInstance.stageParameters;
-</pre>
+<pre class="brush: js">var myStageParameters = vrDisplayInstance.stageParameters;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -32,7 +32,7 @@ browser-compat: api.VRDisplay.stageParameters
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRStageParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRStageParameters#examples"><code>VRStageParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplayEvent/display
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -31,7 +32,9 @@ browser-compat: api.VRDisplayEvent.display
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayEvent", "Examples")}}</p>
+<pre class="brush: js">window.addEventListener('vrdisplaypresentchange', function(e) {
+    console.log('Display ' + e.display.displayId + ' presentation has changed. Reason given: ' + e.reason + '.');
+  })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplayEvent
 tags:
   - API
   - Experimental
+  - Deprecated
   - Interface
   - Reference
   - VR

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRDisplayEvent/reason
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -38,7 +39,9 @@ browser-compat: api.VRDisplayEvent.reason
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRDisplayEvent", "Examples")}}</p>
+<pre class="brush: js">window.addEventListener('vrdisplaypresentchange', function(e) {
+    console.log('Display ' + e.display.displayId + ' presentation has changed. Reason given: ' + e.reason + '.');
+  })</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -14,7 +14,7 @@ tags:
   - fieldOfView
 browser-compat: api.VREyeParameters.fieldOfView
 ---
-<p>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</p>
+<p>{{APIRef("WebVR API")}}{{Deprecated_header}}</p>
 
 <p>The <strong><code>fieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface returns a {{domxref("VRFieldOfView")}} object <dfn>describing t</dfn>he current field of view for the eye, which can vary as the user adjusts their interpupillary distance (IPD).</p>
 

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VREyeParameters
 tags:
   - API
   - Experimental
+  - Deprecated
   - Landing
   - Reference
   - VR
@@ -22,8 +23,8 @@ browser-compat: api.VREyeParameters
 
 <p>This interface is accessible through the {{domxref("VRDisplay.getEyeParameters()")}} method.</p>
 
-<div class="warning">
-<p>The values in this interface should not be used to compute view or projection matrices. In order to ensure the widest possible hardware compatibility use the matrices provided by {{domxref("VRFrameData")}}.</p>
+<div class="notecard warning">
+<p><strong>Warning:</strong> The values in this interface should not be used to compute view or projection matrices. In order to ensure the widest possible hardware compatibility use the matrices provided by {{domxref("VRFrameData")}}.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>
@@ -33,9 +34,9 @@ browser-compat: api.VREyeParameters
 	<dd><dfn>Represents the o</dfn>ffset from the center point between the user's eyes to the center of the eye, measured in meters.</dd>
 	<dt>{{domxref("VREyeParameters.fieldOfView")}}  {{deprecated_inline}} {{readonlyInline}}</dt>
 	<dd><dfn>Describes t</dfn>he current field of view for the eye, which can vary as the user adjusts their interpupillary distance (IPD).</dd>
-	<dt>{{domxref("VREyeParameters.renderWidth")}} {{readonlyInline}}</dt>
+	<dt>{{domxref("VREyeParameters.renderWidth")}} {{deprecated_inline}} {{readonlyInline}}</dt>
 	<dd>Describes the recommended render target width of each eye viewport, in pixels.</dd>
-	<dt>{{domxref("VREyeParameters.renderHeight")}} {{readonlyInline}}</dt>
+	<dt>{{domxref("VREyeParameters.renderHeight")}} {{deprecated_inline}} {{readonlyInline}}</dt>
 	<dd>Describes the recommended render target height of each eye viewport, in pixels.</dd>
 </dl>
 

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -14,7 +14,7 @@ tags:
   - maximumFieldOfView
 browser-compat: api.VREyeParameters.maximumFieldOfView
 ---
-<div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{deprecated_header}}</div>
 
 <p>The <strong><code>maximumFieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the maximum supported field of view for the current eye.</p>
 

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -14,7 +14,7 @@ tags:
   - minimumFieldOfView
 browser-compat: api.VREyeParameters.minimumFieldOfView
 ---
-<div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{deprecated_header}}</div>
 
 <p>The <strong><code>minimumFieldOfView</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the minimum supported field of view for the current eye.</p>
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VREyeParameters/offset
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -13,7 +14,7 @@ tags:
   - offset
 browser-compat: api.VREyeParameters.offset
 ---
-<p>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</p>
+<p>{{APIRef("WebVR API")}}{{Deprecated_header}}</p>
 
 <p>The <strong><code>offset</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface <dfn>r</dfn><dfn>epresents the o</dfn>ffset from the center point between the user's eyes to the center of the eye, measured in meters.</p>
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VREyeParameters/renderHeight
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -33,7 +34,7 @@ browser-compat: api.VREyeParameters.renderHeight
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VREyeParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VREyeParameters#examples"><code>VREyeParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VREyeParameters/renderWidth
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -33,7 +34,7 @@ browser-compat: api.VREyeParameters.renderWidth
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VREyeParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VREyeParameters#examples"><code>VREyeParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Dictionary
   - Experimental
+  - Deprecated
   - Interface
   - Reference
   - VR

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRLayerInit/leftBounds
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -41,7 +42,7 @@ myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRLayerInit", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRLayerInit#examples"><code>VRLayerInit</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRLayerInit/rightBounds
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -41,7 +42,7 @@ myVRLayerInit.rightBounds = [0.5, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRLayerInit", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRLayerInit#examples"><code>VRLayerInit</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRLayerInit/source
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -32,7 +33,7 @@ myVRLayerInit.source = myCanvas;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRLayerInit", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRLayerInit#examples"><code>VRLayerInit</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRStageParameters
 tags:
   - API
   - Experimental
+  - Deprecated
   - Interface
   - Reference
   - VR

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRStageParameters/sittingToStandingTransform
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -33,7 +34,7 @@ browser-compat: api.VRStageParameters.sittingToStandingTransform
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRStageParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRStageParameters#examples"><code>VRStageParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRStageParameters/sizeX
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -33,7 +34,7 @@ browser-compat: api.VRStageParameters.sizeX
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRStageParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRStageParameters#examples"><code>VRStageParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -4,6 +4,7 @@ slug: Web/API/VRStageParameters/sizeY
 tags:
   - API
   - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -33,7 +34,7 @@ browser-compat: api.VRStageParameters.sizeY
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/Web/API/VRStageParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/VRStageParameters#examples"><code>VRStageParameters</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link in most cases. In a few cases with trivial examples I copied the text. Also added Deprecated tag in quite a few cases. I'll go through and fully tag this API another day.