### PR TITLE
Use HTTPS for an external link

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
@@ -123,7 +123,7 @@ tags:
   so on according to the current transformation.</p>
 
 <p>Ted Mielczarek's <a class="external external-icon"
-    href="http://ted.mielczarek.org/code/mozilla/tabpreview/">tab preview</a> extension
+    href="https://ted.mielczarek.org/code/mozilla/tabpreview/">tab preview</a> extension
   uses this technique in chrome to provide thumbnails of web pages, and the source is
   available for reference.</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This fixes the following broken link flaw:

1. http://ted.mielczarek.org/code/mozilla/tabpreview/ 👀 line 130:11 Fixable 👍🏼
**Suggestion:** ~~http~~*https*://ted.mielczarek.org/code/mozilla/tabpreview/