### PR TITLE
update accent-color

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -23,6 +23,7 @@ tags:
 
 <ul>
   <li>The keywords <code>avoid-page</code> and <code>avoid-column</code> are now supported for the {{cssxref("break-inside")}} property ({{bug(1722945)}}).</li>
+  <li>The CSS {{cssxref("accent-color")}} property has been implemented ({{bug(1722031)}}).</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>

--- a/files/en-us/web/css/accent-color/index.html
+++ b/files/en-us/web/css/accent-color/index.html
@@ -13,7 +13,7 @@ tags:
 - 'recipe:css-property'
 browser-compat: css.properties.accent-color
 ---
-<div>{{CSSRef}}{{SeeCompatTable}}</div>
+<div>{{CSSRef}}</div>
 
 <p>The <strong><code>accent-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the color of the elements {{Glossary("accent")}}. An accent appears in elements such as {{HTMLElement("input")}} of <code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">type="checkbox"</a></code>, or <code><a href="/en-US/docs/Web/HTML/Element/input/radio">type="radio"</a></code>.</p>
 


### PR DESCRIPTION
Part of #7752 

Updates release note, and removes experimental macro as this is also shipping in CHrome at the same time.

