### PR TITLE
Correct casing of location.reload method

### DIFF
--- a/files/en-us/web/api/location/reload/index.html
+++ b/files/en-us/web/api/location/reload/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Location.reload
 ---
 <div>{{ APIRef("HTML DOM") }}</div>
 
-<p><span class="seoSummary">The <code><strong>Location.reload()</strong></code> method
+<p><span class="seoSummary">The <code><strong>location.reload()</strong></code> method
     reloads the current URL, like the Refresh button.</span></p>
 
 <p>The reload may be blocked and a <code>SECURITY_ERROR</code> {{domxref("DOMException")}}


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

`location.reload();` should start with a lowercase letter

