### PR TITLE
Fix typo in WebGL2RenderingContext»texImage3D()

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
@@ -73,7 +73,7 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
       <li><code>gl.RGB32F</code></li>
       <li><code>gl.RGB8UI</code></li>
       <li><code>gl.RGBA8</code></li>
-      <li><code>gl.SRGB_APLHA8</code></li>
+      <li><code>gl.SRGB8_ALPHA8</code></li>
       <li><code>gl.RGB5_A1</code></li>
       <li><code>gl.RGBA4444</code></li>
       <li><code>gl.RGBA16F</code></li>


### PR DESCRIPTION
Fixed typo  in `internalformat` section

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #7714 


