### PR TITLE
Make clear: typed arrays can only be copy-constructed from same type

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
@@ -23,7 +23,7 @@ index syntax (that is, using bracket notation).
 ```js
 new BigInt64Array();
 new BigInt64Array(length);
-new BigInt64Array(typedArray);
+new BigInt64Array(bigInt64Array);
 new BigInt64Array(object);
 
 new BigInt64Array(buffer);
@@ -37,13 +37,8 @@ new BigInt64Array(buffer, byteOffset, length);
   - : When called with a `length` argument, an internal array buffer
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+- `bigInt64Array`
+  - : A `BigInt64Array` object to copy.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
@@ -23,7 +23,7 @@ using standard array index syntax (that is, using bracket notation).
 ```js
 new BigUint64Array();
 new BigUint64Array(length);
-new BigUint64Array(typedArray);
+new BigUint64Array(bigUint64Array);
 new BigUint64Array(object);
 
 new BigUint64Array(buffer);
@@ -37,13 +37,8 @@ new BigUint64Array(buffer, byteOffset, length);
   - : When called with a `length` argument, an internal array buffer
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+- `bigUint64Array`
+  - : A `BigUint64Array` object to copy.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -24,7 +24,7 @@ notation).
 ```js
 new Float32Array(); // new in ES2017
 new Float32Array(length);
-new Float32Array(typedArray);
+new Float32Array(float32Array);
 new Float32Array(object);
 
 new Float32Array(buffer);
@@ -38,13 +38,8 @@ new Float32Array(buffer, byteOffset, length);
   - : When called with a `length` argument, an internal array buffer
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+- `float32Array`
+  - : A `Float32Array` to copy.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -24,7 +24,7 @@ notation).
 ```js
 new Float64Array(); // new in ES2017
 new Float64Array(length);
-new Float64Array(typedArray);
+new Float64Array(float64Array);
 new Float64Array(object);
 
 new Float64Array(buffer);
@@ -38,13 +38,8 @@ new Float64Array(buffer, byteOffset, length);
   - : When called with a `length` argument, an internal array buffer
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+- `float64array`
+  - : A `Float64array` object to copy.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -83,12 +83,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+  - : A typed array object of the same type as the constructor. For example, for an `Int32Array()` constructor, an `Int32Array` object.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/7592