### PR TITLE
Use a ul instead of a dl in "CSS Counter Styles"

### DIFF
--- a/files/en-us/web/css/css_counter_styles/index.html
+++ b/files/en-us/web/css/css_counter_styles/index.html
@@ -24,9 +24,8 @@ tags:
 
 <h3 id="At-rules">At-rules</h3>
 
-<dl>
- <dt>{{cssxref("@counter-style")}}</dt>
- <dd>
+<ul>
+ <li>{{cssxref("@counter-style")}}
  <ul>
   <li>{{cssxref("@counter-style/system","system")}}</li>
   <li>{{cssxref("@counter-style/additive-symbols", "additive-symbols")}}</li>
@@ -38,8 +37,8 @@ tags:
   <li>{{cssxref("@counter-style/speak-as", "speak-as")}}</li>
   <li>{{cssxref("@counter-style/fallback", "fallback")}}</li>
  </ul>
- </dd>
-</dl>
+ </li>
+</ul>
 
 <h2 id="Guides">Guides</h2>
 


### PR DESCRIPTION
Here's a tiny conversion problem that I missed, probably because it was hiding in a previously unconvertible `<div>`.

In https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Counter_Styles, we have a `<dl>` containing a `<ul>` as an immediate child, and we can't convert this.

I've filed this as an issue in the converter: https://github.com/mdn/yari/issues/4307 but in all cases I've seen of this the content is improved by working around the issue.

In this case it seems better to use a `<ul>` on the outside rather than a `<dl>`, so that's what I did.
