### PR TITLE
Page macro: FileReaderSync - include rather than transclude exceptions

### DIFF
--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -33,7 +33,24 @@ readAsBinaryString(<em>Blob</em>);
 
 <h2 id="Exceptions">Exceptions</h2>
 
-<p>{{page("Web/API/FileReaderSync/readAsArrayBuffer","Exceptions")}}</p>
+<p>The following exceptions can be raised by this method:</p>
+
+<dl>
+ <dt><code>NotFoundError</code></dt>
+ <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
+ <dt><code>SecurityError</code></dt>
+ <dd>is raised when one of the following problematic situation is detected:
+ <ul>
+  <li>the resource has been modified by a third party;</li>
+  <li>too many read are performed simultaneously;</li>
+  <li>the file pointed by the resource is unsafe for a use from the Web (like it is a system file).</li>
+ </ul>
+ </dd>
+ <dt><code>NotReadableError</code></dt>
+ <dd>is raised when the resource cannot be read due to a permission problem, like a concurrent lock.</dd>
+ <dt><code>EncodingError</code></dt>
+ <dd>is raised when the resource is a data URL and exceed the limit length defined by each browser.</dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.html
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.html
@@ -26,7 +26,24 @@ readAsDataURL(<em>Blob</em>);
 
 <h2 id="Exceptions">Exceptions</h2>
 
-<p>{{page("Web/API/FileReaderSync/readAsArrayBuffer","Exceptions")}}</p>
+<p>The following exceptions can be raised by this method:</p>
+
+<dl>
+ <dt><code>NotFoundError</code></dt>
+ <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
+ <dt><code>SecurityError</code></dt>
+ <dd>is raised when one of the following problematic situation is detected:
+ <ul>
+  <li>the resource has been modified by a third party;</li>
+  <li>too many read are performed simultaneously;</li>
+  <li>the file pointed by the resource is unsafe for a use from the Web (like it is a system file).</li>
+ </ul>
+ </dd>
+ <dt><code>NotReadableError</code></dt>
+ <dd>is raised when the resource cannot be read due to a permission problem, like a concurrent lock.</dd>
+ <dt><code>EncodingError</code></dt>
+ <dd>is raised when the resource is a data URL and exceed the limit length defined by each browser.</dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/filereadersync/readastext/index.html
+++ b/files/en-us/web/api/filereadersync/readastext/index.html
@@ -30,7 +30,24 @@ readAsText(<em>Blob</em>, <em>encoding</em>);
 
 <h2 id="Exceptions">Exceptions</h2>
 
-<p>{{page("Web/API/FileReaderSync/readAsArrayBuffer","Exceptions")}}</p>
+<p>The following exceptions can be raised by this method:</p>
+
+<dl>
+ <dt><code>NotFoundError</code></dt>
+ <dd>is raised when the resource represented by the DOM {{DOMxRef("File")}} or {{DOMxRef("Blob")}} cannot be found, e.g. because it has been erased.</dd>
+ <dt><code>SecurityError</code></dt>
+ <dd>is raised when one of the following problematic situation is detected:
+ <ul>
+  <li>the resource has been modified by a third party;</li>
+  <li>too many read are performed simultaneously;</li>
+  <li>the file pointed by the resource is unsafe for a use from the Web (like it is a system file).</li>
+ </ul>
+ </dd>
+ <dt><code>NotReadableError</code></dt>
+ <dd>is raised when the resource cannot be read due to a permission problem, like a concurrent lock.</dd>
+ <dt><code>EncodingError</code></dt>
+ <dd>is raised when the resource is a data URL and exceed the limit length defined by each browser.</dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

In `FileReaderSync` some of the sub pages were transcluding a list of exceptions. This just duplicates that information.