### PR TITLE
http docs: update syntax for `Access-Control-{Allow, Expose}-Headers` to allow empty values

### DIFF
--- a/files/en-us/web/http/headers/access-control-allow-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.html
@@ -34,7 +34,7 @@ browser-compat: http.headers.Access-Control-Allow-Headers
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Access-Control-Allow-Headers: <em>&lt;header-name&gt;</em>[, <em>&lt;header-name&gt;</em>]*
+<pre class="brush: html">Access-Control-Allow-Headers: [<em>&lt;header-name&gt;</em>[, <em>&lt;header-name&gt;</em>]*]
 Access-Control-Allow-Headers: *
 </pre>
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.html
@@ -29,7 +29,7 @@ browser-compat: http.headers.Access-Control-Expose-Headers
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Access-Control-Expose-Headers: &lt;header-name&gt;, &lt;header-name&gt;, ...
+<pre class="brush: html">Access-Control-Expose-Headers: [<em>&lt;header-name&gt;</em>[, <em>&lt;header-name&gt;</em>]*]
 Access-Control-Expose-Headers: *
 </pre>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Per the [fetch spec](https://fetch.spec.whatwg.org/#http-new-header-syntax), these headers can be empty.