### PR TITLE
Added note about addition of new keywords for break-inside in Firefox 92

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -21,6 +21,10 @@ tags:
 
 <h3 id="CSS">CSS</h3>
 
+<ul>
+  <li>The keywords <code>avoid-page</code> and <code>avoid-column</code> are now supported for the {{cssxref("break-inside")}} property ({{bug(1722945)}}).</li>
+</ul>
+
 <h4 id="removals_css">Removals</h4>
 
 <h3 id="JavaScript">JavaScript</h3>


### PR DESCRIPTION
This adds a hint to the Firefox 92 release notes that the `break-inside` CSS property now supports two new keywords `avoid-page` and `avoid-column`.

There's also an update to BCD in https://github.com/mdn/browser-compat-data/pull/11924 for that.

Sebastian