### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.html
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.html
@@ -83,6 +83,6 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms" title="Using Deviceorientation with 3D Transforms">Using device orientation with 3D Transforms</a></li>
- <li><a href="https://desandro.github.com/3dtransforms/">Intro to CSS 3D transforms</a> (Blog post by David DeSandro)</li>
+ <li><a href="https://desandro.github.io/3dtransforms/">Intro to CSS 3D transforms</a> (Blog post by David DeSandro)</li>
  <li><a href="https://css-transform.moro.es/">CSS Transform Playground</a> (Online tool to visualize CSS Transform functions)</li>
 </ul>


### PR DESCRIPTION

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
null

> What was wrong/why is this fix needed? (quick summary only)
Before this change, if one presses on the "Intro to CSS 3D transforms" link one receives a 404 error.


> Anything else that could help us review it
Image of the 404 screen 
![grafik](https://user-images.githubusercontent.com/69518450/128630364-f976ce36-6b63-4af0-a7df-50e065288eab.png)

