### PR TITLE
remove links to www.fxsitecompat.com (part 2)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/22/index.html
+++ b/files/en-us/mozilla/firefox/releases/22/index.html
@@ -79,7 +79,6 @@ tags:
 
 <ul>
  <li><a href="https://www.mozilla.org/en-US/firefox/22.0beta/releasenotes/">Firefox 22 Beta Release Notes</a></li>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/22/">Site Compatibility for Firefox 22</a></li>
  <li><a href="https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/">Add-on Compatibility for Firefox 22</a></li>
 </ul>
 

--- a/files/en-us/mozilla/firefox/releases/24/index.html
+++ b/files/en-us/mozilla/firefox/releases/24/index.html
@@ -71,7 +71,6 @@ tags:
 
 <ul>
  <li><a href="https://www.mozilla.org/en-US/firefox/24.0a2/auroranotes/">Firefox 24 Aurora Notes</a></li>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/24/">Site Compatibility for Firefox 24</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/25/index.html
+++ b/files/en-us/mozilla/firefox/releases/25/index.html
@@ -79,12 +79,6 @@ tags:
 
 <p><em>No change.</em></p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/25/">Site Compatibility for Firefox 25</a></li>
-</ul>
-
 <h3 id="Older_versions">Older versions</h3>
 
 <p>{{Firefox_for_developers('24')}}</p>

--- a/files/en-us/mozilla/firefox/releases/31/index.html
+++ b/files/en-us/mozilla/firefox/releases/31/index.html
@@ -119,12 +119,6 @@ tags:
 
 <p><a class="external external-icon" href="https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&amp;chfieldto=2014-04-29&amp;chfield=resolution&amp;query_format=advanced&amp;chfieldfrom=2014-03-18&amp;chfieldvalue=FIXED&amp;bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;bug_status=CLOSED&amp;product=Add-on%20SDK&amp;list_id=10493962">Bugs fixed between Firefox 30 and Firefox 31</a>. This will not include any uplifts made after this release entered Aurora.</p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/31/">Site Compatibility for Firefox 31</a></li>
-</ul>
-
 <h3 id="Older_versions">Older versions</h3>
 
 <p>{{Firefox_for_developers('30')}}</p>

--- a/files/en-us/mozilla/firefox/releases/40/index.html
+++ b/files/en-us/mozilla/firefox/releases/40/index.html
@@ -203,12 +203,6 @@ install Firefox Developer Edition</a> Firefox 40 was released on August 11, 2015
  <li>The automated testing system now supports skipping individual test functions. See {{SectionOnPage("/en-US/docs/Mozilla/QA/Writing_xpcshell-based_unit_tests", "Conditional test functions")}}.</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/40/">Site Compatibility for Firefox 40</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers('39')}}</p>

--- a/files/en-us/mozilla/firefox/releases/46/index.html
+++ b/files/en-us/mozilla/firefox/releases/46/index.html
@@ -179,12 +179,6 @@ tags:
 
 <p><em>No change.</em></p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/46/">Site Compatibility for Firefox 46</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(45)}}</p>

--- a/files/en-us/mozilla/firefox/releases/47/index.html
+++ b/files/en-us/mozilla/firefox/releases/47/index.html
@@ -168,12 +168,6 @@ tags:
 
 <p><em>No change.</em></p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/47">Site Compatibility for Firefox 47</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(46)}}</p>

--- a/files/en-us/mozilla/firefox/releases/48/index.html
+++ b/files/en-us/mozilla/firefox/releases/48/index.html
@@ -163,12 +163,6 @@ install Firefox Developer Edition</a> Firefox 48 was released on August 2, 2016.
 	<li>Added the <code><a href="/en-US/docs/Mozilla/Gecko/Chrome/CSS/-moz-bool-pref">-moz-bool-pref()</a></code> <a href="/en-US/docs/Web/CSS">CSS</a> {{CSSxRef("@supports")}} function to allow hiding portions of chrome stylesheets behind boolean preferences. ({{bug(1259889)}})</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
-	<li><a href="https://www.fxsitecompat.com/en-US/versions/48">Site Compatibility for Firefox 48</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(47)}}</p>

--- a/files/en-us/mozilla/firefox/releases/49/index.html
+++ b/files/en-us/mozilla/firefox/releases/49/index.html
@@ -340,12 +340,6 @@ tags:
 
 <p><em>No change.</em></p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/49">Site Compatibility for Firefox 49</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(48)}}</p>

--- a/files/en-us/mozilla/firefox/releases/52/index.html
+++ b/files/en-us/mozilla/firefox/releases/52/index.html
@@ -209,7 +209,7 @@ tags:
 
 <h2 id="Plugins">Plugins</h2>
 
-<p>All NPAPI <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugin</a> support except Flash has been dropped (see <a href="https://www.fxsitecompat.com/en-CA/docs/2016/plug-in-support-has-been-dropped-other-than-flash/">Plug-in support has been dropped other than Flash</a> for more details). Flash usage is also set to be phased out in the future.</p>
+<p>All NPAPI <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugin</a> support except Flash has been dropped. Flash usage is also set to be phased out in the future.</p>
 
 <h2 id="Changes_for_add-on_and_Mozilla_developers">Changes for add-on and Mozilla developers</h2>
 
@@ -239,12 +239,6 @@ tags:
 <ul>
  <li><code><a href="/en-US/docs/Mozilla/Tech/XUL/tabbrowser">tabbrowser</a>.<a href="/en-US/docs/Mozilla/Tech/XUL/Method/loadTabs">loadTabs</a>(uris, params)</code> method overload has been added ({{bug(92737)}}).</li>
  <li><code><a href="/en-US/docs/Mozilla/Tech/XUL/browser">browser</a>.<a href="/en-US/docs/Mozilla/Tech/XUL/Attribute/droppedLinkHandler">droppedLinkHandler</a></code> function signature has been changed ({{bug(92737)}}).</li>
-</ul>
-
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/52">Site Compatibility for Firefox 52</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/53/index.html
+++ b/files/en-us/mozilla/firefox/releases/53/index.html
@@ -212,12 +212,6 @@ tags:
  <li>The asynchronous <a href="../../../Add-ons/Add-on_Manager/AddonManager">AddonManager APIs</a> now support {{jsxref("Promise", "Promises")}} as well as callbacks ({{bug(987512)}}.</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/53">Site Compatibility for Firefox 53</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(52)}}</p>

--- a/files/en-us/mozilla/firefox/releases/55/index.html
+++ b/files/en-us/mozilla/firefox/releases/55/index.html
@@ -185,7 +185,7 @@ tags:
   <p>The {{htmlelement("style")}} element's {{htmlattrxref("scoped","style")}} attribute has been hidden behind a pref (<code>layout.css.scoped-style.enabled</code>) in content documents in Firefox 55+, as no other browsers support it.</p>
  </li>
  <li>
-  <p>Support for the obscure <code>MSThemeCompatible</code> value of the {{htmlelement("meta")}} element's {{htmlattrxref("http-equiv","meta")}} attribute has been removed from Gecko. No other modern browsers support it, and it was <a href="https://www.fxsitecompat.com/en-CA/docs/2017/checkboxes-and-radio-buttons-are-not-displayed-when-msthemecompatible-is-no/">causing compatibility problems</a> ({{bug("966240")}}).</p>
+  <p>Support for the obscure <code>MSThemeCompatible</code> value of the {{htmlelement("meta")}} element's {{htmlattrxref("http-equiv","meta")}} attribute has been removed from Gecko. No other modern browsers support it, and it was causing compatibility problems ({{bug("966240")}}).</p>
  </li>
 </ul>
 
@@ -223,12 +223,6 @@ tags:
  <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides">chrome_settings_overrides key enables you to override the browser's homepage.</a></li>
  <li>browser_style property enables you to have browser-like styling for <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action">browser action popups</a>, <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action">sidebars</a>, and <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui">options pages</a>.</li>
  <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions">permissions API</a></li>
-</ul>
-
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/55">Site Compatibility for Firefox 55</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/62/index.html
+++ b/files/en-us/mozilla/firefox/releases/62/index.html
@@ -213,12 +213,6 @@ tags:
  <li>The warning about <code>browser_style</code> displayed when temporarily loading an extension for testing is no longer displayed ({{bug(1404724)}}).</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-US/versions/62">Site compatibility for Firefox 62</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(61)}}</p>

--- a/files/en-us/mozilla/firefox/releases/64/index.html
+++ b/files/en-us/mozilla/firefox/releases/64/index.html
@@ -96,7 +96,7 @@ tags:
  <li>The {{domxref("XMLHttpRequest.getAllResponseHeaders()")}} method now returns header names all in lowercase, as per spec ({{bug(1398718)}}).</li>
  <li>The legacy <code>HTMLAllCollection</code> interface has been updated as per recent <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlallcollection">spec updates</a> ({{bug(1398354)}}).</li>
  <li>{{domxref("Navigator.buildID")}} now returns a fixed timestamp as a privacy measure ({{bug(583181)}}).</li>
- <li>The following {{domxref("Document.execCommand()")}} UI feature commands have been disabled by default ({{bug(1490641)}}, see also <a href="https://www.fxsitecompat.com/en-CA/docs/2018/firefox-specific-html-editing-ui-has-been-disabled-by-default/">Firefox-specific HTML editing UI has been disabled by default</a> for more details):
+ <li>The following {{domxref("Document.execCommand()")}} UI feature commands have been disabled by default ({{bug(1490641)}}:
   <ul>
    <li><code>enableObjectResizing</code></li>
    <li><code>enableInlineTableEditing</code></li>
@@ -206,7 +206,6 @@ tags:
 
 <ul>
  <li>Hacks release post: <a href="https://hacks.mozilla.org/2018/12/firefox-64-released/">Firefox 64 Released</a></li>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/64/">Site compatibility for Firefox 64</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/65/index.html
+++ b/files/en-us/mozilla/firefox/releases/65/index.html
@@ -135,8 +135,8 @@ tags:
 <h4 id="Media_Web_Audio_and_WebRTC">Media, Web Audio, and WebRTC</h4>
 
 <ul>
- <li>The {{domxref("WebRTC API", "WebRTC", "", "1")}} {{domxref("RTCIceCandidateStats")}} dictionary has been updated according to the latest spec changes ({{bug(1324788)}}, {{bug(1489040)}}; see also<br>
-  <a href="https://www.fxsitecompat.com/en-CA/docs/2018/rtcicecandidatestats-has-been-updated-to-the-latest-spec/">RTCIceCandidateStats has been updated to the latest spec</a> for more details on exactly what has changed).</li>
+ <li>The {{domxref("WebRTC API", "WebRTC", "", "1")}} {{domxref("RTCIceCandidateStats")}} dictionary has been updated according to the latest spec changes ({{bug(1324788)}}, {{bug(1489040)}};<br>
+  RTCIceCandidateStats has been updated to the latest spec for more details on exactly what has changed).</li>
  <li>The {{domxref("MediaRecorder")}} <code>pause</code> and <code>resume</code> events (and their corresponding event handler properties — {{domxref("MediaRecorder.onpause")}} and {{domxref("MediaRecorder.onresume")}}) were not previously implemented, even though compatibility tables claimed they had been. They have now been implemented ({{bug(1458538)}}, {{bug(1514016)}}).</li>
 </ul>
 
@@ -236,7 +236,6 @@ tags:
 
 <ul>
  <li>Hacks release post: <a href="https://hacks.mozilla.org/2019/01/firefox-65-webp-flexbox-inspector-new-tooling/">Firefox 65: WebP support, Flexbox Inspector, new tooling &amp; platform updates</a></li>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/65/">Site compatibility for Firefox 65</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/70/index.html
+++ b/files/en-us/mozilla/firefox/releases/70/index.html
@@ -71,7 +71,7 @@ tags:
 <h4 id="Removals">Removals</h4>
 
 <ul>
- <li>We have retired support for 3-valued &lt;position&gt; (excluding background)({{Bug(1559276)}}). <a href="https://www.fxsitecompat.dev/en-CA/docs/2019/3-valued-css-position-is-no-longer-supported-except-for-background-position/">See site compat note</a>.</li>
+ <li>We have retired support for 3-valued &lt;position&gt; (excluding background)({{Bug(1559276)}}).</li>
  <li>The <code>none</code> value is now invalid in {{cssxref("counter()")}} / {{cssxref("counters()")}} — a change which makes the Level 3 spec match CSS 2.1 {{Bug(1576821)}}).</li>
 </ul>
 
@@ -188,7 +188,6 @@ tags:
 
 <ul>
  <li>Hacks release post: <a href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/">Firefox 70 — a bountiful release for all</a></li>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/70/">Site compatibility for Firefox 70</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/71/index.html
+++ b/files/en-us/mozilla/firefox/releases/71/index.html
@@ -61,7 +61,7 @@ tags:
 <h4 id="Removals">Removals</h4>
 
 <ul>
- <li>CSS Radial Gradients no longer accept negative radii ({{bug(1583736)}}); also see the <a href="https://www.fxsitecompat.dev/en-CA/docs/2019/css-radial-gradients-no-longer-accept-negative-radii/">site compat note</a>.</li>
+ <li>CSS Radial Gradients no longer accept negative radii ({{bug(1583736)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>
@@ -155,7 +155,6 @@ tags:
 
 <ul>
  <li>Hacks release post: <a href="https://hacks.mozilla.org/2019/12/firefox-71-a-year-end-arrival/">Firefox 71: A year-end arrival</a></li>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/71/">Site compatibility for Firefox 71</a></li>
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>

--- a/files/en-us/mozilla/firefox/releases/76/index.html
+++ b/files/en-us/mozilla/firefox/releases/76/index.html
@@ -79,7 +79,7 @@ tags:
 
 <ul>
  <li>UI-parts related items in the <code>windowFeatures</code> parameter of {{domxref("window.open()")}} can no longer control the visibility of each UI part separately, but become a condition for whether to open a popup or not ({{bug(1507375)}}).</li>
- <li>Attempts to navigate to an unknown protocol using methods such as <code><a href="/en-US/docs/Web/API/Location/href">location.href</a></code> or <code><a href="/en-US/docs/Web/HTML/Element/meta">&lt;meta http-equiv="refresh"&gt;</a></code> are now blocked (see {{bug(1528305)}}; also see <a href="https://www.fxsitecompat.dev/en-CA/docs/2020/navigation-to-unknown-protocol-will-be-blocked/">Navigation to unknown protocol will be blocked</a> for more information).</li>
+ <li>Attempts to navigate to an unknown protocol using methods such as <code><a href="/en-US/docs/Web/API/Location/href">location.href</a></code> or <code><a href="/en-US/docs/Web/HTML/Element/meta">&lt;meta http-equiv="refresh"&gt;</a></code> are now blocked (see {{bug(1528305)}}.</li>
  <li>The {{domxref("IntersectionObserver.IntersectionObserver", "IntersectionObserver()")}} constructor now accepts a {{domxref("Document")}} object as its <code>root</code>, as well as an {{domxref("Element")}} object ({{bug(1623623)}}). This lets you explicitly use a window's entire content area as the intersection bounds.</li>
  <li>The <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a> now supports the <code>audioworklet</code> {{domxref("Request.destination", "destination")}} for requests. This causes received data to be dispatched to an {{domxref("AudioWorklet")}} ({{bug(1402784)}}).</li>
 </ul>
@@ -107,12 +107,6 @@ tags:
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <p><em>No changes.</em></p>
-
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/76/">Site compatibility for Firefox 76</a></li>
-</ul>
 
 <h2 id="Older_versions">Older versions</h2>
 

--- a/files/en-us/mozilla/firefox/releases/78/index.html
+++ b/files/en-us/mozilla/firefox/releases/78/index.html
@@ -109,12 +109,6 @@ tags:
  <li>When using <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/download">downloads.download</a></code> with the saveAs option, the recently used directory is now remembered. While this information is not available to developers, it is very convenient to users.</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/78/">Site compatibility for Firefox 78</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(77)}}</p>

--- a/files/en-us/mozilla/firefox/releases/79/index.html
+++ b/files/en-us/mozilla/firefox/releases/79/index.html
@@ -126,12 +126,6 @@ tags:
  <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync#storage_quotas_for_sync_data">Storage quotas are now enforced for the <code>sync</code> storage area</a> (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1634615">bug 1634615</a>) (<a href="https://blog.mozilla.org/addons/2020/07/09/changes-to-storage-sync-in-firefox-79/">addons.mozilla.org blog post</a>)</li>
 </ul>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://www.fxsitecompat.com/en-CA/versions/79/">Site compatibility for Firefox 79</a></li>
-</ul>
-
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(78)}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Part of #7124

> What was wrong/why is this fix needed? (quick summary only)

See issue.

> Anything else that could help us review it

This is the last of the `mozilla/firefox/releases/*` tree. 