### PR TITLE
WebDriver conformance changes for Firefox 91

### DIFF
--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -80,8 +80,10 @@ tags:
 <h4 id="removals_wasm">Removals</h4>
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
-
-<h4 id="removals_webdriver">Removals</h4>
+<ul>
+  <li>Fixed a bug, which caused the commands <code>WebDriver:AcceptAlert</code> and <code>WebDriver:DismissAlert</code> to hang for user prompts as opened by a popup window ({{bug(1721982)}}).</li>
+  <li>Fixed an inappropriate handling of the <code>webSocketUrl</code> capability, which would return <code>true</code> if <code>webSocketUrl</code> was not supported ({{bug(1713775)}}).</li>
+</ul>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -81,7 +81,7 @@ tags:
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 <ul>
-  <li>Fixed a bug, which caused the commands <code>WebDriver:AcceptAlert</code> and <code>WebDriver:DismissAlert</code> to hang for user prompts as opened by a popup window ({{bug(1721982)}}).</li>
+  <li>Fixed a bug, which caused the commands <code>WebDriver:AcceptAlert</code> and <code>WebDriver:DismissAlert</code> to hang for user prompts as opened in a popup window ({{bug(1721982)}}).</li>
   <li>Fixed an inappropriate handling of the <code>webSocketUrl</code> capability, which would return <code>true</code> if <code>webSocketUrl</code> was not supported ({{bug(1713775)}}).</li>
 </ul>
 


### PR DESCRIPTION
The following PR contains all the user facing changes to Marionette for the Firefox 91 release. Here a [list of all the changes](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&f1=cf_status_firefox91&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&f2=cf_status_firefox91&v1=fixed&component=Marionette&v2=verified&product=Testing&).

@whimboo can you please cross-check? Thanks.