### PR TITLE
Page macro: Replace property/method inclusion with link

### DIFF
--- a/files/en-us/web/api/customevent/index.html
+++ b/files/en-us/web/api/customevent/index.html
@@ -24,16 +24,16 @@ browser-compat: api.CustomEvent
 
 <h2 id="Properties">Properties</h2>
 
+<p><em>This interface inherits properties from its parent, </em> {{domxref("Event")}}.</p>
+
 <dl>
  <dt>{{domxref("CustomEvent.detail")}} {{readonlyinline}}</dt>
  <dd>Any data passed when initializing the event.</dd>
 </dl>
 
-<p><em>This interface inherits properties from its parent, </em>{{domxref("Event")}}:</p>
-
-<p>{{Page("/en-US/docs/Web/API/Event", "Properties")}}</p>
-
 <h2 id="Methods">Methods</h2>
+
+<p><em>This interface inherits methods from its parent, </em>{{domxref("Event")}}.</p>
 
 <dl>
  <dt>{{domxref("CustomEvent.initCustomEvent()")}} {{deprecated_inline}}</dt>
@@ -41,10 +41,6 @@ browser-compat: api.CustomEvent
  <p>Initializes a <code>CustomEvent</code> object. If the event has already being dispatched, this method does nothing.</p>
  </dd>
 </dl>
-
-<p><em>This interface inherits methods from its parent, </em>{{domxref("Event")}}:</p>
-
-<p>{{Page("/en-US/docs/Web/API/Event", "Methods")}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -165,7 +165,7 @@ browser-compat: api.Document
  <dd>Returns an ordered list of the applets within a document.</dd>
  <dt>{{DOMxRef("Document.bgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the background color of the current document.</dd>
- <dt>{{DOMxRef("Document.characterSet")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.charset")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.fgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the foreground color, or text color, of the current document.</dd>
@@ -173,7 +173,7 @@ browser-compat: api.Document
  <dd><code>true</code> when the document is in {{DOMxRef("Using_full-screen_mode","full-screen mode")}}.</dd>
  <dt>{{DOMxRef("Document.height")}} {{Non-standard_Inline}} {{deprecated_inline}}</dt>
  <dd>Gets/sets the height of the current document.</dd>
- <dt>{{DOMxRef("Document.characterSet")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.inputEncoding")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.lastStyleSheetSet")}} {{deprecated_inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns the name of the style sheet set that was last enabled. Has the value <code>null</code> until the style sheet is changed by setting the value of {{DOMxRef("Document.selectedStyleSheetSet","selectedStyleSheetSet")}}.</dd>

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -165,7 +165,7 @@ browser-compat: api.Document
  <dd>Returns an ordered list of the applets within a document.</dd>
  <dt>{{DOMxRef("Document.bgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the background color of the current document.</dd>
- <dt>{{DOMxRef("Document.charset")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.characterSet","Document.charset")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.fgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the foreground color, or text color, of the current document.</dd>
@@ -173,7 +173,7 @@ browser-compat: api.Document
  <dd><code>true</code> when the document is in {{DOMxRef("Using_full-screen_mode","full-screen mode")}}.</dd>
  <dt>{{DOMxRef("Document.height")}} {{Non-standard_Inline}} {{deprecated_inline}}</dt>
  <dd>Gets/sets the height of the current document.</dd>
- <dt>{{DOMxRef("Document.inputEncoding")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.characterSet", "Document.inputEncoding")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.lastStyleSheetSet")}} {{deprecated_inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns the name of the style sheet set that was last enabled. Has the value <code>null</code> until the style sheet is changed by setting the value of {{DOMxRef("Document.selectedStyleSheetSet","selectedStyleSheetSet")}}.</dd>

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -126,6 +126,9 @@ browser-compat: api.Document
 
 <h3 id="Event_handlers">Event handlers</h3>
 
+<p><em>The <code>Document</code> interface is extended with additional event handlers defined in <a href="/en-US/docs/Web/API/GlobalEventHandlers#event_handlers">GlobalEventHandlers</a>.</em></p>
+
+
 <dl>
  <dt>{{DOMxRef("Document.onafterscriptexecute")}} {{Non-standard_Inline}}</dt>
  <dd>Represents the event handling code for the {{event("afterscriptexecute")}} event.</dd>
@@ -149,10 +152,6 @@ browser-compat: api.Document
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("visibilitychange")}} event is raised.</dd>
 </dl>
 
-<p>The <code>Document</code> interface is extended with the {{DOMxRef("GlobalEventHandlers")}} interface:</p>
-
-<p>{{Page("/en-US/docs/Web/API/GlobalEventHandlers", "Properties")}}</p>
-
 <h3 id="Deprecated_properties">Deprecated properties</h3>
 
 <dl>
@@ -166,7 +165,7 @@ browser-compat: api.Document
  <dd>Returns an ordered list of the applets within a document.</dd>
  <dt>{{DOMxRef("Document.bgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the background color of the current document.</dd>
- <dt>{{DOMxRef("Document.charset")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.characterSet")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.fgColor")}} {{Deprecated_Inline}}</dt>
  <dd>Gets/sets the foreground color, or text color, of the current document.</dd>
@@ -174,7 +173,7 @@ browser-compat: api.Document
  <dd><code>true</code> when the document is in {{DOMxRef("Using_full-screen_mode","full-screen mode")}}.</dd>
  <dt>{{DOMxRef("Document.height")}} {{Non-standard_Inline}} {{deprecated_inline}}</dt>
  <dd>Gets/sets the height of the current document.</dd>
- <dt>{{DOMxRef("Document.inputEncoding")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
+ <dt>{{DOMxRef("Document.characterSet")}} {{Deprecated_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Alias of {{DOMxRef("Document.characterSet")}}. Use this property instead.</dd>
  <dt>{{DOMxRef("Document.lastStyleSheetSet")}} {{deprecated_inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns the name of the style sheet set that was last enabled. Has the value <code>null</code> until the style sheet is changed by setting the value of {{DOMxRef("Document.selectedStyleSheetSet","selectedStyleSheetSet")}}.</dd>

--- a/files/en-us/web/api/filerequest/index.html
+++ b/files/en-us/web/api/filerequest/index.html
@@ -17,16 +17,14 @@ tags:
 
 <h2 id="Properties">Properties</h2>
 
+<p><em><code>FileRequest</code> also inherits properties from the <a href="/en-US/docs/Web/API/DOMRequest#properties"><code>DOMRequest</code></a> interface</em>.</p>
+
 <dl>
  <dt>{{domxref("FileRequest.lockedFile")}} {{readonlyinline}}</dt>
  <dd>The {{domxref("LockedFile")}} object from which the request was started.</dd>
  <dt>{{domxref("FileRequest.onprogress")}}</dt>
  <dd>A callback handler called repeatedly while the operation represented by the <code>FileRequest</code> is in progress.</dd>
 </dl>
-
-<p>The <code>FileRequest</code> interface also inherits from the {{domxref("DOMRequest")}} interface.</p>
-
-<p>{{page("/en-US/docs/Web/API/DOMRequest","Properties")}}</p>
 
 <h2 id="Methods">Methods</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

Replaces a few inherited properties and methods with a link (as previously agreed).