### PR TITLE
"MediaRecorder": Add deprecated/non-standard/experimental flags

### DIFF
--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -34,11 +34,11 @@ browser-compat: api.MediaRecorder
  <dd>Returns the current state of the <code>MediaRecorder</code> object (<code>inactive</code>, <code>recording</code>, or <code>paused</code>.)</dd>
  <dt>{{domxref("MediaRecorder.stream")}} {{readonlyInline}}</dt>
  <dd>Returns the stream that was passed into the constructor when the <code>MediaRecorder</code> was created.</dd>
- <dt>{{domxref("MediaRecorder.ignoreMutedMedia")}}</dt>
+ <dt>{{domxref("MediaRecorder.ignoreMutedMedia")}} {{deprecated_inline}} {{non-standard_inline}}</dt>
  <dd>Indicates whether the <code>MediaRecorder</code> instance will record input when the input {{domxref("MediaStreamTrack")}} is muted. If this attribute is <code>false</code>, <code>MediaRecorder</code> will record silence for audio and black frames for video. The default is <code>false</code>.</dd>
- <dt>{{domxref("MediaRecorder.videoBitsPerSecond")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("MediaRecorder.videoBitsPerSecond")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>Returns the video encoding bit rate in use. This may differ from the bit rate specified in the constructor (if it was provided).</dd>
- <dt>{{domxref("MediaRecorder.audioBitsPerSecond")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("MediaRecorder.audioBitsPerSecond")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>Returns the audio encoding bit rate in use. This may differ from the bit rate specified in the constructor (if it was provided).</dd>
 </dl>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

*N/A*

> What was wrong/why is this fix needed? (quick summary only)

`MediaRecorder.onwarning` and the event `warning` have their respective icons, but `MediaRecorder.ignoreMutedMedia`, `MediaRecorder.videoBitsPerSecond` and `MediaRecorder.audioBitsPerSecond` have theirs missing.

> Anything else that could help us review it

Check the browser compatibility data.
