### PR TITLE
Fix cross-reference

### DIFF
--- a/files/en-us/web/javascript/reference/operators/new/index.md
+++ b/files/en-us/web/javascript/reference/operators/new/index.md
@@ -93,7 +93,7 @@ property. This defines a property that is shared by all objects created with tha
 function, rather than by just one instance of the object type. The following code adds a
 color property with value `"original color"` to all objects of type
 `Car`, and then overwrites that value with the string "`black`"
-only in the instance object `car1`. For more information, see [prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function).
+only in the instance object `car1`. For more information, see [prototype](/en-US/docs/Learn/JavaScript/Objects/Object_prototypes).
 
 ```js
 function Car() {}


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #1449 

> What was wrong/why is this fix needed? (quick summary only)
The bug requests a detailed reference for the prototype property.  @ayushi19031 fixed this  in  PR #5182 by adding a link to [Obect_prototypes] (https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_prototypes) which has a detailed explanation of prototype. The PR was closed apparently for reasons not related to the fix.

> Anything else that could help us review it
The preview url doesn't have the [referred url](https://pr7549.content.dev.mdn.mozit.cloud/en-US/docs/Learn/JavaScript/Objects/Object_prototypes). It worked on my local setup but let me know if this is a problem.