### PR TITLE
Fix broken fragment in “Handling text — strings in JavaScript”

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -90,7 +90,7 @@ dblSgl;</pre>
 <pre class="brush: js">let bigmouth = 'I\'ve got no right to take my place...';
 bigmouth;</pre>
 
-<p>This works fine. You can escape other characters in the same way, e.g. <code>\"</code>,  and there are some special codes besides. See <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_notation">Escape notation</a> for more details.</p>
+<p>This works fine. You can escape other characters in the same way, e.g. <code>\"</code>,  and there are some special codes besides. See <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences">Escape sequences</a> for more details.</p>
 
 <h2 id="Concatenating_strings">Concatenating strings</h2>
 


### PR DESCRIPTION
URI fragment in link was incorrect. Updated link and changed link text to match the target section heading.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
Link was broken, so it led to the top of the page rather than the desired section heading.


> Anything else that could help us review it
