### PR TITLE
Update spec tables in API overview pages (s-v)

### DIFF
--- a/files/en-us/web/api/screen_capture_api/index.html
+++ b/files/en-us/web/api/screen_capture_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Screen Capture API")}}</div>
 
-<p><span class="seoSummary">The Screen Capture API introduces additions to the existing Media Capture and Streams API to let the user select a screen or portion of a screen (such as a window) to capture as a media stream.</span> This stream can then be recorded or shared with others over the network.</p>
+<p>The Screen Capture API introduces additions to the existing Media Capture and Streams API to let the user select a screen or portion of a screen (such as a window) to capture as a media stream. This stream can then be recorded or shared with others over the network.</p>
 
 <h2 id="Screen_Capture_API_concepts_and_usage">Screen Capture API concepts and usage</h2>
 
@@ -47,9 +47,9 @@ tags:
 
 <dl>
  <dt>{{domxref("MediaTrackConstraints.cursor")}}</dt>
- <dd>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString"><code>ConstrainDOMString</code></a> indicating whether or not the cursor should be included in the captured display surface's stream, and if it should always be visible or if it should only be visible while the mouse is in motion.</dd>
+ <dd>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring"><code>ConstrainDOMString</code></a> indicating whether or not the cursor should be included in the captured display surface's stream, and if it should always be visible or if it should only be visible while the mouse is in motion.</dd>
  <dt>{{domxref("MediaTrackConstraints.displaySurface")}}</dt>
- <dd>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString"><code>ConstrainDOMString</code></a> indicating what type of display surface is to be captured. The value is one of <code>application</code>, <code>browser</code>, <code>monitor</code>, or <code>window</code>.</dd>
+ <dd>A <a href="/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring"><code>ConstrainDOMString</code></a> indicating what type of display surface is to be captured. The value is one of <code>application</code>, <code>browser</code>, <code>monitor</code>, or <code>window</code>.</dd>
  <dt>{{domxref("MediaTrackConstraints.logicalSurface")}}</dt>
  <dd>Indicates whether or not the video in the stream represents a logical display surface (that is, one which may not be entirely visible onscreen, or may be completely offscreen). A value of <code>true</code> indicates a logical display surface is to be captured.</dd>
 </dl>
@@ -99,19 +99,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Screen Capture')}}</td>
-   <td>{{Spec2('Screen Capture')}}</td>
-   <td>Initial definition</td>
+   <td><a href="https://w3c.github.io/mediacapture-screen-share/">Screen Capture</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/screen_wake_lock_api/index.html
+++ b/files/en-us/web/api/screen_wake_lock_api/index.html
@@ -117,24 +117,16 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Screen Wake Lock')}}</td>
-   <td>{{Spec2('Screen Wake Lock')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://w3c.github.io/screen-wake-lock/">Screen Wake Lock API</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div>
 
 <p>{{Compat("api.WakeLock")}}</p>
 
@@ -145,4 +137,3 @@ try {
  <li><a href="https://wake-lock-demo.glitch.me/">A Screen Wake Lock API demo on glitch</a></li>
  <li><a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> directive {{HTTPHeader("Feature-Policy/screen-wake-lock","screen-wake-lock")}}</li>
 </ul>
-</div>

--- a/files/en-us/web/api/sensor_apis/index.html
+++ b/files/en-us/web/api/sensor_apis/index.html
@@ -197,44 +197,29 @@ magSensor.start();
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Generic Sensor')}}</td>
-   <td>{{Spec2('Generic Sensor')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://w3c.github.io/sensors/">Generic Sensor API</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('Accelerometer')}}</td>
-   <td>{{Spec2('Accelerometer')}}</td>
-   <td>Defines <code>Accelerometer</code>, <code>GravitySensor</code>, and <code>LinearAccelerationSensor</code>.</td>
+   <td><a href="https://w3c.github.io/accelerometer/">Accelerometer</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('AmbientLight')}}</td>
-   <td>{{Spec2('AmbientLight')}}</td>
-   <td></td>
+   <td><a href="https://w3c.github.io/ambient-light/">Ambient Light Sensor</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('Gyroscope')}}</td>
-   <td>{{Spec2('Gyroscope')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://w3c.github.io/gyroscope/">Gyroscope</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('Magnetometer')}}</td>
-   <td>{{Spec2('Magnetometer')}}</td>
-   <td></td>
+   <td><a href="https://w3c.github.io/magnetometer/">Magnetometer</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('Orientation Sensor')}}</td>
-   <td>{{Spec2('Orientation Sensor')}}</td>
-   <td>Defines <code>AbsoluteOrientationSensor</code> and <code>RelativeOrientationSensor</code>.</td>
+   <td><a href="https://w3c.github.io/orientation-sensor/">Orientation Sensor</a></td>
   </tr>
- </tbody>
+
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/server-sent_events/index.html
+++ b/files/en-us/web/api/server-sent_events/index.html
@@ -36,21 +36,14 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
- </thead>
- <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', '#server-sent-events', 'Server-sent events')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
+   <td><a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events">HTML Living Standard<br/><small># server-sent-events</small></a></td>
   </tr>
- </tbody>
+
 </table>
 
 <h2 id="See_also">See also</h2>
@@ -63,7 +56,7 @@ tags:
  <li>Remy Sharp’s <a class="link-https" href="https://github.com/remy/polyfills/blob/master/EventSource.js">EventSource polyfill</a></li>
  <li>Yaffle’s <a class="link-https" href="https://github.com/Yaffle/EventSource">EventSource polyfill</a></li>
  <li>Rick Waldron’s <a class="link-https" href="https://github.com/rwldrn/jquery.eventsource">jquery plugin</a></li>
- <li>intercooler.js <a href="http://intercoolerjs.org/docs.html#sse">declarative SSE support</a></li>
+ <li>intercooler.js <a href="https://intercoolerjs.org/docs.html#sse">declarative SSE support</a></li>
 </ul>
 
 <h3 id="Related_Topics">Related Topics</h3>
@@ -77,7 +70,7 @@ tags:
 <h3 id="Other_resources">Other resources</h3>
 
 <ul>
- <li>A <a href="http://hacks.mozilla.org/2011/06/a-wall-powered-by-eventsource-and-server-sent-events/">Twitter like application</a> powered by server-sent events and <a class="link-https" href="https://github.com/mozilla/webowonder-demos/tree/master/demos/friends%20timeline">its code on Github</a>.</li>
- <li><a href="http://dsheiko.com/weblog/html5-and-server-sent-events">HTML5 and Server-sent events</a></li>
- <li><a href="http://rajudasa.blogspot.in/2012/05/html5-server-sent-events-using-aspnet.html">Server-sent events using Asp.Net</a></li>
+ <li>A <a href="https://hacks.mozilla.org/2011/06/a-wall-powered-by-eventsource-and-server-sent-events/">Twitter like application</a> powered by server-sent events and <a class="link-https" href="https://github.com/mozilla/webowonder-demos/tree/master/demos/friends%20timeline">its code on Github</a>.</li>
+ <li><a href="https://dsheiko.com/weblog/html5-and-server-sent-events">HTML5 and Server-sent events</a></li>
+ <li><a href="https://rajudasa.blogspot.in/2012/05/html5-server-sent-events-using-aspnet.html">Server-sent events using Asp.Net</a></li>
 </ul>

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -150,21 +150,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
- </thead>
- <tbody>
   <tr>
-   <td>{{SpecName("Service Workers")}}</td>
-   <td>{{Spec2("Service Workers")}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://w3c.github.io/ServiceWorker/">Service Workers</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/storage_access_api/index.html
+++ b/files/en-us/web/api/storage_access_api/index.html
@@ -7,7 +7,6 @@ tags:
   - Storage
   - Storage Access API
 ---
-
 <div>{{DefaultAPISidebar("Storage Access API")}}{{SeeCompatTable}}</div>
 
 <p><span class="seoSummary">The Storage Access API provides a way for embedded, cross-origin content to gain unrestricted access to storage that it would normally only have access to in a first-party context (we refer to this as an origin’s <em>first-party</em> storage).</span> The API provides methods that allow embedded resources to check whether they currently have access to their first-party storage, and to request access to their first-party storage from the user agent.</p>
@@ -55,7 +54,7 @@ tags:
  <li>In Firefox, the storage access grants are phased out after 30 calendar days passing, whereas in Safari the storage access grants are phased out after 30 days of browser usage passed without user interaction. This is currently a limitation of the Firefox implementation, which we may address in a future version.  In Safari, successful use of the storage access API resets this counter.</li>
 </ul>
 
-<p>Documentation for Firefox's new storage access policy for blocking tracking cookies includes <a href="/en-US/docs/Web/Privacy/Storage_Access_Policy#Storage_access_grants">a detailed description</a> of the scope of storage access grants.</p>
+<p>Documentation for Firefox's new storage access policy for blocking tracking cookies includes <a href="/en-US/docs/Web/Privacy/Storage_Access_Policy#storage_access_grants">a detailed description</a> of the scope of storage access grants.</p>
 
 <h2 id="Storage_Access_API_methods">Storage Access API methods</h2>
 

--- a/files/en-us/web/api/storage_api/index.html
+++ b/files/en-us/web/api/storage_api/index.html
@@ -88,19 +88,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Storage')}}</td>
-   <td>{{Spec2('Storage')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://storage.spec.whatwg.org/">Storage Living Standard</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/streams_api/index.html
+++ b/files/en-us/web/api/streams_api/index.html
@@ -124,19 +124,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Streams')}}</td>
-   <td>{{Spec2('Streams')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://streams.spec.whatwg.org/">Streams Living Standard</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/touch_events/index.html
+++ b/files/en-us/web/api/touch_events/index.html
@@ -296,23 +296,12 @@ document.addEventListener("DOMContentLoaded", startup);</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table>
- <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Touch Events 2', '#touch-interface', 'Touch')}}</td>
-   <td>{{Spec2('Touch Events 2')}}</td>
-   <td>Added <code>radiusX</code>, <code>radiusY</code>, <code>rotationAngle</code>, <code>force</code> properties</td>
+   <td><a href="https://w3c.github.io/touch-events/">Touch Events</a></td>
   </tr>
-  <tr>
-   <td>{{SpecName('Touch Events', '#touch-interface', 'Touch')}}</td>
-   <td>{{Spec2('Touch Events')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/url_api/index.html
+++ b/files/en-us/web/api/url_api/index.html
@@ -16,7 +16,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("URL API")}}</p>
 
-<p><span class="seoSummary">The URL API is a component of the URL standard, which defines what constitutes a valid {{Glossary("URL", "Uniform Resource Locator")}} and the API that accesses and manipulates URLs.</span> The URL standard also defines concepts such as domains, hosts, and IP addresses, and also attempts to describe in a standard way the legacy <code>application/x-www-form-urlencoded</code> {{Glossary("MIME type")}} used to submit web forms' contents as a set of key/value pairs.</p>
+<p>The URL API is a component of the URL standard, which defines what constitutes a valid {{Glossary("URL", "Uniform Resource Locator")}} and the API that accesses and manipulates URLs. The URL standard also defines concepts such as domains, hosts, and IP addresses, and also attempts to describe in a standard way the legacy <code>application/x-www-form-urlencoded</code> {{Glossary("MIME type")}} used to submit web forms' contents as a set of key/value pairs.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -67,12 +67,10 @@ try {
 
 <p>The URL API is a simple one, with only a couple of interfaces to its name:</p>
 
-<div class="index">
 <ul>
- <li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/URL"><code>URL</code></a></span></span></li>
- <li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/URLSearchParams"><code>URLSearchParams</code></a></span></span></li>
+ <li><a href="/en-US/docs/Web/API/URL"><code>URL</code></a></li>
+ <li><<a href="/en-US/docs/Web/API/URLSearchParams"><code>URLSearchParams</code></a></li>
 </ul>
-</div>
 
 <h2 id="Examples">Examples</h2>
 
@@ -102,19 +100,13 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('URL')}}</td>
-   <td>{{Spec2('URL')}}</td>
-   <td>WHATWG specification</td>
+   <td><a href="https://url.spec.whatwg.org/">URL Living Standard</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/vibration_api/index.html
+++ b/files/en-us/web/api/vibration_api/index.html
@@ -70,21 +70,13 @@ function startPersistentVibrate(duration, interval) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
- </thead>
- <tbody>
   <tr>
-   <td>{{SpecName("Vibration API")}}</td>
-   <td>{{Spec2("Vibration API")}}</td>
-   <td>Linked to spec is the latest editor's draft; W3C version is a REC.</td>
+   <td><a href="https://w3c.github.io/vibration/">Vibration API</a></td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/visual_viewport_api/index.html
+++ b/files/en-us/web/api/visual_viewport_api/index.html
@@ -76,7 +76,14 @@ window.visualViewport.addEventListener('resize', viewportHandler);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications("api.VisualViewport")}}
+<table>
+  <tr>
+    <th>Specification</th>
+  </tr>
+  <tr>
+    <td><a href="https://w3c.github.io/vibration/">Visual Viewport API</a></td>
+  </tr>
+</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Next part of updating overview pages tables (letter s-v in Web/API)

For bookmarking purposes: this is related to #1146 and #7387.