### PR TITLE
Reduce the “CSS pixels” glossary entry to align with spec

### DIFF
--- a/files/en-us/glossary/css_pixel/index.html
+++ b/files/en-us/glossary/css_pixel/index.html
@@ -12,21 +12,9 @@ tags:
   - unit
   - width
 ---
-<p>The <strong>CSS pixel</strong>—denoted in {{Glossary("CSS")}} with the suffix <code>px</code>—is a unit of length which roughly corresponds to the width or height of a single dot that can be comfortably seen by the human eye without strain, but is otherwise as small as possible. By definition, this is the physical size of a single pixel at a pixel density of 96 DPI, located an arm's length away from the viewer's eyes.</p>
-
-<p>That definition, of course, leaves a lot of wiggle room, as the terms "be comfortably seen" and "an arm's length away" are imprecise, varying from person to person. When a user is sitting at a desk in front of a desktop, the display is generally substantially farther away from their eyes than when they're on a cell phone, for instance.</p>
-
-<p>As such, it generally suffices to say that when the unit <code>px</code> is used, the goal is to try to have the distance <code>96px</code> equal about 1 inch on the screen, regardless of the actual pixel density of the screen. In other words, if the user is on a phone with a pixel density of 266 DPI, and an element is placed on the screen with a width of <code>96px</code>, the actual width of the element would be 266 {{Glossary("Device pixel","device pixels")}}.</p>
+<p>The term <strong>CSS pixel</strong> is synonymous with the CSS unit of absolute length <em>px</em> — which is <a href="https://drafts.csswg.org/css-values/#absolute-lengths">normatively defined</a> as being exactly 1/96th of 1 inch.</p>
 
 <h2 id="Learn_more">Learn more</h2>
-
-<h3 id="Technical_reference">Technical reference</h3>
-
-<ul>
- <li><a href="https://drafts.csswg.org/css-values-3/#absolute-lengths">CSS Values and Units Module, section 5.2: Absolute Lengths</a></li>
-</ul>
-
-<h3 id="Learn_about_it">Learn about it</h3>
 
 <ul>
  <li><a href="https://hacks.mozilla.org/2013/09/css-length-explained/">CSS Length Explained</a> on the MDN Hacks Blog</li>


### PR DESCRIPTION
The current content of the “CSS pixels” glossary entry contains a lot more words than necessary. “CSS pixel” just means “px”, and 1px is normatively defined as being 1/96th of 1in — so let’s reduce the glossary entry to just saying that.

For readers who want a more thorough explanation, the glossary entry has a link to https://hacks.mozilla.org/2013/09/css-length-explained/, which goes into much more detail than what's necessary or appropriate for the glossary entry itself.

Fixes https://github.com/mdn/content/issues/7806