### PR TITLE
Remove <dl> list for return value of DOMException()

### DIFF
--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -31,10 +31,7 @@ var domException = new DOMException(message, name);</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<dl>
-  <dt><strong>{{domxref("DOMException")}}</strong></dt>
-  <dd>A newly created {{domxref("DOMException")}} object.</dd>
-</dl>
+<p>A newly created {{domxref("DOMException")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Return values are always unique, no need for a `<dl>`.