### PR TITLE
Fix broken link flaw in ForEach Page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -175,7 +175,7 @@ if (!Array.prototype['forEach']) {
     var len = O.length >>> 0;
 
     // 4. If isCallable(callback) is false, throw a TypeError exception.
-    // See: https://es5.github.com/#x9.11
+    // See: https://es5.github.io/#x9.11
     if (typeof callback !== "function") { throw new TypeError(callback + ' is not a function'); }
 
     // 5. If thisArg was supplied, let T be thisArg; else let


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This fixes the following broken link flaw: 

1. https://es5.github.com/#x9.11 to https://es5.github.io/#x9.11 [Line 178] 
    

Please review this @sideshowbarker 
