### PR TITLE
AutoUrlDetect added

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -222,6 +222,8 @@ browser-compat: api.Document.execCommand
   <dt><code>styleWithCSS</code></dt>
   <dd>Replaces the <code>useCSS</code> command. <code>true</code> modifies/generates
     <code>style</code> attributes in markup, false generates presentational elements.<br></dd>
+  <dt><code>AutoUrlDetect</code></dt>
+  <dd>Changes the browser auto-link behavior (Internet Explorer only)</dd>
 </dl>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
Added an aCommandName AutoUrlDetect that is only supported by IE browser

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'


> What was wrong/why is this fix needed? (quick summary only)

In the contenteditable div, if you enter the @ symbol, the IE browser will automatically change the entered content into `<a href="mailto:entered content`, maybe this attribute is a missing item.

> Anything else that could help us review it
