### PR TITLE
Fixed typo

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -98,7 +98,7 @@ The BigInt type is a numeric primitive in JavaScript that can represent integers
 
 A BigInt is created by appending `n` to the end of an integer or by calling the constructor.
 
-You can obtain the safest value that can be incremented with Numbers by using the constant {{jsxref("Number.MAX_SAFE_INTEGER")}}. With the introduction of BigInts, you can operate with numbers beyond the {{jsxref("Number.MAX_SAFE_INTEGER")}}.
+You can obtain the largest safe value that can be incremented with Numbers by using the constant {{jsxref("Number.MAX_SAFE_INTEGER")}}. With the introduction of BigInts, you can operate with numbers beyond the {{jsxref("Number.MAX_SAFE_INTEGER")}}.
 
 This example demonstrates, where incrementing the {{jsxref("Number.MAX_SAFE_INTEGER")}} returns the expected result:
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A

> What was wrong/why is this fix needed? (quick summary only)

Doc for BigInt said (capitalization mine), 
"You can obtain the SAFEST value that can be incremented with Numbers by using the constant {{jsxref("Number.MAX_SAFE_INTEGER")}}." 
I think it's supposed to say, 
"You can obtain the LARGEST SAFE value that can be incremented with Numbers by using the constant {{jsxref("Number.MAX_SAFE_INTEGER")}}.

> Anything else that could help us review it
