### PR TITLE
Update (most) tables to be md compatible in Web/HTTP

### DIFF
--- a/files/en-us/web/http/basics_of_http/mime_types/common_types/index.html
+++ b/files/en-us/web/http/basics_of_http/mime_types/common_types/index.html
@@ -162,7 +162,7 @@ tags:
    <td><code>.js</code></td>
    <td>JavaScript</td>
    <td>
-    <code>text/javascript</code>
+    <code>text/javascript</code> (Specifications: <a href="https://html.spec.whatwg.org/multipage/#scriptingLanguages">HTML</a> and its <a href="https://html.spec.whatwg.org/multipage/#dependencies:willful-violation">reasoning</a>, and <a href="https://datatracker.ietf.org/doc/draft-ietf-dispatch-javascript-mjs/">IETF</a>)
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/http/basics_of_http/mime_types/common_types/index.html
+++ b/files/en-us/web/http/basics_of_http/mime_types/common_types/index.html
@@ -27,12 +27,12 @@ tags:
 
 <p>IANA is the official registry of MIME media types and maintains a <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">list of all the official MIME types</a>. This table lists some important MIME types for the Web:</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Extension</th>
-   <th scope="col">Kind of document</th>
-   <th scope="col">MIME Type</th>
+   <th>Extension</th>
+   <th>Kind of document</th>
+   <th>MIME Type</th>
   </tr>
  </thead>
  <tbody>
@@ -162,13 +162,7 @@ tags:
    <td><code>.js</code></td>
    <td>JavaScript</td>
    <td>
-    <p><code>text/javascript</code>, per the following specifications:</p>
-
-    <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/#scriptingLanguages">https://html.spec.whatwg.org/multipage/#scriptingLanguages</a></li>
-     <li><a href="https://html.spec.whatwg.org/multipage/#dependencies:willful-violation">https://html.spec.whatwg.org/multipage/#dependencies:willful-violation</a></li>
-     <li><a href="https://datatracker.ietf.org/doc/draft-ietf-dispatch-javascript-mjs/">https://datatracker.ietf.org/doc/draft-ietf-dispatch-javascript-mjs/</a></li>
-    </ul>
+    <code>text/javascript</code>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/http/csp/errors/cspviolation/index.html
+++ b/files/en-us/web/http/csp/errors/cspviolation/index.html
@@ -18,32 +18,28 @@ tags:
 ---
 <p>{{HTTPSidebar}}</p>
 
-<p>The warning "Content Security Policy: The page’s settings blocked the loading of a resource: xyz" occurs when the page's CSP configuration given by <code>xyz</code> prevents the resource from being loaded into the document's context.</p>
+<p>The warning "Content Security Policy: The page's settings blocked the loading of a resource: xyz" occurs when the page's CSP configuration given by <code>xyz</code> prevents the resource from being loaded into the document's context.</p>
 
 <h2 id="Message">Message</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Firefox</th>
-   <td><code>Content Security Policy: The page’s settings blocked the loading of a resource: <em>xyz</em></code></td>
-  </tr>
-  <tr>
-   <th rowspan="4" scope="row">Chrome</th>
-   <td><code>Refused to apply inline style because it violates the following Content Security Policy Directive: "<em>xyz</em>". <em>uvw</em>.</code></td>
-  </tr>
-  <tr>
-   <td><code>Refused to execute inline script because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></td>
-  </tr>
-  <tr>
-   <td><code>Refused to run the JavaScript URL because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></td>
-  </tr>
-  <tr>
-   <td><code>Refused to execute inline event handler because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></td>
-  </tr>
- </tbody>
-</table>
+<h3>Firefox</h3>
+<p><code>Content Security Policy: The pages settings blocked the loading of a resource: <em>xyz</em></code></p>
+</p>with:</p>
+<dl>
+ <dt><code>xyz</code></dt>
+ <dd>The name of the CSP directive that blocked the resource. This may be expressed as either just the name of the directive, or as the entire policy directive string.</dd>
+ <dt><code>uvw</code></dt>
+ <dd>Text that provides information that may help you resolve the problem, potentially including specific changes you might make to the CSP configuration.</dd>
+</dl>
 
+<h3>Chrome</h3>
+<ul>
+   <li><code>Refused to apply inline style because it violates the following Content Security Policy Directive: "<em>xyz</em>". <em>uvw</em>.</code></li>
+   <li><code>Refused to execute inline script because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></li>
+   <li><code>Refused to run the JavaScript URL because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></li>
+   <li><code>Refused to execute inline event handler because it violates the following Content Security Policy directive: "<em>xyz</em>". <em>uvw</em>.</code></li>
+</ul>
+<p>with:</p>
 <dl>
  <dt><code>xyz</code></dt>
  <dd>The name of the CSP directive that blocked the resource. This may be expressed as either just the name of the directive, or as the entire policy directive string.</dd>
@@ -62,7 +58,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/CSP/Errors">CSP errors and warnings</a></li>
+ <li><a href="/en-US/docs/Web/HTTP/CSP/Errors">CSP errors and warnings</a></li>
  <li><a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a></li>
  <li>{{HTTPHeader("Content-Security-Policy")}}</li>
  <li>{{HTTPHeader("Content-Security-Policy-Report-Only")}}</li>

--- a/files/en-us/web/http/headers/digest/index.html
+++ b/files/en-us/web/http/headers/digest/index.html
@@ -11,22 +11,21 @@ browser-compat: http.headers.Digest
 <p>The <code><strong>Digest</strong></code> response HTTP header provides a
   {{Glossary("digest")}} of the requested resource.</p>
 
-<p>In <a href="https://datatracker.ietf.org/doc/html/rfc7231">RFC 7231</a> terms this is the
-  <em>selected representation</em> of a resource. The selected representation depends on
-  the <code><a href="/en-US/docs/Web/HTTP/Headers/Content-Type">Content-Type</a></code>
-  and
-  <code><a href="/en-US/docs/Web/HTTP/Headers/Content-Encoding">Content-Encoding</a></code>
-  header values: so a single resource may have multiple different digest values.</p>
+<p>
+  In <a href="https://datatracker.ietf.org/doc/html/rfc7231">RFC 7231</a> terms,
+  this is the <em>selected representation</em> of a resource.
+  The selected representation depends
+  on the <code><a href="/en-US/docs/Web/HTTP/Headers/Content-Type">Content-Type</a></code>
+  and <code><a href="/en-US/docs/Web/HTTP/Headers/Content-Encoding">Content-Encoding</a></code> header values,
+  so a single resource may have multiple different digest values.
+</p>
 
-<p>The digest is calculated over the entire representation. The representation itself may
-  be:</p>
+<p>The digest is calculated over the entire representation. The representation itself may be:</p>
 
 <ul>
-  <li>fully contained in the response message body</li>
-  <li>not at all contained in the message body (for example, in a response to a
-    <code><a href="/en-US/docs/Web/HTTP/Methods/HEAD">HEAD</a></code> request)</li>
-  <li>partially contained in the message body (for example, in a response to a <a
-      href="/en-US/docs/Web/HTTP/Range_requests">range request</a>).</li>
+  <li>fully contained in the response message body,</li>
+  <li>not at all contained in the message body (for example, in a response to a <code><a href="/en-US/docs/Web/HTTP/Methods/HEAD">HEAD</a></code> request),</li>
+  <li>or partially contained in the message body (for example, in a response to a <a href="/en-US/docs/Web/HTTP/Range_requests">range request</a>).</li>
 </ul>
 
 <table class="properties">
@@ -44,8 +43,7 @@ browser-compat: http.headers.Digest
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Digest: &lt;digest-algorithm&gt;=&lt;digest-value&gt;
-
+<pre>Digest: &lt;digest-algorithm&gt;=&lt;digest-value&gt;
 Digest: &lt;digest-algorithm&gt;=&lt;digest-value&gt;,&lt;digest-algorithm&gt;=&lt;digest-value&gt;
 </pre>
 
@@ -67,35 +65,26 @@ Digest: &lt;digest-algorithm&gt;=&lt;digest-value&gt;,&lt;digest-algorithm&gt;=&
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: html">Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+<pre>Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
+<table>
     <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
+      <th>Specification</th>
     </tr>
-  </thead>
-  <tbody>
     <tr>
-      <td>
-        <p><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
-        </p>
-      </td>
-      <td>Resource Digests for HTTP</td>
+      <td><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a></td>
     </tr>
-  </tbody>
 </table>
 
-<p>This header was originally defined in <a href="https://datatracker.ietf.org/doc/html/rfc3230">RFC
-    3230</a>, but the definition of "selected representation" in <a
-    href="https://www.rfc-editor.org/info/rfc7231">RFC 7231</a> made the original
-  definition inconsistent with current HTTP specifications. When released, The "Resource
-  Digests for HTTP" draft therefore will obsolete RFC 3230 and will update the standard to
-  be consistent.</p>
+<p>
+  This header was originally defined in <a href="https://datatracker.ietf.org/doc/html/rfc3230">RFC 3230</a>,
+  but the definition of "selected representation" in <a  href="https://www.rfc-editor.org/info/rfc7231">RFC 7231</a> made the original definition inconsistent with current HTTP specifications.
+  When released, The "Resource Digests for HTTP" draft therefore will obsolete RFC 3230
+  and will update the standard to be consistent.
+</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -100,108 +100,167 @@ Referrer-Policy: unsafe-url
 <p>CSS can fetch resources referenced from stylesheets. These resources follow a referrer policy as well:</p>
 
 <ul>
- <li>External CSS stylesheets use the default policy (<code>strict-origin-when-cross-origin</code>), unless it's overwritten via a <code>Referrer-Policy</code> HTTP header on the CSS stylesheet’s response.</li>
+ <li>External CSS stylesheets use the default policy (<code>strict-origin-when-cross-origin</code>), unless it's overwritten via a <code>Referrer-Policy</code> HTTP header on the CSS stylesheet's response.</li>
  <li>For {{HTMLElement("style")}} elements or <a href="/en-US/docs/Web/API/HTMLElement/style"><code>style</code> attributes</a>, the owner document's referrer policy is used.</li>
 </ul>
 
 <h2 id="Examples">Examples</h2>
 
-<table class="standard-table">
- <thead>
+<h3><code>no-referrer</code></h3>
+<table>
   <tr>
-   <th scope="col">Policy</th>
-   <th scope="col">Document</th>
-   <th scope="col">Navigation to</th>
-   <th scope="col">Referrer</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th><code>no-referrer</code></th>
-   <td>https://example.com/page</td>
-   <td><em>anywhere</em></td>
-   <td><em>(no referrer)</em></td>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <th rowspan="3"><code>no-referrer-when-downgrade</code></th>
-   <td rowspan="3">https://example.com/page</td>
-   <td>https://example.com/otherpage</td>
-   <td>https://example.com/page</td>
+    <td>https://example.com/page</td>
+    <td><em>anywhere</em></td>
+    <td><em>(no referrer)</em></td>
+  </tr>
+</table>
+
+<h3><code>no-referrer-when-downgrade</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <td>https://mozilla.org</td>
-   <td>https://example.com/page</td>
+    <td>https://example.com/page</td>
+    <td>https://example.com/otherpage</td>
+    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.com</td>
-   <td><em>(no referrer)</em></td>
+    <td>https://example.com/page</td>
+    <td>https://mozilla.org</td>
+    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <th><code>origin</code></th>
-   <td>https://example.com/page</td>
-   <td><em>anywhere</em></td>
-   <td>https://example.com/</td>
+    <td>https://example.com/page</td>
+    <td><strong>http</strong>://example.com</td>
+    <td><em>(no referrer)</em></td>
+  </tr>
+</table>
+
+<h3><code>origin</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <th rowspan="3"><code>origin-when-cross-origin</code></th>
-   <td rowspan="3">https://example.com/page</td>
-   <td>https://example.com/otherpage</td>
-   <td>https://example.com/page</td>
+    <td>https://example.com/page</td>
+    <td><em>anywhere</em></td>
+    <td>https://example.com/</td>
+  </tr>
+</table>
+
+<h3><code>origin-when-cross-origin</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <td>https://mozilla.org</td>
-   <td>https://example.com/</td>
+    <td>https://example.com/page</td>
+    <td>https://example.com/otherpage</td>
+    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.com/page</td>
-   <td>https://example.com/</td>
+    <td>https://example.com/page</td>
+    <td>https://mozilla.org</td>
+    <td>https://example.com/</td>
   </tr>
   <tr>
-   <th rowspan="2"><code>same-origin</code></th>
-   <td rowspan="2">https://example.com/page</td>
-   <td>https://example.com/otherpage</td>
-   <td>https://example.com/page</td>
+    <td>https://example.com/page</td>
+    <td><strong>http</strong>://example.com/page</td>
+    <td>https://example.com/</td>
+  </tr>
+</table>
+
+<h3>><code>same-origin</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <td>https://mozilla.org</td>
-   <td><em>(no referrer)</em></td>
+    <td>https://example.com/page</td>
+    <td>https://example.com/otherpage</td>
+    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <th rowspan="3"><code>strict-origin</code></th>
-   <td rowspan="2">https://example.com/page</td>
-   <td>https://mozilla.org</td>
-   <td>https://example.com/</td>
+    <td>https://example.com/page</td>
+    <td>https://mozilla.org</td>
+    <td><em>(no referrer)</em></td>
+  </tr>
+</table>
+
+<h3><code>strict-origin</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.com</td>
-   <td><em>(no referrer)</em></td>
+    <td>https://example.com/page</td>
+    <td>https://mozilla.org</td>
+    <td>https://example.com/</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.com/page</td>
-   <td><em>anywhere</em></td>
-   <td>http://example.com/</td>
+    <td>https://example.com/page</td>
+    <td><strong>http</strong>://example.com</td>
+    <td><em>(no referrer)</em></td>
   </tr>
   <tr>
-   <th rowspan="3"><code>strict-origin-when-cross-origin</code></th>
-   <td rowspan="3">https://example.com/page</td>
-   <td>https://example.com/otherpage</td>
-   <td>https://example.com/page</td>
+    <td><strong>http</strong>://example.com/page</td>
+    <td><em>anywhere</em></td>
+    <td>http://example.com/</td>
+  </tr>
+</table>
+
+<h3><code>strict-origin-when-cross-origin</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
   </tr>
   <tr>
-   <td>https://mozilla.org</td>
-   <td>https://example.com/</td>
+    <td>https://example.com/page</td>
+    <td>https://example.com/otherpage</td>
+    <td>https://example.com/page</td>
   </tr>
   <tr>
-   <td><strong>http</strong>://example.com</td>
-   <td><em>(no referrer)</em></td>
+    <td>https://example.com/page</td>
+    <td>https://mozilla.org</td>
+    <td>https://example.com/</td>
   </tr>
   <tr>
-   <th><code>unsafe-url</code></th>
-   <td>https://example.com/page?q=123</td>
-   <td><em>anywhere</em></td>
-   <td>https://example.com/page?q=123</td>
+    <td>https://example.com/page</td>
+    <td><strong>http</strong>://example.com</td>
+    <td><em>(no referrer)</em></td>
   </tr>
- </tbody>
+</table>
+
+<h3><code>unsafe-url</code></h3>
+<table>
+  <tr>
+    <th>From document</th>
+    <th>Navigation to</th>
+    <th>Referrer used</th>
+  </tr>
+  <tr>
+    <td>https://example.com/page?q=123</td>
+    <td><em>anywhere</em></td>
+    <td>https://example.com/page?q=123</td>
+  </tr>
 </table>
 
 <h3 id="Specifying_a_fallback_policy">Specifying a fallback policy</h3>

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -76,11 +76,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Windows user agents have the following variations, where <em>x.y</em> is the Windows NT version (for instance, Windows NT 6.1).</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Windows version</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Windows version</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -101,11 +101,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Note that <a href="https://support.mozilla.org/kb/firefox-no-longer-works-mac-os-10-4-or-powerpc">Firefox no longer officially supports Mac OS X on PowerPC</a>.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Mac OS X version</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Mac OS X version</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -124,11 +124,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Linux is a more diverse platform. Your distribution of Linux might include an extension that changes your user-agent. A few common examples are given below.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Linux version</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Linux version</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -149,11 +149,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <h2 id="Android_version_40_and_below">Android (version 40 and below)</h2>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Form factor</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Form factor</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -172,11 +172,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Beginning in version 41, Firefox for Android will contain the Android version as part of the <var>platform</var> token. For increased interoperability, if the browser is running on a version below 4 it will report 4.4. Android versions 4 and above will report the version accurately. Note that the same Gecko—with the same capabilities—is shipped to all versions of Android.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Form factor</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Form factor</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -201,11 +201,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Starting in Version 6, users can opt into using a GeckoView-based Focus for Android with a hidden preference: it uses a GeckoView UA string to advertise Gecko compatibility.</p>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Focus Version (Rendering Engine)</th>
-   <th scope="col">User Agent string</th>
+   <th>Focus Version (Rendering Engine)</th>
+   <th>User Agent string</th>
   </tr>
   <tr>
    <td>1.0 (WebView Mobile)</td>
@@ -226,11 +226,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Since version 4.1, Klar for Android uses the same UA string as <a href="#focus_for_android">Focus for Android</a>. Before version 4.1, it sent a <var>Klar/&lt;version&gt;</var> <var>product/version</var> token.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Klar Version (Rendering Engine)</th>
-   <th scope="col">User Agent string</th>
+   <th>Klar Version (Rendering Engine)</th>
+   <th>User Agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -263,17 +263,15 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <pre>Mozilla/5.0 (Linux; &lt;Android version&gt;) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/&lt;firefoxversion&gt; Chrome/&lt;Chrome Rev&gt; Safari/&lt;WebKit Rev&gt;</pre>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <td><strong>Firefox TV version</strong></td>
-   <td><strong>User Agent string</strong></td>
+   <th>Firefox TV version</th>
+   <th>User Agent string</th>
   </tr>
   <tr>
    <td>v3.0</td>
    <td>Mozilla/5.0 (Linux; Android 7.1.2) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/3.0 Chrome/59.0.3017.125 Safari/537.36</td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Firefox_for_Echo_Show">Firefox for Echo Show</h2>
@@ -283,26 +281,23 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 <pre>Mozilla/5.0 (Linux; &lt;Android version&gt;) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/&lt;firefoxversion&gt; Chrome/&lt;Chrome Rev&gt; Safari/&lt;WebKit Rev&gt;
 </pre>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <td><strong>Firefox for Echo Show version</strong></td>
-   <td><strong>User agent string</strong></td>
+   <th>Firefox for Echo Show version</th>
+   <th>User agent string</th>
   </tr>
   <tr>
    <td>v1.1</td>
    <td>Mozilla/5.0 (Linux; Android 5.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.1 Chrome/59.0.3017.125 Safari/537.36</td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Firefox_OS">Firefox OS</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Form factor</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Form factor</th>
+   <th>Gecko user agent string</th>
   </tr>
   <tr>
    <td>Phone</td>
@@ -320,7 +315,6 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
    <td>Device-specific</td>
    <td>Mozilla/5.0 (Mobile; <em><strong>nnnn;</strong></em> rv:26.0) Gecko/26.0 Firefox/26.0</td>
   </tr>
- </tbody>
 </table>
 
 <h3 id="Device-specific_user_agent_strings">Device-specific user agent strings</h3>
@@ -337,11 +331,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>While the version number for Firefox OS is not included in the UA string, it is possible to infer version information from the Gecko version number present in the UA string.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Firefox OS version number</th>
-   <th scope="col">Gecko version number</th>
+   <th>Firefox OS version number</th>
+   <th>Gecko version number</th>
   </tr>
  </thead>
  <tbody>
@@ -394,11 +388,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Firefox for iOS uses the default Mobile Safari UA string, with an additional <strong>FxiOS/&lt;version&gt;</strong> token, similar to how <a href="https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent">Chrome for iOS identifies itself</a>.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Form factor</th>
-   <th scope="col">Firefox for iOS user agent string</th>
+   <th>Form factor</th>
+   <th>Firefox for iOS user agent string</th>
   </tr>
  </thead>
  <tbody>
@@ -425,11 +419,11 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>These are some sample UA strings from other Gecko-based browsers on various platforms. Note that many of these have not yet been released on Gecko 2.0!</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Browser</th>
-   <th scope="col">Gecko user agent string</th>
+   <th>Browser</th>
+   <th>Gecko user agent string</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -121,30 +121,23 @@ Response:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Title</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a>
-        </p>
-      </td>
-      <td>Resource Digests for HTTP</td>
-    </tr>
-  </tbody>
+<table>
+  <tr>
+    <th>Specification</th>
+  </tr>
+  <tr>
+    <td><a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers">draft-ietf-httpbis-digest-headers-latest</a></td>
+  </tr>
 </table>
 
-<p>This header was originally defined in <a href="https://datatracker.ietf.org/doc/html/rfc3230">RFC
-    3230</a>, but the definition of "selected representation" in <a
-    href="https://www.rfc-editor.org/info/rfc7231">RFC 7231</a> made the original
-  definition inconsistent with current HTTP specifications. When released, The "Resource
-  Digests for HTTP" draft therefore will obsolete RFC 3230 and will update the standard to
-  be consistent.</p>
+<p>
+  This header was originally defined in <a href="https://datatracker.ietf.org/doc/html/rfc3230">RFC 3230</a>,
+  but the definition of "selected representation"
+  in <a href="https://www.rfc-editor.org/info/rfc7231">RFC 7231</a>
+  made the original definition inconsistent with current HTTP specifications.
+  When released, The "Resource Digests for HTTP" draft therefore will obsolete RFC 3230
+  and will update the standard to be consistent.
+</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/redirections/index.html
+++ b/files/en-us/web/http/redirections/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Principle">Principle</h2>
 
-<p>In HTTP, redirection is triggered by a server sending a special <em>redirect</em> response to a request. Redirect responses have <a href="/en-US/docs/Web/HTTP/Status">status codes</a> that start with <code>3</code>, and a {{ httpheader("Location") }} header holding the URL to redirect to.</p>
+<p>In HTTP, redirection is triggered by a server sending a special <em>redirect</em> response to a request. Redirect responses have <a href="/en-US/docs/Web/HTTP/Status">status codes</a> that start with <code>3</code>, and a {{ httpheader("Location") }} header holding the URL to redirect to.</p>
 
 <p>When browsers receive a redirect, they immediately load the new URL provided in the <code>Location</code> header. Besides the small performance hit of an additional round-trip, users rarely notice the redirection.</p>
 
@@ -37,25 +37,25 @@ tags:
 
 <p>These redirections are meant to last forever. They imply that the original URL should no longer be used, and replaced with the new one.Search engine robots, RSS readers, and other crawlers will update the original URL for the resource.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="row">Code</th>
-   <th scope="col">Text</th>
-   <th scope="col">Method handling</th>
-   <th scope="col">Typical use case</th>
+   <th>Code</th>
+   <th>Text</th>
+   <th>Method handling</th>
+   <th>Typical use case</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><code>301</code></th>
+   <td><code>301</code></td>
    <td><code>Moved Permanently</code></td>
    <td>{{HTTPMethod("GET")}} methods unchanged.<br>
     Others may or may not be changed to {{HTTPMethod("GET")}}. [1]</td>
    <td>Reorganization of a Web site.</td>
   </tr>
   <tr>
-   <th scope="row"><code>308</code></th>
+   <td><code>308</code></td>
    <td><code>Permanent Redirect</code></td>
    <td>Method and body not changed.</td>
    <td>Reorganization of a Web site, with non-GET links/operations.</td>
@@ -71,32 +71,32 @@ tags:
 
 <p>Search engine robots and other crawlers don't memorize the new, temporary URL. Temporary redirections are also used when creating, updating, or deleting resources, to show temporary progress pages.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="row">Code</th>
-   <th scope="col">Text</th>
-   <th scope="col">Method handling</th>
-   <th scope="col">Typical use case</th>
+   <th>Code</th>
+   <th>Text</th>
+   <th>Method handling</th>
+   <th>Typical use case</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><code>302</code></th>
+   <td><code>302</code></td>
    <td><code>Found</code></td>
    <td>{{HTTPMethod("GET")}} methods unchanged.<br>
     Others may or may not be changed to {{HTTPMethod("GET")}}. [2]</td>
    <td>The Web page is temporarily unavailable for unforeseen reasons.</td>
   </tr>
   <tr>
-   <th scope="row"><code>303</code></th>
+   <td><code>303</code></td>
    <td><code>See Other</code></td>
    <td>{{HTTPMethod("GET")}} methods unchanged.<br>
     Others <em>changed</em> to <code>GET</code> (body lost).</td>
    <td>Used to redirect after a {{HTTPMethod("PUT")}} or a {{HTTPMethod("POST")}}, so that refreshing the result page doesn't re-trigger the operation.</td>
   </tr>
   <tr>
-   <th scope="row"><code>307</code></th>
+   <td><code>307</code></td>
    <td><code>Temporary Redirect</code></td>
    <td>Method and body not changed</td>
    <td>The Web page is temporarily unavailable for unforeseen reasons. Better than <code>302</code> when non-<code>GET</code> operations are available on the site.</td>
@@ -110,22 +110,22 @@ tags:
 
 <p>{{HTTPStatus("304")}} (Not Modified) redirects a page to the locally cached copy (that was stale), and {{HTTPStatus("300")}} (Multiple Choice) is a manual redirection: the body, presented by the browser as a Web page, lists the possible redirections and the user clicks on one to select it.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="row">Code</th>
-   <th scope="col">Text</th>
-   <th scope="col">Typical use case</th>
+   <th>Code</th>
+   <th>Text</th>
+   <th>Typical use case</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><code>300</code></th>
+   <td><code>300</code></td>
    <td><code>Multiple Choice</code></td>
    <td>Not many: the choices are listed in an HTML page in the body. Machine-readable choices are encouraged to be sent as {{HTTPHeader("Link")}} headers with <code>rel=alternate</code>.</td>
   </tr>
   <tr>
-   <th scope="row"><code>304</code></th>
+   <td><code>304</code></td>
    <td><code>Not Modified</code></td>
    <td>Sent for revalidated conditional requests. Indicates that the cached response is still fresh and can be used.</td>
   </tr>


### PR DESCRIPTION
This makes most tables in Web/HTTP compatible with the Markdown conversion script.

- I removed all the `standard-table` classes.
- Some are just adapted (updating the `<th>`, removing the `scope` attributes, removing the `rowspan`, often by repeating the info.
- Some tables have been broken into sub-tables, between headings, to remove the first column.
- A couple were old-style specification tables that I converted to the new style, compatible with md.

Properties tables are not dealt with here (I will keep them) 

After this, there are still two documents with tables to convert, but they will be in a separate PR as they are more complex.

For bookkeeping purposes: this is part of #7536.