### PR TITLE
Page macro: RTC* fix example include to links

### DIFF
--- a/files/en-us/web/api/rtcdtlstransport/state/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.html
@@ -15,13 +15,11 @@ browser-compat: api.RTCDtlsTransport.state
 
 <p>The <strong><code>state</code></strong> read-only property of the
   {{DOMxRef("RTCDtlsTransport")}} interface provides information which describes a
-  Datagram Transport Layer Security (<strong>{{Glossary("DTLS")}}</strong>) transport
-  state.</p>
+  Datagram Transport Layer Security (<strong>{{Glossary("DTLS")}}</strong>) transport state.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">let <var>myState</var> = <var>dtlsTransport</var>.state;</pre>
+<pre class="brush: js">let <var>myState</var> = <var>dtlsTransport</var>.state;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -31,11 +29,9 @@ browser-compat: api.RTCDtlsTransport.state
   <dt><code>new</code></dt>
   <dd>The initial state when DTLS has not started negotiating yet.</dd>
   <dt><code>connecting</code></dt>
-  <dd>DTLS is in the process of negotiating a secure connection and verifying the remote
-    fingerprint.</dd>
+  <dd>DTLS is in the process of negotiating a secure connection and verifying the remote fingerprint.</dd>
   <dt><code>connected</code></dt>
-  <dd>DTLS has completed negotiation of a secure connection and verified the remote
-    fingerprint.</dd>
+  <dd>DTLS has completed negotiation of a secure connection and verified the remote fingerprint.</dd>
   <dt><code>closed</code></dt>
   <dd>The transport has been closed intentionally as the result of receipt of a
     <code>close_notify</code> alert, or calling {{DOMxRef("RTCPeerConnection.close()")}}.
@@ -47,7 +43,7 @@ browser-compat: api.RTCDtlsTransport.state
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/RTCDtlsTransport", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/RTCDtlsTransport#examples"><code>RTCDtlsTransport</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepair/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/index.html
@@ -17,7 +17,7 @@ browser-compat: api.RTCIceCandidatePair
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p><span class="seoSummary">The <code><strong>RTCIceCandidatePair</strong></code> dictionary describes a pair of ICE candidates which together comprise a description of a viable connection between two WebRTC endpoints.</span> It is used as the return value from {{domxref("RTCIceTransport.getSelectedCandidatePair()")}} to identify the currently-selected candidate pair identified by the ICE agent.</p>
+<p>The <code><strong>RTCIceCandidatePair</strong></code> dictionary describes a pair of ICE candidates which together comprise a description of a viable connection between two WebRTC endpoints. It is used as the return value from {{domxref("RTCIceTransport.getSelectedCandidatePair()")}} to identify the currently-selected candidate pair identified by the ICE agent.</p>
 
 <h2 id="Properties">Properties</h2>
 
@@ -28,9 +28,9 @@ browser-compat: api.RTCIceCandidatePair
  <dd>The <code><strong>RTCIceCandidate</strong></code> describing the configuration of the remote end of the connection.</dd>
 </dl>
 
-<h2 id="Example">Example</h2>
+<h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange#example"><code>RTCIceTransport.onselectedcandidatepairchange</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
+++ b/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
@@ -22,13 +22,11 @@ browser-compat: api.RTCIceTransport.getSelectedCandidatePair
 <p><span class="seoSummary">The {{domxref("RTCIceTransport")}} method
 		<code><strong>getSelectedCandidatePair()</strong></code> returns an
 		{{domxref("RTCIceCandidatePair")}} object containing the current best-choice pair
-		of {{Glossary("ICE")}} candidates describing the configuration of the endpoints of
-		the transport.</span></p>
+		of {{Glossary("ICE")}} candidates describing the configuration of the endpoints of the transport.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>candidatePair</em> = <em>RTCIceTransport</em>.getSelectedCandidatePair();
-</pre>
+<pre class="brush: js"><em>candidatePair</em> = <em>RTCIceTransport</em>.getSelectedCandidatePair();</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -57,17 +55,15 @@ browser-compat: api.RTCIceTransport.getSelectedCandidatePair
 
 <p>As ICE negotiation continues, any time a pair of candidates is discovered that is
 	better than the currently-selected pair, the new pair is selected, replacing the
-	previous pairing, and the <code>selectedcandidatepairchange</code> event is fired
-	again.</p>
+	previous pairing, and the <code>selectedcandidatepairchange</code> event is fired again.</p>
 
 <div class="note">
-	<p><strong>Note:</strong> It's possible for one of the configurations in the selected
-		candidate pair to remain unchanged when a new pairing is chosen.</p>
+	<p><strong>Note:</strong> It's possible for one of the configurations in the selected candidate pair to remain unchanged when a new pairing is chosen.</p>
 </div>
 
-<h2 id="Example">Example</h2>
+<h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/RTCIceCandidatePair", "Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange#example"><code>RTCIceTransport.onselectedcandidatepairchange</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
@@ -19,16 +19,13 @@ browser-compat: api.RTCIceTransport.onselectedcandidatepairchange
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p><span class="seoSummary">The {{domxref("RTCIceTransport")}} interface's
-    <strong><code>onselectedcandidatepairchange</code></strong> event handler specifies a
+<p>The {{domxref("RTCIceTransport")}} interface's <strong><code>onselectedcandidatepairchange</code></strong> event handler specifies a
     function to be called to handle the {{event("selectedcandidatepairchange")}} event,
-    which is fired when the ICE agent selects a new candidate pair to be used for the
-    connection.</span></p>
+    which is fired when the ICE agent selects a new candidate pair to be used for the connection.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>RTCIceTransport</em>.onselectedcandidatepairchange = <em>candidatePairHandler</em>;
-</pre>
+<pre class="brush: js"><em>RTCIceTransport</em>.onselectedcandidatepairchange = <em>candidatePairHandler</em>;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -49,8 +46,7 @@ browser-compat: api.RTCIceTransport.onselectedcandidatepairchange
 <h2 id="Example">Example</h2>
 
 <p>In this example, an event handler for {{event("selectedcandidatepairchange")}} is set
-  up to update an on-screen display showing the protocol used by the currently selected
-  candidate pair.</p>
+  up to update an on-screen display showing the protocol used by the currently selected candidate pair.</p>
 
 <pre class="brush: js">var iceTransport = pc.getSenders()[0].transport.iceTransport;
 var localProto = document.getElementById("local-protocol");

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
@@ -40,8 +40,8 @@ browser-compat: api.RTCPeerConnection.addTransceiver
   <dt><code>init</code> {{optional_inline}}</dt>
   <dd>An object that conforms to the {{domxref("RTCRtpTransceiverInit")}} dictionary which
     provides any options that you may wish to specify when creating the new transceiver.
-    Possible values are: {{page("/en-US/docs/Web/API/RTCRtpTransceiverInit",
-    "Properties")}}</dd>
+    Possible values are:
+    {{page("/en-US/docs/Web/API/RTCRtpTransceiverInit", "Properties")}}</dd>
 </dl>
 
 <h3 id="Exceptions">Exceptions</h3>

--- a/files/en-us/web/api/rtcrtpreceiveparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiveparameters/index.html
@@ -26,7 +26,7 @@ browser-compat: api.RTCRtpReceiveParameters
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/RTCRtpReceiver/getParameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/RTCRtpReceiver/getParameters#example"><code>RTCRtpReceiver.getParameters()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces examples pulled in page macro with a link for a few RTC* objects - also a little minor layout "improvement"