### PR TITLE
Document support for svg syntax highlighting in Markdown

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -51,6 +51,7 @@ In MDN, writers will use code fences for example code blocks. They must specify 
   <li><code>php</code></li>
   <li><code>python</code></li>
   <li><code>sql</code></li>
+  <li><code>svg</code></li>
   <li><code>xml</code></li>
   <li><code>wasm</code> (for WebAssembly text format)</li>
 </ul>

--- a/files/en-us/mdn/guidelines/css_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/css_style_guide/index.html
@@ -53,6 +53,7 @@ This gives you the following output:
   <li><code>php</code></li>
   <li><code>python</code></li>
   <li><code>sql</code></li>
+  <li><code>svg</code></li>
   <li><code>xml</code></li>
   <li><code>wasm</code> (for WebAssembly text format)</li>
 </ul>


### PR DESCRIPTION
It turns out we currently support SVG syntax highlighting: https://github.com/mdn/content/blob/9ac9ff201b0e8de930af4f19cd5850eeba63ecc6/files/en-us/web/css/filter/index.html#L161-L165

...but because this was undocumented it never made it into the h2m converter. Now this is fixed: https://github.com/mdn/yari/pull/4444 we should update the docs.
