### PR TITLE
Add docs for WebXR Depth Sensing - part 3

### DIFF
--- a/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.html
+++ b/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.html
@@ -1,0 +1,94 @@
+---
+title: XRWebGLBinding.getDepthInformation()
+slug: Web/API/XRWebGLBinding/getDepthInformation
+tags:
+- API
+- Method
+- Reference
+- AR
+- XR
+- WebXR
+browser-compat: api.XRWebGLBinding.getDepthInformation
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <code><strong>getDepthInformation()</strong></code> method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRWebGLDepthInformation")}} object containing WebGL depth information.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">getDepthInformation(view)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>view</code></dt>
+  <dd>An {{domxref("XRView")}} object obtained from a viewer pose.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>An {{domxref("XRWebGLDepthInformation")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>Throws a <code>NotSupportedError</code> if "depth-sensing" is not in the list of enabled features for this {{domxref("XRSession")}}.</li>
+  <li>Throws an <code>InvalidStateError</code> if the <code>XRFrame</code> is not active nor animated. Obtaining depth information is only valid within the {{domxref("XRSession.requestAnimationFrame()", "requestAnimationFrame()")}} callback.</li>
+  <li>Throws an <code>InvalidStateError</code> if the the session’s {{domxref("XRSession.depthUsage", "depthUsage")}} is not "gpu-optimized".</li>
+
+</ul>
+
+<h2>Examples</h2>
+
+<h3>Obtaining WebGL depth information</h3>
+
+<pre class="brush: js">
+const canvasElement = document.querySelector(".output-canvas");
+const gl = canvasElement.getContext("webgl");
+await gl.makeXRCompatible();
+
+// Make sure  to request a session with depth-sensing enabled
+const session = navigator.xr.requestSession("immersive-ar", {
+  requiredFeatures: ["depth-sensing"],
+  depthSensing: {
+    usagePreference: ["gpu-optimized"],
+    formatPreference: ["luminance-alpha"]
+  }
+});
+
+const glBinding = new XRWebGLBinding(session, gl);
+
+// ...
+
+// Obtain depth information in an active and animated frame
+function rafCallback(time, frame) {
+  session.requestAnimationFrame(rafCallback);
+  const pose = frame.getViewerPose(referenceSpace);
+  if (pose) {
+    for (const view of pose.views) {
+      const depthInformation = glBinding.getDepthInformation(view);
+      if (depthInformation) {
+        // Do something with the depth information
+        // gl.bindTexture(gl.TEXTURE_2D, depthInformation.texture);
+        // ...
+      }
+    }
+  }
+}
+
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRWebGLDepthInformation.texture")}}</li>
+</ul>
+

--- a/files/en-us/web/api/xrwebglbinding/index.html
+++ b/files/en-us/web/api/xrwebglbinding/index.html
@@ -1,0 +1,45 @@
+---
+title: XRWebGLBinding
+slug: Web/API/XRWebGLBinding
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRWebGLBinding
+---
+<p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
+
+<p>The <code><strong>XRWebGLBinding</strong></code> interface is used to create layers that have a GPU backend.</p>
+
+<h2 id="Constructor">Constructor</h2>
+
+<dl>
+ <dt>{{domxref("XRWebGLBinding.XRWebGLBinding", "XRWebGLBinding()")}}</dt>
+ <dd>Creates a new <code>XRWebGLBinding</code> object for the specified XR session and WebGL rendering context.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("XRWebGLBinding.getDepthInformation()")}}</dt>
+  <dd>Returns an {{domxref("XRWebGLDepthInformation")}} object containing WebGL depth information.</dd>
+ </dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRWebGLLayer")}}</li>
+  <li>{{domxref('WebGLRenderingContext')}} and {{domxref("WebGL2RenderingContext")}}</li>
+</ul>

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.html
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.html
@@ -1,0 +1,79 @@
+---
+title: XRWebGLBinding()
+slug: Web/API/XRWebGLBinding/XRWebGLBinding
+tags:
+  - API
+  - Constructor
+  - Reference
+  - WebXR
+  - XR
+browser-compat: api.XRWebGLBinding.XRWebGLBinding
+---
+<p>{{APIRef("WebXR Device API")}}</p>
+
+<p>The <code><strong>XRWebGLBinding()</strong></code> constructor creates and
+    returns a new {{domxref("XRWebGLBinding")}} object.</p>
+
+<h2 id="Syntax">Syntax</h2>
+<pre class="brush: js">new XRWebGLBinding(session, <em>context</em>)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>session</code></dt>
+  <dd>An {{domxref("XRSession")}} object specifying the WebXR session which will be
+    rendered using the WebGL context.</dd>
+  <dt><code>context</code></dt>
+  <dd>A {{domxref("WebGLRenderingContext")}} or {{domxref("WebGL2RenderingContext")}}
+    identifying the WebGL drawing context to use for rendering the scene for the specified
+    WebXR session.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>A newly-created {{domxref("XRWebGLBinding")}}.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt><code>InvalidStateError</code></dt>
+  <dd>
+    <p>The new <code>XRWebGLBinding</code> could not be created due to one of a number of
+      possible state errors:</p>
+
+    <ul>
+      <li>The {{domxref("XRSession")}} specified by <code>session</code> has already been
+        stopped.</li>
+      <li>The specified WebGL context, <code>context</code>, <a
+          href="/en-US/docs/Web/API/WebGLRenderingContext/isContextLost#usage_notes">has
+          been lost</a> for any reason, such as a GPU switch or reset.</li>
+      <li>The specified <code>session</code> is immersive but the <code>context</code> is
+        not WebXR compatible.</li>
+    </ul>
+  </dd>
+</dl>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush: js">
+const canvasElement = document.querySelector(".output-canvas");
+const gl = canvasElement.getContext("webgl");
+const xrSession = await navigator.xr.requestSession("immersive-vr");
+await gl.makeXRCompatible();
+
+const glBinding = new XRWebGLBinding(xrSession, gl);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("WebGLRenderingContext.makeXRCompatible()")}}</li>
+</ul>

--- a/files/en-us/web/api/xrwebgldepthinformation/index.html
+++ b/files/en-us/web/api/xrwebgldepthinformation/index.html
@@ -1,0 +1,54 @@
+---
+title: XRWebGLDepthInformation
+slug: Web/API/XRWebGLDepthInformation
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRWebGLDepthInformation
+---
+<p>{{APIRef("WebXR Device API")}} {{secureContext_header}}</p>
+
+<p>The <code><strong>XRWebGLDepthInformation</strong></code> interface contains depth information from the GPU/WebGL (returned by {{domxref("XRWebGLBinding.getDepthInformation()")}}).</p>
+
+{{InheritanceDiagram}}
+
+<p>This interface inherits properties from its parent, {{domxref("XRDepthInformation")}}.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+ <dt>{{domxref("XRDepthInformation.height")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the height of the depth buffer (number of rows).</dd>
+ <dt>{{domxref("XRDepthInformation.normDepthBufferFromNormView")}} {{ReadOnlyInline}}</dt>
+ <dd>An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth buffer coordinates that can then be scaled by depth buffer’s <code>width</code> and <code>height</code> to obtain the absolute depth buffer coordinates.</dd>
+ <dt>{{domxref("XRDepthInformation.rawValueToMeters")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.</dd>
+ <dt>{{domxref("XRWebGLDepthInformation.texture")}} {{ReadOnlyInline}}</dt>
+ <dd>A {{domxref("WebGLTexture")}} containing depth buffer information as an opaque texture.</dd>
+ <dt>{{domxref("XRDepthInformation.width")}} {{ReadOnlyInline}}</dt>
+ <dd>Contains the width of the depth buffer (number of columns).</dd>
+</dl>
+
+<h2>Examples</h2>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRDepthInformation")}}</li>
+  <li>{{domxref("XRCPUDepthInformation")}}</li>
+  <li>{{domxref("XRWebGLBinding.getDepthInformation()")}}</li>
+</ul>

--- a/files/en-us/web/api/xrwebgldepthinformation/texture/index.html
+++ b/files/en-us/web/api/xrwebgldepthinformation/texture/index.html
@@ -1,0 +1,60 @@
+---
+title: XRWebGLDepthInformation.texture
+slug: Web/API/XRWebGLDepthInformation/texture
+tags:
+- API
+- AR
+- Augmented Reality
+- Experimental
+- Property
+- Reference
+- VR
+- WebXR
+- WebXR Device API
+browser-compat: api.XRWebGLDepthInformation.texture
+---
+<div>{{APIRef("WebXR Device API")}}</div>
+
+<p>The <em>read-only</em> <strong><code>texture</code></strong> property of the {{DOMxRef("XRWebGLDepthInformation")}} interface is a {{domxref("WebGLTexture")}} containing depth buffer information as an opaque texture.</p>
+
+<h3 id="Value">Value</h3>
+
+<p>A {{domxref("WebGLTexture")}}.</p>
+
+<h2>Examples</h2>
+
+<p>Use {{domxref("XRWebGLBinding.getDepthInformation()")}} to obtain GPU depth information. The returned <code>XRWebGLDepthInformation</code> object will contain the <code>texture</code> buffer which can then be bound to a texture and depth buffer information can be made available to a WebGL fragment shader.</p>
+
+<pre class="brush: js">
+const depthInfo = glBinding.getDepthInformation(view);
+const uvTransform = depthInfo.normDepthBufferFromNormView.matrix;
+
+const u_DepthTextureLocation = gl.getUniformLocation(program, "u_DepthTexture");
+const u_UVTransformLocation = gl.getUniformLocation(program, "u_UVTransform");
+const u_RawValueToMeters = gl.getUniformLocation(program, "u_RawValueToMeters");
+
+gl.bindTexture(gl.TEXTURE_2D, depthInfo.texture);
+gl.activeTexture(gl.TEXTURE0);
+gl.uniform1i(u_DepthTextureLocation, 0);
+
+// UV transform to correctly index into the depth map
+gl.uniformMatrix4fv(u_UVTransformLocation, false, uvTransform);
+
+// scaling factor to convert from the raw number to meters
+gl.uniform1f(u_RawValueToMeters, depthInfo.rawValueToMeters);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat}}</div>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("XRWebGLBinding.getDepthInformation()")}}</li>
+  <li>{{domxref("WebGLRenderingContext.bindTexture()")}}</li>
+</ul>


### PR DESCRIPTION
Document how to obtain depth data (using the GPU / WebGL)

Spec: https://immersive-web.github.io/depth-sensing/#xr-gpu-depth-info-section & https://immersive-web.github.io/layers/#xrwebglbinding