### PR TITLE
Page macro fix in using notification API - and event link

### DIFF
--- a/files/en-us/web/api/notification/index.html
+++ b/files/en-us/web/api/notification/index.html
@@ -84,7 +84,7 @@ browser-compat: api.Notification
  <dt>{{domxref("Notification.onclose")}}</dt>
  <dd>A handler for the {{domxref("HTMLDialogElement/close_event", "close")}} event. It is triggered when the user closes the notification.</dd>
  <dt>{{domxref("Notification.onerror")}}</dt>
- <dd>A handler for the {{domxref("HTMLElement/error_event", "error")}} event. It is triggered each time the notification encounters an error.</dd>
+ <dd>A handler for the {{domxref("Element/error_event", "error")}} event. It is triggered each time the notification encounters an error.</dd>
  <dt>{{domxref("Notification.onshow")}}</dt>
  <dd>A handler for the {{domxref("Element/show_event", "show")}} event. It is triggered when the notification is displayed.</dd>
 </dl>

--- a/files/en-us/web/api/notification/onerror/index.html
+++ b/files/en-us/web/api/notification/onerror/index.html
@@ -14,10 +14,9 @@ browser-compat: api.Notification.onerror
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
 <p>The <strong><code>onerror</code></strong> property of the {{domxref("Notification")}}
-  interface specifies an event listener to receive {{domxref("HTMLElement/error_event",
-  "error")}} events. These events occur when something goes wrong with a
-  {{domxref("Notification")}} (in many cases an error preventing the notification from
-  being displayed.)</p>
+  interface specifies an event listener to receive {{domxref("Element/error_event", "error")}} events.
+  These events occur when something goes wrong with a {{domxref("Notification")}} 
+  (in many cases an error preventing the notification from being displayed.)</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
@@ -240,24 +240,12 @@ document.addEventListener('visibilitychange', function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications("api.Notification")}}
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{page("/en-US/docs/Web/API/Notification","Browser compatibility")}}</p>
+{{Compat("api.Notification")}}
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
This is part of fixing #3196 - replaces a page inclusion macro with specification and compat macros.