### PR TITLE
Add note about Chrome for storage manager quota

### DIFF
--- a/files/en-us/web/api/storageestimate/quota/index.html
+++ b/files/en-us/web/api/storageestimate/quota/index.html
@@ -28,6 +28,10 @@ browser-compat: api.StorageEstimate.quota
 
 <p>A numeric value specifying an approximation of the total amount of storage space available for use by the application.</p>
 
+<div class="note">
+  <p><strong>Note</strong>: Chrome always reports 60% of the actual disk size for privacy reasons.</p>
+</div>
+
 <h2 id="Example">Example</h2>
 
 <p>See <a href="/en-US/docs/Web/API/StorageManager/estimate#example"><code>StorageManager.estimate</code></a> for example code.</p>

--- a/files/en-us/web/api/storageestimate/quota/index.html
+++ b/files/en-us/web/api/storageestimate/quota/index.html
@@ -29,7 +29,7 @@ browser-compat: api.StorageEstimate.quota
 <p>A numeric value specifying an approximation of the total amount of storage space available for use by the application.</p>
 
 <div class="note">
-  <p><strong>Note</strong>: Chrome always reports 60% of the actual disk size for privacy reasons.</p>
+  <p><strong>Note</strong>: User agents might not report the actual storage space for privacy reasons. Chrome, for instance, always reports 60% of the actual disk size.</p>
 </div>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
As noted in https://web.dev/storage-for-the-web/#:~:text=60%25%20of%20the%20actual%20disk%20size, Chrome always reports 60% of the actual disk size in the StorageManager API for privacy reasons.
