### PR TITLE
Page macro: link rather than include StorageEstimate

### DIFF
--- a/files/en-us/web/api/storageestimate/quota/index.html
+++ b/files/en-us/web/api/storageestimate/quota/index.html
@@ -22,17 +22,15 @@ browser-compat: api.StorageEstimate.quota
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>quota</em> = <em>StorageEstimate</em>.quota;
-</pre>
+<pre class="brush: js"><em>quota</em> = <em>StorageEstimate</em>.quota;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A numeric value specifying an approximation of the total amount of storage space
-  available for use by the application.</p>
+<p>A numeric value specifying an approximation of the total amount of storage space available for use by the application.</p>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/StorageManager/estimate", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/StorageManager/estimate#example"><code>StorageManager.estimate</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/storageestimate/usage/index.html
+++ b/files/en-us/web/api/storageestimate/usage/index.html
@@ -27,12 +27,11 @@ browser-compat: api.StorageEstimate.usage
 
 <h3 id="Value">Value</h3>
 
-<p>A numeric value specifying an approximation of the total amount of storage space
-  available for use by the application.</p>
+<p>A numeric value specifying an approximation of the total amount of storage space available for use by the application.</p>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/StorageManager/estimate", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/StorageManager/estimate#example"><code>StorageManager.estimate</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/submitevent/submitter/index.html
+++ b/files/en-us/web/api/submitevent/submitter/index.html
@@ -22,8 +22,7 @@ browser-compat: api.SubmitEvent.submitter
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">let <em>submitter</em> = <em>submitEvent</em>.submitter;</pre>
+<pre class="brush: js">let <em>submitter</em> = <em>submitEvent</em>.submitter;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -32,12 +31,11 @@ browser-compat: api.SubmitEvent.submitter
   is often an {{HTMLElement("input")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code> or a {{HTMLElement("button")}} element whose <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdeftype"><code>type</code></a> is <code>submit</code>, it could be some other element which has initiated a
   submission process.</p>
 
-<p>If the submission was not triggered by a button of some kind, the value
-  of <code>submitter</code> is <code>null</code>.</p>
+<p>If the submission was not triggered by a button of some kind, the value of <code>submitter</code> is <code>null</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/SubmitEvent", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/SubmitEvent#examples"><code>SubmitEvent</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link (for a small bunch of cases)