### PR TITLE
Page macro: Document:Adoptnode - Replace macro with text in a note

### DIFF
--- a/files/en-us/web/api/document/importnode/index.html
+++ b/files/en-us/web/api/document/importnode/index.html
@@ -14,10 +14,9 @@ browser-compat: api.Document.importNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p><span class="seoSummary">The {{domxref("Document")}} object's
-    <strong><code>importNode()</code></strong> method creates a copy of a
+<p>The {{domxref("Document")}} object's <strong><code>importNode()</code></strong> method creates a copy of a
     {{domxref("Node")}} or {{domxref("DocumentFragment")}} from another document, to be
-    inserted into the current document later.</span></p>
+    inserted into the current document later.</p>
 
 <p>The imported node is not yet included in the document tree. To include it, you need to
   call an insertion method such as {{domxref("Node.appendChild", "appendChild()")}} or
@@ -29,8 +28,8 @@ browser-compat: api.Document.importNode
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">const <var>importedNode</var> = document.importNode(<var>externalNode</var> [, <var>deep</var>]);
-</pre>
+<pre class="brush: js">importNode(externalNode)
+importNode(externalNode, deep)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -57,9 +56,7 @@ browser-compat: api.Document.importNode
 </p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> <code><var>importedNode</var></code>'s
-    {{domxref("Node.parentNode")}} is <code>null</code>, since it has not yet been
-    inserted into the document tree!</p>
+  <p><strong>Note:</strong> <code>importedNode</code>'s {{domxref("Node.parentNode")}} is <code>null</code>, since it has not yet been inserted into the document tree!</p>
 </div>
 
 <h2 id="Example">Example</h2>
@@ -72,7 +69,18 @@ document.getElementById("container").appendChild(newNode);
 
 <h2 id="Notes">Notes</h2>
 
-<p>{{page("/en-US/docs/Web/API/Document/adoptNode", "Notes")}}</p>
+<p>Before they can be inserted into the current document, nodes from external documents should either be:</p>
+
+<ul>
+  <li>cloned using {{domXref("document.importNode()")}}; or</li>
+  <li>adopted using {{domXref("document.adoptNode()")}}.</li>
+</ul>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> Although Firefox doesn't currently enforce this rule, we encourage you to follow this rule for improved future compatibility.</p>
+</div>
+
+<p>For more on the {{domXref("Node.ownerDocument")}} issues, see the W3C DOM FAQ.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196 - replaces a page inclusion macro with the actual text it was including (a note in `Document.importnode`)

Also did a little general tidy - e.g. fix syntax box and remove seosummary in a class.