### PR TITLE
Update "Simplifying list selectors" example code

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -187,9 +187,7 @@ dir ol dir,   dir ul dir,   dir menu dir,   dir dir dir {
 
 ```css
 /* 3-deep (or more) unordered lists use a square */
-:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) ul,
-:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) menu,
-:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) dir {
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
   list-style-type: square;
 }
 ```


### PR DESCRIPTION
The replacement code for "Simplifying list selectors" can use an `:if` as the last selector instead of having a comma-separated list of complex selectors.

If it's felt that we should show the 3 separate selectors for clarity, then I would suggest adding `<p>Or even...</p>` followed by the sorter code example.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
