### PR TITLE
Add to DocumentFragment Usage notes of invalid HTML created with DocumentFragment

### DIFF
--- a/files/en-us/web/api/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/index.html
@@ -64,6 +64,8 @@ browser-compat: api.DocumentFragment
 
 <p>An empty <code>DocumentFragment</code> can be created using the {{domxref("document.createDocumentFragment()")}} method or the constructor.</p>
 
+<p><strong>Caution:</strong>It's possible to create constructs that HTML doesn't allow with <code>DocumentFragment</code>s. When those <code>DocumentFragment</code>s are inserted into a <code>Document</code> object, the HTML parser will mutate the <code>Document</code> to create a valid <code>HTMLDocument</code></p>
+
 <h2 id="Example">Example</h2>
 
 <h3 id="HTML">HTML</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Add content to DocumentFragment Usage notes section to inform the reader that it's possible to create "invalid" HTML with `DocumentFragment` s that will be removed by the HTML parser

 
> Anything else that could help us review it

Consider the following test case:
1. Run the following code in console:
```javascript
let fragment = document.createDocumentFragment()
const bodyElement = document.createElement("body")
const trElement = document.createElement("tr")
fragment.appendChild(bodyElement)
fragment.querySelector('body').appendChild(trElement) // create invalid HTML with DocumentFragment
let testDocument = document.implementation.createHTMLDocument('test document');
testDocument.querySelector('body').replaceWith(fragment)
```
2. Check that `testDocument` is not a valid `HTMLDocument`. Here's two ways of testing this:
 - Create an HTML document (e.g. `test.html`) with the value of `testDocument`, then open `test.html` and inspect element with devtools. The `tr` element should be stripped out out of the `body` element.
```html 
<!DOCTYPE html>
<html>
  <head>
    <title>test document</title>
  </head>
  <body>
    <tr></tr>
  </body>
</html>
```
 - Paste `testDocument` into [Nu HTML Checker](https://validator.w3.org/nu/#textarea)
 
![image](https://user-images.githubusercontent.com/14011954/128605801-b57a9ef7-92fa-450a-bfd7-dbc1fb36b9e6.png)
