### PR TITLE
Change property name

### DIFF
--- a/files/en-us/web/css/overflow-clip-margin/index.html
+++ b/files/en-us/web/css/overflow-clip-margin/index.html
@@ -26,7 +26,7 @@ overflow-clip-margin: revert;
 overflow-clip-margin: unset;
 </pre>
 
-<p>The <code>overflow-block</code> property is specified as a length, negative values are not allowed.</p>
+<p>The <code>overflow-clip-margin</code> property is specified as a length, negative values are not allowed.</p>
 
 <div class="note notecard">
 <p><strong>Note:</strong> If the element does not have <code>overflow: clip</code> then this property will be ignored.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Was referring to `overflow-block` when it should refer to 'overflow-clip-margin'.
