### PR TITLE
RTCPeerConnection.addIceCandidate() - remove RTCIceCandidateInit dict…

### DIFF
--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
@@ -44,10 +44,8 @@ browser-compat: api.RTCIceCandidate.sdpMid
   the candidate.</p>
 
 <div class="note">
-  <p><strong>Note:</strong> Attempting to add a candidate (using
-    {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}) that has a
-    value of <code>null</code> for either <code>sdpMid</code> or
-    <code>sdpMLineIndex</code> will throw a <code>TypeError</code> exception.</p>
+  <p><strong>Note:</strong> Attempting to add a candidate (using {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}) that has a
+    value of <code>null</code> for both <code>sdpMid</code> and <code>sdpMLineIndex</code> will throw a <code>TypeError</code> exception.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
@@ -17,36 +17,22 @@ browser-compat: api.RTCPeerConnection.addIceCandidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p>>When a web site or app using {{domxref("RTCPeerConnection")}}
-		receives a new ICE candidate from the remote peer over its signaling channel, it
-		delivers the newly-received candidate to the browser's {{Glossary("ICE")}} agent
-		by calling
-		<code><strong>RTCPeerConnection.addIceCandidate()</strong></code>. This
-	adds this new remote candidate to the <code>RTCPeerConnection</code>'s remote
-	description, which describes the state of the remote end of the connection.</p>
+<p>When a web site or app using {{domxref("RTCPeerConnection")}} receives a new ICE candidate from the remote peer over its signaling channel, it delivers the newly-received candidate to the browser's {{Glossary("ICE")}} agent by calling <code><strong>RTCPeerConnection.addIceCandidate()</strong></code>.
+	This adds this new remote candidate to the <code>RTCPeerConnection</code>'s remote description, which describes the state of the remote end of the connection.</p>
 
-<p>If the <code>candidate</code> parameter is missing or a value of <code>null</code> is
-	given when calling <code>addIceCandidate()</code>, the added ICE candidate is an
-	"end-of-candidates" indicator. The same is the case if the value of the specified
-	object's {{domxref("RTCIceCandidate.candidate", "candidate")}} is either missing or an
-	empty string (<code>""</code>), it signals that all remote candidates have been
-	delivered.</p>
+<p>If the <code>candidate</code> parameter is missing or a value of <code>null</code> is given when calling <code>addIceCandidate()</code>, the added ICE candidate is an "end-of-candidates" indicator.
+	The same is the case if the value of the specified object's {{domxref("RTCIceCandidate.candidate", "candidate")}} is either missing or an empty string (<code>""</code>), it signals that all remote candidates have been delivered.</p>
 
-<p>The end-of-candidates notification is transmitted to the remote peer using a candidate
-	with an a-line value of <code>end-of-candidates</code>.</p>
+<p>The end-of-candidates notification is transmitted to the remote peer using a candidate with an a-line value of <code>end-of-candidates</code>.</p>
 
-<p>During negotiation, your app will likely receive many candidates which you'll deliver
-	to the ICE agent in this way, allowing it to build up a list of potential connection
-	methods. This is covered in more detail in the articles <a
-		href="/en-US/docs/Web/API/WebRTC_API/Connectivity">WebRTC connectivity</a> and <a
-		href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and
-		video calling</a>.</p>
+<p>During negotiation, your app will likely receive many candidates which you'll deliver to the ICE agent in this way, allowing it to build up a list of potential connection methods.
+	This is covered in more detail in the articles <a href="/en-US/docs/Web/API/WebRTC_API/Connectivity">WebRTC connectivity</a> and 
+	<a href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video calling</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>aPromise </em>= <em>pc</em>.addIceCandidate(<em>candidate</em>);
-
-addIceCandidate(<em>candidate</em>, <em>successCallback</em>, <em>failureCallback</em>); {{deprecated_inline}}
+<pre class="brush: js">addIceCandidate(candidate)
+addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -54,19 +40,79 @@ addIceCandidate(<em>candidate</em>, <em>successCallback</em>, <em>failureCallbac
 <dl>
 	<dt><code>candidate</code> {{optional_inline}}</dt>
 	<dd>
-		<p>An object conforming to the {{domxref("RTCIceCandidateInit")}} dictionary, or
-			an {{domxref("RTCIceCandidate")}} object; the contents of the object should be
-			constructed from a message received over the signaling channel, describing a
-			newly received ICE candidate that's ready to be delivered to the local ICE
-			agent.</p>
+		<p>An {{domxref("RTCIceCandidate")}} object, or an object that has the following properties:</p>
+		<!-- The spec calls this object an RTCIceCandidateInit -->
+			<dl>
+				<dt><code>candidate</code> {{optional_inline}}</dt>
+				<dd><p>A {{domxref("DOMString")}} describing the properties of the candidate, taken directly
+						from the {{Glossary("SDP")}} attribute <code>"candidate"</code>. The candidate string
+						specifies the network connectivity information for the candidate. If the
+						<code>candidate</code> is an empty string (<code>""</code>), the end of the candidate
+						list has been reached; this candidate is known as the "end-of-candidates" marker.</p>
+					  
+					  <p>The syntax of the candidate string is described in {{RFC(5245, "", 15.1)}}. For an
+						a-line (attribute line) that looks like this:</p>
+					  
+					  <pre>a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host</pre>
+					  
+					  <p>the corresponding <code>candidate</code> string's value will be
+						<code>"candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host"</code>.</p>
+					  
+					  <p>The {{Glossary("user agent")}} always prefers candidates with the highest
+						{{domxref("RTCIceCandidate.priority", "priority")}}, all else being equal. In the
+						example above, the priority is <code>2043278322</code>. The attributes are all separated
+						by a single space character, and are in a specific order. The complete list of
+						attributes for this example candidate is:</p>
+					  
+					  <ul>
+						<li>{{domxref("RTCIceCandidate.foundation", "foundation")}} = 4234997325</li>
+						<li>{{domxref("RTCIceCandidate.component", "component")}} = <code>"rtp"</code> (the
+						  number 1 is encoded to this string; 2 becomes <code>"rtcp"</code>)</li>
+						<li>{{domxref("RTCIceCandidate.protocol", "protocol")}} = <code>"udp"</code></li>
+						<li>{{domxref("RTCIceCandidate.priority", "priority")}} = 2043278322</li>
+						<li>{{domxref("RTCIceCandidate/address", "ip")}} = <code>"192.168.0.56"</code></li>
+						<li>{{domxref("RTCIceCandidate.port", "port")}} = 44323</li>
+						<li>{{domxref("RTCIceCandidate.type", "type")}} = <code>"host"</code></li>
+					  </ul>
 
-		<p>If no <code>candidate</code> object is specified, or its value is
-			<code>null</code>, an end-of-candidates signal is sent to the remote peer
-			using the <code>end-of-candidates</code> a-line, formatted like this:</p>
+					  <p>Additional information can be found in {{domxref("RTCIceCandidate.candidate")}}.</p>
 
+					  <div class="notecard note">
+						  <p>For backward compatibility with older versions of the WebRTC specification, the constructor also accepts this string directly as an argument.</p>
+					  </div>
+				</dd>
+				<dt><code>sdpMid</code> {{optional_inline}} <!-- RTCIceCandidateInit.sdpMid --></dt>
+				<dd>A {{domxref("DOMString")}} containing the identification tag of the media stream with which the candidate is associated, or <code>null</code> if there is no associated media stream. The default is <code>null</code>. 
+
+					<p>Additional information can be found in {{domxref("RTCIceCandidate.sdpMid")}}.</p></dd>
+				<dt><code>sdpMLineIndex</code> {{optional_inline}}</dt>
+				<dd>A number property containing the zero-based index of the m-line with which the candidate is associated, within the SDP of the media description, or <code>null</code> if no such associated exists. The default is <code>null</code>.
+
+					<p>Additional information can be found in {{domxref("RTCIceCandidate.sdpMLineIndex")}}.</p>
+				</dd>
+				<dt><code>usernameFragment</code> {{optional_inline}}</dt>
+				<dd>A {{domxref("DOMString")}} containing the username fragment (usually referred to in shorthand as "ufrag" or "ice-ufrag").
+					This fragment, along with the ICE password ("ice-pwd"), uniquely identifies a single ongoing ICE interaction (including for any communication with the {{Glossary("STUN")}} server).
+						
+						<p>The string is generated by WebRTC at the beginning of the session.
+						It  may be up to 256 characters long, and at least 24 bits must contain random data.
+						It has no default value and is not present unless set explicitly.</p>
+					  
+					<p>Additional information can be found in {{domxref("RTCIceCandidate.usernameFragment")}}.</p>
+				</dd>
+			   </dl>
+
+		<p>The method will throw a <code>TypeError</code> exception if both <code>sdpMid</code> and <code>sdpMLineIndex</code> are <code>null</code>.</p>
+
+		<p>The contents of the object should be constructed from a message received over the signaling channel, describing a newly received ICE candidate that's ready to be delivered to the local ICE agent.</p>
+
+		<p>If no <code>candidate</code> object is specified, or its value is <code>null</code>, an end-of-candidates signal is sent to the remote peer using the <code>end-of-candidates</code> a-line, formatted like this:</p>
 		<pre>a=end-of-candidates</pre>
 	</dd>
 </dl>
+
+
+
 
 <h3 id="Deprecated_parameters">Deprecated parameters</h3>
 
@@ -74,8 +120,7 @@ addIceCandidate(<em>candidate</em>, <em>successCallback</em>, <em>failureCallbac
 	This has been deprecated and its use is <strong>strongly</strong> discouraged. You
 	should update any existing code to use the {{jsxref("Promise")}}-based version of
 	<code>addIceCandidate()</code> instead. The parameters for this form of
-	<code>addIceCandidate()</code> are described below, to aid in updating existing code.
-</p>
+	<code>addIceCandidate()</code> are described below, to aid in updating existing code.</p>
 
 <dl>
 	<dt><code>successCallback</code> {{deprecated_inline}}</dt>
@@ -89,8 +134,7 @@ addIceCandidate(<em>candidate</em>, <em>successCallback</em>, <em>failureCallbac
 <h3 id="Return_value">Return value</h3>
 
 <p>A {{jsxref("Promise")}} which is fulfilled when the candidate has been successfully
-	added to the remote peer's description by the ICE agent. The promise does not receive
-	any input parameters.</p>
+	added to the remote peer's description by the ICE agent. The promise does not receive any input parameters.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 
@@ -102,12 +146,10 @@ addIceCandidate(<em>candidate</em>, <em>successCallback</em>, <em>failureCallbac
 <dl>
 	<dt><code>TypeError</code></dt>
 	<dd>The specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
-		{{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} are both
-		<code>null</code>.</dd>
+		{{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} are both <code>null</code>.</dd>
 	<dt><code>InvalidStateError</code></dt>
 	<dd>The <code>RTCPeerConnection</code> currently has no remote peer established
-		({{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is
-		<code>null</code>).</dd>
+		({{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is <code>null</code>).</dd>
 	<dt><code>OperationError</code></dt>
 	<dd>This can happen for a number of reasons:
 		<ul>
@@ -185,11 +227,8 @@ signalingChannel.onmessage = receivedString =&gt; {
 
 <ul>
 	<li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a></li>
-	<li><a href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and
-			video calling</a></li>
-	<li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture">WebRTC architecture
-			overview</a></li>
+	<li><a href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video calling</a></li>
+	<li><a href="/en-US/docs/Web/API/WebRTC_API/Protocols">Introduction to WebRTC protocols</a></li>
 	<li><a href="/en-US/docs/Web/API/WebRTC_API/Connectivity">WebRTC connectivity</a></li>
-	<li><a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime">Lifetime of a WebRTC
-			session</a></li>
+	<li><a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime">Lifetime of a WebRTC session</a></li>
 </ul>

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
@@ -44,30 +44,25 @@ addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 		<!-- The spec calls this object an RTCIceCandidateInit -->
 			<dl>
 				<dt><code>candidate</code> {{optional_inline}}</dt>
-				<dd><p>A {{domxref("DOMString")}} describing the properties of the candidate, taken directly
-						from the {{Glossary("SDP")}} attribute <code>"candidate"</code>. The candidate string
-						specifies the network connectivity information for the candidate. If the
-						<code>candidate</code> is an empty string (<code>""</code>), the end of the candidate
-						list has been reached; this candidate is known as the "end-of-candidates" marker.</p>
+				<dd><p>A {{domxref("DOMString")}} describing the properties of the candidate, taken directly from the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#sdp">SDP</a> attribute <code>"candidate"</code>.
+					The candidate string specifies the network connectivity information for the candidate.
+					If the <code>candidate</code> is an empty string (<code>""</code>), the end of the candidate list has been reached; this candidate is known as the "end-of-candidates" marker.</p>
 					  
-					  <p>The syntax of the candidate string is described in {{RFC(5245, "", 15.1)}}. For an
-						a-line (attribute line) that looks like this:</p>
+					  <p>The syntax of the candidate string is described in {{RFC(5245, "", 15.1)}}.
+						  For an a-line (attribute line) that looks like this:</p>
 					  
 					  <pre>a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host</pre>
 					  
 					  <p>the corresponding <code>candidate</code> string's value will be
 						<code>"candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host"</code>.</p>
 					  
-					  <p>The {{Glossary("user agent")}} always prefers candidates with the highest
-						{{domxref("RTCIceCandidate.priority", "priority")}}, all else being equal. In the
-						example above, the priority is <code>2043278322</code>. The attributes are all separated
-						by a single space character, and are in a specific order. The complete list of
-						attributes for this example candidate is:</p>
+					  <p>The {{Glossary("user agent")}} always prefers candidates with the highest {{domxref("RTCIceCandidate.priority", "priority")}}, all else being equal.
+						  In the example above, the priority is <code>2043278322</code>. The attributes are all separated by a single space character, and are in a specific order.
+						  The complete list of attributes for this example candidate is:</p>
 					  
 					  <ul>
 						<li>{{domxref("RTCIceCandidate.foundation", "foundation")}} = 4234997325</li>
-						<li>{{domxref("RTCIceCandidate.component", "component")}} = <code>"rtp"</code> (the
-						  number 1 is encoded to this string; 2 becomes <code>"rtcp"</code>)</li>
+						<li>{{domxref("RTCIceCandidate.component", "component")}} = <code>"rtp"</code> (the number 1 is encoded to this string; 2 becomes <code>"rtcp"</code>)</li>
 						<li>{{domxref("RTCIceCandidate.protocol", "protocol")}} = <code>"udp"</code></li>
 						<li>{{domxref("RTCIceCandidate.priority", "priority")}} = 2043278322</li>
 						<li>{{domxref("RTCIceCandidate/address", "ip")}} = <code>"192.168.0.56"</code></li>
@@ -86,7 +81,7 @@ addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 
 					<p>Additional information can be found in {{domxref("RTCIceCandidate.sdpMid")}}.</p></dd>
 				<dt><code>sdpMLineIndex</code> {{optional_inline}}</dt>
-				<dd>A number property containing the zero-based index of the m-line with which the candidate is associated, within the SDP of the media description, or <code>null</code> if no such associated exists. The default is <code>null</code>.
+				<dd>A number property containing the zero-based index of the m-line with which the candidate is associated, within the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#sdp">SDP</a> of the media description, or <code>null</code> if no such associated exists. The default is <code>null</code>.
 
 					<p>Additional information can be found in {{domxref("RTCIceCandidate.sdpMLineIndex")}}.</p>
 				</dd>

--- a/files/en-us/web/api/webrtc_api/protocols/index.html
+++ b/files/en-us/web/api/webrtc_api/protocols/index.html
@@ -17,7 +17,7 @@ tags:
   - WebRTC
   - WebRTC API
 ---
-<div>{{WebRTCSidebar}}{{draft}}</div>
+<div>{{WebRTCSidebar}}</div>
 
 <p>This article introduces the protocols on top of which the WebRTC API is built.</p>
 


### PR DESCRIPTION
[RTCPeerConnection.addIceCandidate()](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addIceCandidate) takes a dictionary option [RTCIceCandidateInit](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateInit). This PR takes all of the relevant info from `RTCIceCandidateInit` and the `RTCIceCandidateInit` properties and puts it into an options argument in `RTCPeerConnection.addIceCandidate()`.

I have also linked each property to the matching properties in [RTCIceCandidate](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate) (e.g. [RTCIceCandidate.sdpMid](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/sdpMid) as these sometimes have additional information/examples).

This is first step in the activity. IFF this looks OK I will:
- Propagate the same changes to other things that use the `RTCIceCandidateInit`, including 
  - [`RTCIceCandidate` constructor](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/RTCIceCandidate) 
  - [`RTCIceCandidate.toJSON()` method return value ](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/toJSON)
- Delete the  `RTCIceCandidateInit` page and it's property pages
- Delete/tidy up any mention of `RTCIceCandidateInit` 

I'm also looking at BCD work for this in https://github.com/mdn/browser-compat-data/pull/11941
