### PR TITLE
Fix heading in word-break page

### DIFF
--- a/files/en-us/web/css/word-break/index.html
+++ b/files/en-us/web/css/word-break/index.html
@@ -33,7 +33,7 @@ word-break: unset;
 
 <p>The <code>word-break</code> property is specified as a single keyword chosen from the list of values below.</p>
 
-<h3>id="Values">Values</h3>
+<h3 id="Values">Values</h3>
 
 <dl>
  <dt><code>normal</code></dt>


### PR DESCRIPTION
Fix an error I introduced in https://github.com/mdn/content/pull/7720. Oops.