### PR TITLE
Add and remove commas in CSS Logical Properties' Basic concepts

### DIFF
--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The Logical Properties and Values Specification introduces flow-relative mappings for many of the properties and values in CSS. This article introduces the specification, and explains flow relative properties and values.</p>
+<p>The Logical Properties and Values Specification introduces flow-relative mappings for many of the properties and values in CSS. This article introduces the specification and explains flow relative properties and values.</p>
 
 <h2 id="Why_do_we_need_logical_properties">Why do we need logical properties?</h2>
 
@@ -20,7 +20,7 @@ tags:
 
 <p><img alt="A grid in a horizontal writing mode" src="grid-horizontal-width-sm.png"></p>
 
-<p>If I now change the writing mode of this component to <code>vertical-rl</code> using the {{CSSxRef("writing-mode")}} property, the alignment continues to work in the same way. The inline dimension is now running vertically and the block dimension horizontally. The grid doesn't look the same however, as the width assigned to the container is a horizontal measure, a measure tied to the physical and not the logical or flow relative running of the text.</p>
+<p>If I now change the writing mode of this component to <code>vertical-rl</code> using the {{CSSxRef("writing-mode")}} property, the alignment continues to work in the same way. The inline dimension is now running vertically and the block dimension horizontally. The grid doesn't look the same, however, as the width assigned to the container is a horizontal measure, a measure tied to the physical and not the logical or flow relative running of the text.</p>
 
 <p><img alt="A grid in vertical writing mode." src="grid-vertical-width-sm.png"></p>
 
@@ -38,9 +38,9 @@ tags:
 
 <p>A key concept of working with flow relative properties and values is the two dimensions of block and inline. As we saw above, newer CSS layout methods such as Flexbox and Grid Layout use the concepts of <code>block</code> and <code>inline</code> rather than <code>right</code> and <code>left</code>/<code>top</code> and <code>bottom</code> when aligning items.</p>
 
-<p>The <code>inline</code> dimension is the dimension along which a line of text runs in the writing mode in use. Therefore, in an English document with the text running horizontally left to right, or an Arabic document with the text running horizontally right to left, the inline dimension is <em>horizontal</em>. Switch to a vertical writing mode (e.g. a Japanese document) and the inline dimension is now <em>vertical</em>, as lines in that writing mode run vertically.</p>
+<p>The <code>inline</code> dimension is the dimension along which a line of text runs in the writing mode in use. Therefore, in an English document with the text running horizontally left to right or an Arabic document with the text running horizontally right to left, the inline dimension is <em>horizontal</em>. Switch to a vertical writing mode (e.g. a Japanese document) and the inline dimension is now <em>vertical</em>, as lines in that writing mode run vertically.</p>
 
-<p>The block dimension is the other dimension, and the direction in which blocks — such as paragraphs — display one after the other. In English and Arabic these run vertically, whereas in any vertical writing mode these run horizontally.</p>
+<p>The block dimension is the other dimension and the direction in which blocks — such as paragraphs — display one after the other. In English and Arabic, these run vertically, whereas in any vertical writing mode these run horizontally.</p>
 
 <p>The below diagram shows the inline and block directions in a horizontal writing mode:</p>
 

--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The Logical Properties and Values Specification introduces flow-relative mappings for many of the properties and values in CSS. This article introduces the specification and explains flow relative properties and values.</p>
+<p>The Logical Properties and Values Specification introduces flow-relative mappings for many of the properties and values in CSS. This article introduces the specification, and explains flow relative properties and values.</p>
 
 <h2 id="Why_do_we_need_logical_properties">Why do we need logical properties?</h2>
 

--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>A key concept of working with flow relative properties and values is the two dimensions of block and inline. As we saw above, newer CSS layout methods such as Flexbox and Grid Layout use the concepts of <code>block</code> and <code>inline</code> rather than <code>right</code> and <code>left</code>/<code>top</code> and <code>bottom</code> when aligning items.</p>
 
-<p>The <code>inline</code> dimension is the dimension along which a line of text runs in the writing mode in use. Therefore, in an English document with the text running horizontally left to right or an Arabic document with the text running horizontally right to left, the inline dimension is <em>horizontal</em>. Switch to a vertical writing mode (e.g. a Japanese document) and the inline dimension is now <em>vertical</em>, as lines in that writing mode run vertically.</p>
+<p>The <code>inline</code> dimension is the dimension along which a line of text runs in the writing mode in use. Therefore, in an English document with the text running horizontally left to right, or an Arabic document with the text running horizontally right to left, the inline dimension is <em>horizontal</em>. Switch to a vertical writing mode (e.g. a Japanese document) and the inline dimension is now <em>vertical</em>, as lines in that writing mode run vertically.</p>
 
 <p>The block dimension is the other dimension and the direction in which blocks — such as paragraphs — display one after the other. In English and Arabic, these run vertically, whereas in any vertical writing mode these run horizontally.</p>
 

--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.html
@@ -40,7 +40,7 @@ tags:
 
 <p>The <code>inline</code> dimension is the dimension along which a line of text runs in the writing mode in use. Therefore, in an English document with the text running horizontally left to right, or an Arabic document with the text running horizontally right to left, the inline dimension is <em>horizontal</em>. Switch to a vertical writing mode (e.g. a Japanese document) and the inline dimension is now <em>vertical</em>, as lines in that writing mode run vertically.</p>
 
-<p>The block dimension is the other dimension and the direction in which blocks — such as paragraphs — display one after the other. In English and Arabic, these run vertically, whereas in any vertical writing mode these run horizontally.</p>
+<p>The block dimension is the other dimension, and the direction in which blocks — such as paragraphs — display one after the other. In English and Arabic, these run vertically, whereas in any vertical writing mode these run horizontally.</p>
 
 <p>The below diagram shows the inline and block directions in a horizontal writing mode:</p>
 


### PR DESCRIPTION
Unnecessary comma in the compound object, consider removing it.
you are missing a comma after the introductory phrase <b>In English and Arabic</b>. Consider adding a comma.
you are missing a comma or two with the interrupter <b>however</b> Consider adding the comma(s).

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
