### PR TITLE
Code example fix and a small enhancement on `learn/performance/multimedia`

### DIFF
--- a/files/en-us/learn/performance/multimedia/index.html
+++ b/files/en-us/learn/performance/multimedia/index.html
@@ -101,7 +101,7 @@ tags:
 <pre class="html">&lt;picture&gt;
    &lt;source type="video/mp4" src="giphy.mp4"&gt;
    &lt;source type="image/webp" src="giphy.webp"&gt;
-   &lt;img src="giphy.gif"&gt;
+   &lt;img src="giphy.gif" alt="" /&gt;
 &lt;/picture&gt;</pre>
 
 <h4 id="Serving_the_optimal_size">Serving the optimal size</h4>
@@ -119,7 +119,7 @@ tags:
 
 <p>Getting the most important images in front of visitors sooner than the less important can deliver improved perceived performance.</p>
 
-<p>The first thing to check is that your content images use  <code>&lt;img&gt;</code> elements and your background images are defined in CSS with <code>background-image</code> — images referenced in <code>&lt;img&gt;</code> elements are assigned a higher loading priority than background images.</p>
+<p>The first thing to check is that your content images use <code>&lt;img&gt;</code> or <code>&lt;picture&gt;</code> elements and your background images are defined in CSS with <code>background-image</code> — images referenced in <code>&lt;img&gt;</code> elements are assigned a higher loading priority than background images.</p>
 
 <p>Secondly, with the adoption of Priority Hints, you can control the priority further by adding an <code>importance</code> attribute to your image tags. An example use case for priority hints on images are carousels where the first image is a higher priority than the subsequent images.</p>
 

--- a/files/en-us/learn/performance/multimedia/index.html
+++ b/files/en-us/learn/performance/multimedia/index.html
@@ -121,7 +121,7 @@ tags:
 
 <p>The first thing to check is that your content images use <code>&lt;img&gt;</code> or <code>&lt;picture&gt;</code> elements and your background images are defined in CSS with <code>background-image</code> — images referenced in <code>&lt;img&gt;</code> elements are assigned a higher loading priority than background images.</p>
 
-<p>Secondly, with the adoption of Priority Hints, you can control the priority further by adding an <code>importance</code> attribute to your image tags. An example use case for priority hints on images are carousels where the first image is a higher priority than the subsequent images.</p>
+<p>Secondly, with the adoption of <a href="/en-US/docs/Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests">Priority Hints</a>, you can control the priority further by adding an <code>importance</code> attribute to your image tags. An example use case for priority hints on images are carousels where the first image is a higher priority than the subsequent images.</p>
 
 <h3 id="Rendering_strategy">Rendering strategy</h3>
 

--- a/files/en-us/learn/performance/multimedia/index.html
+++ b/files/en-us/learn/performance/multimedia/index.html
@@ -121,7 +121,7 @@ tags:
 
 <p>The first thing to check is that your content images use <code>&lt;img&gt;</code> or <code>&lt;picture&gt;</code> elements and your background images are defined in CSS with <code>background-image</code> — images referenced in <code>&lt;img&gt;</code> elements are assigned a higher loading priority than background images.</p>
 
-<p>Secondly, with the adoption of <a href="/en-US/docs/Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests">Priority Hints</a>, you can control the priority further by adding an <code>importance</code> attribute to your image tags. An example use case for priority hints on images are carousels where the first image is a higher priority than the subsequent images.</p>
+<p>Secondly, with the adoption of Priority Hints, you can control the priority further by adding an <code>importance</code> attribute to your image tags. An example use case for priority hints on images are carousels where the first image is a higher priority than the subsequent images.</p>
 
 <h3 id="Rendering_strategy">Rendering strategy</h3>
 


### PR DESCRIPTION
In this PR, you'll find two small enhancements to the `learn/performance/multimedia` reference:
- add a needed (empty) alt attribute in one code example
- add `<picture>` alongside `<img>` element

Cheers,
Jb