### PR TITLE
Change DJANGO_DEBUG='False" to double quotes

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -599,15 +599,10 @@ DJANGO_SECRET_KEY: eu09(ilk6@4sfdofb=b_2ht@vad*$ehh9-)3u_83+y%(+phh
 
 <p>We similarly set <code>DJANGO_DEBUG</code>:</p>
 
-<pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG="False"
+<pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG=False
 
 Setting DJANGO_DEBUG and restarting locallibrary... done, v8
 DJANGO_DEBUG: False</pre>
-
-<div class="notecard note">
-  <h4>Note</h4>
-  <p>Make sure that a <strong>DJANGO_DEBUG</strong> variable in the output does not contain any additional characters. <code>DJANGO_DEBUG: False</code> is OK, while <code>DJANGO_DEBUG: 'False'</code> may lead to Django debug mode being active.</p>
-</div>
 
 <p>If you visit the site now you'll get a "Bad request" error, because the <a href="https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts">ALLOWED_HOSTS</a> setting is <em>required</em> if you have <code>DEBUG=False</code> (as a security measure). Open <strong>/locallibrary/settings.py</strong> and change the <code>ALLOWED_HOSTS</code> setting to include your base app url (e.g. 'locallibrary1234.herokuapp.com') and the URL you normally use on your local development server.</p>
 

--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -601,8 +601,8 @@ DJANGO_SECRET_KEY: eu09(ilk6@4sfdofb=b_2ht@vad*$ehh9-)3u_83+y%(+phh
 
 <pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG="False"
 
-Setting DJANGO_DEBUG and restarting locallibrary... done, v8</pre>
-DJANGO_DEBUG: False
+Setting DJANGO_DEBUG and restarting locallibrary... done, v8
+DJANGO_DEBUG: False</pre>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -599,7 +599,7 @@ DJANGO_SECRET_KEY: eu09(ilk6@4sfdofb=b_2ht@vad*$ehh9-)3u_83+y%(+phh
 
 <p>We similarly set <code>DJANGO_DEBUG</code>:</p>
 
-<pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG='False'
+<pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG="False"
 
 Setting DJANGO_DEBUG and restarting locallibrary... done, v8</pre>
 DJANGO_DEBUG: False

--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -602,6 +602,12 @@ DJANGO_SECRET_KEY: eu09(ilk6@4sfdofb=b_2ht@vad*$ehh9-)3u_83+y%(+phh
 <pre class="brush: bash">&gt; heroku config:set DJANGO_DEBUG='False'
 
 Setting DJANGO_DEBUG and restarting locallibrary... done, v8</pre>
+DJANGO_DEBUG: False
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Make sure that a <strong>DJANGO_DEBUG</strong> variable in the output does not contain any additional characters. <code>DJANGO_DEBUG: False</code> is OK, while <code>DJANGO_DEBUG: 'False'</code> may lead to Django debug mode being active.</p>
+</div>
 
 <p>If you visit the site now you'll get a "Bad request" error, because the <a href="https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts">ALLOWED_HOSTS</a> setting is <em>required</em> if you have <code>DEBUG=False</code> (as a security measure). Open <strong>/locallibrary/settings.py</strong> and change the <code>ALLOWED_HOSTS</code> setting to include your base app url (e.g. 'locallibrary1234.herokuapp.com') and the URL you normally use on your local development server.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

> What was wrong/why is this fix needed? (quick summary only)

While following the Django deployment guide with the windows CMD I have encountered following issue:
```
>heroku version
heroku/7.56.1 win32-x64 node-v12.21.0

>heroku config:set DJANGO_DEBUG='False'
Setting DJANGO_DEBUG and restarting ⬢ homekeeper-backend... done, v13
DJANGO_DEBUG: 'False'

>heroku config:set DJANGO_DEBUG="False"
Setting DJANGO_DEBUG and restarting ⬢ homekeeper-backend... done, v14
DJANGO_DEBUG: False
```
With single quotes DJANGO_DEBUG was wrongly set to `'False'` and because of that, in the settings.py: `DEBUG = "'False'" != "False"` => `DEBUG = True` .

> Anything else that could help us review it

Not sure if this parsing behavior is related to the Windows, so I have also added a note to make user pay attention to the value that was assigned to DJANGO_DEBUG. Note that a few lines above the requested change, there is
```
<pre class="brush: bash">&gt; heroku config:set DJANGO_SECRET_KEY="eu09(ilk6@4sfdofb=b_2ht@vad*$ehh9-)3u_83+y%(+phh&amp;="
``` 
which has double quotes, so it may be additional reason to the requested change.
