### PR TITLE
Add WindowOrWorkerGlobalScope.structuredClone page

### DIFF
--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.html
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.html
@@ -8,7 +8,7 @@ tags:
   - JavaScript
   - Reference
 ---
-<p><span class="seoSummary">The <strong>structured clone algorithm</strong> copies complex JavaScript objects. It is used internally to transfer data between <a href="/en-US/docs/Web/API/Worker">Workers</a> via {{domxref("Worker.postMessage()", "postMessage()")}}, storing objects with <a href="/en-US/docs/Glossary/IndexedDB">IndexedDB</a>, or copying objects for <a href="#see_also">other APIs</a>.</span> It clones by recursing through the input object while maintaining a map of previously visited references, to avoid infinitely traversing cycles.</p>
+<p><span class="seoSummary">The <strong>structured clone algorithm</strong> copies complex JavaScript objects. It is used internally when invoking {{domxref("WindowOrWorkerGlobalScope.structuredClone()", "structuredClone()")}}, to transfer data between <a href="/en-US/docs/Web/API/Worker">Workers</a> via {{domxref("Worker.postMessage()", "postMessage()")}}, storing objects with <a href="/en-US/docs/Glossary/IndexedDB">IndexedDB</a>, or copying objects for <a href="#see_also">other APIs</a>.</span> It clones by recursing through the input object while maintaining a map of previously visited references, to avoid infinitely traversing cycles.</p>
 
 <h2 id="Things_that_dont_work_with_structured_clone">Things that don't work with structured clone</h2>
 
@@ -108,10 +108,10 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
+ <li>{{ domxref("WindowOrWorkerGlobalScope.structuredClone()", "structuredClone()") }}</li>
  <li><a href="https://www.w3.org/TR/html5/infrastructure.html#safe-passing-of-structured-data">HTML Specification: Safe passing of structured data</a></li>
  <li>{{ domxref("window.history") }}</li>
  <li>{{ domxref("window.postMessage()") }}</li>
  <li><a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a></li>
  <li><a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB</a></li>
- <li><a href="/en-US/docs/Components.utils.cloneInto">Components.utils.cloneInto</a></li>
 </ul>

--- a/files/en-us/web/api/windoworworkerglobalscope/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/index.html
@@ -61,6 +61,8 @@ browser-compat: api.WindowOrWorkerGlobalScope
  <dd>Schedules a function to execute every time a given number of milliseconds elapses.</dd>
  <dt>{{domxref("WindowOrWorkerGlobalScope.setTimeout()")}}</dt>
  <dd>Schedules a function to execute in a given amount of time.</dd>
+ <dt>{{domxref("WindowOrWorkerGlobalScope.structuredClone()")}}</dt>
+ <dd>Deep clone a JavaScript value using the structured clone algorithm.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/windoworworkerglobalscope/structuredclone/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/structuredclone/index.html
@@ -1,0 +1,68 @@
+---
+title: WindowOrWorkerGlobalScope.structuredClone()
+slug: Web/API/WindowOrWorkerGlobalScope/structuredClone
+tags:
+  - API
+  - DOM
+  - Method
+  - NeedsCompatTable
+  - Reference
+  - structuredClone
+  - WindowOrWorkerGlobalScope
+---
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p>The <strong><code>structuredClone()</code></strong> method of the
+  {{domxref("WindowOrWorkerGlobalScope")}} {{Glossary("mixin")}} deep clones a given value using the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone algorithm</a>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">const <var>clonedValue</var> = structuredClone(<var>value</var>[, { <var>transfer</var> }]);
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code><var>value</var></code></dt>
+  <dd>The value to be cloned. This can be any <a
+    href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured-clonable
+    type</a>.</dd>
+    <dt><code><var>transfer</var></code> {{optional_inline}}</dt>
+    <dd>A sequence of objects that are <a
+        href="/en-US/docs/Web/API/Transferable">transferred</a> with value. The
+      ownership of these objects is transfered from the input value to the cloned value
+      that is returned.</dd>
+  </dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>The returned <code><var>clonedValue</var></code> is a clone of the original passed
+  <code><var>value</var></code>, with transfered values for items passed in the
+  <code><var>transfer</var></code> array.</p>
+
+<h2>Description</h2>
+
+<p>This function can be used to deep copy JavaScript values. The structured clone algorithm
+  also supports circular references. The below example demonstrates this:</p>
+
+<pre class="brush: js">// Create an object with a value and a circular reference to itself.
+const original = { name: "MDN" };
+original.itself = original;
+
+// Clone it
+const clone = self.structuredClone(original);
+
+console.assert(clone !== original); // object are not the same (not same identity)
+console.assert(clone.name === "MDN"); // they do have the same values
+console.assert(clone.itself === clone); // and the circular reference is preserved
+</pre>
+
+  
+<!-- TODO(lucacasonato): Add "Specifications" and "Compat" tables when https://github.com/mdn/browser-compat-data/pull/11967 is released. -->
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a
+    href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</li>
+</ul>


### PR DESCRIPTION
Adds a page for `self.structuredClone`, introduced in
https://github.com/whatwg/html/commit/1b5099fcf55cc6332fb9af5d36ac4db47749438b.

Currently only available in Deno, but implementation bugs for other engines are
filed.

- Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1233571
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1722576
- Safari: https://bugs.webkit.org/show_bug.cgi?id=228331

BCD data is on its way: https://github.com/mdn/browser-compat-data/pull/11967
