### PR TITLE
&lt at line 103 needs to be changed to &gt

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.html
+++ b/files/en-us/web/api/window/requestanimationframe/index.html
@@ -100,7 +100,7 @@ function step(timestamp) {
     element.style.transform = 'translateX(' + count + 'px)';
   }
 
-  if (elapsed &lt; 2000) { // Stop the animation after 2 seconds
+  if (elapsed &gt; 2000) { // Stop the animation after 2 seconds
     previousTimeStamp = timestamp
     window.requestAnimationFrame(step);
   }


### PR DESCRIPTION
Given "Stop the animation after 2 seconds" commented at line 103, 
&gt instead of &lt makes all the things sense well.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
