### PR TITLE
Add secure context banner to main XR page & navigator.xr

### DIFF
--- a/files/en-us/web/api/navigator/xr/index.html
+++ b/files/en-us/web/api/navigator/xr/index.html
@@ -16,7 +16,7 @@ tags:
 - XR
 browser-compat: api.Navigator.xr
 ---
-<div>{{APIRef("WebXR Device API")}}</div>
+<div>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</div>
 
 <p>The read-only <code><strong>xr</strong></code> property
 provided by the {{domxref("Navigator")}}  interface returns an {{domxref("XRSystem")}} object

--- a/files/en-us/web/api/webxr_device_api/index.html
+++ b/files/en-us/web/api/webxr_device_api/index.html
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
   - XR
 ---
-<p>{{DefaultAPISidebar("WebXR Device API")}}</p>
+<p>{{DefaultAPISidebar("WebXR Device API")}} {{SecureContext_Header}}</p>
 
 <p><span class="seoSummary"><strong>WebXR</strong> is a group of standards which are used together to support rendering 3D scenes to hardware designed for presenting virtual worlds (<strong>virtual reality</strong>, or <strong>VR</strong>), or for adding graphical imagery to the real world, (<strong>augmented reality</strong>, or <strong>AR</strong>).</span> The <strong>WebXR Device API</strong> implements the core of the WebXR feature set, managing the selection of output devices, render the 3D scene to the chosen device at the appropriate frame rate, and manage motion vectors created using input controllers.</p>
 


### PR DESCRIPTION
See the discussion on https://github.com/mdn/content/pull/7070#issuecomment-891053929

It makes sense to add a secure context banner to the main XR landing page and to the navigator.xr property which is an entry point to the API.