### PR TITLE
Update link to Mozilla's MathML Torture Test

### DIFF
--- a/files/en-us/web/mathml/examples/index.html
+++ b/files/en-us/web/mathml/examples/index.html
@@ -15,6 +15,6 @@ tags:
  <dd>Small example showing a proof of the Pythagorean Theorem.</dd>
  <dt><a href="/en-US/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula">Deriving the Quadratic Formula</a></dt>
  <dd>Outlines the derivation of the Quadratic Formula.</dd>
- <dt><a href="/en-US/docs/Mozilla/MathML_Project/MathML_Torture_Test">MathML Torture Test</a></dt>
+ <dt><a href="https://fred-wang.github.io/MathFonts/mozilla_mathml_test/">MathML Torture Test</a></dt>
  <dd>Large set of test markup.</dd>
 </dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes https://github.com/mdn/content/issues/6878

> What was wrong/why is this fix needed? (quick summary only)

The link to the MathML torture test is broken, as seems to be any archived MathML content.

> Anything else that could help us review it

I moved the test to https://fred-wang.github.io/MathFonts/mozilla_mathml_test/ instead.
