### PR TITLE
Fix case of publicKey property in navigator.credentials.get and create examples

### DIFF
--- a/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
@@ -42,7 +42,7 @@ browser-compat: api.AuthenticatorAssertionResponse.authenticatorData
    <li><dfn><strong>credentialPublicKey</strong> (variable length) - </dfn>A <a href="https://datatracker.ietf.org/doc/html/rfc8152">COSE</a> encoded public key. This public key will be stored on the server associated with a user's account and be used for future authentications.</li>
   </ul>
  </li>
- <li><strong>extensions</strong> (variable length) - An optional <a href="/en-US/docs/">CBOR</a> map of extensions.</li>
+ <li><strong>extensions</strong> (variable length) - An optional <a href="https://datatracker.ietf.org/doc/html/rfc7049">CBOR</a> map of extensions.</li>
 </ul>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
@@ -52,7 +52,7 @@ browser-compat: api.AuthenticatorAssertionResponse.authenticatorData
   timeout: 60000
 };
 
-navigator.credentials.get({  publickey: options })
+navigator.credentials.get({  publicKey: options })
   .then(function (assertionPKCred) {
     var authenticatorData = assertionPKCred.response.authenticatorData;
     // Maybe try to convert the authenticatorData to see what's inside

--- a/files/en-us/web/api/authenticatorassertionresponse/signature/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/signature/index.html
@@ -56,7 +56,7 @@ browser-compat: api.AuthenticatorAssertionResponse.signature
   timeout: 60000
 };
 
-navigator.credentials.get({  publickey: options })
+navigator.credentials.get({  publicKey: options })
   .then(function (assertionPKCred) {
     var signature = assertionPKCred.response.signature;
 

--- a/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.html
@@ -51,7 +51,7 @@ browser-compat: api.AuthenticatorAssertionResponse.userHandle
   timeout: 60000
 };
 
-navigator.credentials.get({  publickey: options })
+navigator.credentials.get({  publicKey: options })
   .then(function (assertionPKCred) {
     var userHandle = assertionPKCred.response.userHandle;
 

--- a/files/en-us/web/api/publickeycredential/rawid/index.html
+++ b/files/en-us/web/api/publickeycredential/rawid/index.html
@@ -58,7 +58,7 @@ browser-compat: api.PublicKeyCredential.rawId
   ]
 };
 
-navigator.credentials.create({  publickey: options })
+navigator.credentials.create({  publicKey: options })
   .then(function (pubKeyCredential) {
     var rawId = pubKeyCredential.rawId;
     // Do something with rawId

--- a/files/en-us/web/api/publickeycredential/response/index.html
+++ b/files/en-us/web/api/publickeycredential/response/index.html
@@ -83,7 +83,7 @@ browser-compat: api.PublicKeyCredential.response
   ]
 };
 
-navigator.credentials.create({  publickey: options })
+navigator.credentials.create({  publicKey: options })
   .then(function (pubKeyCredential) {
     var response = pubKeyCredential.response;
     var clientExtResults = pubKeyCredential.getClientExtensionResults();


### PR DESCRIPTION
per https://w3c.github.io/webauthn/#sctn-credentialrequestoptions-extension and https://w3c.github.io/webauthn/#sctn-credentialcreationoptions-extension
