### PR TITLE
Removed example covered by other examples

### DIFF
--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -38,7 +38,6 @@ import * as name from "module-name";
 import { export1 } from "module-name";
 import { export1 as alias1 } from "module-name";
 import { export1 , export2 } from "module-name";
-import { foo , bar } from "module-name/path/to/specific/un-exported/file";
 import { export1 , export2 as alias2 , [...] } from "module-name";
 import defaultExport, { export1 [ , [...] ] } from "module-name";
 import defaultExport, * as name from "module-name";


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #1436

> What was wrong/why is this fix needed? (quick summary only)
An example was confusing because it looked different without illustrating any difference. The explanations that follow don't cover this particular example in any detail. While we could address that, we need not. In particular, you can only `import` `export`ed symbols, so nothing new there. And the other examples use `module-name` which can also refer to a path -

> **This is often a relative or absolute path name to the .js file containing the module.** 

> Anything else that could help us review it
The SO thread seems to indicate one possible use case for this example which is the ability to import the unexported. I tried this but couldn't import `bar`

```javascript
function foo() {
  return "foo";
}

function bar() {
  return "bar";
}

export {foo};
```

```javascript
import {foo, bar} from "./foobar.mjs";

console.log(foo());
```

```bash
$ node test.mjs
file:///home/hgarg/test.mjs:1
import {foo, bar} from "./foobar.mjs";
             ^^^
SyntaxError: The requested module './foobar.mjs' does not provide an export named 'bar'

```
