### PR TITLE
Fix XRInputSourcesChangeEvent macros

### DIFF
--- a/files/en-us/web/api/webxr_device_api/inputs/index.html
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.html
@@ -507,7 +507,7 @@ mat4.getRotation(targetRayDirection, viewerRefSpace);</pre>
 
 <p>To determine what object is targeted, follow the targeting ray until it intersects an object. This process is called <strong>hit testing</strong> or <strong>collision detection</strong>. The approach you take to hit testing depends very much on the specific needs of your app. The first question is: are you detecting collisions with virtual objects or terrain, real-world objects or terrain, or both?</p>
 
-<p>In any case, to identify the targeted object, you need to determine if the ray specified by the {{domxref("XRInputSession")}} property {{domxref("XRInputSession.targetRaySpace", "targetRaySpace")}} intersects any objects in the scene, whether thye're virtual or real-world.</p>
+<p>In any case, to identify the targeted object, you need to determine if the ray specified by the {{domxref("XRInputSource")}} property {{domxref("XRInputSource.targetRaySpace", "targetRaySpace")}} intersects any objects in the scene, whether thye're virtual or real-world.</p>
 
 <p>See <a href="/en-US/docs/Web/API/WebXR_Device_API/Targeting">Targeting and hit detection</a> for a more detailed look at what's involved..</p>
 
@@ -531,7 +531,7 @@ mat4.getRotation(targetRayDirection, viewerRefSpace);</pre>
 
 <p>This <code>gamepad</code> object is not only used to obtain access to specialty buttons, trackpads, and so forth, but also provides a way to more directly access and monitor the controls that serve as the primary select and squeeze inputs, since these are included in its {{domxref("Gamepad.buttons", "buttons")}} list.</p>
 
-<p>Because this use of the <code>Gamepad</code> interface is a convenience rather than a true application of the Gamepad API, there are several differences between how it's used with WebXR and how it's used in Gamepad API applications. The most notable—but not the only—difference is that WebXR adds the <code>xr-standard</code> gamepad mapping, expanding the {{domxref("GamepadMappingType")}} enumerated type. This gamepad mapping defines how the controls on a typical one-hand handheld VR controller are mapped to gamepad controls. </p>
+<p>Because this use of the <code>Gamepad</code> interface is a convenience rather than a true application of the Gamepad API, there are several differences between how it's used with WebXR and how it's used in Gamepad API applications. The most notable—but not the only—difference is that WebXR adds the <code>xr-standard</code> gamepad mapping, see the {{domxref("XRInputSource.gamepad")}} property for additional differences. This gamepad mapping defines how the controls on a typical one-hand handheld VR controller are mapped to gamepad controls. </p>
 
 <p>For details on the gamepad mapping as well as the other differences how the use of the {{domxref("Gamepad")}} object and its children differs from its use in the Gamepad API, see the article <a href="/en-US/docs/Web/WebXR_Device_API/Gamepads">Supporting advanced controllers and gamepads in WebXR applications</a>.</p>
 

--- a/files/en-us/web/api/webxr_device_api/inputs/index.html
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>A full WebXR experience isn't just about showing the user a wholly virtual scene or augmenting reality by adding to or altering the world around them. In order to make an experience that's fulfilling and engaging, the user needs to be able to interact with it. To that end, WebXR provides support for a variety of kinds of input devices.</p>
 
-<p><span class="seoSummary">In this guide, we'll look at how to use WebXR's input device management features to determine what input sources are available and how to then monitor those sources for inputs in order to handle user interactivity with your virtual or augmented environment.</span></p>
+<p>In this guide, we'll look at how to use WebXR's input device management features to determine what input sources are available and how to then monitor those sources for inputs in order to handle user interactivity with your virtual or augmented environment.</p>
 
 <h2 id="Inputs_in_WebXR">Inputs in WebXR</h2>
 
@@ -188,14 +188,14 @@ xrSession.addEventListener("inputsourceschange", event =&gt; {
 });
 </pre>
 
-<p>The <code>inputsourceschange</code> event is also fired once when the session's creation callback first completes execution, so you can use it to fetch the input source list as soon as it's available at startup time. The event is delivered as an {{domxref("XRInputSourceChangeEvent")}}, which includes three properties of interest:</p>
+<p>The <code>inputsourceschange</code> event is also fired once when the session's creation callback first completes execution, so you can use it to fetch the input source list as soon as it's available at startup time. The event is delivered as an {{domxref("XRInputSourcesChangeEvent")}}, which includes three properties of interest:</p>
 
 <dl>
- <dt>{{domxref("XRInputSourceChangeEvent.session", "session")}}</dt>
+ <dt>{{domxref("XRInputSourcesChangeEvent.session", "session")}}</dt>
  <dd>The <code>XRSession</code> for which the input sources have changed.</dd>
- <dt>{{domxref("XRInputSourceChangeEvent.added", "added")}}</dt>
+ <dt>{{domxref("XRInputSourcesChangeEvent.added", "added")}}</dt>
  <dd>An array of zero or more {{domxref("XRInputSource")}} objects indicating the input sources that have been newly added to the XR system.</dd>
- <dt>{{domxref("XRInputSourceChangeEvent.removed", "removed")}}</dt>
+ <dt>{{domxref("XRInputSourcesChangeEvent.removed", "removed")}}</dt>
  <dd>An array of zero or more {{domxref("XRInputSource")}} objects indicating any input sources that have been removed from the XR system.</dd>
 </dl>
 


### PR DESCRIPTION
- Is there any interface named `XRInputSession` ?  - https://github.com/mdn/content/blob/main/files/en-us/web/api/webxr_device_api/inputs/index.html#L510
- Is this `{{domxref("GamepadMappingType")}}` referring to `{{domxref("Gamepad.mapping")}}` at https://github.com/mdn/content/blob/main/files/en-us/web/api/webxr_device_api/inputs/index.html#L534