### PR TITLE
FF91 Clarify Error option.cause for custom class

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -145,8 +145,15 @@ try {
 }
 ```
 
-> **Note** You should also use the `cause` property if re-throwing [custom error types](#custom_error_types). 
-
+You can also use the `cause` property in [custom error types](#custom_error_types), provided the subclasses' constructor passes the `options` parameter when calling `super()`:
+```js
+class MyError extends Error {
+  constructor(/* some arguments */) {
+    // Needs to pass both `message` and `options` to install the "cause" property. 
+    super(message, options);
+  }
+}
+```
 
 ### Custom Error Types
 


### PR DESCRIPTION
This is part of #6714

Previously I just noted that you can should use the options.cause with custom errors. That's not quite correct - you might want to (not should), but it doesn't happen by magic. This adds a very small example showing that the custom class must pass the options.
