### PR TITLE
Incorrect heading hierarchy on `performance/how_long_is_too_long` reference

### DIFF
--- a/files/en-us/web/performance/how_long_is_too_long/index.html
+++ b/files/en-us/web/performance/how_long_is_too_long/index.html
@@ -19,11 +19,11 @@ tags:
 
 <p>In optimizing for performance, do set an ambitious first load goal, such as 5 seconds over the mobile 3G network and 1.5 seconds on an office T1 line, with even more ambitious page load goals for subsequent page loads, leveraging service workers and caching. There are different suggested times for initially loading the page versus loading additional assets, responding to user interaction, and ensuring smooth animations:</p>
 
-<h3 id="Idling_goal">Idling goal</h3>
+<h2 id="Idling_goal">Idling goal</h2>
 
 <p>Browsers are single threaded (though background threads are supported for web workers). This means that user interaction, painting, and script execution are all on the same thread. If the thread is busy doing complex JavaScript execution, the main thread will not be available to react to user input, such as pressing a button. For this reason, script execution should be limited in scope, divided into chunks of code that can be executed in 50ms or less. This makes the thread available for user interactions.</p>
 
-<h3 id="Animation_goal">Animation goal</h3>
+<h2 id="Animation_goal">Animation goal</h2>
 
 <p>For scrolling and other animations to look smooth and feel responsive, the content repaints should occur at 60 frames per second (60fps), which is once every 16.7ms. The 16.7 milliseconds includes scripting, reflow, and repaint. Realize a document takes about 6ms to render a frame, leaving about 10ms for the rest. Anything less than 60fps, especially an un-even or changing frame rate, will appear janky.</p>
 

--- a/files/en-us/web/performance/how_long_is_too_long/index.html
+++ b/files/en-us/web/performance/how_long_is_too_long/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>There are no clear set rules as to what constitutes a slow pace when loading pages, but there are specific guidelines for indicating content will load (1 second), idling (50ms), animating (16.7s) and responding to user input (50 to 200ms).</p>
 
-<h2 id="Load_goal">Load goal</h3>
+<h2 id="Load_goal">Load goal</h2>
 
 <p>The  'Under a second' is often touted as optimal for load, but what does that mean? A second should be considered a rule in the maximum amount of time to indicate to a user that the request for new content was made and will load, such as the browser displaying the page title and the background color of the page displaying. </p>
 

--- a/files/en-us/web/performance/how_long_is_too_long/index.html
+++ b/files/en-us/web/performance/how_long_is_too_long/index.html
@@ -27,6 +27,6 @@ tags:
 
 <p>For scrolling and other animations to look smooth and feel responsive, the content repaints should occur at 60 frames per second (60fps), which is once every 16.7ms. The 16.7 milliseconds includes scripting, reflow, and repaint. Realize a document takes about 6ms to render a frame, leaving about 10ms for the rest. Anything less than 60fps, especially an un-even or changing frame rate, will appear janky.</p>
 
-<h3 id="Responsiveness_goal">Responsiveness goal</h3>
+<h2 id="Responsiveness_goal">Responsiveness goal</h2>
 
 <p>When the user interacts with content, it is important to provide feedback and acknowledge the user's response or interaction and to do so within 100ms, preferably within 50ms. 50ms seconds feels immediate. The acknowledgment of user interaction should often feel immediate, such as a hover or button press, but that doesn't mean the completed response should be instantaneous. While a slower than 100ms reaction may create a disconnect between the user interaction and the response, a 100 to 200ms transition for a response may help the user notice the response their interaction initiated, such as a menu opening.  If a response takes longer than 100ms  to complete, provide some form of feedback to inform the user the interaction has occurred.</p>

--- a/files/en-us/web/performance/how_long_is_too_long/index.html
+++ b/files/en-us/web/performance/how_long_is_too_long/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>There are no clear set rules as to what constitutes a slow pace when loading pages, but there are specific guidelines for indicating content will load (1 second), idling (50ms), animating (16.7s) and responding to user input (50 to 200ms).</p>
 
-<h3 id="Load_goal">Load goal</h3>
+<h2 id="Load_goal">Load goal</h3>
 
 <p>The  'Under a second' is often touted as optimal for load, but what does that mean? A second should be considered a rule in the maximum amount of time to indicate to a user that the request for new content was made and will load, such as the browser displaying the page title and the background color of the page displaying. </p>
 


### PR DESCRIPTION
This PR fixes an incorrect heading hierarchy on the `performance/how_long_is_too_long` reference.