### PR TITLE
Allow rebase strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,11 @@ resolving them. You can do this by merging the `main` branch into your
 branch (`git pull mdn main`), and then pushing the updated branch to
 your fork (`git push`).
 
-1. Once you've created your pull request, never use `git rebase` on your
-branch if you need to make changes. Any changes should be made as
-additional commits.
+1. An alternative strategy is `git rebase` of `main` on your branch.
+This will rewrite the git history and might confuse reviewers as notifications
+from GitHub leed to nowhere. Your changes are replayed on top of the current
+main branch at that point in time. Any additional changes should be made as
+commits.
 
 1. Each pull request should contain a single logical change, or related set
 of changes that make sense to submit together. If a pull request becomes

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ your fork (`git push`).
 
 1. An alternative strategy is `git rebase` of `main` on your branch.
 This will rewrite the git history and might confuse reviewers as notifications
-from GitHub leed to nowhere. Your changes are replayed on top of the current
+from GitHub lead to nowhere. Your changes are replayed on top of the current
 main branch at that point in time. Any additional changes should be made as
 commits.
 

--- a/README.md
+++ b/README.md
@@ -345,8 +345,7 @@ your fork (`git push`).
 1. An alternative strategy is `git rebase` of `main` on your branch.
 This will rewrite the git history and might confuse reviewers as notifications
 from GitHub lead to nowhere. Your changes are replayed on top of the current
-main branch at that point in time. Any additional changes should be made as
-commits.
+main branch at that point in time.
 
 1. Each pull request should contain a single logical change, or related set
 of changes that make sense to submit together. If a pull request becomes


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

As discussed in https://github.com/mdn/content/discussions/6480 rebase should not be forbidden outright any more.
However, a warning is still apt.

> What was wrong/why is this fix needed? (quick summary only)

Looking at actual behaviour, sometimes a PR branch was updated by rebasing main instead of merging it.
If this becomes acceptable behaviour, we should reflect that in our documentation.

> Anything else that could help us review it

I'd like to have the discussion of the general direction in https://github.com/mdn/content/discussions/6480 and use this PR for forging the wording.