### PR TITLE
Recommend AudioNode constructor instead of factory function

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -394,7 +394,7 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 <p>Feel free to change these as you are making other changes, but editing an article just to change capitalization is not necessary.</p>
 </div>
 
-<p>Keyboard keys should use sentence-style capitalization, not all-caps capitalization. For example, "<kbd>Enter</kbd>" not "<kbd>ENTER</kbd>". The only exception is that you can use "<kbd>ESC</kbd>" to abbreviate he "<kbd>Escape</kbd>" key.</p>
+<p>Keyboard keys should use sentence-style capitalization, not all-caps capitalization. For example, "<kbd>Enter</kbd>" not "<kbd>ENTER</kbd>". The only exception is that you can use "<kbd>ESC</kbd>" to abbreviate the "<kbd>Escape</kbd>" key.</p>
 
 <p>Certain words should always be capitalized (such as trademarks which include capital letters), or words derived from the name of a person (unless it's being used within code, and code’s syntax requires lower-casing). Some examples:</p>
 

--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -17,7 +17,7 @@ browser-compat: api.AnalyserNode.AnalyserNode
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <var>analyserNode</var> = new AnalyserNode(<var>context</var>, ?<var>options</var>);</pre>
+<pre class="brush: js">var <var>analyserNode</var> = new AnalyserNode(<var>context</var>, <var>options</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/index.html
@@ -47,7 +47,7 @@ browser-compat: api.AudioBufferSourceNode
 
 <dl>
  <dt>{{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}</dt>
- <dd>Creates and returns a new <code>AudioBufferSourceNode</code> object. An {{domxref("AudioBufferSourceNode")}} can be instantiated using the {{domxref("BaseAudioContext/createBufferSource", "AudioContext.createBufferSource()")}} method.</dd>
+ <dd>Creates and returns a new <code>AudioBufferSourceNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createBufferSource()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/index.html
@@ -47,7 +47,7 @@ browser-compat: api.AudioBufferSourceNode
 
 <dl>
  <dt>{{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}</dt>
- <dd>Creates and returns a new <code>AudioBufferSourceNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createBufferSource()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
+ <dd>Creates and returns a new <code>AudioBufferSourceNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createBufferSource()")}} factory method; see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/audionode/index.html
+++ b/files/en-us/web/api/audionode/index.html
@@ -69,8 +69,6 @@ analyserNode.smoothingTimeConstant = 0.5;</pre>
  <li>Slightly better performance: In both Chrome and Firefox, the factory methods call the constructors internally.</li>
 </ul>
 
-<p>Keep in mind that Microsoft Edge does not yet appear to support the constructors; it will throw a "Function expected" error when you use the constructors.</p>
-
 <p><em>Brief history:</em> The first version of the Web Audio spec only defined the factory methods. After a <a href="https://github.com/WebAudio/web-audio-api/issues/250">design review in October 2013</a>, it was decided to add constructors because they have numerous benefits over factory methods. The constructors were added to the spec from August to October 2016. Factory methods continue to be included in the spec and are not deprecated.</p>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -19,7 +19,7 @@ browser-compat: api.BaseAudioContext.createAnalyser
 
   <div class="notecard note">
     <p><strong>Note:</strong> The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
-      recommended way to create an {{domxref("AnalyserNode")}}, see
+      recommended way to create an {{domxref("AnalyserNode")}}; see
       <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
   </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -17,14 +17,14 @@ browser-compat: api.BaseAudioContext.createAnalyser
   {{domxref("BaseAudioContext")}} interface creates an {{domxref("AnalyserNode")}}, which
   can be used to expose audio time and frequency data and create data visualisations.</p>
 
-  <div class="note">
-    <p><strong>Note</strong>: The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
+  <div class="notecard note">
+    <p><strong>Note:</strong> The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
       recommended way to create an {{domxref("AnalyserNode")}}, see
       <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
   </div>
 
-<div class="note">
-  <p><strong>Note</strong>: For more on using this node, see the
+<div class="notecard note">
+  <p><strong>Note:</strong> For more on using this node, see the
     {{domxref("AnalyserNode")}} page.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -17,6 +17,12 @@ browser-compat: api.BaseAudioContext.createAnalyser
   {{domxref("BaseAudioContext")}} interface creates an {{domxref("AnalyserNode")}}, which
   can be used to expose audio time and frequency data and create data visualisations.</p>
 
+  <div class="note">
+    <p><strong>Note</strong>: The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
+      recommended way to create an {{domxref("AnalyserNode")}}, see
+      <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+  </div>
+
 <div class="note">
   <p><strong>Note</strong>: For more on using this node, see the
     {{domxref("AnalyserNode")}} page.</p>

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
@@ -19,8 +19,8 @@ browser-compat: api.BaseAudioContext.createBiquadFilter
     filter configurable as several different common filter types.</p>
 </div>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
     recommended way to create a {{domxref("BiquadFilterNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
@@ -21,7 +21,7 @@ browser-compat: api.BaseAudioContext.createBiquadFilter
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
-    recommended way to create a {{domxref("BiquadFilterNode")}}, see
+    recommended way to create a {{domxref("BiquadFilterNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
@@ -19,6 +19,12 @@ browser-compat: api.BaseAudioContext.createBiquadFilter
     filter configurable as several different common filter types.</p>
 </div>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
+    recommended way to create a {{domxref("BiquadFilterNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">baseAudioContext.createBiquadFilter();</pre>

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -23,6 +23,12 @@ browser-compat: api.BaseAudioContext.createBufferSource
     track.</p>
 </div>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
+    constructor is the recommended way to create a {{domxref("AudioBufferSourceNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -25,7 +25,7 @@ browser-compat: api.BaseAudioContext.createBufferSource
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
-    constructor is the recommended way to create a {{domxref("AudioBufferSourceNode")}}, see
+    constructor is the recommended way to create a {{domxref("AudioBufferSourceNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -23,8 +23,8 @@ browser-compat: api.BaseAudioContext.createBufferSource
     track.</p>
 </div>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
     constructor is the recommended way to create a {{domxref("AudioBufferSourceNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -17,8 +17,8 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 <p>The <code>createChannelMerger()</code> method of the {{domxref("BaseAudioContext")}} interface creates a {{domxref("ChannelMergerNode")}},
   which combines channels from multiple audio streams into a single audio stream.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
     recommended way to create a {{domxref("ChannelMergerNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -19,7 +19,7 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
-    recommended way to create a {{domxref("ChannelMergerNode")}}, see
+    recommended way to create a {{domxref("ChannelMergerNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -17,6 +17,12 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 <p>The <code>createChannelMerger()</code> method of the {{domxref("BaseAudioContext")}} interface creates a {{domxref("ChannelMergerNode")}},
   which combines channels from multiple audio streams into a single audio stream.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
+    recommended way to create a {{domxref("ChannelMergerNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">createChannelMerger(<em>numberOfInputs</em>)</pre>

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -16,6 +16,12 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 <p>The <code>createChannelSplitter()</code> method of the {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("ChannelSplitterNode")}},
   which is used to access the individual channels of an audio stream and process them separately.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}} 
+    constructor is the recommended way to create a {{domxref("ChannelSplitterNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">createChannelSplitter(<em>numberOfOutputs</em>)</pre>

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -16,8 +16,8 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 <p>The <code>createChannelSplitter()</code> method of the {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("ChannelSplitterNode")}},
   which is used to access the individual channels of an audio stream and process them separately.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}} 
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}} 
     constructor is the recommended way to create a {{domxref("ChannelSplitterNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -18,7 +18,7 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}} 
-    constructor is the recommended way to create a {{domxref("ChannelSplitterNode")}}, see
+    constructor is the recommended way to create a {{domxref("ChannelSplitterNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -22,7 +22,7 @@ browser-compat: api.BaseAudioContext.createConstantSource
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
-    constructor is the recommended way to create a {{domxref("ConstantSourceNode")}}, see
+    constructor is the recommended way to create a {{domxref("ConstantSourceNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -20,8 +20,8 @@ browser-compat: api.BaseAudioContext.createConstantSource
     outputs a monaural (one-channel) sound signal whose samples all have the same
     value.</span></p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
     constructor is the recommended way to create a {{domxref("ConstantSourceNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -20,6 +20,12 @@ browser-compat: api.BaseAudioContext.createConstantSource
     outputs a monaural (one-channel) sound signal whose samples all have the same
     value.</span></p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
+    constructor is the recommended way to create a {{domxref("ConstantSourceNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
@@ -21,6 +21,12 @@ browser-compat: api.BaseAudioContext.createConvolver
       Convolution</a> for more information.</p>
 </div>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
+    constructor is the recommended way to create a {{domxref("ConvolverNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">baseAudioContext.createConvolver();</pre>

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
@@ -23,7 +23,7 @@ browser-compat: api.BaseAudioContext.createConvolver
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
-    constructor is the recommended way to create a {{domxref("ConvolverNode")}}, see
+    constructor is the recommended way to create a {{domxref("ConvolverNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
@@ -21,8 +21,8 @@ browser-compat: api.BaseAudioContext.createConvolver
       Convolution</a> for more information.</p>
 </div>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
     constructor is the recommended way to create a {{domxref("ConvolverNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -17,6 +17,12 @@ browser-compat: api.BaseAudioContext.createDelay
   {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("DelayNode")}},
   which is used to delay the incoming audio signal by a certain amount of time.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
+    constructor is the recommended way to create a {{domxref("DelayNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -17,8 +17,8 @@ browser-compat: api.BaseAudioContext.createDelay
   {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("DelayNode")}},
   which is used to delay the incoming audio signal by a certain amount of time.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
     constructor is the recommended way to create a {{domxref("DelayNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -19,7 +19,7 @@ browser-compat: api.BaseAudioContext.createDelay
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
-    constructor is the recommended way to create a {{domxref("DelayNode")}}, see
+    constructor is the recommended way to create a {{domxref("DelayNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -26,8 +26,8 @@ browser-compat: api.BaseAudioContext.createDynamicsCompressor
   sounds are played simultaneously, where you want to control the overall signal level and
   help avoid clipping (distorting) of the audio output.</p>
 
-  <div class="note">
-    <p><strong>Note</strong>: The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
+  <div class="notecard note">
+    <p><strong>Note:</strong> The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
       constructor is the recommended way to create a {{domxref("DynamicsCompressorNode")}}, see
       <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
   </div>

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -28,7 +28,7 @@ browser-compat: api.BaseAudioContext.createDynamicsCompressor
 
   <div class="notecard note">
     <p><strong>Note:</strong> The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
-      constructor is the recommended way to create a {{domxref("DynamicsCompressorNode")}}, see
+      constructor is the recommended way to create a {{domxref("DynamicsCompressorNode")}}; see
       <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
   </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -26,6 +26,12 @@ browser-compat: api.BaseAudioContext.createDynamicsCompressor
   sounds are played simultaneously, where you want to control the overall signal level and
   help avoid clipping (distorting) of the audio output.</p>
 
+  <div class="note">
+    <p><strong>Note</strong>: The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
+      constructor is the recommended way to create a {{domxref("DynamicsCompressorNode")}}, see
+      <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+  </div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">baseAudioCtx.createDynamicsCompressor();</pre>

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.html
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.html
@@ -20,8 +20,8 @@ browser-compat: api.BaseAudioContext.createGain
   interface creates a {{ domxref("GainNode") }}, which can be used to control the
   overall gain (or volume) of the audio graph.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("GainNode.GainNode", "GainNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("GainNode.GainNode", "GainNode()")}}
     constructor is the recommended way to create a {{domxref("GainNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.html
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.html
@@ -22,7 +22,7 @@ browser-compat: api.BaseAudioContext.createGain
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("GainNode.GainNode", "GainNode()")}}
-    constructor is the recommended way to create a {{domxref("GainNode")}}, see
+    constructor is the recommended way to create a {{domxref("GainNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.html
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.html
@@ -20,6 +20,12 @@ browser-compat: api.BaseAudioContext.createGain
   interface creates a {{ domxref("GainNode") }}, which can be used to control the
   overall gain (or volume) of the audio graph.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("GainNode.GainNode", "GainNode()")}}
+    constructor is the recommended way to create a {{domxref("GainNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
@@ -21,8 +21,8 @@ browser-compat: api.BaseAudioContext.createIIRFilter
     response")}}</strong> (IIR) filter which can be configured to serve as various types
   of filter.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
     constructor is the recommended way to create a {{domxref("IIRFilterNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
@@ -23,7 +23,7 @@ browser-compat: api.BaseAudioContext.createIIRFilter
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
-    constructor is the recommended way to create a {{domxref("IIRFilterNode")}}, see
+    constructor is the recommended way to create a {{domxref("IIRFilterNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
@@ -21,6 +21,12 @@ browser-compat: api.BaseAudioContext.createIIRFilter
     response")}}</strong> (IIR) filter which can be configured to serve as various types
   of filter.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
+    constructor is the recommended way to create a {{domxref("IIRFilterNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
@@ -17,6 +17,12 @@ browser-compat: api.BaseAudioContext.createOscillator
   interface creates an {{domxref("OscillatorNode")}}, a source representing a periodic
   waveform. It basically generates a constant tone.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
+    constructor is the recommended way to create a {{domxref("OscillatorNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
@@ -17,8 +17,8 @@ browser-compat: api.BaseAudioContext.createOscillator
   interface creates an {{domxref("OscillatorNode")}}, a source representing a periodic
   waveform. It basically generates a constant tone.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
     constructor is the recommended way to create a {{domxref("OscillatorNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
@@ -19,7 +19,7 @@ browser-compat: api.BaseAudioContext.createOscillator
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
-    constructor is the recommended way to create a {{domxref("OscillatorNode")}}, see
+    constructor is the recommended way to create a {{domxref("OscillatorNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -22,8 +22,8 @@ browser-compat: api.BaseAudioContext.createPanner
   attribute), which represents the position and orientation of the person listening to the
   audio.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
     constructor is the recommended way to create a {{domxref("PannerNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -24,7 +24,7 @@ browser-compat: api.BaseAudioContext.createPanner
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
-    constructor is the recommended way to create a {{domxref("PannerNode")}}, see
+    constructor is the recommended way to create a {{domxref("PannerNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -22,6 +22,12 @@ browser-compat: api.BaseAudioContext.createPanner
   attribute), which represents the position and orientation of the person listening to the
   audio.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
+    constructor is the recommended way to create a {{domxref("PannerNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">createPanner();</pre>

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
@@ -21,8 +21,8 @@ browser-compat: api.BaseAudioContext.createStereoPanner
     href="https://webaudio.github.io/web-audio-api/#equal-power">equal-power</a> panning
   algorithm.</p>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
     constructor is the recommended way to create a {{domxref("StereoPannerNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
@@ -21,6 +21,12 @@ browser-compat: api.BaseAudioContext.createStereoPanner
     href="https://webaudio.github.io/web-audio-api/#equal-power">equal-power</a> panning
   algorithm.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
+    constructor is the recommended way to create a {{domxref("StereoPannerNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">baseAudioContext.createStereoPanner();</pre>

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
@@ -23,7 +23,7 @@ browser-compat: api.BaseAudioContext.createStereoPanner
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
-    constructor is the recommended way to create a {{domxref("StereoPannerNode")}}, see
+    constructor is the recommended way to create a {{domxref("StereoPannerNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
@@ -19,6 +19,12 @@ browser-compat: api.BaseAudioContext.createWaveShaper
     distortion. It is used to apply distortion effects to your audio.</p>
 </div>
 
+<div class="note">
+  <p><strong>Note</strong>: The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
+    constructor is the recommended way to create a {{domxref("WaveShaperNode")}}, see
+    <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">baseAudioCtx.createWaveShaper();</pre>

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
@@ -19,8 +19,8 @@ browser-compat: api.BaseAudioContext.createWaveShaper
     distortion. It is used to apply distortion effects to your audio.</p>
 </div>
 
-<div class="note">
-  <p><strong>Note</strong>: The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
+<div class="notecard note">
+  <p><strong>Note:</strong> The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
     constructor is the recommended way to create a {{domxref("WaveShaperNode")}}, see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
@@ -21,7 +21,7 @@ browser-compat: api.BaseAudioContext.createWaveShaper
 
 <div class="notecard note">
   <p><strong>Note:</strong> The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
-    constructor is the recommended way to create a {{domxref("WaveShaperNode")}}, see
+    constructor is the recommended way to create a {{domxref("WaveShaperNode")}}; see
     <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 </div>
 

--- a/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
@@ -16,8 +16,7 @@ browser-compat: api.BiquadFilterNode.BiquadFilterNode
 <p><span class="seoSummary">The <strong><code>BiquadFilterNode()</code></strong>
     constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>
     creates a new {{domxref("BiquadFilterNode")}} object, which represents a simple
-    low-order filter, and is created using the AudioContext.createBiquadFilter()
-    method.</span></p>
+    low-order filter.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/index.html
@@ -34,7 +34,7 @@ browser-compat: api.ConstantSourceNode
 
 <dl>
  <dt>{{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}</dt>
- <dd>Creates and returns a new <code>ConstantSourceNode</code> instance, optionally specifying an object which establishes initial values for the object's properties. You can also create a <code>ConstantSourceNode</code> whose properties are initialized to their default values by calling {{domxref("BaseAudioContext/createConstantSource", "AudioContext.createConstantSource()")}}.</dd>
+ <dd>Creates and returns a new <code>ConstantSourceNode</code> instance, optionally specifying an object which establishes initial values for the object's properties. As an alternative, you can use the {{domxref("BaseAudioContext.createConstantSource()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/index.html
@@ -34,7 +34,7 @@ browser-compat: api.ConstantSourceNode
 
 <dl>
  <dt>{{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}</dt>
- <dd>Creates and returns a new <code>ConstantSourceNode</code> instance, optionally specifying an object which establishes initial values for the object's properties. As an alternative, you can use the {{domxref("BaseAudioContext.createConstantSource()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
+ <dd>Creates and returns a new <code>ConstantSourceNode</code> instance, optionally specifying an object which establishes initial values for the object's properties. As an alternative, you can use the {{domxref("BaseAudioContext.createConstantSource()")}} factory method; see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -47,7 +47,7 @@ browser-compat: api.DelayNode
 
 <dl>
 	<dt>{{domxref("DelayNode.DelayNode", "DelayNode()")}}</dt>
-	<dd>Creates a new instance of an DelayNode object instance. As an alternative, you can use the {{domxref("BaseAudioContext.createDelay()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
+	<dd>Creates a new instance of an DelayNode object instance. As an alternative, you can use the {{domxref("BaseAudioContext.createDelay()")}} factory method; see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -47,7 +47,7 @@ browser-compat: api.DelayNode
 
 <dl>
 	<dt>{{domxref("DelayNode.DelayNode", "DelayNode()")}}</dt>
-	<dd>Creates a new instance of an DelayNode object instance. Alternatively, you can use the {{domxref("BaseAudioContext.createDelay()")}} factory method.</dd>
+	<dd>Creates a new instance of an DelayNode object instance. As an alternative, you can use the {{domxref("BaseAudioContext.createDelay()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/index.html
@@ -14,7 +14,7 @@ browser-compat: api.DynamicsCompressorNode
 <p>{{ APIRef("Web Audio API") }}</p>
 
 <div>
-<p>The <code>DynamicsCompressorNode</code> interface provides a compression effect, which lowers the volume of the loudest parts of the signal in order to help prevent clipping and distortion that can occur when multiple sounds are played and multiplexed together at once. This is often used in musical production and game audio. <code>DynamicsCompressorNode</code> is an {{domxref("AudioNode")}} that has exactly one input and one output; it is created using the {{domxref("BaseAudioContext.createDynamicsCompressor")}} method.</p>
+<p>The <code>DynamicsCompressorNode</code> interface provides a compression effect, which lowers the volume of the loudest parts of the signal in order to help prevent clipping and distortion that can occur when multiple sounds are played and multiplexed together at once. This is often used in musical production and game audio. <code>DynamicsCompressorNode</code> is an {{domxref("AudioNode")}} that has exactly one input and one output.</p>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/api/gainnode/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/gainnode/index.html
@@ -15,7 +15,6 @@ browser-compat: api.GainNode.GainNode
 
 <p>The <strong><code>GainNode()</code></strong> constructor of the <a
 		href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new
-	{{domxref("GainNode")}} object which an {{domxref("AudioNode")}} that represents a
 	change in volume.</p>
 
 <div class="note">
@@ -34,7 +33,6 @@ browser-compat: api.GainNode.GainNode
 
 <dl>
 	<dt><code>context</code></dt>
-	<dd>A reference to an {{domxref("AudioContext")}}.</dd>
 	<dt><code>options</code> {{optional_inline}}</dt>
 	<dd>Options are as follows:
 		<ul>

--- a/files/en-us/web/api/gainnode/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/gainnode/index.html
@@ -15,12 +15,8 @@ browser-compat: api.GainNode.GainNode
 
 <p>The <strong><code>GainNode()</code></strong> constructor of the <a
 		href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new
+	{{domxref("GainNode")}} object which is an {{domxref("AudioNode")}} that represents a
 	change in volume.</p>
-
-<div class="note">
-	<p><strong>Note</strong>: You should typically call
-		{{domxref("BaseAudioContext.createGain")}} to create a gain node.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -33,6 +29,7 @@ browser-compat: api.GainNode.GainNode
 
 <dl>
 	<dt><code>context</code></dt>
+	<dd>A reference to a {{domxref("BaseAudioContext")}}, e.g. an {{domxref("AudioContext")}}.</dd>
 	<dt><code>options</code> {{optional_inline}}</dt>
 	<dd>Options are as follows:
 		<ul>

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -46,7 +46,7 @@ browser-compat: api.GainNode
 
 <dl>
  <dt>{{domxref("GainNode.GainNode", "GainNode()")}}</dt>
- <dd>Creates and returns a new <code>GainNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createGain()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
+ <dd>Creates and returns a new <code>GainNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createGain()")}} factory method; see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -46,7 +46,7 @@ browser-compat: api.GainNode
 
 <dl>
  <dt>{{domxref("GainNode.GainNode", "GainNode()")}}</dt>
- <dd>Creates a new instance of a <code>GainNode</code> object. You shouldn't manually create a gain node; instead, use the method {{domxref("BaseAudioContext.createGain")}}.</dd>
+ <dd>Creates and returns a new <code>GainNode</code> object. As an alternative, you can use the {{domxref("BaseAudioContext.createGain()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -46,7 +46,7 @@ browser-compat: api.OscillatorNode
 
 <dl>
  <dt>{{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}</dt>
- <dd>Creates a new instance of an <code>OscillatorNode</code> object, optionally providing an object specifying default values for the node's {{anch("properties")}}.  If the default values are acceptable, you can call the {{domxref("BaseAudioContext.createOscillator()")}} factory method.</dd>
+ <dd>Creates a new instance of an <code>OscillatorNode</code> object, optionally providing an object specifying default values for the node's {{anch("properties")}}.  As an alternative, you can use the {{domxref("BaseAudioContext.createOscillator()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -15,8 +15,6 @@ browser-compat: api.OscillatorNode
 
 <p>The <strong><code>OscillatorNode</code></strong> interface represents a periodic waveform, such as a sine wave. It is an {{domxref("AudioScheduledSourceNode")}} audio-processing module that causes a specified frequency of a given wave to be created—in effect, a constant tone.</p>
 
-<p>An <code>OscillatorNode</code> is created using the {{domxref("BaseAudioContext.createOscillator()")}} method. It always has exactly one output and no inputs. Its basic property defaults (see {{domxref("AudioNode")}} for definitions) are:</p>
-
 <table class="properties">
  <tbody>
   <tr>

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -44,7 +44,7 @@ browser-compat: api.OscillatorNode
 
 <dl>
  <dt>{{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}</dt>
- <dd>Creates a new instance of an <code>OscillatorNode</code> object, optionally providing an object specifying default values for the node's {{anch("properties")}}.  As an alternative, you can use the {{domxref("BaseAudioContext.createOscillator()")}} factory method, see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
+ <dd>Creates a new instance of an <code>OscillatorNode</code> object, optionally providing an object specifying default values for the node's {{anch("properties")}}.  As an alternative, you can use the {{domxref("BaseAudioContext.createOscillator()")}} factory method; see <a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -20,7 +20,8 @@ browser-compat: api.OscillatorNode.OscillatorNode
 	properties' values to match values in a specified object.</p>
 
 <p>If the default values of the properties are acceptable, you can optionally use the
-	{{domxref("BaseAudioContext.createOscillator")}} factory method instead.</p>
+	{{domxref("BaseAudioContext.createOscillator()")}} factory method instead, see
+	<a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -20,7 +20,7 @@ browser-compat: api.OscillatorNode.OscillatorNode
 	properties' values to match values in a specified object.</p>
 
 <p>If the default values of the properties are acceptable, you can optionally use the
-	{{domxref("BaseAudioContext.createOscillator()")}} factory method instead, see
+	{{domxref("BaseAudioContext.createOscillator()")}} factory method instead; see
 	<a href="/en-US/docs/Web/API/AudioNode#creating_an_audionode">Creating an AudioNode</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -47,7 +47,8 @@ browser-compat: api.PannerNode
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{domxref("PannerNode.PannerNode")}}</dt>
+  <dt>{{domxref("PannerNode.PannerNode", "PannerNode()")}}</dt>
+
  <dd>Creates a new <code>PannerNode</code> object instance.</dd>
 </dl>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #7426


> What was wrong/why is this fix needed? (quick summary only)

Existing docs sometimes recommend the AudioNode factory method, but the constructor should be recommend instead, see #7426.


> Anything else that could help us review it

I added a bunch of smaller clean ups along the way. Feel free to suggest a rewording to the sentences that I used - since the wording is now consistent, I can change it pretty quickly.
