### PR TITLE
Fix broken link flaw on arrow functions page

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -162,7 +162,7 @@ params => ({foo: "a"}) // returning the object {foo: "a"}
 ```
 
 [Rest
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Rest_parameters) are supported:
+parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) are supported:
 
 ```js
 (a, b, ...r) => expression


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This fixes the following broken link flaw:

1. /en-US/docs/Web/JavaScript/Reference/Functions/Rest_parameters 👀 line 164:1 Fixable 👍🏼
**Suggestion:** /en-US/docs/Web/JavaScript/Reference/Functions/~~Rest_parameters~~*rest_parameters*