### PR TITLE
Make clear that 'hours' param for Date() constructor is 24H

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -96,8 +96,8 @@ There are four basic forms for the `Date()` constructor:
     - `day` {{optional_inline}}
       - : Integer value representing the day of the month. The default is `1`.
     - `hours` {{optional_inline}}
-      - : Integer value representing the hour of the day. The default is `0`
-        (midnight).
+      - : Integer value representing the hour of the day, uses 24 hours, The default is `0`
+        (midnight) and max value is 23.
     - `minutes` {{optional_inline}}
       - : Integer value representing the minute segment of a time. The default is
         `0` minutes past the hour.
@@ -126,10 +126,10 @@ The following examples show several ways to create JavaScript dates:
 
 ```js
 let today = new Date()
-let birthday = new Date('December 17, 1995 03:24:00')
-let birthday = new Date('1995-12-17T03:24:00')
+let birthday = new Date('December 17, 1995 13:24:00')
+let birthday = new Date('1995-12-17T13:24:00')
 let birthday = new Date(1995, 11, 17)            // the month is 0-indexed
-let birthday = new Date(1995, 11, 17, 3, 24, 0)
+let birthday = new Date(1995, 11, 17, 13, 24, 0)
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -96,8 +96,7 @@ There are four basic forms for the `Date()` constructor:
     - `day` {{optional_inline}}
       - : Integer value representing the day of the month. The default is `1`.
     - `hours` {{optional_inline}}
-      - : Integer value representing the hour of the day, uses 24 hours, The default is `0`
-        (midnight) and max value is 23.
+      - : Integer value between `0` and `23` representing the hour of the day. Defaults to `0`.
     - `minutes` {{optional_inline}}
       - : Integer value representing the minute segment of a time. The default is
         `0` minutes past the hour.


### PR DESCRIPTION
changed the example to 13 instead of 3 to illustrate it's in 24 hours format, and wrote that explicitly in the description of the hour argument

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
