### PR TITLE
Adds missing pages to CSSStyleSheet

### DIFF
--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -26,7 +26,7 @@ new CSSStyleSheet(options);</pre>
   <dd>An object containing the following:
     <dl>
       <dt><code>baseURL</code>{{optional_inline}}</dt>
-      <dd>A {{domxref("DOMString","string")}} containing the baseURL used to resolve relative URLs in the stylesheet.</dd>
+      <dd>A {{domxref("DOMString","string")}} containing the <code>baseURL</code> used to resolve relative URLs in the stylesheet.</dd>
       <dt><code>media</code>{{optional_inline}}</dt>
       <dd>A {{domxref("MediaList")}} containing a list of media rules, or a {{domxref("DOMString","string")}} containing a single rule.</dd>
       <dt><code>disabled</code>{{optional_inline}}</dt>

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -1,0 +1,44 @@
+---
+title: CSSStyleSheet.CSSStyleSheet()
+slug: Web/API/CSSStyleSheet/CSSStyleSheet
+tags:
+  - API
+  - Constructor
+  - Reference
+  - CSSStyleSheet
+browser-compat: api.CSSStyleSheet.CSSStyleSheet
+---
+<div>{{APIRef("CSSOM")}}</div>
+
+<p class="summary">The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">new CSSStyleSheet();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CSSStyleSheet.CSSStyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which </p>
+<p class="summary">The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which represents a single <a href="/en-US/docs/Glossary/Stylesheet">Stylesheet</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -56,8 +56,4 @@ console.log(stylesheet.media);</pre>
   <li><a href="https://www.npmjs.com/package/construct-style-sheets-polyfill">construct-style-sheets-polyfill</a></li>
 </ul>
 
-<h2>See also</h2>
 
-<ul>
-  <li><a href="https://developers.google.com/web/updates/2019/02/constructable-stylesheets">Constructable Stylesheets</a></li>
-</ul>

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -12,24 +12,35 @@ browser-compat: api.CSSStyleSheet.CSSStyleSheet
 
 <p class="summary">The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which represents a single <a href="/en-US/docs/Glossary/Stylesheet">Stylesheet</a>.</p>
 
+<p>After constructing a stylesheet the {{domxref("CSSStyleSheet.replace()")}} or {{domxref("CSSStyleSheet.replaceSync()")}} methods can be used to add rules to the new stylesheet.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">new CSSStyleSheet();</pre>
+<pre class="brush: js">new CSSStyleSheet();
+new CSSStyleSheet(options);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
-
+<dl>
+  <dt><code>options</code>{{optional_inline}}</dt>
+  <dd>An object containing the following:
+    <dl>
+      <dt><code>baseURL</code>{{optional_inline}}</dt>
+      <dd>A {{domxref("DOMString","string")}} containing the baseURL used to resolve relative URLs in the stylesheet.</dd>
+      <dt><code>media</code>{{optional_inline}}</dt>
+      <dd>A {{domxref("MediaList")}} containing a list of media rules, or a {{domxref("DOMString","string")}} containing a single rule.</dd>
+      <dt><code>disabled</code>{{optional_inline}}</dt>
+      <dd>A {{jsxref("Boolean")}} indicated whether the stylesheet is disabled. False by default.</dd>
+    </dl>
+  </dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>In the following example a new {{domxref("CSSStyleSheet")}} is constructed, with a media rule of <code>"print"</code>. Printing {{domxref("StyleSheet.media")}} to the console returns a {{domxref("MediaList")}} with a single entry for this print rule.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
-
-<pre class="brush: js">
-my code block</pre>
-
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+<pre class="brush: css">let stylesheet = new CSSStyleSheet({media: 'print'});
+console.log(stylesheet.media);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -37,8 +48,16 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
+<h2>Polyfill</h2>
 
+<ul>
+  <li><a href="https://www.npmjs.com/package/construct-style-sheets-polyfill">construct-style-sheets-polyfill</a></li>
+</ul>
+
+<h2>See also</h2>
+
+<ul>
+  <li><a href="https://developers.google.com/web/updates/2019/02/constructable-stylesheets">Constructable Stylesheets</a></li>
+</ul>

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -30,7 +30,7 @@ new CSSStyleSheet(options);</pre>
       <dt><code>media</code>{{optional_inline}}</dt>
       <dd>A {{domxref("MediaList")}} containing a list of media rules, or a {{domxref("DOMString","string")}} containing a single rule.</dd>
       <dt><code>disabled</code>{{optional_inline}}</dt>
-      <dd>A {{jsxref("Boolean")}} indicated whether the stylesheet is disabled. False by default.</dd>
+      <dd>A {{jsxref("Boolean")}} indicating whether the stylesheet is disabled. False by default.</dd>
     </dl>
   </dd>
 </dl>

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -43,12 +43,12 @@ browser-compat: api.CSSStyleSheet
 <p><em>Inherits properties from its parent, {{domxref("StyleSheet")}}.</em></p>
 
 <dl>
- <dt>{{domxref("CSSStyleSheet.cssRules")}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("CSSStyleSheet.cssRules")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.
-    <div class="notecard note"><p><strong>Note: </strong>In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in <code>SecurityError</code>.</p></div>
+    <div class="notecard note"><p><strong>Note: </strong>In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in a<code>SecurityError</code>.</p></div>
 
  </dd>
- <dt>{{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("CSSStyleSheet.ownerRule")}}{{ReadOnlyInline}}</dt>
  <dd>If this stylesheet is imported into the document using an {{cssxref("@import")}} rule, the <code>ownerRule</code> property returns the corresponding {{domxref("CSSImportRule")}}; otherwise, this property's value is <code>null</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -29,7 +29,14 @@ browser-compat: api.CSSStyleSheet
 
 <p>Another rule might be an <em>at-rule</em> such as {{cssxref("@import")}} or {{cssxref("@media")}}, and so forth.</p>
 
-<p>See the {{anch("Notes")}} section for the various ways a <code>CSSStyleSheet</code> object can be obtained.</p>
+<p>See the {{anch("Obtaining a StyleSheet")}} section for the various ways a <code>CSSStyleSheet</code> object can be obtained. A <code>CSSStyleSheet</code> object can also be directly constructed. The constructor, and the {{domxref("CSSStyleSheet.replace()")}}, and {{domxref("CSSStyleSheet.replaceSync()")}} methods are newer additions to the specification, enabling <em>Constructable Stylesheets</em>.</p>
+
+<h2 id="Constructor">Constructor</h2>
+
+<dl>
+  <dt>{{domxref("CSSStyleSheet.CSSStyleSheet()")}}</dt>
+  <dd>Creates a new <code>CSSStyleSheet</code> object.</dd>
+</dl>
 
 <h2 id="Properties">Properties</h2>
 
@@ -37,7 +44,10 @@ browser-compat: api.CSSStyleSheet
 
 <dl>
  <dt>{{domxref("CSSStyleSheet.cssRules")}} {{ReadOnlyInline}}</dt>
- <dd>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.</dd>
+ <dd>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.
+    <div class="notecard note"><p><strong>Note: </strong>In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in <code>SecurityError</code>.</p></div>
+
+ </dd>
  <dt>{{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}</dt>
  <dd>If this stylesheet is imported into the document using an {{cssxref("@import")}} rule, the <code>ownerRule</code> property returns the corresponding {{domxref("CSSImportRule")}}; otherwise, this property's value is <code>null</code>.</dd>
 </dl>
@@ -52,9 +62,9 @@ browser-compat: api.CSSStyleSheet
  <dt>{{domxref("CSSStyleSheet.insertRule()")}}</dt>
  <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
  <dt>{{domxref("CSSStyleSheet.replace()")}}</dt>
- <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
+ <dd>Asynchronously replaces the content of the stylesheet and returns a {{jsxref("Promise")}} that resolves with the updated <code>CSSStyleSheet</code>.</dd>
  <dt>{{domxref("CSSStyleSheet.replaceSync()")}}</dt>
- <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
+ <dd>Synchronously replaces the content of the stylesheet.</dd>
 </dl>
 
 <h2 id="Legacy_properties">Legacy properties</h2>
@@ -81,13 +91,11 @@ browser-compat: api.CSSStyleSheet
  <dd>Functionally identical to {{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}}; removes the rule at the specified index from the stylesheet's rule list.</dd>
 </dl>
 
-<h2 id="Notes">Notes</h2>
-
-<p>In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in <code>SecurityError</code>.</p>
+<h2 id="Obtaining_a_Stylesheet">Obtaining a StyleSheet</h2>
 
 <p>A stylesheet is associated with at most one {{domxref("Document")}}, which it applies to (unless {{domxref("StyleSheet.disabled", "disabled", "", 1)}}). A list of <code>CSSStyleSheet</code> objects for a given document can be obtained using the {{domxref("Document.styleSheets")}} property. A specific style sheet can also be accessed from its <em>owner</em> object (<code>Node</code> or <code>CSSImportRule</code>), if any.</p>
 
-<p>A <code>CSSStyleSheet</code> object is created and inserted into the document's {{domxref("Document.styleSheets")}} list automatically by the browser, when a stylesheet is loaded for a document. As the stylesheet list cannot be modified directly, there's no useful way to create a new <code>CSSStyleSheet</code> object manually (although <a href="https://wicg.github.io/construct-stylesheets/">Constructable Stylesheet Objects</a> is coming to the web platform soon and is already supported in Blink). To create a new stylesheet, insert a {{HTMLElement("style")}} or {{HTMLElement("link")}} element into the document.</p>
+<p>A <code>CSSStyleSheet</code> object is created and inserted into the document's {{domxref("Document.styleSheets")}} list automatically by the browser, when a stylesheet is loaded for a document.</p>
 
 <p>A (possibly incomplete) list of ways a stylesheet can be associated with a document follows:</p>
 
@@ -158,4 +166,5 @@ browser-compat: api.CSSStyleSheet
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a></li>
  <li><a href="/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information">Using dynamic styling information</a></li>
+ <li><a href="https://developers.google.com/web/updates/2019/02/constructable-stylesheets">Constructable Stylesheets</a></li>
 </ul>

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSStyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p><span class="seoSummary">The <strong><code>CSSStyleSheet</code></strong> interface represents a single <a href="/en-US/docs/Web/CSS">CSS</a> stylesheet, and lets you inspect and modify the list of rules contained in the stylesheet.</span> It inherits properties and methods from its parent, {{domxref("StyleSheet")}}.</p>
+<p>The <strong><code>CSSStyleSheet</code></strong> interface represents a single <a href="/en-US/docs/Web/CSS">CSS</a> stylesheet, and lets you inspect and modify the list of rules contained in the stylesheet. It inherits properties and methods from its parent, {{domxref("StyleSheet")}}.</p>
 
 <p>A stylesheet consists of a collection of {{domxref("CSSRule")}} objects representing each of the rules in the stylesheet. The rules are contained in a {{domxref("CSSRuleList")}}, which can be obtained from the stylesheet's {{domxref("CSSStyleSheet.cssRules", "cssRules")}} property.</p>
 
@@ -36,17 +36,9 @@ browser-compat: api.CSSStyleSheet
 <p><em>Inherits properties from its parent, {{domxref("StyleSheet")}}.</em></p>
 
 <dl>
- <dt id="cssRules">{{domxref("CSSStyleSheet.cssRules", "cssRules")}} {{ReadOnlyInline}}</dt>
- <dd>
- <p>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.</p>
-
- <p>This is normally used to access individual rules like this:</p>
-
- <pre><code>styleSheet.cssRules[i] // where i = 0..cssRules.length-1</code></pre>
-
- <p>To add or remove items in <code>cssRules</code>, use the <code>CSSStyleSheet</code>'s {{domxref("CSSStyleSheet.insertRule", "insertRule()")}} and {{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}} methods.</p>
- </dd>
- <dt id="ownerRule">{{domxref("CSSStyleSheet.ownerRule", "ownerRule")}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("CSSStyleSheet.cssRules")}} {{ReadOnlyInline}}</dt>
+ <dd>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.</dd>
+ <dt>{{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}</dt>
  <dd>If this stylesheet is imported into the document using an {{cssxref("@import")}} rule, the <code>ownerRule</code> property returns the corresponding {{domxref("CSSImportRule")}}; otherwise, this property's value is <code>null</code>.</dd>
 </dl>
 
@@ -55,15 +47,19 @@ browser-compat: api.CSSStyleSheet
 <p><em>Inherits methods from its parent, {{domxref("StyleSheet")}}.</em></p>
 
 <dl>
- <dt id="deleteRule">{{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}}</dt>
+ <dt>{{domxref("CSSStyleSheet.deleteRule()")}}</dt>
  <dd>Deletes the rule at the specified index into the stylesheet's rule list.</dd>
- <dt id="insertRule">{{domxref("CSSStyleSheet.insertRule", "insertRule()")}}</dt>
+ <dt>{{domxref("CSSStyleSheet.insertRule()")}}</dt>
+ <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
+ <dt>{{domxref("CSSStyleSheet.replace()")}}</dt>
+ <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
+ <dt>{{domxref("CSSStyleSheet.replaceSync()")}}</dt>
  <dd>Inserts a new rule at the specified position in the stylesheet, given the textual representation of the rule.</dd>
 </dl>
 
 <h2 id="Legacy_properties">Legacy properties</h2>
 
-<p><em>These properties are legacy properties first introduced by Microsoft long ago; they shouldn't be used but are not likely to be removed anytime soon.</em></p>
+<p><em>These properties are legacy properties as introduced by Microsoft; these are maintained for compatibility with existing sites.</em></p>
 
 <dl>
  <dt>{{domxref("CSSStyleSheet.rules", "rules")}} {{ReadOnlyInline}}</dt>
@@ -72,7 +68,7 @@ browser-compat: api.CSSStyleSheet
 
 <h2 id="Legacy_methods">Legacy methods</h2>
 
-<p><em>These methods are legacy methods first introduced by Microsoft; they should not be used if they can be avoided, but are not in danger of being removed anytime soon.</em></p>
+<p><em>These methods are legacy methods as introduced by Microsoft; these are maintained for compatibility with existing sites.</em></p>
 
 <dl>
  <dt>{{domxref("CSSStyleSheet.addRule", "addRule()")}}</dt>

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -166,5 +166,4 @@ browser-compat: api.CSSStyleSheet
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a></li>
  <li><a href="/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information">Using dynamic styling information</a></li>
- <li><a href="https://developers.google.com/web/updates/2019/02/constructable-stylesheets">Constructable Stylesheets</a></li>
 </ul>

--- a/files/en-us/web/api/cssstylesheet/replace/index.html
+++ b/files/en-us/web/api/cssstylesheet/replace/index.html
@@ -41,7 +41,7 @@ browser-compat: api.CSSStyleSheet.replace
   <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
   <dd>Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</dd>
   <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
-  <dd>If the stylesheet has its disallow modification flag yet to indicate it may not be changed.</dd>
+  <dd>If the stylesheet is flagged as unmodifiable.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/cssstylesheet/replace/index.html
+++ b/files/en-us/web/api/cssstylesheet/replace/index.html
@@ -9,50 +9,59 @@ tags:
   - CSSStyleSheet
 browser-compat: api.CSSStyleSheet.replace
 ---
-<div>{{DefaultAPISidebar("")}}</div>
+<div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>replace()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface  </p>
+<p class="summary">The <strong><code>replace()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface asynchronously replaces the content of the stylesheet with the content passed into it. The method returns a promise that resolves with a <code>CSSStyleSheet</code> object.</p>
+
+<p>The <code>replace()</code> and {{domxref("CSSStyleSheet.replaceSync()")}} methods can only be used on a stylesheet created with the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">CSSStyleSheet.replace();</pre>
+<pre class="brush: js">CSSStyleSheet.replace(text);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
+<dl>
+  <dt><code>text</code></dt>
+  <dd>A {{domxref("USVString","string")}} containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.</dd>
+</dl>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> If any of the rules passed in <code>text</code> are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.</p>
+</div>
 
 <h3 id="Returns">Return value</h3>
 
-<p></p>
+<p>A {{jsxref("Promise")}} that resolves with a {{domxref("CSSStyleSheet")}}.</p>
+
 
 <h3 id="Exceptions">Exceptions</h3>
 
-
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</dd>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>If the stylesheet has its disallow modification flag yet to indicate it may not be changed.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>In the following example a new stylesheet is created and two CSS rules are added using <code>replace</code>. The first rule is then printed to the console, which will return: <code>body { font-size: 1.4em };</code></p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">let stylesheet = new CSSStyleSheet();
 
-<pre class="brush: js">
-my code block</pre>
-
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
-
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
+stylesheet.replace('body { font-size: 1.4em };p { color: red; }')
+  .then(() => {   console.log(stylesheet.cssRules[0].cssText);
+})
+.catch(err => {
+  console.error('Failed to replace styles:', err);
+});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
 <p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/cssstylesheet/replace/index.html
+++ b/files/en-us/web/api/cssstylesheet/replace/index.html
@@ -46,7 +46,7 @@ browser-compat: api.CSSStyleSheet.replace
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following example a new stylesheet is created and two CSS rules are added using <code>replace</code>. The first rule is then printed to the console, which will return: <code>body { font-size: 1.4em };</code></p>
+<p>In the following example a new stylesheet is created and two CSS rules are added using <code>replace()</code>. The first rule is then printed to the console, which will return: <code>body { font-size: 1.4em };</code></p>
 
 <pre class="brush: js">let stylesheet = new CSSStyleSheet();
 
@@ -64,5 +64,4 @@ stylesheet.replace('body { font-size: 1.4em };p { color: red; }')
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
 

--- a/files/en-us/web/api/cssstylesheet/replace/index.html
+++ b/files/en-us/web/api/cssstylesheet/replace/index.html
@@ -1,0 +1,59 @@
+---
+title: CSSStyleSheet.replace()
+slug: Web/API/CSSStyleSheet/replace
+tags:
+  - API
+  - Method
+  - Reference
+  - replace
+  - CSSStyleSheet
+browser-compat: api.CSSStyleSheet.replace
+---
+<div>{{DefaultAPISidebar("")}}</div>
+
+<p class="summary">The <strong><code>replace()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">CSSStyleSheet.replace();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+
+
+<h3 id="Returns">Return value</h3>
+
+<p></p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.html
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.html
@@ -1,0 +1,59 @@
+---
+title: CSSStyleSheet.replaceSync()
+slug: Web/API/CSSStyleSheet/replaceSync
+tags:
+  - API
+  - Method
+  - Reference
+  - replaceSync
+  - CSSStyleSheet
+browser-compat: api.CSSStyleSheet.replaceSync
+---
+<div>{{APIRef("CSSOM")}}</div>
+
+<p class="summary">The <strong><code>replaceSync()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface  </p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">CSSStyleSheet.replaceSync();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+
+
+<h3 id="Returns">Return value</h3>
+
+<p></p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+
+<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+
+<pre class="brush: js">
+my code block</pre>
+
+<p>And/or include a list of links to useful code samples that live elsewhere:</p>
+
+<ul>
+	<li>x</li>
+	<li>y</li>
+	<li>z</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.html
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.html
@@ -11,40 +11,46 @@ browser-compat: api.CSSStyleSheet.replaceSync
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>replaceSync()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface  </p>
+<p class="summary">The <strong><code>replaceSync()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface synchronously replaces the content of the stylesheet with the content passed into it.</p>
+
+<p>The <code>replaceSync()</code> and {{domxref("CSSStyleSheet.replace()")}} methods can only be used on a stylesheet created with the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">CSSStyleSheet.replaceSync();</pre>
+<pre class="brush: js">CSSStyleSheet.replaceSync(text);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
+<dl>
+  <dt><code>text</code></dt>
+  <dd>A {{domxref("USVString","string")}} containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.</dd>
+</dl>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> If any of the rules passed in <code>text</code> are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.</p>
+</div>
 
 <h3 id="Returns">Return value</h3>
 
-<p></p>
+<p>Undefined.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 
-
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</dd>
+  <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
+  <dd>If the stylesheet has its disallow modification flag yet to indicate it may not be changed.</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add <a href="/en-US/docs/MDN/Contribute/Structures/Code_examples">code examples</a> for more information).</p>
+<p>In the following example a new stylesheet is created and two CSS rules are added using <code>replaceSync</code>.</p>
 
-<p>This text should be replaced with a brief description of what the example demonstrates.</p>
+<pre class="brush: js">let stylesheet = new CSSStyleSheet();
 
-<pre class="brush: js">
-my code block</pre>
+stylesheet.replaceSync('body { font-size: 1.4em };p { color: red; }');</pre>
 
-<p>And/or include a list of links to useful code samples that live elsewhere:</p>
-
-<ul>
-	<li>x</li>
-	<li>y</li>
-	<li>z</li>
-</ul>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -52,7 +58,6 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.html
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.html
@@ -40,7 +40,7 @@ browser-compat: api.CSSStyleSheet.replaceSync
   <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
   <dd>Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</dd>
   <dt>{{domxref("DOMException")}} <code>NotAllowedError</code></dt>
-  <dd>If the stylesheet has its disallow modification flag yet to indicate it may not be changed.</dd>
+  <dd>If the stylesheet is flagged as unmodifiable.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
The newer constructor and methods for creating stylesheets (known as Constructable StyleSheets) were missing from the docs. This PR adds them.

Reviewer: @jpmedley 