### PR TITLE
example shows indexing into low surrogate

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -43,10 +43,18 @@ A decimal number representing the code point value of the character at the given
 ### Using codePointAt()
 
 ```js
-'ABC'.codePointAt(1)           // 66
-'\uD800\uDC00'.codePointAt(0)  // 65536
+'ABC'.codePointAt(0)                        // 65
+'ABC'.codePointAt(0).toString(16)           // 41
 
-'XYZ'.codePointAt(42)          // undefined
+'😍'.codePointAt(0)                         // 128525
+'\ud83d\ude0d'.codePointAt(0)               // 128525
+'\ud83d\ude0d'.codePointAt(0).toString(16)  // 1f60d
+
+'😍'.codePointAt(1)                         // 56845
+'\ud83d\ude0d'.codePointAt(1)               // 56845
+'\ud83d\ude0d'.codePointAt(1).toString(16)  // de0d
+
+'ABC'.codePointAt(42)                       // undefined
 ```
 
 ### Looping with codePointAt()

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -62,7 +62,7 @@ A decimal number representing the code point value of the character at the given
 Because indexing to a `pos` whose element is a UTF-16 low surrogate, returns _only_ the low surrogate,
 it's better not to index directly into a UTF-16 string.
 
-Instead, use a [`for...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement) statement
+Instead, use a [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement) statement
 or an Array's [`forEach()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method
 (or anything which correctly iterates UTF-16 surrogates) to iterate the string, using `codePointAt(0)` to get the code point of each element.
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

> What was wrong/why is this fix needed? (quick summary only)
- edit example usage to show what happens when `codePointAt()` is used to index into _low_ surrogate.
  (hex values included in output as decimals are rarely used for Unicode)

> Anything else that could help us review it
