### PR TITLE
Fix mixin example in Object.create() article

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -309,33 +309,6 @@ console.log('Is rect an instance of Shape?', rect instanceof Shape); // true
 rect.move(1, 1); // Outputs, 'Shape moved.'
 ```
 
-If you wish to inherit from multiple objects, then mixins are a possibility.
-
-```js
-function MyClass() {
-  SuperClass.call(this);
-  OtherSuperClass.call(this);
-}
-
-// inherit one class
-MyClass.prototype = Object.create(SuperClass.prototype);
-// mixin another
-Object.assign(MyClass.prototype, OtherSuperClass.prototype);
-// re-assign constructor
-MyClass.prototype.constructor = MyClass;
-
-MyClass.prototype.myMethod = function() {
-  // do something
-};
-```
-
-{{jsxref("Object.assign()")}} copies properties from the OtherSuperClass prototype to
-the MyClass prototype, making them available to all instances of MyClass.
-`Object.assign()` was introduced with ES2015 and [can
-be polyfilled](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#polyfill). If support for older browsers is necessary,
-[`jQuery.extend()`](https://api.jquery.com/jQuery.extend/) or
-[`_.assign()`](https://lodash.com/docs/#assign) can be used.
-
 ### Using propertiesObject argument with Object.create()
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -320,7 +320,7 @@ function MyClass() {
 // inherit one class
 MyClass.prototype = Object.create(SuperClass.prototype);
 // mixin another
-Object.assign(Object.getPrototypeOf(MyClass.prototype), OtherSuperClass.prototype);
+Object.assign(MyClass.prototype, OtherSuperClass.prototype);
 // re-assign constructor
 MyClass.prototype.constructor = MyClass;
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A


> What was wrong/why is this fix needed? (quick summary only)

The previous version was mutating the first superclass's prototype (i.e. `Object.getPrototypeOf(MyClass.prototype)` returns `SuperClass.prototype`, and we don't want to mutate that).


> Anything else that could help us review it

For what it's worth, this is a horrifically ugly pattern and should never be used (in my humble opinion), so I'd also be happy to just delete the whole section.
