### PR TITLE
Changes the return type from void as suggested in issue #3001

### DIFF
--- a/files/en-us/web/api/performance/mark/index.html
+++ b/files/en-us/web/api/performance/mark/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Performance.mark
   {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's <em>performance entry
     buffer</em> with the given name.</p>
 
-<p>The application defined timestamp can be retrieved by one of the
+<p>The application defined timestamp can also be retrieved by one of the
   {{domxref("Performance")}} interface's <code>getEntries*()</code> methods
   ({{domxref("Performance.getEntries","getEntries()")}},
   {{domxref("Performance.getEntriesByName","getEntriesByName()")}} or
@@ -43,8 +43,8 @@ browser-compat: api.Performance.mark
 <h3 id="Return_value">Return value</h3>
 
 <dl>
-  <dt>void</dt>
-  <dd></dd>
+  <dt>entry</dt>
+  <dd>The created {{domxref("PerformanceMark")}} entry</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/performance/mark/index.html
+++ b/files/en-us/web/api/performance/mark/index.html
@@ -44,7 +44,7 @@ browser-compat: api.Performance.mark
 
 <dl>
   <dt>entry</dt>
-  <dd>The created {{domxref("PerformanceMark")}} entry</dd>
+  <dd>The {{domxref("PerformanceMark")}} entry that was created.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/performance/measure/index.html
+++ b/files/en-us/web/api/performance/measure/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Performance.measure
   measuring between two marks, there is a <em>start mark</em> and <em>end mark</em>,
   respectively. The named timestamp is referred to as a <em>measure</em>.</p>
 
-<p>The <code>measure</code> can be retrieved by one of the {{domxref("Performance")}}
+<p>The <code>measure</code> can also be retrieved by one of the {{domxref("Performance")}}
   interfaces: ({{domxref("Performance.getEntries","getEntries()")}},
   {{domxref("Performance.getEntriesByName","getEntriesByName()")}} or
   {{domxref("Performance.getEntriesByType","getEntriesByType()")}}).</p>
@@ -65,8 +65,8 @@ browser-compat: api.Performance.measure
 <h3 id="Return_value">Return value</h3>
 
 <dl>
-  <dt>void</dt>
-  <dd></dd>
+  <dt>entry</dt>
+  <dd>The created {{domxref("PerformanceMeasure")}} entry</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/performance/measure/index.html
+++ b/files/en-us/web/api/performance/measure/index.html
@@ -66,7 +66,7 @@ browser-compat: api.Performance.measure
 
 <dl>
   <dt>entry</dt>
-  <dd>The created {{domxref("PerformanceMeasure")}} entry</dd>
+  <dd>The {{domxref("PerformanceMeasure")}} entry that was created.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #3001


> What was wrong/why is this fix needed? (quick summary only)
The return type of two functions `Performance.mark()` and `Performance.measure()` was void. Updated to suggested.


> Anything else that could help us review it
The bug asks for updating the parameter types as well. I have left those alone as Rumyra suggests updating return values, perhaps for a reason. And this had a '10-minute' label. But let me know if I should make further changes. Also note that the code examples are untouched.
