### PR TITLE
Fix invalid classes and IDs in Web/HTTP (md conversion)

### DIFF
--- a/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.html
+++ b/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.html
@@ -59,7 +59,7 @@ tags:
 
 <h2 id="Deciding_the_case">Deciding the case</h2>
 
-<p class="entry-title">This is a very subjective topic it could be considered a <a href="https://bikeshed.com/">bikeshedding</a> issue. If you wish to read deeper, please see some of the <a href="https://www.netlify.com/blog/2017/02/28/to-www-or-not-www/">many</a> <a href="https://www.wpbeginner.com/beginners-guide/www-vs-non-www-which-is-better-for-wordpress-seo/">articles</a> on the subject.</p>
+<p>This is a very subjective topic it could be considered a <a href="https://bikeshed.com/">bikeshedding</a> issue. If you wish to read deeper, please see some of the <a href="https://www.netlify.com/blog/2017/02/28/to-www-or-not-www/">many</a> <a href="https://www.wpbeginner.com/beginners-guide/www-vs-non-www-which-is-better-for-wordpress-seo/">articles</a> on the subject.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/basics_of_http/mime_types/index.html
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.html
@@ -178,7 +178,7 @@ tags:
 
 <h4 id="Multipart_types">Multipart types</h4>
 
-<p id="sect1"><strong>Multipart</strong> types indicate a category of document broken into
+<p><strong>Multipart</strong> types indicate a category of document broken into
   pieces, often with different MIME types; they can also be used — especially in email
   scenarios — to represent multiple, separate files which are all part of the same
   transaction. They represent a <strong>composite document</strong>.</p>

--- a/files/en-us/web/http/conditional_requests/index.html
+++ b/files/en-us/web/http/conditional_requests/index.html
@@ -41,7 +41,7 @@ tags:
 
 <h3 id="Strong_validation">Strong validation</h3>
 
-<p id="sect1">Strong validation consists of guaranteeing that the resource is, byte to byte, identical to the one it is compared too. This is mandatory for some conditional headers, and the default for the others. Strong validation is very strict and may be difficult to guarantee at the server level, but it does guarantee no data loss at any time, sometimes at the expense of performance.</p>
+<p>Strong validation consists of guaranteeing that the resource is, byte to byte, identical to the one it is compared too. This is mandatory for some conditional headers, and the default for the others. Strong validation is very strict and may be difficult to guarantee at the server level, but it does guarantee no data loss at any time, sometimes at the expense of performance.</p>
 
 <p>It is quite difficult to have a unique identifier for strong validation with {{HTTPHeader("Last-Modified")}}. Often this is done using an {{HTTPHeader("ETag")}} with the MD5 hash of the resource (or a derivative).</p>
 

--- a/files/en-us/web/http/cookies/index.html
+++ b/files/en-us/web/http/cookies/index.html
@@ -60,7 +60,7 @@ Set-Cookie: tasty_cookie=strawberry
 
 [page content]</pre>
 
-<p id="The_client_sends_back_to_the_server_its_cookies_previously_stored">Then, with every subsequent request to the server, the browser sends back all previously stored cookies to the server using the {{HTTPHeader("Cookie")}} header.</p>
+<p>Then, with every subsequent request to the server, the browser sends back all previously stored cookies to the server using the {{HTTPHeader("Cookie")}} header.</p>
 
 <pre>GET /sample_page.html HTTP/2.0
 Host: www.example.org

--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -60,7 +60,7 @@ tags:
 
 <h3 id="Simple_requests">Simple requests</h3>
 
-<p>Some requests don’t trigger a <a href="#preflighted_requests">CORS preflight</a>. Those are called <em>“simple requests”</em> in this article, though the {{SpecName('Fetch')}} spec (which defines CORS) doesn’t use that term. A “simple request” is one that <strong>meets all the following conditions</strong>:</p>
+<p>Some requests don't trigger a {{Glossary("Preflight_request","CORS preflight")}}. Those are called <em>simple requests</em>, though the {{SpecName('Fetch')}} spec (which defines CORS) doesn't use that term. A <em>simple request</em> is one that <strong>meets all the following conditions</strong>:</p>
 
 <ul>
  <li>One of the allowed methods:
@@ -70,7 +70,7 @@ tags:
    <li>{{HTTPMethod("POST")}}</li>
   </ul>
  </li>
- <li>Apart from the headers automatically set by the user agent (for example, {{HTTPHeader("Connection")}}, {{HTTPHeader("User-Agent")}}, or <a href="https://fetch.spec.whatwg.org/#forbidden-header-name">the other headers defined in the Fetch spec as a “forbidden header name”</a>), the only headers which are allowed to be manually set are <a href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header">those which the Fetch spec defines as a “CORS-safelisted request-header”</a>, which are:
+ <li>Apart from the headers automatically set by the user agent (for example, {{HTTPHeader("Connection")}}, {{HTTPHeader("User-Agent")}}, or <a href="https://fetch.spec.whatwg.org/#forbidden-header-name">the other headers defined in the Fetch spec as a <em>forbidden header name</em></a>), the only headers which are allowed to be manually set are <a href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header">those which the Fetch spec defines as a </em>CORS-safelisted request-header</em></a>, which are:
   <ul>
    <li>{{HTTPHeader("Accept")}}</li>
    <li>{{HTTPHeader("Accept-Language")}}</li>
@@ -99,7 +99,7 @@ tags:
   <p>No other browsers implement these extra restrictions, because they're not part of the spec.</p>
 </div>
 
-<p>For example, suppose web content at <code class="plain">https://foo.example</code> wishes to invoke content on domain <code class="plain">https://bar.other</code>. Code of this sort might be used in JavaScript deployed on <code>foo.example</code>:</p>
+<p>For example, suppose web content at <code>https://foo.example</code> wishes to invoke content on domain <code>https://bar.other</code>. Code of this sort might be used in JavaScript deployed on <code>foo.example</code>:</p>
 
 <pre class="brush: js">const xhr = new XMLHttpRequest();
 const url = 'https://bar.other/resources/public-data/';
@@ -125,7 +125,7 @@ Connection: keep-alive
 <strong>Origin: https://foo.example</strong>
 </pre>
 
-<p>The request header of note is {{HTTPHeader("Origin")}}, which shows that the invocation is coming from <code class="plain">https://foo.example</code>.</p>
+<p>The request header of note is {{HTTPHeader("Origin")}}, which shows that the invocation is coming from <code>https://foo.example</code>.</p>
 
 <pre>HTTP/1.1 200 OK
 Date: Mon, 01 Dec 2008 00:23:53 GMT
@@ -142,9 +142,9 @@ Content-Type: application/xml
 
 <pre class="brush: html">Access-Control-Allow-Origin: *</pre>
 
-<p>This pattern of the {{HTTPHeader("Origin")}} and {{HTTPHeader("Access-Control-Allow-Origin")}} headers is the simplest use of the access control protocol. If the resource owners at <code class="plain">https://bar.other</code> wished to restrict access to the resource to requests <em>only</em> from <code class="plain">https://foo.example</code>, (i.e no domain other than <code class="plain">https://foo.example</code> can access the resource in a cross-site manner) they would send:</p>
+<p>This pattern of the {{HTTPHeader("Origin")}} and {{HTTPHeader("Access-Control-Allow-Origin")}} headers is the simplest use of the access control protocol. If the resource owners at <code>https://bar.other</code> wished to restrict access to the resource to requests <em>only</em> from <code>https://foo.example</code>, (i.e no domain other than <code>https://foo.example</code> can access the resource in a cross-site manner) they would send:</p>
 
-<pre><code class="plain">Access-Control-Allow-Origin: https://foo.example</code>
+<pre><code>Access-Control-Allow-Origin: https://foo.example</code>
 </pre>
 
 <div class="notecard note">
@@ -153,7 +153,7 @@ Content-Type: application/xml
 
 <h3 id="Preflighted_requests">Preflighted requests</h3>
 
-<p>Unlike <a href="#simple_requests">“simple requests” (discussed above)</a>, for "preflighted" requests the browser first sends an HTTP request using the {{HTTPMethod("OPTIONS")}} method to the resource on the other origin, in order to determine if the actual request is safe to send. Cross-site requests are preflighted like this since they may have implications to user data.</p>
+<p>Unlike <a href="#simple_requests"><em>simple requests</em> </a>, for "preflighted" requests the browser first sends an HTTP request using the {{HTTPMethod("OPTIONS")}} method to the resource on the other origin, in order to determine if the actual request is safe to send. Cross-site requests are preflighted like this since they may have implications to user data.</p>
 
 <p>The following is an example of a request that will be preflighted:</p>
 
@@ -277,7 +277,7 @@ Content-Type: text/plain
 
 <ol>
  <li>Make a <a href="#simple_requests">simple request</a> (using {{domxref("Response.url")}} for the Fetch API, or {{domxref("XMLHttpRequest.responseURL")}}) to determine what URL the real preflighted request would end up at.</li>
- <li>Make another request (the “real” request) using the URL you obtained from <code>Response.url</code> or <code>XMLHttpRequest.responseURL</code> in the first step.</li>
+ <li>Make another request (the <em>real</em> request) using the URL you obtained from <code>Response.url</code> or <code>XMLHttpRequest.responseURL</code> in the first step.</li>
 </ol>
 
 <p>However, if the request is one that triggers a preflight due to the presence of the <code>Authorization</code> header in the request, you won't be able to work around the limitation using the steps above. And you won't be able to work around it at all unless you have control over the server the request is being made to.</p>
@@ -290,7 +290,7 @@ Content-Type: text/plain
 
 <p>The most interesting capability exposed by both {{domxref("XMLHttpRequest")}} or <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> and CORS is the ability to make "credentialed" requests that are aware of <a href="/en-US/docs/Web/HTTP/Cookies">HTTP cookies</a> and HTTP Authentication information. By default, in cross-site <code>XMLHttpRequest</code> or <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> invocations, browsers will <strong>not</strong> send credentials. A specific flag has to be set on the <code>XMLHttpRequest</code> object or the {{domxref("Request")}} constructor when it is invoked.</p>
 
-<p>In this example, content originally loaded from <code class="plain">https://foo.example</code> makes a simple GET request to a resource on <code class="plain">https://bar.other</code> which sets Cookies. Content on foo.example might contain JavaScript like this:</p>
+<p>In this example, content originally loaded from <code>https://foo.example</code> makes a simple GET request to a resource on <code>https://bar.other</code> which sets Cookies. Content on foo.example might contain JavaScript like this:</p>
 
 <pre class="brush: js">const invocation = new XMLHttpRequest();
 const url = 'https://bar.other/resources/credentialed-content/';
@@ -339,7 +339,7 @@ Content-Type: text/plain
 [text/plain payload]
 </pre>
 
-<p>Although line 10 contains the Cookie destined for the content on <code class="plain">https://bar.other</code>, if bar.other did not respond with an {{HTTPHeader("Access-Control-Allow-Credentials")}}<code>: true</code> (line 17) the response would be ignored and not made available to web content.</p>
+<p>Although line 10 contains the Cookie destined for the content on <code>https://bar.other</code>, if bar.other did not respond with an {{HTTPHeader("Access-Control-Allow-Credentials")}}<code>: true</code> (line 17) the response would be ignored and not made available to web content.</p>
 
 <h4 id="Preflight_requests_and_credentials">Preflight requests and credentials</h4>
 
@@ -354,7 +354,7 @@ Content-Type: text/plain
 
 <p>When responding to a credentialed request, the server <strong>must</strong> specify an origin in the value of the <code>Access-Control-Allow-Origin</code> header, instead of specifying the "<code>*</code>" wildcard.</p>
 
-<p>Because the request headers in the above example include a <code>Cookie</code> header, the request would fail if the value of the <code>Access-Control-Allow-Origin</code> header was "*". But it does not fail: Because the value of the <code>Access-Control-Allow-Origin</code> header is "<code class="plain">https://foo.example</code>" (an actual origin) rather than the "<code>*</code>" wildcard, the credential-cognizant content is returned to the invoking web content.</p>
+<p>Because the request headers in the above example include a <code>Cookie</code> header, the request would fail if the value of the <code>Access-Control-Allow-Origin</code> header was "*". But it does not fail: Because the value of the <code>Access-Control-Allow-Origin</code> header is "<code>https://foo.example</code>" (an actual origin) rather than the "<code>*</code>" wildcard, the credential-cognizant content is returned to the invoking web content.</p>
 
 <p>Note that the <code>Set-Cookie</code> response header in the example above also sets a further cookie. In case of failure, an exception—depending on the API used—is raised.</p>
 
@@ -416,7 +416,7 @@ Vary: Origin</pre>
 <pre>Access-Control-Allow-Credentials: true
 </pre>
 
-<p><a class="internal" href="#requests_with_credentials">Credentialed requests</a> are discussed above.</p>
+<p><a href="#requests_with_credentials">Credentialed requests</a> are discussed above.</p>
 
 <h3 id="Access-Control-Allow-Methods">Access-Control-Allow-Methods</h3>
 
@@ -425,11 +425,11 @@ Vary: Origin</pre>
 <pre>Access-Control-Allow-Methods: &lt;method&gt;[, &lt;method&gt;]*
 </pre>
 
-<p>An example of a <a class="internal" href="#preflighted_requests">preflight request is given above</a>, including an example which sends this header to the browser.</p>
+<p>An example of a {{Glossary("preflight request")}} is given above</a>, including an example which sends this header to the browser.</p>
 
 <h3 id="Access-Control-Allow-Headers">Access-Control-Allow-Headers</h3>
 
-<p>The {{HTTPHeader("Access-Control-Allow-Headers")}} header is used in response to a <a class="internal" href="#preflighted_requests">preflight request</a> to indicate which HTTP headers can be used when making the actual request. This header is the server side response to the browser's {{HTTPHeader("Access-Control-Request-Headers")}} header.</p>
+<p>The {{HTTPHeader("Access-Control-Allow-Headers")}} header is used in response to a {{Glossary("preflight request")}} to indicate which HTTP headers can be used when making the actual request. This header is the server side response to the browser's {{HTTPHeader("Access-Control-Request-Headers")}} header.</p>
 
 <pre>Access-Control-Allow-Headers: &lt;header-name&gt;[, &lt;header-name&gt;]*
 </pre>
@@ -460,7 +460,7 @@ Vary: Origin</pre>
 <pre>Access-Control-Request-Method: &lt;method&gt;
 </pre>
 
-<p>Examples of this usage can be <a class="internal" href="#preflighted_requests">found above.</a></p>
+<p>Examples of this usage can be <a href="#preflighted_requests">found above.</a></p>
 
 <h3 id="Access-Control-Request-Headers">Access-Control-Request-Headers</h3>
 
@@ -469,7 +469,7 @@ Vary: Origin</pre>
 <pre>Access-Control-Request-Headers: &lt;field-name&gt;[, &lt;field-name&gt;]*
 </pre>
 
-<p>Examples of this usage can be <a class="internal" href="#preflighted_requests">found above</a>.</p>
+<p>Examples of this usage can be <a href="#preflighted_requests">found above</a>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
+++ b/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
@@ -8,9 +8,9 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p class="summary"><strong>Cross-Origin Resource Policy</strong> is a policy set by the <a href="/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy"><code>Cross-Origin-Resource-Policy</code> HTTP header</a> that lets web sites and applications opt in to protection against certain requests from other origins (such as those issued with elements like <code>&lt;script&gt;</code> and <code>&lt;img&gt;</code>), to mitigate speculative side-channel attacks, like <a href="https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)">Spectre</a>, as well as Cross-Site Script Inclusion attacks.</p>
+<p><strong>Cross-Origin Resource Policy</strong> is a policy set by the <a href="/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy"><code>Cross-Origin-Resource-Policy</code> HTTP header</a> that lets web sites and applications opt in to protection against certain requests from other origins (such as those issued with elements like <code>&lt;script&gt;</code> and <code>&lt;img&gt;</code>), to mitigate speculative side-channel attacks, like <a href="https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)">Spectre</a>, as well as Cross-Site Script Inclusion attacks.</p>
 
-<p class="summary">CORP is an additional layer of protection beyond the default {{Glossary("same-origin policy")}}. Cross-Origin Resource Policy complements <a href="https://fetch.spec.whatwg.org/#corb">Cross-Origin Read Blocking</a> (CORB), which is a mechanism to prevent some cross-origin reads by default.</p>
+<p>CORP is an additional layer of protection beyond the default {{Glossary("same-origin policy")}}. Cross-Origin Resource Policy complements <a href="https://fetch.spec.whatwg.org/#corb">Cross-Origin Read Blocking</a> (CORB), which is a mechanism to prevent some cross-origin reads by default.</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> The policy is only effective for <a href="https://fetch.spec.whatwg.org/#concept-request-mode"><code>no-cors</code></a> requests, which are issued by default for CORS-safelisted methods/headers.</p>

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.html
@@ -59,63 +59,61 @@ Content-Security-Policy: default-src &lt;source&gt; &lt;source&gt;;
 
 <h3 id="Sources">Sources</h3>
 
-<div id="common_sources">
 <p>&lt;source&gt; can be one of the following:</p>
 
 <dl>
- <dt>&lt;host-source&gt;</dt>
- <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
- Examples:
- <ul>
-  <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
-  <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
-  <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
-  <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
- </ul>
- </dd>
- <dt>&lt;scheme-source&gt;</dt>
- <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
- <ul>
-  <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
-  <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
-  <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
-  <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
- </ul>
- </dd>
- <dt><code>'self'</code></dt>
- <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
- <dt><code>'unsafe-eval'</code></dt>
- <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
- <dt id="unsafe-hashes"><code>'unsafe-hashes'</code></dt>
- <dd>Allows enabling specific inline <a href="/en-US/docs/Web/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</dd>
- <dt><code>'unsafe-inline'</code></dt>
- <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, inline event handlers, and inline {{HTMLElement("style")}} elements. The single quotes are required.</dd>
- <dt><code>'none'</code></dt>
- <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
- <dt>'nonce-&lt;base64-value&gt;'</dt>
- <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
-  <div class="notecard note">
-    <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g., as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
-  </div>
- </dd>
- <dt>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</dt>
- <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
-</dl>
-</div>
+  <dt><code>&lt;host-source&gt;</code></dt>
+  <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
+    Examples:
+    <ul>
+      <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
+      <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
+      <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
+      <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
+    </ul>
+  </dd>
 
-<div id="strict-dynamic">
-<dl>
- <dt>'strict-dynamic'</dt>
- <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
-</dl>
-</div>
+  <dt><code>&lt;scheme-source&gt;</code></dt>
+  <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
+    <ul>
+      <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
+      <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
+      <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
+      <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
+    </ul>
+  </dd>
 
-<div id="report-sample">
-<dl>
- <dt>'report-sample'</dt>
- <dd>Requires a sample of the violating code to be included in the violation report.</dd>
+  <dt><code>'self'</code></dt>
+  <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
+
+  <dt><code>'unsafe-eval'</code></dt>
+  <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
+
+  <dt><code>'unsafe-hashes'</code></dt>
+  <dd>Allows enabling specific inline <a href="/en-US/docs/Web/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</dd>
+
+  <dt><code>'unsafe-inline'</code></dt>
+  <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, inline event handlers, and inline {{HTMLElement("style")}} elements. The single quotes are required.</dd>
+
+  <dt><code>'none'</code></dt>
+  <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
+
+  <dt><code>'nonce-&lt;base64-value&gt;'</code></dt>
+  <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
+    <div class="notecard note">
+      <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g., as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
+    </div>
+  </dd>
+
+  <dt><code>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</code></dt>
+  <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
+
+  <dt><code>'strict-dynamic'</code></dt>
+  <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
+
+  <dt><code>'report-sample'</code></dt>
+  <dd>Requires a sample of the violating code to be included in the violation report.</dd>
 </dl>
-</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
@@ -58,59 +58,59 @@ Content-Security-Policy: script-src-attr &lt;source&gt;;
 <h3 id="Sources">Sources</h3>
 
 <dl>
-  <dt>&lt;host-source&gt;</dt>
+  <dt><code>&lt;host-source&gt;</code></dt>
   <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
-  Examples:
-  <ul>
-   <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
-   <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
-   <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
-   <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
-  </ul>
+    Examples:
+    <ul>
+      <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
+      <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
+      <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
+      <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
+    </ul>
   </dd>
-  <dt>&lt;scheme-source&gt;</dt>
+
+  <dt><code>&lt;scheme-source&gt;</code></dt>
   <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-  <ul>
-   <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
-   <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
-   <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
-   <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
-  </ul>
+    <ul>
+      <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
+      <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
+      <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
+      <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
+    </ul>
   </dd>
+
   <dt><code>'self'</code></dt>
   <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
+
   <dt><code>'unsafe-eval'</code></dt>
   <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
-  <dt id="unsafe-hashes"><code>'unsafe-hashes'</code></dt>
+
+  <dt><code>'unsafe-hashes'</code></dt>
   <dd>Allows enabling specific inline <a href="/en-US/docs/Web/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</dd>
+
   <dt><code>'unsafe-inline'</code></dt>
   <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, and inline event handlers. The single quotes are required.</dd>
+
   <dt><code>'none'</code></dt>
   <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
-  <dt>'nonce-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'nonce-&lt;base64-value&gt;'</code></dt>
   <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource^s policy is otherwise trivial. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
     <div class="notecard note">
       <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g., as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
     </div>
   </dd>
-  <dt>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</code></dt>
   <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
- </dl>
-</div>
 
-<div id="strict-dynamic">
-<dl>
- <dt>'strict-dynamic'</dt>
- <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
-</dl>
-</div>
+  <dt><code>'strict-dynamic'</code></dt>
+  <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
 
-<div id="report-sample">
-<dl>
- <dt>'report-sample'</dt>
- <dd>Requires a sample of the violating code to be included in the violation report.</dd>
+  <dt><code>'report-sample'</code></dt>
+  <dd>Requires a sample of the violating code to be included in the violation report.</dd>
 </dl>
-</div>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Fallback_to_script-src">Fallback to script-src</h3>
@@ -118,10 +118,6 @@ Content-Security-Policy: script-src-attr &lt;source&gt;;
 <p>If <code>script-src-attr</code> is absent, User Agent falls back to
   the {{CSP("script-src")}} directive, and if that is absent as well, to
   {{CSP("default-src")}}.</p>
-
-<div class="hidden">
-  <p>TODO: Add comprehensive examples.</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
@@ -52,68 +52,64 @@ Content-Security-Policy: script-src-elem &lt;source&gt;;
 <h3 id="Sources">Sources</h3>
 
 <dl>
-  <dt>&lt;host-source&gt;</dt>
+  <dt><code>&lt;host-source&gt;</code></dt>
   <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
-  Examples:
-  <ul>
-   <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
-   <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
-   <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
-   <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
-  </ul>
+    Examples:
+    <ul>
+      <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>
+      <li><code>mail.example.com:443</code>: Matches all attempts to access port 443 on mail.example.com.</li>
+      <li><code>https://store.example.com</code>: Matches all attempts to access store.example.com using <code>https:</code>.</li>
+      <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
+    </ul>
   </dd>
-  <dt>&lt;scheme-source&gt;</dt>
+
+  <dt></ode>&lt;scheme-source&gt;</code></dt>
   <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-  <ul>
-   <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
-   <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
-   <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
-   <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
-  </ul>
+    <ul>
+      <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
+      <li><code>mediastream:</code> Allows <a href="/en-US/docs/Web/API/Media_Streams_API"><code>mediastream:</code> URIs</a> to be used as a content source.</li>
+      <li><code>blob:</code> Allows <a href="/en-US/docs/Web/API/Blob"><code>blob:</code> URIs</a> to be used as a content source.</li>
+      <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
+    </ul>
   </dd>
+
   <dt><code>'self'</code></dt>
   <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
+
   <dt><code>'unsafe-eval'</code></dt>
   <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
-  <dt id="unsafe-hashes"><code>'unsafe-hashes'</code></dt>
+
+  <dt><code>'unsafe-hashes'</code></dt>
   <dd>Allows enabling specific inline <a href="/en-US/docs/Web/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</dd>
+
   <dt><code>'unsafe-inline'</code></dt>
   <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, and inline event handlers. The single quotes are required.</dd>
+
   <dt><code>'none'</code></dt>
   <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
-  <dt>'nonce-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'nonce-&lt;base64-value&gt;'</code></dt>
   <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
     <div class="notecard note">
       <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g., as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
     </div>
   </dd>
-  <dt>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</code></dt>
   <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
- </dl>
-</div>
 
-<div id="strict-dynamic">
-<dl>
- <dt>'strict-dynamic'</dt>
- <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
-</dl>
-</div>
+  <dt><code>'strict-dynamic'</code></dt>
+  <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic">script-src</a> for an example.</dd>
 
-<div id="report-sample">
-<dl>
- <dt>'report-sample'</dt>
- <dd>Requires a sample of the violating code to be included in the violation report.</dd>
+  <dt><code>'report-sample'</code></dt>
+  <dd>Requires a sample of the violating code to be included in the violation report.</dd>
 </dl>
-</div>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Fallback_to_script-src">Fallback to script-src</h3>
 
 <p>If <code>script-src-elem</code> is absent, User Agent falls back to the {{CSP("script-src")}} directive, and if that is absent as well, to {{CSP("default-src")}}.</p>
-
-<div class="hidden">
-<p>TODO: Add comprehensive examples.</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.html
@@ -46,7 +46,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 <h3 id="Sources">Sources</h3>
 
 <dl>
-  <dt>&lt;host-source&gt;</dt>
+  <dt><code>&lt;host-source&gt;</code></dt>
   <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
   Examples:
   <ul>
@@ -56,7 +56,8 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
    <li><code>*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the current protocol.</li>
   </ul>
   </dd>
-  <dt>&lt;scheme-source&gt;</dt>
+
+  <dt><code>&lt;scheme-source&gt;</code></dt>
   <dd>A scheme such as <code>http:</code> or <code>https:</code>. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
   <ul>
    <li><code>data:</code> Allows <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URIs</a> to be used as a content source.<em> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.</em></li>
@@ -65,47 +66,46 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
    <li><code>filesystem:</code> Allows <a href="/en-US/docs/Web/API/FileSystem"><code>filesystem:</code> URIs</a> to be used as a content source.</li>
   </ul>
   </dd>
+
   <dt><code>'self'</code></dt>
   <dd>Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude <code>blob</code> and <code>filesystem</code> from source directives. Sites needing to allow these content types can specify them using the Data attribute.</dd>
+
   <dt><code>'unsafe-eval'</code></dt>
   <dd>Allows the use of <code>eval()</code> and similar methods for creating code from strings. You must include the single quotes.</dd>
-  <dt id="unsafe-hashes"><code>'unsafe-hashes'</code></dt>
+
+  <dt><code>'unsafe-hashes'</code></dt>
   <dd>Allows enabling specific inline <a href="/en-US/docs/Web/Events/Event_handlers">event handlers</a>. If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or <code>javascript:</code> URLs, this is a safer method than using the <code>unsafe-inline</code> expression.</dd>
+
   <dt><code>'unsafe-inline'</code></dt>
   <dd>Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, <code>javascript:</code> URLs, and inline event handlers. The single quotes are required.</dd>
+
   <dt><code>'none'</code></dt>
   <dd>Refers to the empty set; that is, no URLs match. The single quotes are required.</dd>
-  <dt>'nonce-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'nonce-&lt;base64-value&gt;'</code></dt>
   <dd>An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See <a href="#unsafe_inline_script">unsafe inline script</a> for an example. Specifying nonce makes a modern browser ignore <code>'unsafe-inline'</code> which could still be set for older browsers without nonce support.
     <div class="notecard note">
       <p><strong>Note:</strong> The CSP <code>nonce</code> source can only be applied to <em>nonceable</em> elements (e.g., as the {{HTMLElement("img")}} element has no <code>nonce</code> attribute, there is no way to associate it with this CSP source).</p>
     </div>
   </dd>
-  <dt>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</dt>
+
+  <dt><code>'&lt;hash-algorithm&gt;-&lt;base64-value&gt;'</code></dt>
   <dd>A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the &lt;script&gt; or &lt;style&gt; tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See <a href="#unsafe_inline_script">unsafe inline script</a> for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of <code>script-src</code> for external scripts.</dd>
- </dl>
-</div>
 
-<div id="strict-dynamic">
-<dl>
- <dt>'strict-dynamic'</dt>
- <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored. See <a href="#strict-dynamic">script-src</a> for an example.</dd>
-</dl>
-</div>
+  <dt><code>'strict-dynamic'</code></dt>
+  <dd>The <code>strict-dynamic</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> are ignored.</dd>
 
-<div id="report-sample">
-<dl>
- <dt>'report-sample'</dt>
- <dd>Requires a sample of the violating code to be included in the violation report.</dd>
+   <dt><code>'report-sample'</code></dt>
+  <dd>Requires a sample of the violating code to be included in the violation report.</dd>
 </dl>
-</div>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Violation_case">Violation case</h3>
 
 <p>Given this CSP header:</p>
 
-<pre class="brush: bash">Content-Security-Policy: script-src https://example.com/</pre>
+<pre>Content-Security-Policy: script-src https://example.com/</pre>
 
 <p>the following script is blocked and won't be loaded or executed:</p>
 
@@ -115,7 +115,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <pre class="brush: html">&lt;button id="btn" onclick="doSomething()"&gt;</pre>
 
-<p>You should replace them with {{domxref("EventTarget.addEventListener", "addEventListener")}} calls:</p>
+<p>You should replace them with {{domxref("EventTarget.addEventListener", "addEventListener")}} calls:</p>
 
 <pre class="brush: js">document.getElementById("btn").addEventListener('click', doSomething);</pre>
 
@@ -127,7 +127,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <p>To allow inline scripts and inline event handlers, <code>'unsafe-inline'</code>, a nonce-source or a hash-source that matches the inline block can be specified.</p>
 
-<pre class="brush: bash">Content-Security-Policy: script-src 'unsafe-inline';
+<pre>Content-Security-Policy: script-src 'unsafe-inline';
 </pre>
 
 <p>The above Content Security Policy will allow inline {{HTMLElement("script")}} elements</p>
@@ -138,7 +138,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <p>You can use a nonce-source to only allow specific inline script blocks:</p>
 
-<pre class="brush: bash">Content-Security-Policy: script-src 'nonce-2726c7f26c'</pre>
+<pre>Content-Security-Policy: script-src 'nonce-2726c7f26c'</pre>
 
 <p>You will have to set the same nonce on the {{HTMLElement("script")}} element:</p>
 
@@ -148,7 +148,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <p>Alternatively, you can create hashes from your inline scripts. CSP supports sha256, sha384 and sha512.</p>
 
-<pre class="brush: bash">Content-Security-Policy: script-src 'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='</pre>
+<pre>Content-Security-Policy: script-src 'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='</pre>
 
 <p>When generating the hash, don't include the {{HTMLElement("script")}} tags and note that capitalization and whitespace matter, including leading or trailing whitespace.</p>
 
@@ -171,20 +171,20 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
  <li><code>window.execScript()</code> {{non-standard_inline}} (IE &lt; 11 only)</li>
 </ul>
 
-<h3 id="examples-strict-dynamic">strict-dynamic</h3>
+<h3 id="strict-dynamic">strict-dynamic</h3>
 
 <p>The <code>'strict-dynamic'</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any whitelist or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> will be ignored. For example, a policy such as <code>script-src 'strict-dynamic' 'nonce-R4nd0m' https://whitelisted.com/</code> would allow loading of a root script with <code>&lt;script nonce="R4nd0m" src="https://example.com/loader.js"&gt;</code> and propagate that trust to any script loaded by <code>loader.js</code>, but disallow loading scripts from <code>https://whitelisted.com/</code> unless accompanied by a nonce or loaded from a trusted script.</p>
 
-<pre class="brush: bash">script-src 'strict-dynamic' 'nonce-<em>someNonce</em>'</pre>
+<pre>Content-Security-Policy: script-src 'strict-dynamic' 'nonce-<em>someNonce</em>'</pre>
 
-<p><em>Or</em></p>
+<p>Or:</p>
 
-<pre class="brush: bash">script-src 'strict-dynamic' 'sha256-<em>base64EncodedHash</em>'</pre>
+<pre>Content-Security-Policy: script-src 'strict-dynamic' 'sha256-<em>base64EncodedHash</em>'</pre>
 
 <p>It is possible to deploy <code>strict-dynamic</code> in a backwards compatible way, without requiring user-agent sniffing.<br>
  The policy:</p>
 
-<pre class="brush: bash">script-src 'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'</pre>
+<pre>Content-Security-Policy: script-src 'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'</pre>
 
 <p>will act like <code>'unsafe-inline' https:</code> in browsers that support CSP1, <code>https: 'nonce-abcdefg'</code> in browsers that support CSP2, and <code>'nonce-abcdefg' 'strict-dynamic'</code> in browsers that support CSP3.</p>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
@@ -66,9 +66,7 @@ Content-Security-Policy: <code>style</code>-src-attr &lt;source&gt;;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<div class="hidden">
-  <p>TODO: add examples</p>
-</div>
+<p>TBD</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
@@ -67,9 +67,7 @@ Content-Security-Policy: <code>style</code>-src-elem &lt;source&gt;;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<div class="hidden">
-  <p>TODO: add examples</p>
-</div>
+<p>TBD</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
@@ -12,7 +12,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.trusted-types
 
 <p>The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) <code><strong>trusted-types</strong></code> {{experimental_inline}} directive instructs user agents to restrict the creation of Trusted Types policies - functions that build non-spoofable, typed values intended to be passed to DOM XSS sinks in place of strings.</p>
 
-<p>Together with <code><strong><a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for">require-trusted-types-for</a></strong></code> directive, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review. This directive declares an allow-list of trusted type policy names created with <code>TrustedTypes.createPolicy</code> from Trusted Types API.</p>
+<p>Together with <strong><a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for"><code>require-trusted-types-for</code></a></strong> directive, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review. This directive declares an allow-list of trusted type policy names created with <code>TrustedTypes.createPolicy</code> from Trusted Types API.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/http/headers/digest/index.html
+++ b/files/en-us/web/http/headers/digest/index.html
@@ -82,8 +82,7 @@ Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637</pre>
   <tbody>
     <tr>
       <td>
-        <p><a class="smpl"
-            href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
+        <p><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
         </p>
       </td>
       <td>Resource Digests for HTTP</td>

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -62,7 +62,7 @@ Referrer-Policy: unsafe-url
  <dd>Send the {{glossary("origin")}}, path, and query string for {{glossary("Same-origin_policy", "same-origin")}} requests. Don't send the {{HTTPHeader("Referer")}} header for cross-origin requests.</dd>
  <dt><code>strict-origin</code></dt>
  <dd>Send the origin (only) when the protocol security level stays the same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).</dd>
- <dt><a id="strict-origin-when-cross-origin"></a><code>strict-origin-when-cross-origin</code> (default)</dt>
+ <dt><code>strict-origin-when-cross-origin</code> (default)</dt>
  <dd>Send the origin, path, and querystring when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
 
   <div class="notecard note">

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -471,6 +471,3 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
  <li><a href="/en-US/docs/Web/API/Window/navigator" rel="internal">window.navigator.userAgent</a></li>
  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1169772">Add Android version to Fennec UA String (bug 1169772)</a></li>
 </ul>
-
-<hr>
-<p>Comments to <a class="link-news" href="news://news.mozilla.org/netscape.public.mozilla.netlib">mozilla.dev.platform</a></p>

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -131,8 +131,7 @@ Response:
   <tbody>
     <tr>
       <td>
-        <p><a class="smpl"
-            href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
+        <p><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
         </p>
       </td>
       <td>Resource Digests for HTTP</td>

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.html
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.html
@@ -100,10 +100,7 @@ X-DNS-Prefetch-Control: off
 <pre class="brush: html">&lt;link rel="dns-prefetch" href="https://www.mozilla.org/contribute/"&gt;
 </pre>
 
-<p>In this example, the domain name "<a class="linkification-ext external"
-    href="https://www.mozilla.org/contribute/"
-    title="Linkification: https://www.mozilla.org/contribute/">www.mozilla.org/contribute</a>"
-  will be pre-resolved.</p>
+<p>In this example, the domain name <code>www.mozilla.org/contribute</code> will be pre-resolved.</p>
 
 <p>Similarly, the link element can be used to resolve hostnames without providing a
   complete URL, but only, by preceding the hostname with two slashes:</p>
@@ -124,8 +121,6 @@ X-DNS-Prefetch-Control: off
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a       href="https://bitsup.blogspot.com/2008/11/dns-prefetching-for-firefox.html">DNS
-      Prefetching for Firefox (blog post)</a></li>
-  <li><a       href="https://dev.chromium.org/developers/design-documents/dns-prefetching">Google
-      Chrome handles DNS prefetching control</a></li>
+  <li><a href="https://bitsup.blogspot.com/2008/11/dns-prefetching-for-firefox.html">DNS Prefetching for Firefox (blog post)</a></li>
+  <li><a href="https://dev.chromium.org/developers/design-documents/dns-prefetching">Google Chrome handles DNS prefetching control</a></li>
 </ul>

--- a/files/en-us/web/http/link_prefetching_faq/index.html
+++ b/files/en-us/web/http/link_prefetching_faq/index.html
@@ -53,7 +53,7 @@ tags:
 
 <h3 id="How_is_browser_idle_time_determined.3F">How is browser idle time determined?</h3>
 
-<p>In the current implementation (Mozilla 1.2), idle time is determined using the <code>nsIWebProgressListener</code> API. We attach a listener to the toplevel <code>nsIWebProgress</code> object ("@<a class="linkification-ext external" href="https://mozilla.org/docloaderservice;1" title="Linkification: https://mozilla.org/docloaderservice;1">mozilla.org/docloaderservice;1</a>"). From this, we receive document start &amp; stop notifications, and we approximate idle time as the period between the last document stop and the next document start. The last document stop notification occurs roughly when the onLoad handler would fire for the toplevel document. This is when we kick off prefetch requests. If a subframe contains prefetching hints, prefetching will not begin until the top-most frame and all its "child" frames finish loading.</p>
+<p>In the current implementation (Mozilla 1.2), idle time is determined using the <code>nsIWebProgressListener</code> API. We attach a listener to the toplevel <code>nsIWebProgress</code> object ("@mozilla.org/docloaderservice;1"). From this, we receive document start &amp; stop notifications, and we approximate idle time as the period between the last document stop and the next document start. The last document stop notification occurs roughly when the onLoad handler would fire for the toplevel document. This is when we kick off prefetch requests. If a subframe contains prefetching hints, prefetching will not begin until the top-most frame and all its "child" frames finish loading.</p>
 
 <h3 id="What_happens_if_I_click_on_a_link_while_something_is_being_prefetched.3F">What happens if I click on a link while something is being prefetched?</h3>
 
@@ -106,7 +106,7 @@ tags:
 
 <h3 id="Privacy_implications">Privacy implications</h3>
 
-<p>Along with the referral and URL-following implications already mentioned above, prefetching will generally cause the cookies of the prefetched site to be accessed. (For example, if you google amazon, the google results page will prefetch <a class="linkification-ext external" href="https://www.amazon.com" title="Linkification: https://www.amazon.com">www.amazon.com</a>, causing amazon cookies to be sent back and forth. You can block 3rd party cookies in Firefox, see <a href="https://support.mozilla.com/en-US/kb/Disabling%20third%20party%20cookies">Disabling third party cookies</a>.)</p>
+<p>Along with the referral and URL-following implications already mentioned above, prefetching will generally cause the cookies of the prefetched site to be accessed. (For example, if you google amazon, the google results page will prefetch <code>www.amazon.com</code>, causing amazon cookies to be sent back and forth. You can block 3rd party cookies in Firefox, see <a href="https://support.mozilla.com/en-US/kb/Disabling%20third%20party%20cookies">Disabling third party cookies</a>.)</p>
 
 <h3 id="What_about....3F">What about...?</h3>
 

--- a/files/en-us/web/http/network_error_logging/index.html
+++ b/files/en-us/web/http/network_error_logging/index.html
@@ -7,13 +7,11 @@ tags:
   - Network Error Logging
   - Reference
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}}{{SeeCompatTable}}</div>
 
-<p>{{SeeCompatTable}}</p>
+<p>Network Error Logging is a mechanism that can be configured via the {{HTTPHeader("NEL")}} HTTP <em><a href="/en-US/docs/Glossary/Response_header">response header</a></em>. This experimental header allows web sites and applications to opt-in to receive reports about failed (and, if desired, successful) network fetches from supporting browsers.</p>
 
-<p class="summary">Network Error Logging is a mechanism that can be configured via the {{HTTPHeader("NEL")}} HTTP <em><a href="/en-US/docs/Glossary/Response_header">response header</a></em>. This experimental header allows web sites and applications to opt-in to receive reports about failed (and, if desired, successful) network fetches from supporting browsers.</p>
-
-<p class="summary">Reports are sent to a reporting group defined within a {{HTTPHeader("Report-To")}} header.</p>
+<p>Reports are sent to a reporting group defined within a {{HTTPHeader("Report-To")}} header.</p>
 
 <h2 id="Usage">Usage</h2>
 

--- a/files/en-us/web/http/proxy_servers_and_tunneling/index.html
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p>A <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC)</a> file is a <a href="/en-US/docs/Web/JavaScript">JavaScript</a> function that determines whether web browser requests (HTTP, HTTPS, and FTP) go directly to the destination or are forwarded to a web proxy server. The JavaScript function contained in the PAC file defines the function:</p>
 
-<p id="Saving_the_Auto-Config_File_Setting_the_MIME_Type">The auto-config file should be saved to a file with a <code>.pac</code> filename extension:</p>
+<p>The auto-config file should be saved to a file with a <code>.pac</code> filename extension:</p>
 
 <pre class="brush: html">proxy.pac</pre>
 

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
@@ -77,7 +77,7 @@ tags:
  <dd>Use SOCKS if the primary proxy goes down.</dd>
 </dl>
 
-<p id="Saving_the_Auto-Config_File_Setting_the_MIME_Type">The auto-config file should be saved to a file with a .pac filename extension:</p>
+<p>The auto-config file should be saved to a file with a .pac filename extension:</p>
 
 <pre class="brush: html">proxy.pac</pre>
 

--- a/files/en-us/web/http/redirections/index.html
+++ b/files/en-us/web/http/redirections/index.html
@@ -51,7 +51,7 @@ tags:
    <th scope="row"><code>301</code></th>
    <td><code>Moved Permanently</code></td>
    <td>{{HTTPMethod("GET")}} methods unchanged.<br>
-    Others may or may not be changed to {{HTTPMethod("GET")}}. (See <a href="#attr1">[1]</a>)</td>
+    Others may or may not be changed to {{HTTPMethod("GET")}}. [1]</td>
    <td>Reorganization of a Web site.</td>
   </tr>
   <tr>
@@ -63,7 +63,7 @@ tags:
  </tbody>
 </table>
 
-<p id="attr1">[1] The specification did not intend to allow method changes, but there are existing user agents that do change their method. {{HTTPStatus("308")}} was created to remove the ambiguity of the behavior when using non-<code>GET</code> methods.</p>
+<p>[1] The specification did not intend to allow method changes, but there are existing user agents that do change their method. {{HTTPStatus("308")}} was created to remove the ambiguity of the behavior when using non-<code>GET</code> methods.</p>
 
 <h3 id="Temporary_redirections">Temporary redirections</h3>
 
@@ -85,7 +85,7 @@ tags:
    <th scope="row"><code>302</code></th>
    <td><code>Found</code></td>
    <td>{{HTTPMethod("GET")}} methods unchanged.<br>
-    Others may or may not be changed to {{HTTPMethod("GET")}}. (See<a href="#attr2">[2]</a>)</td>
+    Others may or may not be changed to {{HTTPMethod("GET")}}. [2]</td>
    <td>The Web page is temporarily unavailable for unforeseen reasons.</td>
   </tr>
   <tr>
@@ -104,7 +104,7 @@ tags:
  </tbody>
 </table>
 
-<p id="attr2">[2] The specification did not intend to allow method changes, but there are existing user agents that do change their method. {{HTTPStatus("307")}} was created to remove the ambiguity of the behavior when using non-<code>GET</code> methods.</p>
+<p>[2] The specification did not intend to allow method changes, but there are existing user agents that do change their method. {{HTTPStatus("307")}} was created to remove the ambiguity of the behavior when using non-<code>GET</code> methods.</p>
 
 <h3 id="Special_redirections">Special redirections</h3>
 

--- a/files/en-us/web/http/session/index.html
+++ b/files/en-us/web/http/session/index.html
@@ -43,7 +43,7 @@ tags:
 
 <h3 id="Example_requests">Example requests</h3>
 
-<p>Fetching the root page of developer.mozilla.org, i.e. <a class="linkification-ext external" href="/" title="Linkification: https://developer.mozilla.org/">https://developer.mozilla.org/</a>, and telling the server that the user-agent would prefer the page in French, if possible:</p>
+<p>Fetching the root page of developer.mozilla.org, (<code>https://developer.mozilla.org/</code>), and telling the server that the user-agent would prefer the page in French, if possible:</p>
 
 <pre>GET / HTTP/1.1
 Host: developer.mozilla.org

--- a/files/en-us/web/http/status/103/index.html
+++ b/files/en-us/web/http/status/103/index.html
@@ -34,7 +34,7 @@ browser-compat: http.status.103
   <tbody>
     <tr>
       <td>{{RFC(8297, "103 Early Hints")}}</td>
-      <td><span class="spec-RFC">IETF RFC</span></td>
+      <td>IETF RFC</td>
       <td>Initial definition</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/status/206/index.html
+++ b/files/en-us/web/http/status/206/index.html
@@ -29,7 +29,7 @@ browser-compat: http.status.206
 
 <p>A response containing one single range:</p>
 
-<pre class="newpage">HTTP/1.1 206 Partial Content
+<pre>HTTP/1.1 206 Partial Content
 Date: Wed, 15 Nov 2015 06:25:24 GMT
 Last-Modified: Wed, 15 Nov 2015 04:58:08 GMT
 Content-Range: bytes 21010-47021/47022
@@ -40,7 +40,7 @@ Content-Type: image/gif
 
 <p>A response containing several ranges:</p>
 
-<pre class="newpage">HTTP/1.1 206 Partial Content
+<pre>HTTP/1.1 206 Partial Content
 Date: Wed, 15 Nov 2015 06:25:24 GMT
 Last-Modified: Wed, 15 Nov 2015 04:58:08 GMT
 Content-Length: 1741

--- a/files/en-us/web/http/status/405/index.html
+++ b/files/en-us/web/http/status/405/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>The HyperText Transfer Protocol (HTTP) <code><strong>405 Method Not Allowed</strong></code> response status code indicates that the request method is known by the server but is not supported by the target resource.</p>
 
-<p class="newpage">The server MUST generate an <strong><code>Allow</code></strong> header field in a 405 response containing a list of the target resource's currently supported methods.</p>
+<p>The server <strong>must</strong> generate an <strong><code>Allow</code></strong> header field in a 405 response containing a list of the target resource's currently supported methods.</p>
 
 <h2 id="Status">Status</h2>
 


### PR DESCRIPTION
Part of #7536 

This removed invalid/useless `class` and `id` attributes from Web/HTTP in preparation of the .md conversion.