### PR TITLE
Fix a couple of developers.google.com redirects

### DIFF
--- a/files/en-us/games/techniques/audio_for_web_games/index.html
+++ b/files/en-us/games/techniques/audio_for_web_games/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h3 id="Autoplay">Autoplay</h3>
 
-<p>Browser autoplay policy now affects desktop <em>and</em> mobile browsers. There is further information about it <a href="https://developers.google.com/web/updates/2017/09/autoplay-policy-changes">here from the Google Developers site</a>.</p>
+<p>Browser autoplay policy now affects desktop <em>and</em> mobile browsers. There is further information about it <a href="https://developer.chrome.com/blog/autoplay/">here from the Google Developers site</a>.</p>
 
 <p>It is worth noting that autoplay with sound is allowed if:</p>
 

--- a/files/en-us/glossary/progressive_web_apps/index.html
+++ b/files/en-us/glossary/progressive_web_apps/index.html
@@ -14,5 +14,5 @@ tags:
 
 <ul>
  <li>The <a href="/en-US/docs/Web/Progressive_web_apps">App Center</a> on MDN</li>
- <li><a href="https://developers.google.com/web/progressive-web-apps">Progressive web apps</a> on Google Developers</li>
+ <li><a href="https://web.dev/progressive-web-apps/">Progressive web apps</a> on Google Developers</li>
 </ul>

--- a/files/en-us/glossary/time_to_interactive/index.html
+++ b/files/en-us/glossary/time_to_interactive/index.html
@@ -20,5 +20,5 @@ tags:
 <ul>
  <li><a href="https://github.com/WICG/time-to-interactive">Definition of TTI</a> from Web Incubator Community Group</li>
  <li><a href="https://building.calibreapp.com/time-to-interactive-focusing-on-the-human-centric-metrics-22eb7e64dd23">Time to Interactive — focusing on human-centric metrics</a> by Radimir Bitsov</li>
- <li><a href="https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics#tracking_tti">Tracking TTI</a></li>
+ <li><a href="https://web.dev/user-centric-performance-metrics/#tracking_tti">Tracking TTI</a></li>
 </ul>

--- a/files/en-us/web/media/autoplay_guide/index.html
+++ b/files/en-us/web/media/autoplay_guide/index.html
@@ -57,7 +57,7 @@ tags:
 
 <p>Otherwise, the playback will likely be blocked. The exact situations that result in blocking, and the specifics of how sites become whitelisted vary from browser to browser, but the above are good guidelines to go by.</p>
 
-<p>For details, see the auto-play policies for <a href="https://developers.google.com/web/updates/2017/09/autoplay-policy-changes">Google Chrome</a> and <a href="https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/">WebKit</a>.</p>
+<p>For details, see the auto-play policies for <a href="https://developer.chrome.com/blog/autoplay/">Google Chrome</a> and <a href="https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/">WebKit</a>.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Put another way, playback of any media that includes audio is generally blocked if the playback is programmatically initiated in a tab which has not yet had any user interaction. Browsers may additionally choose to block under other circumstances.</p>

--- a/files/en-us/webassembly/index.html
+++ b/files/en-us/webassembly/index.html
@@ -24,7 +24,7 @@ tags:
  <dt><a href="/en-US/docs/WebAssembly/Concepts">WebAssembly concepts</a></dt>
  <dd>Get started by reading the high-level concepts behind WebAssembly — what it is, why it is so useful, how it fits into the web platform (and beyond), and how to use it.</dd>
  <dt><a href="/en-US/docs/WebAssembly/C_to_wasm">Compiling a New C/C++ Module to WebAssembly</a></dt>
- <dd>When you’ve written code in C/C++, you can then compile it into .wasm using a tool like <a href="/en-US/docs/Mozilla/Projects/Emscripten/">Emscripten</a>. Let’s look at how it works.</dd>
+ <dd>When you’ve written code in C/C++, you can then compile it into .wasm using a tool like <a href="https://emscripten.org/">Emscripten</a>. Let’s look at how it works.</dd>
  <dt><a href="/en-US/docs/WebAssembly/existing_C_to_wasm">Compiling an Existing C Module to WebAssembly</a></dt>
  <dd>A core use-case for WebAssembly is to take the existing ecosystem of C libraries and allow developers to use them on the web.</dd>
  <dt><a href="/en-US/docs/WebAssembly/Rust_to_wasm">Compiling from Rust to WebAssembly</a></dt>


### PR DESCRIPTION
This fixes a few redirects highlighted in #7586. 