### PR TITLE
Replace a Number wrapper object with just the word “number”

### DIFF
--- a/files/en-us/web/api/navigator/hardwareconcurrency/index.html
+++ b/files/en-us/web/api/navigator/hardwareconcurrency/index.html
@@ -22,7 +22,7 @@ browser-compat: api.Navigator.hardwareConcurrency
 
 <h2 id="Value">Value</h2>
 
-<p>A {{jsxref("Number")}} indicating the number of logical processor cores.</p>
+<p>A Number indicating the number of logical processor cores.</p>
 
 <p>Modern computers have multiple physical processor cores in their CPU (two or four cores
   is typical), but each physical core is also usually able to run more than one thread at

--- a/files/en-us/web/api/navigator/hardwareconcurrency/index.html
+++ b/files/en-us/web/api/navigator/hardwareconcurrency/index.html
@@ -22,7 +22,7 @@ browser-compat: api.Navigator.hardwareConcurrency
 
 <h2 id="Value">Value</h2>
 
-<p>A Number indicating the number of logical processor cores.</p>
+<p>A number between 1 and the number of logical processors potentially available to the user agent.</p>
 
 <p>Modern computers have multiple physical processor cores in their CPU (two or four cores
   is typical), but each physical core is also usually able to run more than one thread at


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

The value should be a normal number instead of a Number wrapper object.

> Anything else that could help us review it
