### PR TITLE
Space after period and period in i.e.

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/samesite/index.html
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.html
@@ -42,7 +42,7 @@ browser-compat: http.headers.Set-Cookie.SameSite
 
 <h3 id="None"><code>None</code></h3>
 
-<p>Cookies will be sent in all contexts, i.e in responses to both first-party and cross-origin requests.If <code>SameSite=None</code> is set, the cookie <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure"><code>Secure</code></a> attribute must also be set (or the cookie will be blocked).</p>
+<p>Cookies will be sent in all contexts, i.e. in responses to both first-party and cross-origin requests. If <code>SameSite=None</code> is set, the cookie <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure"><code>Secure</code></a> attribute must also be set (or the cookie will be blocked).</p>
 
 <h2 id="Fixing_common_warnings">Fixing common warnings</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Punctuation matters