### PR TITLE
Add docs for WebXR Depth Sensing - part 2

### DIFF
--- a/files/en-us/web/api/xrcpudepthinformation/data/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/data/index.html
@@ -1,0 +1,48 @@
+---
+title: XRCPUDepthInformation.data
+slug: Web/API/XRCPUDepthInformation/data
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRCPUDepthInformation.data
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>data</code></strong> property of the {{DOMxRef("XRCPUDepthInformation")}} interface is an {{jsxref("ArrayBuffer")}} containing depth buffer information in raw format.</p>
+
+<p>The data is stored in row-major format, without padding, with each entry corresponding to distance from the view's near plane to the users' environment, in unspecified units. The size of each data entry and the type is determined by {{domxref("XRSession.depthDataFormat", "depthDataFormat")}}. The values can be converted from unspecified units to meters by multiplying them by {{domxref("XRDepthInformation.rawValueToMeters", "rawValueToMeters")}}. The {{domxref("XRDepthInformation.normDepthBufferFromNormView", "normDepthBufferFromNormView")}} property can be used to transform from normalized view coordinates (an origin in the top left corner of the view, with X axis growing to the right, and Y axis growing downward) into depth buffer’s coordinate system.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An {{jsxref("ArrayBuffer")}}.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} to obtain depth information. The returned <code>XRCPUDepthInformation</code> object will contain the <code>data</code> buffer.</p>
+
+<p>For CPU depth information and a buffer that has "luminance-alpha" format:</p>
+
+<pre class="brush: js">
+const uint16 = new Uint16Array(depthInfo.data);
+const index = column + row * depthInfo.width;
+const depthInMeters = uint16[index] * depthInfo.rawValueToMeters;
+</pre>
+
+<p>(Use {{jsxref("Float32Array")}} for a "float32" data format.)</p>
+
+<p>Note that the depth in meters is in depth buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrcpudepthinformation/data/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/data/index.html
@@ -15,9 +15,9 @@ browser-compat: api.XRCPUDepthInformation.data
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
-<p>The <em>read-only</em> <strong><code>data</code></strong> property of the {{DOMxRef("XRCPUDepthInformation")}} interface is an {{jsxref("ArrayBuffer")}} containing depth buffer information in raw format.</p>
+<p>The <em>read-only</em> <strong><code>data</code></strong> property of the {{DOMxRef("XRCPUDepthInformation")}} interface is an {{jsxref("ArrayBuffer")}} containing depth-buffer information in raw format.</p>
 
-<p>The data is stored in row-major format, without padding, with each entry corresponding to distance from the view's near plane to the users' environment, in unspecified units. The size of each data entry and the type is determined by {{domxref("XRSession.depthDataFormat", "depthDataFormat")}}. The values can be converted from unspecified units to meters by multiplying them by {{domxref("XRDepthInformation.rawValueToMeters", "rawValueToMeters")}}. The {{domxref("XRDepthInformation.normDepthBufferFromNormView", "normDepthBufferFromNormView")}} property can be used to transform from normalized view coordinates (an origin in the top left corner of the view, with X axis growing to the right, and Y axis growing downward) into depth buffer’s coordinate system.</p>
+<p>The data is stored in row-major format, without padding, with each entry corresponding to distance from the view's near plane to the users' environment, in unspecified units. The size of each data entry and the type is determined by {{domxref("XRSession.depthDataFormat", "depthDataFormat")}}. The values can be converted from unspecified units to meters by multiplying them by {{domxref("XRDepthInformation.rawValueToMeters", "rawValueToMeters")}}. The {{domxref("XRDepthInformation.normDepthBufferFromNormView", "normDepthBufferFromNormView")}} property can be used to transform from normalized view coordinates (an origin in the top left corner of the view, with X axis growing to the right, and Y axis growing downward) into the depth buffer’s coordinate system.</p>
 
 <h3 id="Value">Value</h3>
 
@@ -37,7 +37,7 @@ const depthInMeters = uint16[index] * depthInfo.rawValueToMeters;
 
 <p>(Use {{jsxref("Float32Array")}} for a "float32" data format.)</p>
 
-<p>Note that the depth in meters is in depth buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
+<p>Note that the depth in meters is in depth-buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.html
@@ -15,7 +15,7 @@ browser-compat: api.XRCPUDepthInformation.getDepthInMeters
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
-<p>The <strong><code>getDepthInMeters()</code></strong>method of the {{DOMxRef("XRCPUDepthInformation")}} interface returns the depth in meters at (x, y) in normalized view coordinates (origin in the top left corner).</p>
+<p>The <strong><code>getDepthInMeters()</code></strong> method of the {{DOMxRef("XRCPUDepthInformation")}} interface returns the depth in meters at (x, y) in normalized view coordinates (origin in the top left corner).</p>
 
 <h2>Syntax</h2>
 
@@ -25,7 +25,7 @@ browser-compat: api.XRCPUDepthInformation.getDepthInMeters
 
 <dl>
   <dt><code>x</code></dt>
-  <dd>X coordinate. (origin at the left, grows to the right).</dd>
+  <dd>X coordinate (origin at the left, grows to the right).</dd>
   <dt><code>y</code></dt>
   <dd>Y coordinate (origin at the top, grows downward).</dd>
 </dl>

--- a/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.html
@@ -1,0 +1,51 @@
+---
+title: XRCPUDepthInformation.getDepthInMeters()
+slug: Web/API/XRCPUDepthInformation/getDepthInMeters
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Method
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRCPUDepthInformation.getDepthInMeters
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <strong><code>getDepthInMeters()</code></strong>method of the {{DOMxRef("XRCPUDepthInformation")}} interface returns the depth in meters at (x, y) in normalized view coordinates (origin in the top left corner).</p>
+
+<h2>Syntax</h2>
+
+<pre class="brush: js">getDepthInMeters(x, y)</pre>
+
+<h3>Parameters</h3>
+
+<dl>
+  <dt><code>x</code></dt>
+  <dd>X coordinate. (origin at the left, grows to the right).</dd>
+  <dt><code>y</code></dt>
+  <dd>Y coordinate (origin at the top, grows downward).</dd>
+</dl>
+
+<h3>Exceptions</h3>
+
+<ul>
+  <li>A {{jsxref("RangeError")}} is thrown if <code>x</code> or <code>y</code> are greater than 1.0 or less than 0.0.</li>
+</ul>
+
+<h2>Examples</h2>
+
+<pre class="brush: js">
+const distance = depthInfo.getDepthInMeters(x, y);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrcpudepthinformation/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/index.html
@@ -23,11 +23,11 @@ browser-compat: api.XRCPUDepthInformation
 
 <dl>
  <dt>{{domxref("XRCPUDepthInformation.data")}} {{ReadOnlyInline}}</dt>
- <dd>An {{jsxref("ArrayBuffer")}} containing depth buffer information in raw format.</dd>
+ <dd>An {{jsxref("ArrayBuffer")}} containing depth-buffer information in raw format.</dd>
  <dt>{{domxref("XRDepthInformation.height")}} {{ReadOnlyInline}}</dt>
  <dd>Contains the height of the depth buffer (number of rows).</dd>
  <dt>{{domxref("XRDepthInformation.normDepthBufferFromNormView")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</dd>
+ <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth-buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth-buffer coordinates.</dd>
  <dt>{{domxref("XRDepthInformation.rawValueToMeters")}} {{ReadOnlyInline}}</dt>
  <dd>Contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</dd>
  <dt>{{domxref("XRDepthInformation.width")}} {{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/xrcpudepthinformation/index.html
+++ b/files/en-us/web/api/xrcpudepthinformation/index.html
@@ -1,0 +1,61 @@
+---
+title: XRCPUDepthInformation
+slug: Web/API/XRCPUDepthInformation
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRCPUDepthInformation
+---
+<p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
+
+<p>The <code><strong>XRCPUDepthInformation</strong></code> interface contains depth information from the CPU (returned by {{domxref("XRFrame.getDepthInformation()")}}).</p>
+
+{{InheritanceDiagram}}
+
+<p>This interface inherits properties from its parent, {{domxref("XRDepthInformation")}}.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+ <dt>{{domxref("XRCPUDepthInformation.data")}} {{ReadOnlyInline}}</dt>
+ <dd>An {{jsxref("ArrayBuffer")}} containing depth buffer information in raw format.</dd>
+ <dt>{{domxref("XRDepthInformation.height")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the height of the depth buffer (number of rows).</dd>
+ <dt>{{domxref("XRDepthInformation.normDepthBufferFromNormView")}} {{ReadOnlyInline}}</dt>
+ <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</dd>
+ <dt>{{domxref("XRDepthInformation.rawValueToMeters")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</dd>
+ <dt>{{domxref("XRDepthInformation.width")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the width of the depth buffer (number of columns).</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("XRCPUDepthInformation.getDepthInMeters()")}}</dt>
+  <dd>Returns the depth in meters at (x, y) in normalized view coordinates.</dd>
+</dl>
+
+<h2>Examples</h2>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRDepthInformation")}}</li>
+  <li>{{domxref("XRWebGLDepthInformation")}}</li>
+  <li>{{domxref("XRFrame.getDepthInformation()")}}</li>
+</ul>

--- a/files/en-us/web/api/xrdepthinformation/height/index.html
+++ b/files/en-us/web/api/xrdepthinformation/height/index.html
@@ -1,0 +1,39 @@
+---
+title: XRDepthInformation.height
+slug: Web/API/XRDepthInformation/height
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRDepthInformation.height
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>height</code></strong> property of the {{DOMxRef("XRDepthInformation")}} interface contains the height of the depth buffer (number of rows).</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An unsigned long integer.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>height</code> of the depth buffer which you can use for further calculations.</p>
+
+<pre class="brush: js">
+const smallerDepthDimension = Math.min(depthInfo.width, depthInfo.height);
+const largerDepthDimension = Math.max(depthInfo.width, depthInfo.height);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrdepthinformation/height/index.html
+++ b/files/en-us/web/api/xrdepthinformation/height/index.html
@@ -23,7 +23,7 @@ browser-compat: api.XRDepthInformation.height
 
 <h2>Examples</h2>
 
-<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>height</code> of the depth buffer which you can use for further calculations.</p>
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>height</code> of the depth buffer, which you can use for further calculations.</p>
 
 <pre class="brush: js">
 const smallerDepthDimension = Math.min(depthInfo.width, depthInfo.height);

--- a/files/en-us/web/api/xrdepthinformation/index.html
+++ b/files/en-us/web/api/xrdepthinformation/index.html
@@ -13,7 +13,7 @@ browser-compat: api.XRDepthInformation
 ---
 <p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
 
-<p>The <code><strong>XRDepthInformation</strong></code> interface contains information about the distance from the user’s device to the real world geometry in the user’s environment.</p>
+<p>The <code><strong>XRDepthInformation</strong></code> interface contains information about the distance from the user’s device to the real-world geometry in the user’s environment.</p>
 
 <p>This interface is the parent of:</p>
 
@@ -32,7 +32,7 @@ browser-compat: api.XRDepthInformation
  <dt>{{domxref("XRDepthInformation.height")}} {{ReadOnlyInline}}</dt>
  <dd>Contains the height of the depth buffer (number of rows).</dd>
  <dt>{{domxref("XRDepthInformation.normDepthBufferFromNormView")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</dd>
+ <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth-buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth-buffer coordinates.</dd>
  <dt>{{domxref("XRDepthInformation.rawValueToMeters")}} {{ReadOnlyInline}}</dt>
  <dd>Contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</dd>
  <dt>{{domxref("XRDepthInformation.width")}} {{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/xrdepthinformation/index.html
+++ b/files/en-us/web/api/xrdepthinformation/index.html
@@ -1,0 +1,64 @@
+---
+title: XRDepthInformation
+slug: Web/API/XRDepthInformation
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRDepthInformation
+---
+<p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
+
+<p>The <code><strong>XRDepthInformation</strong></code> interface contains information about the distance from the user’s device to the real world geometry in the user’s environment.</p>
+
+<p>This interface is the parent of:</p>
+
+<dl>
+  <dt>{{domxref("XRCPUDepthInformation")}}</dt>
+  <dd>Depth information from the CPU (returned by {{domxref("XRFrame.getDepthInformation()")}}).</dd>
+  <dt>{{domxref("XRWebGLDepthInformation")}}</dt>
+  <dd>Depth information from WebGL (returned by {{domxref("XRWebGLBinding.getDepthInformation()")}}).</dd>
+</dl>
+
+<p>You will usually interact with these child interfaces. However, <code>XRDepthInformation</code> provides some useful properties that are inherited:</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+ <dt>{{domxref("XRDepthInformation.height")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the height of the depth buffer (number of rows).</dd>
+ <dt>{{domxref("XRDepthInformation.normDepthBufferFromNormView")}} {{ReadOnlyInline}}</dt>
+ <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</dd>
+ <dt>{{domxref("XRDepthInformation.rawValueToMeters")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</dd>
+ <dt>{{domxref("XRDepthInformation.width")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the width of the depth buffer (number of columns).</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p>None.</p>
+
+<h2>Examples</h2>
+
+<p>See {{domxref("XRCPUDepthInformation")}} and {{domxref("XRWebGLDepthInformation")}} for code examples.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRCPUDepthInformation")}}</li>
+  <li>{{domxref("XRWebGLDepthInformation")}}</li>
+  <li>{{domxref("XRFrame.getDepthInformation()")}}</li>
+</ul>

--- a/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.html
+++ b/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.html
@@ -19,11 +19,11 @@ browser-compat: api.XRDepthInformation.normDepthBufferFromNormView
 
 <h3 id="Value">Value</h3>
 
-<p>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</p>
+<p>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth-buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</p>
 
 <h2>Examples</h2>
 
-<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>normDepthBufferFromNormView</code> of the depth buffer which you can use for further calculations.</p>
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>normDepthBufferFromNormView</code> of the depth buffer, which you can use for further calculations.</p>
 
 <pre class="brush: js">
 const normDepthFromNormViewMatrix = depthData.normDepthBufferFromNormView.matrix;

--- a/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.html
+++ b/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.html
@@ -1,0 +1,39 @@
+---
+title: XRDepthInformation.normDepthBufferFromNormView
+slug: Web/API/XRDepthInformation/normDepthBufferFromNormView
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRDepthInformation.normDepthBufferFromNormView
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>normDepthBufferFromNormView</code></strong> property of the {{DOMxRef("XRDepthInformation")}} interface contains the 3D geometric transform that needs to be applied when indexing into the depth buffer.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>normDepthBufferFromNormView</code> of the depth buffer which you can use for further calculations.</p>
+
+<pre class="brush: js">
+const normDepthFromNormViewMatrix = depthData.normDepthBufferFromNormView.matrix;
+const normViewFromNormDepth = depthData.normDepthBufferFromNormView.inverse.matrix;
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.html
+++ b/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.html
@@ -1,0 +1,48 @@
+---
+title: XRDepthInformation.rawValueToMeters
+slug: Web/API/XRDepthInformation/rawValueToMeters
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRDepthInformation.rawValueToMeters
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>rawValueToMeters</code></strong> property of the {{DOMxRef("XRDepthInformation")}} interface contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</p>
+
+<p>For CPU depth information, see also the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>A number.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>rawValueToMeters</code> scale factor which can be used for further calculations.</p>
+
+<p>For CPU depth information and a buffer that has "luminance-alpha" format:</p>
+
+<pre class="brush: js">
+const uint16 = new Uint16Array(depthInfo.data);
+const index = column + row * depthInfo.width;
+const depthInMeters = uint16[index] * depthInfo.rawValueToMeters;
+</pre>
+
+<p>(Use {{jsxref("Float32Array")}} for a "float32" data format.)</p>
+
+<p>Note that the depth in meters is in depth buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.html
+++ b/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.html
@@ -25,7 +25,7 @@ browser-compat: api.XRDepthInformation.rawValueToMeters
 
 <h2>Examples</h2>
 
-<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>rawValueToMeters</code> scale factor which can be used for further calculations.</p>
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>rawValueToMeters</code> scale factor, which can be used for further calculations.</p>
 
 <p>For CPU depth information and a buffer that has "luminance-alpha" format:</p>
 
@@ -37,7 +37,7 @@ const depthInMeters = uint16[index] * depthInfo.rawValueToMeters;
 
 <p>(Use {{jsxref("Float32Array")}} for a "float32" data format.)</p>
 
-<p>Note that the depth in meters is in depth buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
+<p>Note that the depth in meters is in depth-buffer coordinates. Additional steps are needed to convert them to normalized view coordinates, or the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method can be used.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/xrdepthinformation/width/index.html
+++ b/files/en-us/web/api/xrdepthinformation/width/index.html
@@ -1,0 +1,39 @@
+---
+title: XRDepthInformation.width
+slug: Web/API/XRDepthInformation/width
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRDepthInformation.width
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>width</code></strong> property of the {{DOMxRef("XRDepthInformation")}} interface contains the width of the depth buffer (number of columns).</p>
+
+<h3 id="Value">Value</h3>
+
+<p>An unsigned long integer.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>width</code> of the depth buffer which you can use for further calculations.</p>
+
+<pre class="brush: js">
+const smallerDepthDimension = Math.min(depthInfo.width, depthInfo.height);
+const largerDepthDimension = Math.max(depthInfo.width, depthInfo.height);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrdepthinformation/width/index.html
+++ b/files/en-us/web/api/xrdepthinformation/width/index.html
@@ -23,7 +23,7 @@ browser-compat: api.XRDepthInformation.width
 
 <h2>Examples</h2>
 
-<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>width</code> of the depth buffer which you can use for further calculations.</p>
+<p>Use {{domxref("XRFrame.getDepthInformation()")}} (CPU) or {{domxref("XRWebGLBinding.getDepthInformation()")}} (WebGL) to obtain depth information. The returned objects will contain the <code>width</code> of the depth buffer, which you can use for further calculations.</p>
 
 <pre class="brush: js">
 const smallerDepthDimension = Math.min(depthInfo.width, depthInfo.height);

--- a/files/en-us/web/api/xrframe/getdepthinformation/index.html
+++ b/files/en-us/web/api/xrframe/getdepthinformation/index.html
@@ -1,0 +1,80 @@
+---
+title: XRFrame.getDepthInformation()
+slug: Web/API/XRFrame/getDepthInformation
+tags:
+- API
+- Method
+- Reference
+- AR
+- XR
+- WebXR
+browser-compat: api.XRFrame.getDepthInformation
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <code><strong>getDepthInformation()</strong></code> method of the {{domxref("XRFrame")}} interface returns an {{domxref("XRCPUDepthInformation")}} object containing CPU depth information for the active and animated frame.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">getDepthInformation(view)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>view</code></dt>
+  <dd>An {{domxref("XRView")}} object obtained from a viewer pose.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>An {{domxref("XRCPUDepthInformation")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>Throws a <code>NotSupportedError</code> if "depth-sensing" is not in the list of enabled features for this {{domxref("XRSession")}}.</li>
+  <li>Throws an <code>InvalidStateError</code> if the <code>XRFrame</code> is not active nor animated. Obtaining depth information is only valid within the {{domxref("XRSession.requestAnimationFrame()", "requestAnimationFrame()")}} callback.</li>
+  <li>Throws an <code>InvalidStateError</code> if the the session’s {{domxref("XRSession.depthUsage", "depthUsage")}} is not "cpu-optimized".</li>
+
+</ul>
+
+<h2>Examples</h2>
+
+<h3>Obtaining CPU depth information</h3>
+
+<pre class="brush: js">
+// Make sure  to request a session with depth-sensing enabled
+const session = navigator.xr.requestSession("immersive-ar", {
+  requiredFeatures: ["depth-sensing"],
+  depthSensing: {
+    usagePreference: ["cpu-optimized", "gpu-optimized"],
+    formatPreference: ["luminance-alpha", "float32"]
+  }
+});
+
+// ...
+
+// Obtain depth information in an active and animated frame
+function rafCallback(time, frame) {
+  session.requestAnimationFrame(rafCallback);
+  const pose = frame.getViewerPose(referenceSpace);
+  if (pose) {
+    for (const view of pose.views) {
+      const depthInformation = frame.getDepthInformation(view);
+      if (depthInformation) {
+        // Do something with the depth information
+        renderDepth(depthInformation);
+      }
+    }
+  }
+}
+
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrframe/index.html
+++ b/files/en-us/web/api/xrframe/index.html
@@ -38,6 +38,8 @@ browser-compat: api.XRFrame
 <dl>
  <dt>{{domxref("XRFrame.createAnchor()", "createAnchor()")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} which resolves to a free-floating {{domxref("XRAnchor")}} object.</dd>
+ <dt>{{domxref("XRFrame.getDepthInformation()", "getDepthInformation()")}}</dt>
+ <dd>Returns an {{domxref("XRCPUDepthInformation")}} object containing CPU depth information for the frame.</dd>
  <dt>{{DOMxRef("XRFrame.getPose", "getPose()")}}</dt>
  <dd>Returns an {{domxref("XRPose")}} object representing the spatial relationship between the two specified {{domxref("XRSpace")}} objects.</dd>
  <dt>{{DOMxRef("XRFrame.getViewerPose", "getViewerPose()")}}</dt>


### PR DESCRIPTION
Document how to obtain depth data (using the CPU)
Spec: https://immersive-web.github.io/depth-sensing/#obtaining-data

(A third and last PR for depth sensing will deal with the GPU/WebGL depth info.)