### PR TITLE
Fix incorrect rotation directions in Window»orientation doc

### DIFF
--- a/files/en-us/web/api/window/orientation/index.html
+++ b/files/en-us/web/api/window/orientation/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Window.orientation
 
 <p>Returns the orientation in degrees (in 90-degree increments) of the viewport relative to the device's natural orientation.</p>
 
-<p>Its only possible values are <code>-90</code>, <code>0</code>, <code>90</code>, and <code>180</code>. Positive values are clockwise; negative values are counterclockwise.</p>
+<p>Its only possible values are <code>-90</code>, <code>0</code>, <code>90</code>, and <code>180</code>. Positive values are counterclockwise; negative values are clockwise.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
The Standard at https://compat.spec.whatwg.org/#dfn-window-orientation-angle states that: "-90 represents a rotation 90 degrees clockwise from the natural orientation. 90 represents a rotation 90 degrees counterclockwise from the natural orientation"

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None

> What was wrong/why is this fix needed? (quick summary only)

The clockwise / counterclockwise rotation for positive and negative numbers was described as the other way round when compared to that specified in the Standard at: https://compat.spec.whatwg.org/#dfn-window-orientation-angle

> Anything else that could help us review it

None