### PR TITLE
Add WebXR Anchors reference pages

### DIFF
--- a/files/en-us/web/api/xranchor/anchorspace/index.html
+++ b/files/en-us/web/api/xranchor/anchorspace/index.html
@@ -1,0 +1,38 @@
+---
+title: XRAnchor.anchorSpace
+slug: Web/API/XRAnchor/anchorSpace
+tags:
+- API
+- Property
+- Reference
+- AR
+- VR
+- XR
+- WebXR
+browser-compat: api.XRAnchor.anchorSpace
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The read-only <code><strong>anchorSpace</strong></code> property of the {{domxref("XRAnchor")}} interface returns an {{domxref("XRSpace")}} object to locate the anchor relative to other <code>XRSpace</code> objects. It can be passed to {{domxref("XRFrame.getPose()")}} subsequently.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An {{domxref("XRSpace")}} object.</p>
+
+<h2>Examples</h2>
+
+<h3>Updating anchors</h3>
+
+<pre class="brush: js">
+for (const anchor of frame.trackedAnchors) {
+  const pose = frame.getPose(anchor.anchorSpace, referenceSpace);
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xranchor/delete/index.html
+++ b/files/en-us/web/api/xranchor/delete/index.html
@@ -1,0 +1,53 @@
+---
+title: XRAnchor.delete()
+slug: Web/API/XRAnchor/delete
+tags:
+- API
+- Method
+- Reference
+- AR
+- VR
+- XR
+- WebXR
+browser-compat: api.XRAnchor.delete
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <code><strong>delete()</strong></code> method of the {{domxref("XRAnchor")}} interface removes an anchor. This can be useful when an application is no longer interested in receiving updates to an anchor.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">delete()</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>Returns {{jsxref("undefined")}}.</p>
+
+<h2>Examples</h2>
+
+<h3>Removing all anchors</h3>
+
+<pre class="brush: js">
+let anchorsCollection = new Set();
+
+// Upon creating anchors, add them to the Set
+// anchorsCollection.add(anchor);
+
+for (const anchor of anchorsCollection) {
+  anchor.delete();
+}
+
+anchorsCollection.clear();
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xranchor/index.html
+++ b/files/en-us/web/api/xranchor/index.html
@@ -13,7 +13,7 @@ browser-compat: api.XRAnchor
 ---
 <p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
 
-<p>The <code><strong>XRAnchor</strong></code> interface creates anchors which keep track of the pose that is fixed relative to the real world. With anchors, you can specify poses in the world that need to be updated to correctly reflect the evolving understanding of the world, such that the poses remain aligned with the same place in the physical world. The helps to build an illusion that the placed objects are really present in the user’s environment.</p>
+<p>The <code><strong>XRAnchor</strong></code> interface creates anchors which keep track of the pose that is fixed relative to the real world. With anchors, you can specify poses in the world that need to be updated to correctly reflect the evolving understanding of the world, such that the poses remain aligned with the same place in the physical world. That helps to build an illusion that the placed objects are really present in the user’s environment.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/xranchor/index.html
+++ b/files/en-us/web/api/xranchor/index.html
@@ -1,0 +1,71 @@
+---
+title: XRAnchor
+slug: Web/API/XRAnchor
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRAnchor
+---
+<p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
+
+<p>The <code><strong>XRAnchor</strong></code> interface creates anchors which keep track of the pose that is fixed relative to the real world. With anchors, you can specify poses in the world that need to be updated to correctly reflect the evolving understanding of the world, such that the poses remain aligned with the same place in the physical world. The helps to build an illusion that the placed objects are really present in the user’s environment.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+ <dt>{{domxref("XRAnchor.anchorSpace")}} {{ReadOnlyInline}}</dt>
+ <dd>Returns an {{domxref("XRSpace")}} object to locate the anchor relative to other <code>XRSpace</code> objects.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("XRAnchor.delete()")}}</dt>
+  <dd>Removes the anchor.</dd>
+</dl>
+
+<h2>Examples</h2>
+
+<h3>Requesting a session with anchors enabled</h3>
+
+<pre class="brush: js">
+navigator.xr.requestSession("immersive-ar", {
+  requireFeatures: ["anchors"],
+}
+</pre>
+
+<h3>Adding anchors</h3>
+
+<p>You can use {{domxref("XRFrame.createAnchor()")}} to create an anchor.</p>
+
+<pre class="brush: js">
+frame.createAnchor(anchorPose, referenceSpace).then((anchor) => {
+
+  // Do stuff with the anchor (assign objects that will be relative to this anchor)
+
+}, (error) => {
+  console.error("Could not create anchor: "" + error);
+});
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRAnchorSet")}}</li>
+  <li>{{domxref("XRFrame.createAnchor()")}}</li>
+  <li>{{domxref("XRFrame.trackedAnchors")}}</li>
+  <li>{{domxref("XRHitTestResult.createAnchor()")}}</li>
+</ul>

--- a/files/en-us/web/api/xranchorset/index.html
+++ b/files/en-us/web/api/xranchorset/index.html
@@ -1,0 +1,53 @@
+---
+title: XRAnchorSet
+slug: Web/API/XRAnchorSet
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRAnchorSet
+---
+<p>{{APIRef("WebXR Device API")}}</p>
+
+<p>The <code><strong>XRAnchorSet</strong></code> interface exposes a collection of anchors. It is returned by {{domxref("XRFrame.trackedAnchors")}} and is a {{jsxref("Set")}}-like object.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p>See {{jsxref("Set")}} for details.</p>
+
+<h2 id="Methods">Methods</h2>
+
+<p>See {{jsxref("Set")}} for details.</p>
+
+<h2>Examples</h2>
+
+<h3>Handling anchor tracking loss</h3>
+
+<pre class="brush: js">
+const trackedAnchors = frame.trackedAnchors;
+
+for (const anchor of previousFrameAnchors) {
+  if (!trackedAnchors.has(anchor)) {
+    // Handle anchor tracking loss
+  }
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRAnchor")}}</li>
+  <li>{{domxref("XRFrame.trackedAnchors")}}</li>
+</ul>

--- a/files/en-us/web/api/xrframe/createanchor/index.html
+++ b/files/en-us/web/api/xrframe/createanchor/index.html
@@ -1,0 +1,55 @@
+---
+title: XRFrame.createAnchor()
+slug: Web/API/XRFrame/createAnchor
+tags:
+- API
+- Method
+- Reference
+- AR
+- VR
+- XR
+- WebXR
+browser-compat: api.XRFrame.createAnchor
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <code><strong>createAnchor()</strong></code> method of the {{domxref("XRFrame")}} interface creates a free-floating {{domxref("XRAnchor")}} which will be fixed relative to the real world.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">createAnchor(pose, space)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>pose</code></dt>
+  <dd>An {{domxref("XRRigidTransform")}} object with the initial pose where the anchor should be created. The system will make sure that the relationship with the physical world made at this moment in time is maintained as the tracking system's understanding of the world evolves.</dd>
+  <dt><code>space</code></dt>
+  <dd>An {{domxref("XRSpace")}} object the pose is relative to.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>A {{jsxref("Promise")}} resolving to an {{domxref("XRAnchor")}} object.</p>
+
+<h2>Examples</h2>
+
+<h3>Creating an anchor</h3>
+
+<pre class="brush: js">
+frame.createAnchor(anchorPose, referenceSpace).then((anchor) => {
+
+  // Do stuff with the anchor (assign objects that will be relative to this anchor)
+
+}, (error) => {
+  console.error("Could not create anchor: "" + error);
+});
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrframe/index.html
+++ b/files/en-us/web/api/xrframe/index.html
@@ -29,11 +29,15 @@ browser-compat: api.XRFrame
 <dl>
  <dt>{{DOMxRef("XRFrame.session", "session")}} {{ReadonlyInline}}</dt>
  <dd>The {{DOMxRef("XRSession")}} that for which this <code>XRFrame</code> describes the tracking details for all objects. The information about a specific object can be obtained by calling one of the methods on the object.</dd>
+ <dt>{{DOMxRef("XRFrame.trackedAnchors", "trackedAnchors")}} {{ReadonlyInline}}</dt>
+ <dd>An {{domxref("XRAnchorSet")}} containing all anchors still tracked in the frame.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
 
 <dl>
+ <dt>{{domxref("XRFrame.createAnchor()", "createAnchor()")}}</dt>
+ <dd>Returns a {{jsxref("Promise")}} which resolves to a free-floating {{domxref("XRAnchor")}} object.</dd>
  <dt>{{DOMxRef("XRFrame.getPose", "getPose()")}}</dt>
  <dd>Returns an {{domxref("XRPose")}} object representing the spatial relationship between the two specified {{domxref("XRSpace")}} objects.</dd>
  <dt>{{DOMxRef("XRFrame.getViewerPose", "getViewerPose()")}}</dt>

--- a/files/en-us/web/api/xrframe/trackedanchors/index.html
+++ b/files/en-us/web/api/xrframe/trackedanchors/index.html
@@ -1,0 +1,38 @@
+---
+title: XRFrame.trackedAnchors
+slug: Web/API/XRFrame/trackedAnchors
+tags:
+- API
+- Property
+- Reference
+- AR
+- VR
+- XR
+- WebXR
+browser-compat: api.XRFrame.trackedAnchors
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The read-only <code><strong>trackedAnchor</strong></code> property of the {{domxref("XRFrame")}} interface returns an {{domxref("XRAnchorSet")}} object containing all anchors still tracked in the frame.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An {{domxref("XRAnchorSet")}} object.</p>
+
+<h2>Examples</h2>
+
+<h3>Updating anchors</h3>
+
+<pre class="brush: js">
+for (const anchor of frame.trackedAnchors) {
+  const pose = frame.getPose(anchor.anchorSpace, referenceSpace);
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrsystem/requestsession/index.html
+++ b/files/en-us/web/api/xrsystem/requestsession/index.html
@@ -103,6 +103,8 @@ browser-compat: api.XRSystem.requestSession
 <h2 id="Session_features">Session features</h2>
 
 <dl>
+  <dt><code>anchor</code></dt>
+  <dd>Enable use of {{domxref("XRAnchor")}} objects.</dd>
   <dt><code>bounded-floor</code></dt>
   <dd>Similar to the <code>local</code> type, except the user is not expected to move outside a predetermined boundary, given by the {{domxref("XRBoundedReferenceSpace.boundsGeometry", "boundsGeometry")}} in the returned object.</dd>
   <dt><code>dom-overlay</code></dt>


### PR DESCRIPTION
Adds reference pages for https://immersive-web.github.io/anchors/ 

(Except for `XRHitTestResult.createAnchor`: the Hit Test module is also entirely undocumented yet, so no `XRHitTestResult` page yet).