### PR TITLE
Fix “Values” header HTML in scroll-behavior

### DIFF
--- a/files/en-us/web/css/scroll-behavior/index.html
+++ b/files/en-us/web/css/scroll-behavior/index.html
@@ -35,7 +35,7 @@ scroll-behavior: unset;
 
 <p>The <code>scroll-behavior</code> property is specified as one of the keyword values listed below.</p>
 
-<h3>id="Values">Values</h3>
+<h3 id="Values">Values</h3>
 
 <dl>
  <dt><code>auto</code></dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

Extraneous `>` instead of a space.


> Anything else that could help us review it
