### PR TITLE
Page macro: DisplayMediaStreamConstraints constraints

### DIFF
--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -45,7 +45,7 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 
 <p>The value may be either a boolean value or a "constraints" object.</p>
 
-<p>If a Boolean is specified, a value of <code>true</code> (the default) indicates that the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}
+<p>If a boolean value is specified, a value of <code>true</code> (the default) indicates that the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}
   should be in whatever format the user agent feels is best.
   A value of <code>false</code> is not permitted and will throw a <code>TypeError</code>.</p>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -21,19 +21,15 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 ---
 <p>{{APIRef("Screen Capture API")}}</p>
 
-<p><span class="seoSummary">The {{domxref("DisplayMediaStreamConstraints")}} dictionary's
-    <strong><code>video</code></strong> property is used to configure the video track in
-    the stream returned by {{domxref("MediaDevices.getDisplayMedia",
-    "getDisplayMedia()")}}.</span> This value may be a Boolean, where <code>true</code>
-  specifies that a default selection of input source be made (typically the entire display
+<p>The {{domxref("DisplayMediaStreamConstraints")}} dictionary's <strong><code>video</code></strong> property is used to configure the video track in
+    the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}.</p>
+    
+<p>This value may be a Boolean, where <code>true</code> specifies that a default selection of input source be made (typically the entire display
   area of the device in use, spanning every screen in a multiple screen configuration).
-  Since a video track must always be included, a value of <code>false</code> results in a
-  <code>TypeError</code> exception being thrown.</p>
+  Since a video track must always be included, a value of <code>false</code> results in a <code>TypeError</code> exception being thrown.</p>
 
-<p>More precise control over the format of the returned video track may be exercised by
-  instead providing a {{domxref("MediaTrackConstraints")}} object, which is used to
-  process the video data after obtaining it from the device but prior to adding it to the
-  stream.</p>
+<p>More precise control over the format of the returned video track may be exercised by providing a constrain object, which is used to
+  process the video data after obtaining it from the device but prior to adding it to the stream.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -47,21 +43,50 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 
 <h3 id="Value">Value</h3>
 
-<p>The value may be either a Boolean or a {{domxref("MediaTrackConstraints")}} object.</p>
+<p>The value may be either a boolean or a "constraints" object.</p>
 
-<p>If a Boolean is specified, a value of <code>true</code> (the default) indicates that
-  the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}
-  should be in whatever format the user agent feels is best. A value of <code>false</code>
-  is not permitted and will throw a <code>TypeError</code>.</p>
+<p>If a Boolean is specified, a value of <code>true</code> (the default) indicates that the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}
+  should be in whatever format the user agent feels is best.
+  A value of <code>false</code> is not permitted and will throw a <code>TypeError</code>.</p>
 
-<p>If a <code>MediaTrackConstraints</code> object is given instead, the video track will
-  be processed to match the settings given in the constraints object.</p>
+<p>If a constraints object is given instead, the video track will be processed to match the settings given in the constraints object.</p>
 
-<h2 id="Constraints_specific_to_screen_sharing">Constraints specific to screen sharing
-</h2>
+<p>The allowed properties of the constraint object are:</p>
 
-<p>{{page("/en-US/docs/Web/API/MediaTrackConstraints", "Properties of shared screen
-  tracks")}}</p>
+<dl>
+ <dt>{{domxref("MediaTrackConstraints.cursor", "cursor")}}</dt>
+ <dd>
+ <p>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring"><code>ConstrainDOMString</code></a> that specifies whether or not to include the mouse cursor in the generated track, and if so, whether or not to hide it while not moving. The value may be a single one of the following strings, or an array of them to allow the browser flexibility in deciding what to do about the cursor.</p>
+
+ <dl>
+  <dt><code>always</code></dt>
+  <dd>The mouse is always visible in the video content of the {domxref("MediaStream"), unless the mouse has moved outside the area of the content.</dd>
+  <dt><code>motion</code></dt>
+  <dd>The mouse cursor is always included in the video if it's moving, and for a short time after it stops moving.</dd>
+  <dt><code>never</code></dt>
+  <dd>The mouse cursor is never included in the shared video.</dd>
+ </dl>
+ </dd>
+ <dt>{{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}}</dt>
+ <dd>
+ <p>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring"><code>ConstrainDOMString</code></a> which specifies the types of display surface that may be selected by the user. This may be a single one of the following strings, or a list of them to allow multiple source surfaces:</p>
+
+ <dl>
+  <dt><code>application</code></dt>
+  <dd>The stream contains all of the windows of the application chosen by the user rendered into the one video track.</dd>
+  <dt><code>browser</code></dt>
+  <dd>The stream contains the contents of a single browser tab selected by the user.</dd>
+  <dt><code>monitor</code></dt>
+  <dd>The stream's video track contains the entire contents of one or more of the user's screens.</dd>
+  <dt><code>window</code></dt>
+  <dd>The stream contains a single window selected by the user for sharing.</dd>
+ </dl>
+ </dd>
+ <dt>{{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}}</dt>
+ <dd>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean"><code>ConstrainBoolean</code></a> value that may contain a single Boolean value or a set of them, indicating whether or not to allow the user to choose source surfaces which do not directly correspond to display areas.
+  These may include backing buffers for windows to allow capture of window contents that are hidden by other windows in front of them, or buffers containing larger documents that need to be scrolled through to see the entire contents in their windows.</dd>
+</dl>
+
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -24,7 +24,7 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 <p>The {{domxref("DisplayMediaStreamConstraints")}} dictionary's <strong><code>video</code></strong> property is used to configure the video track in
     the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}.</p>
     
-<p>This value may be a Boolean, where <code>true</code> specifies that a default selection of input source be made (typically the entire display
+<p>This value may be a boolean value, where <code>true</code> specifies that a default selection of input source be made (typically the entire display
   area of the device in use, spanning every screen in a multiple screen configuration).
   Since a video track must always be included, a value of <code>false</code> results in a <code>TypeError</code> exception being thrown.</p>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -43,7 +43,7 @@ browser-compat: api.DisplayMediaStreamConstraints.video
 
 <h3 id="Value">Value</h3>
 
-<p>The value may be either a boolean or a "constraints" object.</p>
+<p>The value may be either a boolean value or a "constraints" object.</p>
 
 <p>If a Boolean is specified, a value of <code>true</code> (the default) indicates that the stream returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}
   should be in whatever format the user agent feels is best.


### PR DESCRIPTION
This is part of fixing #3196 - replaces a page inclusion macro with specification and compat macros.

[DisplayMediaStreamConstraints.video](https://developer.mozilla.org/en-US/docs/Web/API/DisplayMediaStreamConstraints/video) was importing a section of the [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) indicating the subset of valid values that could be entered. With this change it now includes the actual text that was previously included.

This is a partial fix. In fact both [DisplayMediaStreamConstraints.video](https://developer.mozilla.org/en-US/docs/Web/API/DisplayMediaStreamConstraints/video) and [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) are dictionaries. MDN want to remove dictionary docs and move the information "in place" where it is used - duplicating as needed. 

Unfortunately doing that in this case is a massive undertaking. So this just does the minimum to remove Page.