### PR TITLE
Prefer Python 3 (http.server)

### DIFF
--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.html
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.html
@@ -50,8 +50,8 @@ tags:
 
 <p>To get around the problem of async requests, we need to test such examples by running them through a local web server. One of the easiest ways to do this for our purposes is to use Python's <code>http.server</code> module<code>.
 
-<div class="note">
-<p><strong>Note</strong>: Older versions of Python (up to version 2.7) provided a similar module named <code>SimpleHTTPServer</code>. If you are using Python 2.x, you can follow this guide by replacing all uses of <code>http.server</code> with <code>SimpleHTTPServer</code>. However, we recommend you use the latest version of Python.</p>
+<div class="notecard note">
+ <p><strong>Note:</strong> Older versions of Python (up to version 2.7) provided a similar module named <code>SimpleHTTPServer</code>. If you are using Python 2.x, you can follow this guide by replacing all uses of <code>http.server</code> with <code>SimpleHTTPServer</code>. However, we recommend you use the latest version of Python.</p>
 </div>
 
 <p>To do this:</p>

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.html
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.html
@@ -48,7 +48,11 @@ tags:
 
 <h2 id="Running_a_simple_local_HTTP_server">Running a simple local HTTP server</h2>
 
-<p>To get around the problem of async requests, we need to test such examples by running them through a local web server. One of the easiest ways to do this for our purposes is to use Python's <code>SimpleHTTPServer</code> (or <code>http.server</code>, depending on the version of Python installed.)</p>
+<p>To get around the problem of async requests, we need to test such examples by running them through a local web server. One of the easiest ways to do this for our purposes is to use Python's <code>http.server</code> module<code>.
+
+<div class="note">
+<p><strong>Note</strong>: Older versions of Python (up to version 2.7) provided a similar module named <code>SimpleHTTPServer</code>. If you are using Python 2.x, you can follow this guide by replacing all uses of <code>http.server</code> with <code>SimpleHTTPServer</code>. However, we recommend you use the latest version of Python.</p>
+</div>
 
 <p>To do this:</p>
 
@@ -59,18 +63,20 @@ tags:
   <ul>
    <li>Go to <a href="https://www.python.org/">python.org</a></li>
    <li>Under the Download section, click the link for Python "3.xxx".</li>
-   <li>At the bottom of the page, choose the <em>Windows x86 executable installer</em> and download it.</li>
+   <li>At the bottom of the page, click the <em>Windows Installer</em> link to download the installer file.</li>
    <li>When it has downloaded, run it.</li>
    <li>On the first installer page, make sure you check the "Add Python 3.xxx to PATH" checkbox.</li>
    <li>Click <em>Install</em>, then click <em>Close</em> when the installation has finished.</li>
   </ul>
  </li>
  <li>
-  <p>Open your command prompt (Windows)/ terminal (macOS/ Linux). To check Python is installed, enter the following command:</p>
+  <p>Open your command prompt (Windows) / terminal (macOS/ Linux). To check if Python is installed, enter the following command:</p>
 
   <pre class="brush: bash">python -V
-# Or you might have the py command available,
-# in which case try py -V
+# If the above fails, try:
+python3 -V
+# Or, if the &quot;py&quot; command is available, try:
+py -V
 </pre>
  </li>
  <li>
@@ -85,8 +91,8 @@ cd ..</pre>
   <p>Enter the command to start up the server in that directory:</p>
 
   <pre class="brush: bash"># If Python version returned above is 3.X
+# On Windows, try &quot;python -m http.server&quot; or &quot;py -3 -m http.server&quot;
 python3 -m http.server
-# On windows try &quot;python&quot; instead of &quot;python3&quot;, or &quot;py -3&quot;
 # If Python version returned above is 2.X
 python -m SimpleHTTPServer</pre>
  </li>
@@ -101,10 +107,10 @@ python -m SimpleHTTPServer</pre>
 
 <h2 id="Running_server-side_languages_locally">Running server-side languages locally</h2>
 
-<p>Python's <code>SimpleHTTPServer (python 2.0) http.server (python 3.0)</code> module is useful, but it doesn't know how to run code written in languages such as Python, PHP or JavaScript. To handle that you'll need something more — exactly what you'll need depends on the server-side language you are trying to run. Here are a few examples:</p>
+  <p>Python's <code>http.server</code> (or <code>SimpleHTTPServer</code> for Python 2) module is useful, but it is merely a <em>static</em> file server; it doesn't know how to run code written in languages such as Python, PHP or JavaScript. To handle them, you'll need something more — exactly what you'll need depends on the server-side language you are trying to run. Here are a few examples:</p>
 
 <ul>
- <li>To run Python server-side code, you'll need to use a Python web framework. You can find out how to use the Django framework by reading <a href="/en-US/docs/Learn/Server-side/Django">Django Web Framework (Python)</a>. <a href="http://flask.pocoo.org/">Flask</a> is also a good (slightly less heavyweight) alternative to Django. To run this you'll need to <a href="/en-US/docs/Learn/Server-side/Django/development_environment#installing_python_3">install Python/PIP</a>, then install Flask using <code>pip3 install flask</code>. At this point you should be able to run the Python Flask examples using for example <code>python3 python-example.py</code>, then navigating to <code>localhost:5000</code> in your browser. <a href="https://trypyramid.com">Pyramid</a> is another popular Python web framework that supports both small quick applications as well as large custom architectures.</li>
+ <li>To run Python server-side code, you'll need to use a Python web framework. There are many popular Python web frameworks, such as Django (a <a href="/en-US/docs/Learn/Server-side/Django">guide</a> is available), <a href="https://flask.palletsprojects.com/">Flask</a>, and <a href="https://trypyramid.com">Pyramid</a>.</li>
  <li>To run Node.js (JavaScript) server-side code, you'll need to use raw node or a framework built on top of it. Express is a good choice — see <a href="/en-US/docs/Learn/Server-side/Express_Nodejs">Express Web Framework (Node.js/JavaScript)</a>.</li>
  <li>
   <p>To run PHP server-side code, launch <a href="https://php.net/manual/en/features.commandline.webserver.php">PHP's built-in development server</a>:</p>


### PR DESCRIPTION
Since Python 2 has been sunsetted on Jan 1st, 2020, we should rephrase the guide to focus on Python 3 examples first.

Also cleanup info about (and fix some links for) Python web frameworks. Since all of the frameworks mentioned provide a user guide on their websites, we do not need to describe how to install and run them here.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

> What was wrong/why is this fix needed? (quick summary only)

The guide was mentioning `SimpleHTTPServer` (Python 2) before `http.server` (Python 3). It also had some outdated info.

The instructions for installing and running Flask are extraneous for the purposes of this article.

> Anything else that could help us review it
