### PR TITLE
Fix live sample IDs for CSS docs

### DIFF
--- a/files/en-us/web/css/_colon_user-invalid/index.html
+++ b/files/en-us/web/css/_colon_user-invalid/index.html
@@ -25,7 +25,7 @@ browser-compat: css.selectors.user-invalid
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_invalid">Setting a color and symbol on :user-invalid</h3>
+<h3>Setting a color and symbol on :user-invalid</h3>
 
 <p>In the following example, the red border and ❌ only display once the user has interacted with the field.
 Try typing something other than an email address to see it in action.</p>
@@ -45,7 +45,7 @@ input:user-invalid + span::before {
   color: red;
 }</pre>
 
-<p>{{EmbedLiveSample("Setting_invalid", 140, 100)}}</p>
+<p>{{EmbedLiveSample("Setting_a_color_and_symbol_on_user-invalid", 140, 100)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/_colon_user-valid/index.html
+++ b/files/en-us/web/css/_colon_user-valid/index.html
@@ -34,7 +34,7 @@ browser-compat: css.selectors.user-valid
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_valid">Setting a color and symbol on :user-valid</h3>
+<h3>Setting a color and symbol on :user-valid</h3>
 
 <p>In the following example, the green border and ✅ only display once the user has interacted with the field.
 Try changing the email address to another valid email to see it in action.</p>
@@ -54,7 +54,7 @@ input:user-valid + span::before {
   color: green;
 }</pre>
 
-<p>{{EmbedLiveSample("Setting_valid", 140, 100)}}</p>
+<p>{{EmbedLiveSample("Setting_a_color_and_symbol_on_user-valid", 140, 100)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.html
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.html
@@ -29,7 +29,7 @@ browser-compat: css.selectors.file-selector-button
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="basic_example">Basic example</h3>
+<h3>Basic example</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -63,13 +63,13 @@ input[type=file]::file-selector-button:hover {
 
 <h4>Result</h4>
 
-<p>{{EmbedLiveSample("basic_example", "100%", 150)}}</p>
+<p>{{EmbedLiveSample("Basic_example", "100%", 150)}}</p>
 
 <p>Example with fallback for older browsers supporting the <code>-webkit</code> and <code>-ms</code> prefixes. Note that as a selector you will need to write out the whole code block twice, as an unrecognized selector invalidates the whole list.</p>
 
 <p>Note that <code>::file-selector-button</code> is a whole element, and as such matches the rules from the UA stylesheet. In particular, fonts and colors won't necessarily inherit from the <code>input</code> element.</p>
 
-<h3 id="fallback_example">Fallback example</h3>
+<h3>Fallback example</h3>
 <h4 id="HTML_2">HTML</h4>
 
 <pre class="brush: html">&lt;form&gt;
@@ -127,7 +127,7 @@ input[type=file]::file-selector-button:hover {
 
 <h4>Result</h4>
 
-<p>{{EmbedLiveSample("fallback_example", "100%", 150)}}</p>
+<p>{{EmbedLiveSample("Fallback_example", "100%", 150)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/background-size/index.html
+++ b/files/en-us/web/css/background-size/index.html
@@ -152,7 +152,7 @@ background-size: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="tiling_a_large_image">Tiling a large image</h3>
+<h3>Tiling a large image</h3>
 
 <p>Let's consider a large image, a 2982x2808 Firefox logo image. We want to tile four copies of this image into a 300x300-pixel element. To do this, we can use a fixed <code>background-size</code> value of 150 pixels.</p>
 
@@ -175,7 +175,7 @@ background-size: unset;
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample("tiling_a_large_image", 340, 340)}}</p>
+<p>{{EmbedLiveSample("Tiling_a_large_image", 340, 340)}}</p>
 
 <p>See <a href="/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Scaling_background_images">Scaling background images</a> for more examples.</p>
 

--- a/files/en-us/web/css/border-bottom-left-radius/index.html
+++ b/files/en-us/web/css/border-bottom-left-radius/index.html
@@ -82,7 +82,7 @@ border-bottom-left-radius: unset;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="arc_of_a_circle">Arc of a circle</h3>
+<h3>Arc of a circle</h3>
 
 <p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
 
@@ -98,9 +98,9 @@ border-bottom-left-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_a_circle")}}
+{{EmbedLiveSample("Arc_of_a_circle")}}
 
-<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+<h3>Arc of an ellipse</h3>
 
 <p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
 
@@ -116,9 +116,9 @@ border-bottom-left-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_an_ellipse")}}
+{{EmbedLiveSample("Arc_of_an_ellipse")}}
 
-<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+<h3>Square element with percentage radius</h3>
 
 <p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
 
@@ -134,9 +134,9 @@ border-bottom-left-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Square_element_with_percentage_radius")}}
 
-<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+<h3>Non-square element with percentage radius</h3>
 
 <p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
 
@@ -152,7 +152,7 @@ border-bottom-left-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Non-square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-bottom-right-radius/index.html
+++ b/files/en-us/web/css/border-bottom-right-radius/index.html
@@ -76,7 +76,7 @@ border-bottom-right-radius: unset;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="arc_of_a_circle">Arc of a circle</h3>
+<h3>Arc of a circle</h3>
 
 <p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
 
@@ -92,9 +92,9 @@ border-bottom-right-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_a_circle")}}
+{{EmbedLiveSample("Arc_of_a_circle")}}
 
-<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+<h3>Arc of an ellipse</h3>
 
 <p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
 
@@ -110,9 +110,9 @@ border-bottom-right-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_an_ellipse")}}
+{{EmbedLiveSample("Arc_of_an_ellipse")}}
 
-<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+<h3>Square element with percentage radius</h3>
 
 <p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
 
@@ -128,9 +128,9 @@ border-bottom-right-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Square_element_with_percentage_radius")}}
 
-<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+<h3>Non-square element with percentage radius</h3>
 
 <p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
 
@@ -146,7 +146,7 @@ border-bottom-right-radius: unset;</pre>
 }
 </pre>
 
-{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Non-square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-radius/index.html
+++ b/files/en-us/web/css/border-radius/index.html
@@ -15,7 +15,6 @@ browser-compat: css.properties.border-radius
 
 <div>{{EmbedInteractiveExample("pages/css/border-radius.html")}}</div>
 
-
 <p>The radius applies to the whole {{cssxref("background")}}, even if the element has no border; the exact position of the clipping is defined by the {{cssxref("background-clip")}} property.</p>
 
 <p>The <code>border-radius</code> property does not apply to table elements when {{cssxref("border-collapse")}} is <code>collapse</code>.</p>
@@ -154,7 +153,7 @@ border-bottom-left-radius:  3px 4px;
 
 {{csssyntax}}
 
-<h2 id="examples">Examples</h2>
+<h2>Examples</h2>
 
 <pre class="brush: html hidden">
   &lt;pre id="example-1"&gt;
@@ -241,7 +240,7 @@ pre#example-7 {
 }
 </pre>
 
-{{EmbedLiveSample("examples", "200", "1150")}}
+{{EmbedLiveSample("Examples", "200", "1150")}}
 
 <h3 id="Live_Samples">Live Samples</h3>
 

--- a/files/en-us/web/css/border-style/index.html
+++ b/files/en-us/web/css/border-style/index.html
@@ -107,7 +107,7 @@ border-style: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="all_property_values">All property values</h3>
+<h3>All property values</h3>
 
 <p>Here is an example of all the property values.</p>
 
@@ -183,7 +183,7 @@ pre {
 
 <h4 id="Result">Result</h4>
 
-<div>{{EmbedLiveSample('all_property_values', "1200", 450)}}</div>
+<div>{{EmbedLiveSample('All_property_values', "1200", 450)}}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-top-left-radius/index.html
+++ b/files/en-us/web/css/border-top-left-radius/index.html
@@ -74,7 +74,7 @@ border-top-left-radius: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="arc_of_a_circle">Arc of a circle</h3>
+<h3>Arc of a circle</h3>
 
 <p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
 
@@ -90,9 +90,9 @@ border-top-left-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_a_circle")}}
+{{EmbedLiveSample("Arc_of_a_circle")}}
 
-<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+<h3>Arc of an ellipse</h3>
 
 <p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
 
@@ -108,9 +108,9 @@ border-top-left-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_an_ellipse")}}
+{{EmbedLiveSample("Arc_of_an_ellipse")}}
 
-<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+<h3>Square element with percentage radius</h3>
 
 <p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
 
@@ -126,9 +126,9 @@ border-top-left-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Square_element_with_percentage_radius")}}
 
-<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+<h3>Non-square element with percentage radius</h3>
 
 <p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
 
@@ -144,7 +144,7 @@ border-top-left-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Non-square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-top-right-radius/index.html
+++ b/files/en-us/web/css/border-top-right-radius/index.html
@@ -74,7 +74,7 @@ border-top-right-radius: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="arc_of_a_circle">Arc of a circle</h3>
+<h3>Arc of a circle</h3>
 
 <p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
 
@@ -90,9 +90,9 @@ border-top-right-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_a_circle")}}
+{{EmbedLiveSample("Arc_of_a_circle")}}
 
-<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+<h3>Arc of an ellipse</h3>
 
 <p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
 
@@ -108,9 +108,9 @@ border-top-right-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("arc_of_an_ellipse")}}
+{{EmbedLiveSample("Arc_of_an_ellipse")}}
 
-<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+<h3>Square element with percentage radius</h3>
 
 <p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
 
@@ -126,9 +126,9 @@ border-top-right-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Square_element_with_percentage_radius")}}
 
-<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+<h3>Non-square element with percentage radius</h3>
 
 <p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
 
@@ -144,7 +144,7 @@ border-top-right-radius: unset;
 }
 </pre>
 
-{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
+{{EmbedLiveSample("Non-square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/clear/index.html
+++ b/files/en-us/web/css/clear/index.html
@@ -76,7 +76,7 @@ clear: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="clear-left">clear: left</h3>
+<h3>clear: left</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -115,9 +115,9 @@ p {
 }
 </pre>
 
-<p>{{ EmbedLiveSample('clear-left','100%','250') }}</p>
+<p>{{ EmbedLiveSample('clear_left','100%','250') }}</p>
 
-<h3 id="clear-right">clear: right</h3>
+<h3>clear: right</h3>
 
 <h4 id="HTML_2">HTML</h4>
 
@@ -155,9 +155,9 @@ p {
   width: 50%;
 }</pre>
 
-<p>{{ EmbedLiveSample('clear-right','100%','250') }}</p>
+<p>{{ EmbedLiveSample('clear_right','100%','250') }}</p>
 
-<h3 id="clear-both">clear: both</h3>
+<h3>clear: both</h3>
 
 <h4 id="HTML_3">HTML</h4>
 
@@ -195,7 +195,7 @@ p {
   width: 45%;
 }</pre>
 
-<p>{{ EmbedLiveSample('clear-both','100%','300') }}</p>
+<p>{{ EmbedLiveSample('clear_both','100%','300') }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -864,7 +864,7 @@ browser-compat: css.types.color
 
 <p>If <code>currentColor</code> is used as the value of the <code>color</code> property, it instead takes its value from the inherited value of the <code>color</code> property.</p>
 
-<h4 id="currentcolor_example">currentColor example</h4>
+<h4>currentColor example</h4>
 
 <pre class="brush: html">&lt;div style="color:blue; border: 1px dashed currentColor;"&gt;
   The color of this text is blue.
@@ -872,7 +872,7 @@ browser-compat: css.types.color
   This block is surrounded by a blue border.
 &lt;/div&gt;</pre>
 
-<p>{{EmbedLiveSample('currentcolor_example', 600, 80)}}</p>
+<p>{{EmbedLiveSample('currentColor_example', 600, 80)}}</p>
 
 <h3 id="RGB_colors">RGB colors</h3>
 
@@ -1258,7 +1258,7 @@ Colors specified via the <a href="https://developer.mozilla.org/en-US/docs/Web/C
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Color_value_tester">Color value tester</h3>
+<h3>Color value tester</h3>
 
 <p>In this example we provide a <code>&lt;div&gt;</code> and a text input. Entering a valid color into the input causes the <code>&lt;div&gt;</code> to adopt that color, allowing you to test our color values.</p>
 

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>In addition to the ability to place items accurately onto a created grid, the CSS Grid Layout specification contains rules that control what happens when you create a grid and do not place some or all of the child items. You can see auto-placement in action in the simplest of ways by creating a grid on a set of items.</p>
 
-<h2 id="default_placement">Default placement</h2>
+<h2>Default placement</h2>
 
 <p>If you give the items no placement information they will position themselves on the grid, one in each grid cell.</p>
 
@@ -48,14 +48,14 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('default_placement', '500', '230') }}</p>
+<p>{{ EmbedLiveSample('Default_placement', '500', '230') }}</p>
 </div>
 
 <h2 id="Default_rules_for_auto-placement">Default rules for auto-placement</h2>
 
 <p>As you can see with the above example, if you create a grid all child items will lay themselves out one into each grid cell. The default flow is to arrange items by row. Grid will lay an item out into each cell of row 1. If you have created additional rows using the <code>grid-template-rows</code> property then grid will continue placing items in these rows. If the grid does not have enough rows in the explicit grid to place all of the items new <em>implicit</em> rows will be created.</p>
 
-<h3 id="Sizing_rows_in_the_implicit_grid">Sizing rows in the implicit grid</h3>
+<h3>Sizing rows in the implicit grid</h3>
 
 <p>The default for automatically created rows in the implicit grid is for them to be auto-sized. This means that they will contain the content added to them without causing an overflow.</p>
 
@@ -97,7 +97,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Sizing_rows_in_the_implicit_grid', '500', '330') }}</p>
 
-<h3 id="Sizing_rows_using_minmax">Sizing rows using minmax()</h3>
+<h3>Sizing rows using minmax()</h3>
 
 <p>You can use {{cssxref("minmax()","minmax()")}} in your value for {{cssxref("grid-auto-rows")}} enabling the creation of rows that are a minimum size but then grow to fit content if it is taller.</p>
 
@@ -143,7 +143,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Sizing_rows_using_minmax', '500', '330') }}</p>
 
-<h3 id="Sizing_rows_using_a_track_listing">Sizing rows using a track listing</h3>
+<h3>Sizing rows using a track listing</h3>
 
 <p>You can also pass in a track listing, this will repeat. The following track listing will create an initial implicit row track as 100 pixels and a second as <code>200px</code>. This will continue for as long as content is added to the implicit grid. </p>
 
@@ -186,7 +186,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Sizing_rows_using_a_track_listing', '500', '450') }}</p>
 
-<h3 id="Auto-placement_by_column">Auto-placement by column</h3>
+<h3>Auto-placement by column</h3>
 
 <p>You can also ask grid to auto-place items by column. Using the property {{cssxref("grid-auto-flow")}} with a value of <code>column</code>. In this case grid will add items in rows that you have defined using {{cssxref("grid-template-rows")}}. When it fills up a column it will move onto the next explicit column, or create a new column track in the implicit grid. As with implicit row tracks, these column tracks will be auto sized. You can control the size of implicit column tracks with {{cssxref("grid-auto-columns")}}, this works in the same way as {{cssxref("grid-auto-rows")}}.</p>
 
@@ -240,7 +240,7 @@ tags:
 
 <p>Grid places items that have not been given a grid position in what is described in the specification as “order modified document order”. This means that if you have used the <code>order</code> property at all, the items will be placed by that order, not their DOM order. Otherwise they will stay by default in the order that they are entered in the document source.</p>
 
-<h3 id="Items_with_placement_properties">Items with placement properties</h3>
+<h3>Items with placement properties</h3>
 
 <p>The first thing grid will do is place any items that have a position. In the example below I have 12 grid items. Item 2 and item 5 have been placed using line based placement on the grid. You can see how those items are placed and the other items then auto-place in the spaces. The auto-placed items will place themselves before the placed items in DOM order, they don’t start after the position of a placed item that comes before them.</p>
 
@@ -296,7 +296,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Items_with_placement_properties', '500', '500') }}</p>
 
-<h3 id="Deal_with_items_that_span_tracks">Deal with items that span tracks</h3>
+<h3>Deal with items that span tracks</h3>
 
 <p>You can use placement properties while still taking advantage of auto-placement. In this next example I have added to the layout by setting odd items to span two tracks both for rows and columns. I do this with the {{cssxref("grid-column-end")}} and {{cssxref("grid-row-end")}} properties and setting the value of this to <code>span 2</code>. What this means is that the start line of the item will be set by auto-placement, and the end line will span two tracks.</p>
 
@@ -358,7 +358,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Deal_with_items_that_span_tracks', '500', '800') }}</p>
 
-<h3 id="Filling_in_the_gaps">Filling in the gaps</h3>
+<h3>Filling in the gaps</h3>
 
 <p>So far, other than items we have specifically placed, grid is always progressing forward and keeping items in DOM order. This is generally what you want, if you are laying out a form for example you wouldn’t want the labels and fields to become jumbled up in order to fill in some gap. However sometimes, we are laying things out that don’t have a logical order and we would like to create a layout that doesn’t have gaps in it.</p>
 
@@ -436,7 +436,7 @@ tags:
 
 <p>Anonymous items are always auto-placed because there is no way to target them. Therefore if you have some unwrapped text for some reason in your grid, be aware that it might show up somewhere unexpected as it will be auto-placed according to the auto-placement rules.</p>
 
-<h3 id="Use_cases_for_auto-placement">Use cases for auto-placement</h3>
+<h3>Use cases for auto-placement</h3>
 
 <p>Auto-placement is useful whenever you have a collection of items. That could be items that do not have a logical order such as a gallery of photos, or product listing. In that case you might choose to use the dense packing mode to fill in any holes in your grid. In my image gallery example I have some landscape and some portrait images. I have set landscape images – with a class of <code>landscape</code> to span two column tracks. I then use <code>grid-auto-flow: dense</code> to create a densely packed grid.</p>
 

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>Grid is a powerful specification that, when combined with other parts of CSS such as <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">flexbox</a>, can help you create layouts that were previously impossible to build in CSS. It all starts by creating a grid in your <strong>grid container</strong>.</p>
 
-<h2 id="The_Grid_container">The Grid container</h2>
+<h2>The Grid container</h2>
 
 <p>We create a <em>grid container</em> by declaring <code>display: grid</code> or <code>display: inline-grid</code> on an element. As soon as we do this, all <em>direct children</em> of that element become <em>grid items</em>.</p>
 
@@ -92,7 +92,7 @@ tags:
 
 <p><img alt="" src="1_grid_track.png"></p>
 
-<h3 id="basic_example">Basic example</h3>
+<h3>Basic example</h3>
 
 <p>I can add to our earlier example by adding the <code>grid-template-columns</code> property, then defining the size of the column tracks.</p>
 
@@ -131,9 +131,9 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('basic_example', '610', '140') }}</p>
+<p>{{ EmbedLiveSample('Basic_example', '610', '140') }}</p>
 
-<h3 id="the_fr_unit">The fr unit</h3>
+<h3>The fr unit</h3>
 
 <p>Tracks can be defined using any length unit. Grid also introduces an additional length unit to help us create flexible grid tracks. The new <code>fr</code> unit represents a fraction of the available space in the grid container. The next grid definition would create three equal width tracks that grow and shrink according to the available space.</p>
 
@@ -170,9 +170,9 @@ tags:
 
 </pre>
 
-<p>{{ EmbedLiveSample('the_fr_unit', '220', '140') }}</p>
+<p>{{ EmbedLiveSample('The_fr_unit', '220', '140') }}</p>
 
-<h3 id="unequal_fractions">Unequal fractions</h3>
+<h3>Unequal fractions</h3>
 
 <p>In this next example, we create a definition with a <code>2fr</code> track then two <code>1fr</code> tracks. The available space is split into four. Two parts are given to the first track and one part each to the next two tracks.</p>
 
@@ -209,9 +209,9 @@ tags:
 
 </pre>
 
-<p>{{ EmbedLiveSample('unequal_fractions', '220', '140') }}</p>
+<p>{{ EmbedLiveSample('Unequal_fractions', '220', '140') }}</p>
 
-<h3 id="mixing_fractions_and_absolute_sizes">Mixing fractions and absolute sizes</h3>
+<h3>Mixing fractions and absolute sizes</h3>
 
 <p>In this final example, we mix absolute sized tracks with fraction units. The first track is 500 pixels, so the fixed width is taken away from the available space. The remaining space is divided into three and assigned in proportion to the two flexible tracks.</p>
 
@@ -248,7 +248,7 @@ tags:
 
 </pre>
 
-<p>{{ EmbedLiveSample('mixing_fractions_and_absolute_sizes', '220', '140') }}</p>
+<p>{{ EmbedLiveSample('Mixing_fractions_and_absolute_sizes', '220', '140') }}</p>
 
 <h3 id="Track_listings_with_repeat_notation">Track listings with repeat() notation</h3>
 
@@ -284,7 +284,7 @@ tags:
 }
 </pre>
 
-<h3 id="The_implicit_and_explicit_grid">The implicit and explicit grid</h3>
+<h3>The implicit and explicit grid</h3>
 
 <p>When creating our example grid we specifically defined our column tracks with the {{cssxref("grid-template-columns")}} property, but the grid also created rows on its own. These rows are part of the implicit grid. Whereas the explicit grid consists of any rows and columns defined with {{cssxref("grid-template-columns")}} or {{cssxref("grid-template-rows")}}.</p>
 
@@ -329,7 +329,7 @@ tags:
 
 <p>{{ EmbedLiveSample('The_implicit_and_explicit_grid', '230', '420') }}</p>
 
-<h3 id="Track_sizing_and_minmax">Track sizing and minmax</h3>
+<h3>Track sizing and minmax</h3>
 
 <p>When setting up an explicit grid or defining the sizing for automatically created rows or columns we may want to give tracks a minimum size, but also ensure they expand to fit any content that is added. For example, I may want my rows to never collapse smaller than 100 pixels, but if my content stretches to 300 pixels in height, then I would like the row to stretch to that height.</p>
 
@@ -381,7 +381,7 @@ tags:
 
 <p>Lines are numbered according to the writing mode of the document. In a left-to-right language, line 1 is on the left-hand side of the grid. In a right-to-left language, it is on the right-hand side of the grid. Lines can also be named, and we will look at how to do this in a later guide in this series.</p>
 
-<h3 id="Positioning_items_against_lines">Positioning items against lines</h3>
+<h3>Positioning items against lines</h3>
 
 <p>We will be exploring line based placement in full detail in a later article. The following example demonstrates doing this in a simple way. When placing an item, we target the line – rather than the track.</p>
 
@@ -452,7 +452,7 @@ tags:
 
 <p><img alt="A grid area" src="1_grid_area.png"></p>
 
-<h2 id="Gutters">Gutters</h2>
+<h2>Gutters</h2>
 
 <p><em>Gutters</em> or <em>alleys</em> between grid cells can be created using the {{cssxref("column-gap")}} and {{cssxref("row-gap")}} properties, or the shorthand {{cssxref("gap")}}. In the below example, I am creating a 10-pixel gap between columns and a <code>1em</code> gap between rows.</p>
 
@@ -508,7 +508,7 @@ tags:
 
 <p><img alt="Nested grid in flow" src="1_nested_grids_in_flow.png"></p>
 
-<h3 id="nesting_without_subgrid">Nesting without subgrid</h3>
+<h3>Nesting without subgrid</h3>
 
 <p>If I set <code>box1</code> to <code>display: grid</code> I can give it a track definition and it too will become a grid. The items then lay out on this new grid.</p>
 
@@ -566,7 +566,7 @@ tags:
 </pre>
 </div>
 
-<p>{{ EmbedLiveSample('nesting_without_subgrid', '600', '340') }}</p>
+<p>{{ EmbedLiveSample('Nesting_without_subgrid', '600', '340') }}</p>
 
 <p>In this case the nested grid has no relationship to the parent. As you can see in the example it has not inherited the {{cssxref("gap")}} of the parent and the lines in the nested grid do not align to the lines in the parent grid.</p>
 
@@ -594,7 +594,7 @@ tags:
 
 <p>Grid items can occupy the same cell, and in this case we can use the {{cssxref("z-index")}} property to control the order in which overlapping items stack.</p>
 
-<h3 id="overlapping_without_z-index">Overlapping without z-index</h3>
+<h3>Overlapping without z-index</h3>
 
 <p>If we return to our example with items positioned by line number, we can change this to make two items overlap.</p>
 
@@ -644,11 +644,11 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('overlapping_without_z-index', '230', '460') }}</p>
+<p>{{ EmbedLiveSample('Overlapping_without_z-index', '230', '460') }}</p>
 
 <p>The item <code>box2</code> is now overlapping <code>box1</code>, it displays on top as it comes later in the source order.</p>
 
-<h3 id="Controlling_the_order">Controlling the order</h3>
+<h3>Controlling the order</h3>
 
 <p>We can control the order in which items stack up by using the <code>z-index</code> property - just like positioned items. If we give <code>box2</code> a lower <code>z-index</code> than <code>box1</code> it will display below <code>box1</code> in the stack.</p>
 

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>The {{cssxref("align-self")}} and {{cssxref("align-items")}} properties control alignment on the block axis. When we use these properties, we are changing the alignment of the item within the grid area you have placed it.</p>
 
-<h3 id="using_align-items">Using align-items</h3>
+<h3>Using align-items</h3>
 
 <p>In the following example, I have four grid areas within my grid. I can use the {{cssxref("align-items")}} property on the grid container, to align the items using one of the following values:</p>
 
@@ -100,13 +100,13 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('using_align-items', '500', '500') }}</p>
+<p>{{ EmbedLiveSample('Using_align-items', '500', '500') }}</p>
 
 <p>Keep in mind that once you set <code>align-items: start</code>, the height of each child <code>&lt;div&gt;</code> will be determined by the contents of the <code>&lt;div&gt;</code>.  This is in contrast to omitting <code><a href="/en-US/docs/Web/CSS/align-items">align-items</a></code> completely, in which case the height of each <code>&lt;div&gt;</code> stretches to fill its grid area.</p>
 
 <p>The {{cssxref("align-items")}} property sets the {{cssxref("align-self")}} property for all of the child grid items. This means that you can set the property individually, by using <code>align-self</code> on a grid item.</p>
 
-<h3 id="using_align-self">Using align-self</h3>
+<h3>Using align-self</h3>
 
 <p>In this next example, I am using the <code>align-self</code> property, to demonstrate the different alignment values. The first area, is showing the default behavior of <code>align-self</code>, which is to stretch. The second item, has an <code>align-self</code> value of <code>start</code>, the third <code>end</code> and the fourth <code>center</code>.</p>
 
@@ -163,7 +163,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('using_align-self', '500', '500') }}</p>
+<p>{{ EmbedLiveSample('Using_align-self', '500', '500') }}</p>
 
 <h3 id="Items_with_an_intrinsic_aspect_ratio">Items with an intrinsic aspect ratio</h3>
 
@@ -171,7 +171,7 @@ tags:
 
 <p>This behavior has now been clarified in the specification, with browsers yet to implement the correct behavior. Until that happens, you can ensure that items do not stretch, such as images, which are direct children of the grid, by setting {{cssxref("align-self")}} and {{cssxref("justify-self")}} to start. This will mimic the correct behavior once implemented.</p>
 
-<h2 id="Justifying_Items_on_the_Inline_Axis">Justifying Items on the Inline Axis</h2>
+<h2>Justifying Items on the Inline Axis</h2>
 
 <p>As {{cssxref("align-items")}} and {{cssxref("align-self")}} deal with the alignment of items on the block axis, {{cssxref("justify-items")}} and {{cssxref("justify-self")}} do the same job on the inline axis. The values you can choose from are the same as for <code>align-self</code>.</p>
 
@@ -256,7 +256,7 @@ tags:
  <br>
  The {{CSSxRef("place-self")}} property is shorthand for {{CSSxRef("align-self")}} and {{CSSxRef("justify-self")}}.</p>
 
-<h2 id="Center_an_item_in_the_area">Center an item in the area</h2>
+<h2>Center an item in the area</h2>
 
 <p>By combining the align and justify properties we can easily center an item inside a grid area.</p>
 
@@ -322,7 +322,7 @@ tags:
 
 <p>The <code>align-content</code> property is applied to the grid container as it works on the entire grid.</p>
 
-<h3 id="default_alignment">Default alignment</h3>
+<h3>Default alignment</h3>
 
 <p>The default behavior in grid layout is <code>start</code>, which is why our grid tracks are in the top left corner of the grid, aligned against the start grid lines:</p>
 
@@ -378,9 +378,9 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('default_alignment', '500', '550') }}</p>
+<p>{{ EmbedLiveSample('Default_alignment', '500', '550') }}</p>
 
-<h3 id="align-content_end">Setting align-content: end</h3>
+<h3>Setting align-content: end</h3>
 
 <p>If I add <code>align-content</code> to my container, with a value of <code>end</code>, the tracks all move to the end line of the grid container in the block dimension:</p>
 
@@ -436,9 +436,9 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('align-content_end', '500', '550') }}</p>
+<p>{{ EmbedLiveSample('Setting_align-content_end', '500', '550') }}</p>
 
-<h3 id="align-content_end_space-between">Setting align-content: space-between</h3>
+<h3>Setting align-content: space-between</h3>
 
 <p>We can also use values for this property that you may be familiar with from flexbox; the space distribution values of <code>space-between</code>, <code>space-around</code> and <code>space-evenly</code>. If we update {{cssxref("align-content")}} to <code>space-between</code>, you can see how the elements on our grid space out:</p>
 
@@ -494,7 +494,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('align-content_end_space-between', '500', '600') }}</p>
+<p>{{ EmbedLiveSample('Setting_align-content_space-between', '500', '600') }}</p>
 
 <p>It is worth noting, that using these space distribution values may cause items on your grid to become larger. If an item spans more than one grid track, as further space is added between the tracks, that item needs to become large to absorb the space. We’re always working in a strict grid. Therefore, if you decide to use these values, ensure that the content of your tracks can cope with the extra space, or that you have used alignment properties on the items, to cause them to move to the start rather than stretch.</p>
 
@@ -502,7 +502,7 @@ tags:
 
 <p><img alt="Demonstrating how items become larger if we use space-between." src="7_space-between.png"></p>
 
-<h2 id="Justifying_the_grid_tracks_on_the_inline_axis">Justifying the grid tracks on the inline axis</h2>
+<h2>Justifying the grid tracks on the inline axis</h2>
 
 <p>On the inline axis, we can use {{cssxref("justify-content")}} to perform the same type of alignment that we used {{cssxref("align-content")}} for in the block axis.</p>
 
@@ -563,7 +563,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Justifying_the_grid_tracks_on_the_inline_axis', '500', '550') }}</p>
 
-<h2 id="Alignment_and_auto_margins">Alignment and auto margins</h2>
+<h2>Alignment and auto margins</h2>
 
 <p>Another way to align items inside their area, is to use auto margins. If you have ever centered your layout in the viewport, by setting the right and left margin of the container block to <code>auto</code>, you know that an auto margin absorbs all of the available space. By setting the margin to <code>auto</code> on both sides, it pushes the block into the middle as both margins attempt to take all of the space.</p>
 

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>In Spring of 2017, we saw for the first time a major specification like Grid being shipped into browsers almost simultaneously, and we now have CSS Grid Layout support in the public versions of Firefox, Chrome, Opera, Safari and Edge. However, while evergreen browsers mean that many of us are going to see the majority of users having Grid Layout support very quickly, there are also old or non-supporting browsers to contend with. In this guide we will walk through a variety of strategies for support.</span></p>
+<p>In Spring of 2017, we saw for the first time a major specification like Grid being shipped into browsers almost simultaneously, and we now have CSS Grid Layout support in the public versions of Firefox, Chrome, Opera, Safari and Edge. However, while evergreen browsers mean that many of us are going to see the majority of users having Grid Layout support very quickly, there are also old or non-supporting browsers to contend with. In this guide we will walk through a variety of strategies for support.</p>
 
 <h2 id="The_supporting_browsers">The supporting browsers</h2>
 
@@ -48,7 +48,7 @@ tags:
 
 <p>It is worth noting that you do not have to use grid in an <em>all or nothing</em> way. You could start by enhancing elements in your design with grid, that could otherwise display using an older method. Overwriting of legacy methods with grid layout works surprisingly well, due to the way grid interacts with these other methods.</p>
 
-<h3 id="Floats">Floats</h3>
+<h3>Floats</h3>
 
 <p>We have typically used <a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">floats</a> to create multiple column layouts. If you have floated an item, which is also a grid item in a supporting browser, the float will no longer apply to the item. The fact is that <em>a grid item takes precedence.</em> In the example below, I have a simple media object. In a non-supporting browser, I use {{cssxref("float")}}, however I have also defined the container as a grid container, in order to use the alignment properties that are implemented in CSS Grids.</p>
 
@@ -101,7 +101,7 @@ img {
 
 <p>The above example is very simple, and we can get away without needing to write code that would be a problem to browsers that do not support grid, and legacy code is not an issue to our grid supporting browsers. However, things are not always so simple.</p>
 
-<h4 id="a_more_complex_example">A more complex example</h4>
+<h4>A more complex example</h4>
 
 <p>In this next example, I have a set of floated cards. I have given the cards a {{cssxref("width")}}, in order to {{cssxref("float")}} them. To create gaps between the cards, I use a {{cssxref("margin")}} on the items, and then a negative margin on the container:</p>
 
@@ -160,7 +160,7 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('a_more_complex_example', '550', '450') }}</p>
+<p>{{ EmbedLiveSample('A_more_complex_example', '550', '450') }}</p>
 
 <p>The example demonstrates the typical problem that we have with floated layouts: if additional content is added to any one card, the layout breaks.</p>
 
@@ -174,7 +174,7 @@ img {
 
 <p>If I reset the width to <code>auto</code>, then this will stop the float behavior happening for older browsers. I need to be able to define the width for older browsers, and remove the width for grid supporting browsers. Thanks to <a href="/en-US/docs/Web/CSS/@supports">CSS Feature Queries</a> I can do this, right in my CSS.</p>
 
-<h4 id="a_solution_using_feature_queries">A solution using feature queries</h4>
+<h4>A solution using feature queries</h4>
 
 <p><em>Feature queries</em> will look very familiar if you have ever used a <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a> to create a responsive layout. Rather than checking a {{glossary("viewport")}} width, or some feature of the browser or device, we check for support of a CSS property and value pair using an {{cssxref("@supports")}} rule. Inside the feature query, we can then write any CSS we need to apply our modern layout, and remove anything required for the older layout.</p>
 
@@ -258,9 +258,9 @@ img {
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('a_solution_using_feature_queries', '550', '480') }}</p>
+<p>{{ EmbedLiveSample('A_solution_using_feature_queries', '550', '480') }}</p>
 
-<h2 id="Overwriting_other_values_of_display">Overwriting other values of <code>display</code></h2>
+<h2>Overwriting other values of <code>display</code></h2>
 
 <p>Due to the problems of creating grids of items using floats, many of us would use a different method to the floated method shown above to layout a set of cards. Using <code>display: inline-block</code> is an alternate method.</p>
 

--- a/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>In these guides, I have already touched on an important feature of grid layout: the support for different writing modes that is built into the specification. For this guide, we will look at this feature of grid and other modern layout methods, learning a little about writing modes and logical vs. physical properties as we do so.</span></p>
+<p>In these guides, I have already touched on an important feature of grid layout: the support for different writing modes that is built into the specification. For this guide, we will look at this feature of grid and other modern layout methods, learning a little about writing modes and logical vs. physical properties as we do so.</p>
 
 <h2 id="Logical_and_physical_properties_and_values">Logical and physical properties and values</h2>
 
@@ -53,7 +53,7 @@ tags:
 
 <p>I’m going to introduce another specification here, that I will be using in my examples: the CSS Writing Modes specification. This spec details how we can use these different writing modes in CSS, not just for the support of languages that have a different writing mode to English, but also for creative purposes. I’ll be using the {{cssxref("writing-mode")}} property to make changes to the writing mode applied to our grid, in order to demonstrate how the logical values work. If you want to dig into writing modes further, however, then I would recommend that you read Jen Simmons excellent article on <a href="https://24ways.org/2016/css-writing-modes/">CSS Writing Modes</a>. This goes into more depth on that specification than we will touch upon here.</p>
 
-<h3 id="writing-mode">writing-mode</h3>
+<h3>writing-mode</h3>
 
 <p>Writing Modes are more than just left to right and right to left text, and the <code>writing-mode</code> property helps us display text running in other directions. The {{cssxref("writing-mode")}} property can have values of:</p>
 
@@ -90,7 +90,7 @@ tags:
 
 <p>If we now take a look at a grid layout example, we can see how changing the writing mode means changing our idea of where the Block and Inline Axis are.</p>
 
-<h3 id="default_writing_mode">Default writing mode</h3>
+<h3>Default writing mode</h3>
 
 <p>The grid in this example has three columns and two row tracks. This means there are three tracks running down the block axis. In default writing mode, grid auto-places items starting at the top left, moving along to the right, filling up the three cells on the inline axis. It then moves onto the next line, creating a new Row track, and fills in more items:</p>
 
@@ -128,9 +128,9 @@ gap: 10px;
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('default_writing_mode', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Default_writing_mode', '500', '330') }}</p>
 
-<h3 id="setting_writing_mode">Setting writing mode</h3>
+<h3>Setting writing mode</h3>
 
 <p>If we add <code>writing-mode: vertical-lr</code> to the grid container, we can see that the block and inline Axis are now running in a different direction. The block or <em>column</em> axis now runs across the page from left to right, Inline runs down the page, creating rows from top to bottom.</p>
 
@@ -169,11 +169,11 @@ gap: 10px;
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('setting_writing_mode', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Setting_writing_mode', '500', '330') }}</p>
 
 <p><img alt="A image showing the direction of Block and Inline when writing-mode is vertical-lr" src="8-vertical-lr.png"></p>
 
-<h2 id="Logical_values_for_alignment">Logical values for alignment</h2>
+<h2>Logical values for alignment</h2>
 
 <p>With the block and inline axis able to change direction, the logical values for the alignment properties start to make more sense.</p>
 
@@ -242,7 +242,7 @@ gap: 10px;
 
 <p>The key thing to remember when placing items by line number, is that line 1 is the start line, no matter which writing mode you are in. Line -1 is the end line, no matter which writing mode you are in.</p>
 
-<h3 id="line-based_placement_with_left_to_right_text">Line-based placement with left to right text</h3>
+<h3>Line-based placement with left to right text</h3>
 
 <p>In this next example, I have a grid which is in the default <code>ltr</code> direction. I have positioned three items using line-based placement.</p>
 
@@ -294,9 +294,9 @@ gap: 10px;
     &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('line-based_placement_with_left_to_right_text', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Line-based_placement_with_left_to_right_text', '500', '330') }}</p>
 
-<h3 id="line-based_placement_with_right_to_left_text">Line-based placement with right to left text</h3>
+<h3>Line-based placement with right to left text</h3>
 
 <p>If I now add the {{cssxref("direction")}} property with a value of <code>rtl</code> to the grid container, line 1 becomes the right hand side of the grid, and line -1 on the left.</p>
 
@@ -343,7 +343,7 @@ gap: 10px;
     &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('line-based_placement_with_right_to_left_text', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Line-based_placement_with_right_to_left_text', '500', '330') }}</p>
 
 <p>What this demonstrates, is that if you are switching the direction of your text, either for entire pages or for parts of pages, and are using lines: you may want to name your lines, if you do not want the layout to completely switch direction. For some things, for example, where a grid contains text content, this switching may be exactly what you want. For other usage it may not.</p>
 
@@ -371,7 +371,7 @@ gap: 10px;
 
 <p>This is anti-clockwise! So the reverse of what we do for margins and padding. Once you realize that <code>grid-area</code> sees the world as "block and inline", you can remember that we are setting the two starts, then the two ends. It becomes much more logical once you know!</p>
 
-<h2 id="Mixed_writing_modes_and_grid_layout">Mixed writing modes and grid layout</h2>
+<h2>Mixed writing modes and grid layout</h2>
 
 <p>In addition to displaying documents, using the correct writing mode for the language, writing modes can be used creatively within documents that are otherwise <code>ltr</code>. In this next example I have a grid layout with a set of links down one side. I’ve used writing modes to turn these on their side in the column track:</p>
 

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>In the <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">previous guide</a> we looked at grid lines, and how to position items against those lines. When you use CSS Grid Layout you always have lines, and this can be a straightforward way to place items on your grid. However, there is an alternate method to use for positioning items on the grid which you can use alone or in combination with line-based placement. This method involves placing our items using named template areas, and we will find out exactly how this method works. You will see very quickly why we sometimes call this the ascii-art method of grid layout!</p>
 
-<h2 id="Naming_a_grid_area">Naming a grid area</h2>
+<h2>Naming a grid area</h2>
 
 <p>You have already encountered the {{cssxref("grid-area")}} property. This is the property that can take as a value all four of the lines used to position a grid area.</p>
 
@@ -93,7 +93,7 @@ tags:
 
 <p>Using this method we do not need to specify anything at all on the individual grid items, everything happens on our grid container. We can see the layout described as the value of the {{cssxref("grid-template-areas")}} property.</p>
 
-<h2 id="Leaving_a_grid_cell_empty">Leaving a grid cell empty</h2>
+<h2>Leaving a grid cell empty</h2>
 
 <p>We have completely filled our grid with areas in this example, leaving no white space. However you can leave grid cells empty with this method of layout. To leave a cell empty use the full stop character, '<code>.</code>'. If I want to only display the footer directly under the main content I would need to leave the three cells underneath the sidebar empty.</p>
 
@@ -152,7 +152,7 @@ tags:
 
 <p>In order to make the layout neater I can use multiple <code>.</code> characters. As long as there is no white space between the full stops it will be counted as one cell. For a complex layout there is a benefit to having the rows and columns neatly aligned. It means that you can actually see, right there in the CSS, what this layout looks like.</p>
 
-<h2 id="Spanning_multiple_cells">Spanning multiple cells</h2>
+<h2>Spanning multiple cells</h2>
 
 <p>In our example each of the areas spans multiple grid cells and we achieve this by repeating the name of that grid area multiple times with white space between. You can add extra white space in order to keep your columns neatly lined up in the value of <code>grid-template-areas</code>. You can see that I have done this in order that the <code>hd</code> and <code>ft</code> line up with <code>main</code>.</p>
 
@@ -213,7 +213,7 @@ tags:
 
 <p>The value of {{cssxref("grid-template-areas")}} must show a complete grid, otherwise it is invalid (and the property is ignored). This means that you must have the same number of cells for each row, if empty with a full stop character demonstrating that the cell is to be left empty. You will also create an invalid grid if your areas are not rectangular.</p>
 
-<h2 id="Redefining_the_grid_using_media_queries">Redefining the grid using media queries</h2>
+<h2>Redefining the grid using media queries</h2>
 
 <p>As our layout is now contained in one part of the CSS, this makes it very easy to make changes at different breakpoints. You can do this by redefining the grid, the position of items on the grid, or both at once.</p>
 
@@ -299,7 +299,7 @@ tags:
 
 <p>Many of the grid examples you will find online make the assumption that you will use grid for main page layout, however grid can be just as useful for small elements as those larger ones. Using {{cssxref("grid-template-areas")}} can be especially nice as it is easy to see in the code what your element looks like.</p>
 
-<h3 id="media_object_example">Media object example</h3>
+<h3>Media object example</h3>
 
 <p>As a very simple example we can create a “media object”. This is a component with space for an image or other media on one side and content on the other. The image might be displayed on the right or left of the box.</p>
 
@@ -343,9 +343,9 @@ tags:
     &lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('media_object_example', '300', '200') }}</p>
+<p>{{ EmbedLiveSample('Media_object_example', '300', '200') }}</p>
 
-<h3 id="Displaying_the_image_on_the_other_side_of_the_box">Displaying the image on the other side of the box</h3>
+<h3>Displaying the image on the other side of the box</h3>
 
 <p>We might want to be able to display our box with the image the other way around. To do this, we redefine the grid to put the <code>1fr</code> track last, and flip the values in {{cssxref("grid-template-areas")}}.</p>
 

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>In previous guides we’ve looked at placing items by the lines created by defining grid tracks and also how to place items using named template areas. In this guide we are going to look at how these two things work together when we use named lines. Line naming is incredibly useful, but some of the more baffling looking grid syntax comes from this combination of names and track sizes. Once you work through some examples it should become clearer and easier to work with.</p>
 
-<h2 id="Naming_lines_when_defining_a_grid">Naming lines when defining a grid</h2>
+<h2>Naming lines when defining a grid</h2>
 
 <p>You can assign some or all of the lines in your grid a name when you define your grid with the <code>grid-template-rows</code> and <code>grid-template-columns</code> properties. To demonstrate I’ll use the simple layout created in the guide on line-based placement. This time I’ll create the grid using named lines.</p>
 
@@ -82,7 +82,7 @@ tags:
 
 <p>You may want to give a line more than one name, perhaps it denotes the sidebar-end and the main-start for example. To do this add the names inside the square brackets with whitespace between them <code>[sidebar-end main-start]</code>. You can then refer to that line by either of the names.</p>
 
-<h2 id="Implicit_grid_areas_from_named_lines">Implicit grid areas from named lines</h2>
+<h2>Implicit grid areas from named lines</h2>
 
 <p>When naming the lines, I mentioned that you can name these anything you like. The name is a <a href="https://drafts.csswg.org/css-values-4/#custom-idents">custom ident</a>, an author-defined name. When choosing the name you need to avoid words that might appear in the specification and be confusing - such as <code>span</code>. Idents are not quoted.</p>
 
@@ -126,7 +126,7 @@ tags:
 
 <p>We don’t need to define where our areas are with <code>grid-template-areas</code> as our named lines have created an area for us.</p>
 
-<h2 id="Implicit_Grid_lines_from_named_areas">Implicit Grid lines from named areas</h2>
+<h2>Implicit Grid lines from named areas</h2>
 
 <p>We have seen how named lines create a named area, and this also works in reverse. Named template areas create named lines that you can use to place your items. If we take the layout created in the guide to Grid Template Areas, we can use the lines created by our areas to see how this works.</p>
 
@@ -229,7 +229,7 @@ tags:
 
 <p>If you want to give all of the lines in your grid a unique name then you will need to write out the track definition long-hand rather than using the repeat syntax, as you need to add the name in square brackets while defining the tracks. If you do use the repeat syntax you will end up with multiple lines that have the same name, however this can be very useful too.</p>
 
-<h3 id="twelve_column_grid_using_repeat">12-column grid using repeat()</h3>
+<h3>Twelve-column grid using repeat()</h3>
 
 <p>In this next example I am creating a grid with twelve equal width columns. Before defining the 1fr size of the column track I am also defining a line name of <code>[col-start]</code>. This means that we will end up with a grid that has 12 column lines all named <code>col-start</code> before a <code>1fr</code> width column.</p>
 
@@ -276,13 +276,13 @@ tags:
   &lt;div class="item2"&gt;I am placed from col-start line 7 spanning 3 lines&lt;/div&gt;
 &lt;/div&gt;</pre>
 
-<p>{{ EmbedLiveSample('twelve_column_grid_using_repeat', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Twelve-column_grid_using_repeat', '500', '330') }}</p>
 
 <p>If you take a look at this layout in the Firefox Grid Highlighter you can see how the column lines are shown, and how our items are placed against these lines.</p>
 
 <p><img alt="The 12 column grid with items placed. The Grid Highlighter shows the position of the lines." src="5_named_lines1.png"></p>
 
-<h3 id="defining_named_lines_with_a_track_list">Defining named lines with a track list</h3>
+<h3>Defining named lines with a track list</h3>
 
 <p>The repeat syntax can also take a track list, it doesn’t just need to be a single track size that is being repeated. The code below would create an eight track grid, with a narrower <code>1fr</code> width column named <code>col1-start</code> followed by a wider <code>3fr</code> column named <code>col2-start</code>.</p>
 
@@ -345,9 +345,9 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('defining_named_lines_with_a_track_list', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Defining_named_lines_with_a_track_list', '500', '330') }}</p>
 
-<h3 id="twelve_column_grid_framework">12-column grid framework</h3>
+<h3>Twelve-column grid framework</h3>
 
 <p>Over the last three guides you have discovered that there are a lot of different ways to place items using grid. This can seem a little bit overcomplicated at first, but remember you don’t need to use all of them. In practice I find that for straightforward layouts, using named template areas works well, it gives that nice visual representation of what your layout looks like, and it is then easy to move things around on the grid.</p>
 
@@ -411,7 +411,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('twelve_column_grid_framework', '500', '330') }}</p>
+<p>{{ EmbedLiveSample('Twelve-column_grid_framework', '500', '330') }}</p>
 
 <p>Once again, the grid highlighter is helpful to show us how the grid we have placed our items on works.</p>
 

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>To round off this set of guides to CSS Grid Layout, I am going to walk through a few different layouts, which demonstrate some of the different techniques you can use when designing with grid layout. We will look at an example using <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">grid-template-areas</a>, a typical 12-column flexible grid system, and also a product listing using auto-placement. As you can see from this set of examples, there is often more than one way to achieve the result you want with grid layout. Choose the method you find most helpful for the problems that you are solving and the designs that you need to implement.</p>
 
-<h2 id="A_responsive_layout_with_1_to_3_fluid_columns_using_grid-template-areas">A responsive layout with 1 to 3 fluid columns using <code>grid-template-areas</code></h2>
+<h2>A responsive layout with 1 to 3 fluid columns using <code>grid-template-areas</code></h2>
 
 <p>Many websites are a variation of this type of layout, with content, sidebars, a header and a footer. In a responsive design, you may want to display the layout as a single column, adding a sidebar at a certain breakpoint and then bring in a three-column layout for wider screens.</p>
 
@@ -142,7 +142,7 @@ tags:
 
 <p>This is a simple example but demonstrates how we can use a grid layout to rearrange our layout for different breakpoints. In particular I am changing the location of that <code>ad</code> block, as appropriate in my different column setups. I find this named areas method very helpful at a prototyping stage, it is easy to play around with the location of elements. You could always begin to use grid in this way for prototyping, even if you can’t rely on it fully in production due to the browsers that visit your site.</p>
 
-<h2 id="A_flexible_12-column_layout">A flexible 12-column layout</h2>
+<h2>A flexible 12-column layout</h2>
 
 <p>If you have been working with one of the many frameworks or grid systems you may be accustomed to laying out your site on a 12- or 16-column flexible grid. We can create this type of system using CSS Grid Layout. As a simple example, I am creating a 12-column flexible grid that has 12 <code>1fr</code>-unit column tracks, they all have a start line named <code>col-start</code>. This means that we will have twelve grid lines named <code>col-start</code>.</p>
 
@@ -205,7 +205,7 @@ tags:
 
 <p>There are some key differences with how a grid layout works over the grid systems you may have used previously. As you can see, we do not need to add any markup to create a row, grid systems need to do this to stop elements popping up into the row above. With CSS Grid Layout, we can place things into rows, with no danger of them rising up into the row above if it is left empty. Due to this <em>strict</em> column and row placement we can also easily leave white space in our layout. We also don’t need special classes to pull or push things, to indent them into the grid. All we need to do is specify the start and end line for the item.</p>
 
-<h2 id="Building_a_layout_using_the_12-column_system">Building a layout using the 12-column system</h2>
+<h2>Building a layout using the 12-column system</h2>
 
 <p>To see how this layout method works in practice, we can create the same layout that we created with {{cssxref("grid-template-areas")}}, this time using the 12-column grid system. I am starting with the same markup as used for the grid template areas example.</p>
 
@@ -326,7 +326,7 @@ tags:
 
 <p>Something to note as we create this layout is that we haven’t needed to explicitly position every element on the grid at each breakpoint. We have been able to inherit the placement set up for earlier breakpoints – an advantage of working “mobile first”. We are also able to take advantage of grid auto-placement. By keeping elements in a logical order, auto-placement does quite a lot of work for us in placing items onto the grid. In the final example in this guide we will create a layout that entirely relies on auto-placement.</p>
 
-<h2 id="A_product_listing_with_auto-placement">A product listing with auto-placement</h2>
+<h2>A product listing with auto-placement</h2>
 
 <p>Many layouts are essentially sets of “cards” – product listings, image galleries, and so on. A grid can make it very easy to create these listings in a way that is responsive without needing to add <a href="/en-US/docs/Web/CSS/Media_Queries">media queries</a> to make it so. In this next example I’m combining CSS Grid and Flexbox Layouts to make a simple product listing layout.</p>
 
@@ -439,7 +439,7 @@ tags:
 
 <p>{{ EmbedLiveSample('A_product_listing_with_auto-placement', '800', '900') }}</p>
 
-<h2 id="preventing_gaps_with_the_dense_keyword">Preventing gaps with the dense keyword</h2>
+<h2>Preventing gaps with the dense keyword</h2>
 
 <p>This is all looking fairly complete now, however we sometimes have these cards which contain far more content than the others. It might be nice to cause those to span two tracks, and then they won’t be so tall. I have a class of <code>wide</code> on my larger item, and I add a rule {{cssxref("grid-column-end")}} with a value of <code>span 2</code>. Now when grid encounters this item, it will assign it two tracks. At some breakpoints, this means that we'll get a gap in the grid – where there isn’t space to lay out a two-track item.</p>
 
@@ -527,7 +527,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('preventing_gaps_with_the_dense_keyword', '800', '900') }}</p>
+<p>{{ EmbedLiveSample('Preventing_gaps_with_the_dense_keyword', '800', '900') }}</p>
 
 <p>This technique of using auto-placement with some rules applied to certain items is very useful, and can help you to deal with content that is being output by a CMS for example, where you have repeated items and can perhaps add a class to certain ones as they are rendered into the HTML.</p>
 

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The basic difference between CSS Grid Layout and <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">CSS Flexbox Layout</a> is that flexbox was designed for layout in one dimension - either a row <em>or</em> a column. Grid was designed for two-dimensional layout - rows, and columns at the same time. The two specifications share some common features, however, and if you have already learned how to use flexbox, the similarities should help you get to grips with Grid.</p>
 
-<h3 id="One-dimensional_versus_two-dimensional_layout">One-dimensional versus two-dimensional layout</h3>
+<h3>One-dimensional versus two-dimensional layout</h3>
 
 <p>A simple example can demonstrate the difference between one- and two-dimensional layouts.</p>
 
@@ -64,7 +64,7 @@ tags:
 
 <p>A common question then is how to make those items line up. This is where you want a two-dimensional layout method: You want to control the alignment by row and column, and this is where grid comes in.</p>
 
-<h3 id="The_same_layout_with_CSS_grids">The same layout with CSS grids</h3>
+<h3>The same layout with CSS grids</h3>
 
 <p>In this next example, I create the same layout using Grid. This time we have three <code>1fr</code> column tracks. We do not need to set anything on the items themselves; they will lay themselves out one into each cell of the created grid. As you can see they stay in a strict grid, lining up in rows and columns. With five items, we get a gap on the end of row two.</p>
 
@@ -117,7 +117,7 @@ tags:
 
 <p>If you are using flexbox and find yourself disabling some of the flexibility, you probably need to use CSS Grid Layout. An example would be if you are setting a percentage width on a flex item to make it line up with other items in a row above. In that case, a grid is likely to be a better choice.</p>
 
-<h3 id="Box_alignment">Box alignment</h3>
+<h3>Box alignment</h3>
 
 <p>The feature of flexbox that was most exciting to many of us was that it gave us proper alignment control for the first time. It made it easy to center a box on the page. Flex items can stretch to the height of the flex container, meaning that equal height columns were possible. These were things we have wanted to do for a very long time, and have come up with all kinds of hacks to accomplish, at least visually.</p>
 
@@ -166,7 +166,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Box_alignment', '300', '230') }}</p>
 
-<h3 id="Alignment_in_CSS_Grids">Alignment in CSS Grids</h3>
+<h3>Alignment in CSS Grids</h3>
 
 <p>This second example uses a grid to create the same layout. This time we are using the box alignment properties as they apply to a grid layout. So we align to <code>start</code> and <code>end</code> rather than <code>flex-start</code> and <code>flex-end</code>. In the case of a grid layout, we are aligning the items inside their grid area. In this case that is a single grid cell, but it could be an area made up of several grid cells.</p>
 
@@ -218,7 +218,7 @@ tags:
 
 <p>In comparison, the grid version always has three column tracks. The tracks themselves will grow and shrink, but there are always three since we asked for three when defining our grid.</p>
 
-<h4 id="Auto-filling_grid_tracks">Auto-filling grid tracks</h4>
+<h4>Auto-filling grid tracks</h4>
 
 <p>We can create a similar effect to flexbox, while still keeping the content arranged in strict rows and columns, by creating our track listing using repeat notation and the <code>auto-fill</code> and <code>auto-fit</code> properties.</p>
 
@@ -256,7 +256,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Auto-filling_grid_tracks', '500', '170') }}</p>
 
-<h3 id="A_flexible_number_of_tracks">A flexible number of tracks</h3>
+<h3>A flexible number of tracks</h3>
 
 <p>This isn’t quite the same as flexbox. In the flexbox example, the items are larger than the 200 pixel basis before wrapping. We can achieve the same in grid by combining <code>auto-fit</code> and the {{cssxref("minmax()", "minmax()")}} function. In this next example, I create auto filled tracks with <code>minmax</code>. I want my tracks to be a minimum of 200 pixels, so I set the maximum to be <code>1fr</code>. Once the browser has worked out how many times 200 pixels will fit into the container–also taking account of grid gaps–it will treat the <code>1fr</code> maximum as an instruction to share out the remaining space between the items.</p>
 
@@ -298,7 +298,7 @@ tags:
 
 <p>Grid interacts with absolutely positioned elements, which can be useful if you want to position an item inside a grid or grid area. The specification defines the behavior when a grid container is a containing block and a parent of the absolutely positioned item.</p>
 
-<h3 id="A_grid_container_as_containing_block">A grid container as containing block</h3>
+<h3>A grid container as containing block</h3>
 
 <p>To make the grid container a containing block you need to add the position property to the container with a value of relative, just as you would make a containing block for any other absolutely positioned items. Once you have done this, if you give a grid item <code>position: absolute</code> it will take as its containing block the grid container or, if the item also has a grid position, the area of the grid it is placed into.</p>
 
@@ -363,7 +363,7 @@ tags:
 
 <p>Once again the item no longer participates in the grid layout in terms of sizing or when other items are auto-placed.</p>
 
-<h3 id="With_a_grid_area_as_the_parent">With a grid area as the parent</h3>
+<h3>With a grid area as the parent</h3>
 
 <p>If the absolutely positioned item is nested inside a grid area then you can create a positioning context on that area. In the below example we have our grid as before but this time I have nested an item inside <code>.box3</code> of the grid.</p>
 
@@ -434,7 +434,7 @@ tags:
 
 <p>If you set an item to <code>display:</code> <code>contents</code> the box it would normally create disappears, and the boxes of the child elements appear as if they have risen up a level. This means that children of a grid item can become grid items. Sound odd? Here is a simple example.</p>
 
-<h3 id="grid_layout_with_nested_child_elements">Grid layout with nested child elements</h3>
+<h3>Grid layout with nested child elements</h3>
 
 <p>In the following markup, I have a grid and the first item on the grid is set to span all three column tracks. It contains three nested items. As these items are not direct children, they don’t become part of the grid layout and so display using regular block layout.</p>
 
@@ -486,9 +486,9 @@ tags:
 
 </pre>
 
-<p>{{ EmbedLiveSample('grid_layout_with_nested_child_elements', '400', '440') }}</p>
+<p>{{ EmbedLiveSample('Grid_layout_with_nested_child_elements', '400', '440') }}</p>
 
-<h3 id="using_display_contents">Using display_contents</h3>
+<h3>Using display_contents</h3>
 
 <p>If I now add <code>display:</code> <code>contents</code> to the rules for <code>box1</code>, the box for that item vanishes and the sub-items now become grid items and lay themselves out using the auto-placement rules.</p>
 
@@ -540,7 +540,7 @@ tags:
 }
 </pre>
 
-<p>{{ EmbedLiveSample('using_display_contents', '400', '350') }}</p>
+<p>{{ EmbedLiveSample('Using_display_contents', '400', '350') }}</p>
 
 <p>This can be a way to get items nested into the grid to act as if they are part of the grid, and is a way around some of the issues that would be solved by subgrids once they are implemented. You can also use <code>display:</code> <code>contents</code> in a similar way with flexbox to enable nested items to become flex items.</p>
 

--- a/files/en-us/web/css/env()/index.html
+++ b/files/en-us/web/css/env()/index.html
@@ -69,7 +69,7 @@ env(safe-area-inset-left, 1.4rem);
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example1">Using <code>env()</code> to ensure buttons are not obscured by device UI</h3>
+<h3>Using env() to ensure buttons are not obscured by device UI</h3>
 
 <p>In the following example <code>env()</code> is used to ensure that fixed app toolbar buttons are not obscured by device notifications appearing at the bottom of the screen. On the desktop <code>safe-area-inset-bottom</code> is <code>0</code>. However, in devices that display notifications at the bottom of the screen, such as iOS, it contains a value that leaves space for the notification to display. This can then be used in the value for {{cssxref("padding-bottom")}} to create a gap that appears natural on that device.</p>
 
@@ -117,9 +117,9 @@ button {
 }
 </pre>
 
-<p>{{EmbedLiveSample("Example1", "200px", "500px")}}</p>
+<p>{{EmbedLiveSample("Using_env_to_ensure_buttons_are_not_obscured_by_device_UI", "200px", "500px")}}</p>
 
-<h3 id="Example2">Using the fallback value</h3>
+<h3>Using the fallback value</h3>
 
 <p>The below example makes use of the optional second parameter of <code>env()</code>, which allows you to provide a fallback value in case the environment variable is not available.</p>
 
@@ -142,7 +142,7 @@ button {
     env(SAFE-AREA-INSET-LEFT, 50px);
 }</pre>
 
-<p>{{EmbedLiveSample("Example2", "350px", "250px")}}</p>
+<p>{{EmbedLiveSample("Using_the_fallback_value", "350px", "250px")}}</p>
 
 <h3 id="Example_values">Example values</h3>
 

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -132,7 +132,7 @@ p { font: bold italic large serif }
 p { font: status-bar }
 </pre>
 
-<h3 id="live_sample">Live sample</h3>
+<h3>Live sample</h3>
 
 <pre class="brush: html hidden">&lt;p&gt;
     Change the radio buttons below to see the generated shorthand and its effect.
@@ -330,7 +330,7 @@ injectCss = function(cssFragment) {
 setCss();</pre>
 </div>
 
-<p>{{ EmbedLiveSample('live_sample','100%', '440px')}}</p>
+<p>{{ EmbedLiveSample('Live_sample','100%', '440px')}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -223,7 +223,7 @@ ul li::before {
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_list_item_markers">Setting list item markers</h3>
+<h3>Setting list item markers</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -258,7 +258,7 @@ ol.shortcut {
 
 <p>{{EmbedLiveSample("Setting_list_item_markers","200","300")}}</p>
 
-<h3 id="all_list_style_types">All list style types</h3>
+<h3>All list style types</h3>
 
 <h4>HTML</h4>
 
@@ -572,7 +572,7 @@ container.addEventListener("change", event => {
 
 <h4>Result</h4>
 
-{{EmbedLiveSample("all_list_style_types", "600", "800")}}
+{{EmbedLiveSample("All_list_style_types", "600", "800")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/specificity/index.html
+++ b/files/en-us/web/css/specificity/index.html
@@ -140,7 +140,7 @@ p.awesome {
  <li><a href="https://stackoverflow.com/questions/2042497/when-to-use-important-to-save-the-day-when-working-with-css">https://stackoverflow.com/questions/2042497/when-to-use-important-to-save-the-day-when-working-with-css</a></li>
 </ul>
 
-<h3 id="The_is_and_not_exceptions">The :is() and :not() exceptions</h3>
+<h3>The :is() and :not() exceptions</h3>
 
 <p>The matches-any pseudo-class {{CSSxRef(":is", ":is()")}} {{Experimental_Inline}} and the negation pseudo-class {{CSSxRef(":not", ":not()")}} are <em>not</em> considered a pseudo-class in the specificity calculation. But selectors placed into the pseudo-class count as normal selectors when determining the count of <a href="#selector_types">selector types</a>.</p>
 
@@ -169,9 +169,7 @@ div:not(.outer) p {
 
 <p>{{EmbedLiveSample("The_is_and_not_exceptions")}}</p>
 
-<h3 id="The_where_exception">The :where() exception {{Experimental_Inline}}</h3>
-
-<p>{{SeeCompatTable}}</p>
+<h3>The :where() exception</h3>
 
 <p>The specificity-adjustment pseudo-class {{CSSxRef(":where", ":where()")}} {{Experimental_Inline}} always has its specificity replaced with zero.</p>
 
@@ -215,7 +213,7 @@ div p {
 
 <p>{{EmbedLiveSample("The_where_exception")}}</p>
 
-<h3 id="Form-based_specificity">Form-based specificity</h3>
+<h3>Form-based specificity</h3>
 
 <p>Specificity is based on the form of a selector. In the following case, the selector <code>*[id="foo"]</code> counts as an attribute selector for the purpose of determining the selector's specificity, even though it selects an ID.</p>
 
@@ -241,7 +239,7 @@ div p {
 
 <p>This is because it matches the same element but the ID selector has a higher specificity.</p>
 
-<h3 id="Tree_proximity_ignorance">Tree proximity ignorance</h3>
+<h3>Tree proximity ignorance</h3>
 
 <p>The proximity of an element to other elements that are referenced in a given selector has no impact on specificity. The following style declaration ...</p>
 
@@ -269,7 +267,7 @@ html h1 {
 
 <p>This is because the two declarations have equal <a href="#selector_types">selector type</a> counts, but the <code>html h1</code> selector is declared last.</p>
 
-<h3 id="Directly_targeted_elements_vs._inherited_styles">Directly targeted elements vs. inherited styles</h3>
+<h3>Directly targeted elements vs. inherited styles</h3>
 
 <p>Styles for a directly targeted element will always take precedence over inherited styles, regardless of the specificity of the inherited rule. This CSS ...</p>
 

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -69,7 +69,7 @@ text-overflow: unset;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="one-value_syntax">One-value syntax</h3>
+<h3>One-value syntax</h3>
 
 <p>This example shows different values for <code>text-overflow</code> applied to a paragraph, for left-to-right and right-to-left text.</p>
 
@@ -138,9 +138,9 @@ body {
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample('one-value_syntax', 600, 320)}}</p>
+<p>{{EmbedLiveSample('One-value_syntax', 600, 320)}}</p>
 
-<h3 id="two-value_syntax">Two-value syntax</h3>
+<h3>Two-value syntax</h3>
 
 <p>This example shows the two-value syntax for <code>text-overflow</code>, where you can define different overflow behavior for the start and end of the text.
 To show the effect we have to scroll the line so the start of the line is also hidden.</p>
@@ -200,7 +200,7 @@ for (let para of paras) {
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample('two-value_syntax', 600, 360)}}</p>
+<p>{{EmbedLiveSample('Two-value_syntax', 600, 360)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/transition-delay/index.html
+++ b/files/en-us/web/css/transition-delay/index.html
@@ -55,7 +55,7 @@ transition-delay: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="example_showing_different_delays">Example showing different delays</h3>
+<h3>Example showing different delays</h3>
 
 <h4>HTML</h4>
 
@@ -123,7 +123,7 @@ changeButton.addEventListener("click", change);
 
 <h4>Result</h4>
 
-<div>{{EmbedLiveSample("example_showing_different_delays",275,200)}}</div>
+<div>{{EmbedLiveSample("Example_showing_different_delays",275,200)}}</div>
 
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/css/transition-duration/index.html
+++ b/files/en-us/web/css/transition-duration/index.html
@@ -49,7 +49,7 @@ transition-duration: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="example_showing_different_durations">Example showing different durations</h3>
+<h3>Example showing different durations</h3>
 
 <h4>HTML</h4>
 
@@ -115,7 +115,7 @@ changeButton.addEventListener("click", change);
 
 <h4>Result</h4>
 
-<div>{{EmbedLiveSample("example_showing_different_durations",275,200)}}</div>
+<div>{{EmbedLiveSample("Example_showing_different_durations",275,200)}}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/vertical-align/index.html
+++ b/files/en-us/web/css/vertical-align/index.html
@@ -115,7 +115,7 @@ vertical-align: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Basic_example">Basic example</h3>
+<h3>Basic example</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -136,7 +136,7 @@ img.middle { vertical-align: middle; }
 
 <p>{{EmbedLiveSample("Basic_example")}}</p>
 
-<h3 id="vertical_alignment_in_a_line_box">Vertical alignment in a line box</h3>
+<h3>Vertical alignment in a line box</h3>
 
 <h4>HTML</h4>
 
@@ -180,9 +180,9 @@ p {
 
 <h4>Result</h4>
 
-<p>{{EmbedLiveSample("vertical_alignment_in_a_line_box", '100%', 160, "", "")}}</p>
+<p>{{EmbedLiveSample("Vertical_alignment_in_a_line_box", '100%', 160, "", "")}}</p>
 
-<h3 id="vertical_alignment_in_a_table_cell">Vertical alignment in a table cell</h3>
+<h3>Vertical alignment in a table cell</h3>
 
 <h4>HTML</h4>
 
@@ -222,7 +222,7 @@ td {
 
 <h4>Result</h4>
 
-<p>{{EmbedLiveSample("vertical_alignment_in_a_table_cell", '100%', 230, "", "")}}</p>
+<p>{{EmbedLiveSample("Vertical_alignment_in_a_table_cell", '100%', 230, "", "")}}</p>
 
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/5865.

On MDN, live samples (the `EmbedLiveSample` macro) are passed an ID that Yari uses to find the code to include in the sample. These IDs typically (almost always, in Markdown-land) refer to headings.

In HTML, we can have explicit `id` attributes for headings, that can differ from the ID that would be auto-generated from the heading's text. Live samples can then use these "custom" IDs to refer to the scope where Yari can find the code.

In Markdown we can't do that - IDs are always generated from the heading text. So if a live sample in the old HTML system was using a custom ID, this will cause an error when we convert to Markdown.

I've checked through the CSS docs to find pages where this was happening - effectively where a live sample was using an ID that differed from the one that would be generated by Yari's [`slugify`](https://github.com/mdn/yari/blob/5ce6f326fab43343a9d86bd8d0e059cdf5fff2d1/kumascript/src/api/util.js#L24) function. In this PR I've fixed all the macro calls to use the auto-generated form.

To make it easier to check that this is working, I've deleted the explicit `id` attribute in all affected files, so all `EmbedLiveSample` calls will need to use an ID that matches the generated one. Note that in some cases here the macro was already using that form, so I just deleted the `id` in the heading. In other cases I've correspondingly adjusted the macro argument.