### PR TITLE
fixed Digit0..Digit9 Windows scancodes

### DIFF
--- a/files/en-us/web/api/keyboardevent/code/code_values/index.html
+++ b/files/en-us/web/api/keyboardevent/code/code_values/index.html
@@ -38,53 +38,53 @@ when using it. </p>
   </tr>
   <tr>
    <th scope="row"><code>0x0002</code></th>
-   <td><code>"Digit0"</code></td>
-   <td><code>"Digit0"</code></td>
+   <td><code>"Digit1"</code></td>
+   <td><code>"Digit1"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0003</code></th>
-   <td><code>"Digit1"</code></td>
-   <td><code>"Digit1"</code></td>
+   <td><code>"Digit2"</code></td>
+   <td><code>"Digit2"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0004</code></th>
-   <td><code>"Digit2"</code></td>
-   <td><code>"Digit2"</code></td>
+   <td><code>"Digit3"</code></td>
+   <td><code>"Digit3"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0005</code></th>
-   <td><code>"Digit3"</code></td>
-   <td><code>"Digit3"</code></td>
+   <td><code>"Digit4"</code></td>
+   <td><code>"Digit4"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0006</code></th>
-   <td><code>"Digit4"</code></td>
-   <td><code>"Digit4"</code></td>
+   <td><code>"Digit5"</code></td>
+   <td><code>"Digit5"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0007</code></th>
-   <td><code>"Digit5"</code></td>
-   <td><code>"Digit5"</code></td>
+   <td><code>"Digit6"</code></td>
+   <td><code>"Digit6"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0008</code></th>
-   <td><code>"Digit6"</code></td>
-   <td><code>"Digit6"</code></td>
+   <td><code>"Digit7"</code></td>
+   <td><code>"Digit7"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0009</code></th>
-   <td><code>"Digit7"</code></td>
-   <td><code>"Digit7"</code></td>
+   <td><code>"Digit8"</code></td>
+   <td><code>"Digit8"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x000A</code></th>
-   <td><code>"Digit8"</code></td>
-   <td><code>"Digit8"</code></td>
+   <td><code>"Digit9"</code></td>
+   <td><code>"Digit9"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x000B</code></th>
-   <td><code>"Digit9"</code></td>
-   <td><code>"Digit9"</code></td>
+   <td><code>"Digit0"</code></td>
+   <td><code>"Digit0"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x000C</code></th>


### PR DESCRIPTION
Digit0, Digit1, ..., Digit9 were off by 1.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

No PR

> What was wrong/why is this fix needed? (quick summary only)

Digit0, Digit1, ..., Digit9 Windows scancodes were off by 1.

> Anything else that could help us review it

