### PR TITLE
Update spec tables in API overview pages (w-z)

### DIFF
--- a/files/en-us/web/api/notifications_api/index.html
+++ b/files/en-us/web/api/notifications_api/index.html
@@ -30,7 +30,7 @@ tags:
 <p>From here the user can choose to allow notifications from this origin, or block them. Once a choice has been made, the setting will generally persist for the current session.</p>
 
 <div class="note">
-<p><strong>Note</strong>: As of Firefox 44, the permissions for Notifications and <a href="/en-US/docs/Web/API/Push_API">Push</a> have been merged. If permission is granted for notifications, push will also be enabled.</p>
+<p><strong>Note:</strong> As of Firefox 44, the permissions for Notifications and <a href="/en-US/docs/Web/API/Push_API">Push</a> have been merged. If permission is granted for notifications, push will also be enabled.</p>
 </div>
 
 <p>Next, a new notification is created using the {{domxref("Notification.Notification","Notification()")}} constructor. This must be passed a title argument, and can optionally be passed an options object to specify options, such as text direction, body text, icon to display, notification sound to play, and more.</p>
@@ -38,7 +38,7 @@ tags:
 <p>In addition, the Notifications API spec specifies a number of additions to the <a href="/en-US/docs/Web/API/Service_Worker_API">ServiceWorker API</a>, to allow service workers to fire notifications.</p>
 
 <div class="note">
-<p><strong>Note</strong>: To find out more about using notifications in your own app, read <a href="/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API">Using the Notifications API</a>.</p>
+<p><strong>Note:</strong> To find out more about using notifications in your own app, read <a href="/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API">Using the Notifications API</a>.</p>
 </div>
 
 <h2 id="Notifications_interfaces">Notifications interfaces</h2>
@@ -61,19 +61,15 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('Web Notifications')}}</td>
-   <td>{{Spec2('Web Notifications')}}</td>
-   <td>Living standard</td>
+   <td><a href="https://notifications.spec.whatwg.org/">Notifications API Living Standard</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/web_animations_api/index.html
+++ b/files/en-us/web/api/web_animations_api/index.html
@@ -22,7 +22,7 @@ tags:
  <dt>{{domxref("Animation")}}</dt>
  <dd>Provides playback controls and a timeline for an animation node or source. Can take an object created with the {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}} constructor.</dd>
  <dt>{{domxref("KeyframeEffect")}}</dt>
- <dd>Describes sets of animatable properties and values, called <strong>keyframes</strong> and their <a href="/en-US/docs/Web/API/Web_Animations_API/Animation_timing_options">timing options</a>. These can then be played using the {{domxref("Animation.Animation", "Animation()")}} constructor.</dd>
+ <dd>Describes sets of animatable properties and values, called <strong>keyframes</strong> and their <a href="/en-US/docs/Web/API/EffectTiming">timing options</a>. These can then be played using the {{domxref("Animation.Animation", "Animation()")}} constructor.</dd>
  <dt>{{domxref("AnimationTimeline")}}</dt>
  <dd>Represents the timeline of animation. This interface exists to define timeline features (inherited by {{domxref("DocumentTimeline")}} and future timeline objects) and is not itself accessed by developers.</dd>
  <dt>{{domxref("AnimationEvent")}}</dt>
@@ -30,7 +30,7 @@ tags:
  <dt>{{domxref("DocumentTimeline")}}</dt>
  <dd>Represents animation timelines, including the default document timeline (accessed using the {{domxref("Document.timeline")}} property).</dd>
  <dt>{{domxref("EffectTiming")}}</dt>
- <dd>{{domxref("Element.animate()")}}, {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect()")}} all accept an optional dictionary object of timing properties.</dd>
+ <dd>{{domxref("Element.animate()")}}, {{domxref("KeyframeEffect.KeyframeEffect")}}, and {{domxref("KeyframeEffect.KeyframeEffect()")}} all accept an optional dictionary object of timing properties.</dd>
 </dl>
 
 <h2 id="Extensions_to_other_interfaces">Extensions to other interfaces</h2>
@@ -57,17 +57,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Web Animations')}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Initial definition</td>
+   <td><a href="https://drafts.csswg.org/web-animations-1/">Web Animations</td>
   </tr>
  </tbody>
 </table>
@@ -80,6 +76,6 @@ tags:
  <li><a href="https://github.com/web-animations/web-animations-js">Polyfill</a></li>
  <li>Firefox's current implementation: <a href="https://birtles.github.io/areweanimatedyet/">AreWeAnimatedYet</a></li>
  <li>
-  <p><a href="http://codepen.io/danwilson/pen/xGBKVq">Browser support test</a></p>
+  <p><a href="https://codepen.io/danwilson/pen/xGBKVq">Browser support test</a></p>
  </li>
 </ul>

--- a/files/en-us/web/api/web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/index.html
@@ -32,14 +32,14 @@ tags:
 	<li>Connect the sources up to the effects, and the effects to the destination.</li>
 </ol>
 
-<p><img alt="A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information." src="audio-context_.png"></p>
+<p><img alt="A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrows between them pointing from left to right, indicating the flow of audio information." src="audio-context_.png"></p>
 
 <p>Timing is controlled with high precision and low latency, allowing developers to write code that responds accurately to events and is able to target specific samples, even at a high sample rate. So applications such as drum machines and sequencers are well within reach.</p>
 
 <p>The Web Audio API also allows us to control how audio is <em>spatialized</em>. Using a system based on a <em>source-listener model</em>, it allows control of the <em>panning model</em> and deals with <em>distance-induced attenuation</em> induced by a moving source (or moving listener).</p>
 
-<div class="note">
-<p>You can read about the theory of the Web Audio API in a lot more detail in our article <a href="/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API">Basic concepts behind Web Audio API</a>.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> You can read about the theory of the Web Audio API in a lot more detail in our article <a href="/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API">Basic concepts behind Web Audio API</a>.</p>
 </div>
 
 <h2 id="Web_Audio_API_target_audience">Web Audio API target audience</h2>
@@ -56,7 +56,7 @@ tags:
 
 <p>We also have other tutorials and comprehensive reference material available that covers all features of the API. See the sidebar on this page for more.</p>
 
-<p>If you are more familiar with the musical side of things, are familiar with music theory concepts, want to start building instruments, then you can go ahead and start building things with the advance tutorial and others as a guide (the above linked tutorial covers scheduling notes, creating bespoke oscillators and envelopes, as well as an LFO among other things.)</p>
+<p>If you are more familiar with the musical side of things, are familiar with music theory concepts, want to start building instruments, then you can go ahead and start building things with the advanced tutorial and others as a guide (the above-linked tutorial covers scheduling notes, creating bespoke oscillators and envelopes, as well as an LFO among other things.)</p>
 
 <p>If you aren't familiar with the programming basics, you might want to consult some beginner's JavaScript tutorials first and then come back here — see our <a href="/en-US/docs/Learn/JavaScript">Beginner's JavaScript learning module</a> for a great place to begin.</p>
 
@@ -196,7 +196,7 @@ tags:
 	<dt>{{event("audioprocess")}} (event) {{deprecated_inline}}</dt>
 	<dd>The <code>audioprocess</code> event is fired when an input buffer of a Web Audio API {{domxref("ScriptProcessorNode")}} is ready to be processed.</dd>
 	<dt>{{domxref("AudioProcessingEvent")}} {{deprecated_inline}}</dt>
-	<dd>The <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> <code>AudioProcessingEvent</code> represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.</dd>
+	<dd>The <code>AudioProcessingEvent</code> represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.</dd>
 </dl>
 
 <h3 id="Offlinebackground_audio_processing">Offline/background audio processing</h3>
@@ -222,17 +222,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
 	<tbody>
 		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
+			<th>Specification</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Web Audio API')}}</td>
-			<td>{{Spec2('Web Audio API')}}</td>
-			<td></td>
+			<a href="https://webaudio.github.io/web-audio-api/">Web Audio API</a>
 		</tr>
 	</tbody>
 </table>
@@ -261,8 +257,8 @@ tags:
 	<li><a href="/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API">Visualizations with Web Audio API</a></li>
 	<li><a href="/en-US/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics">Web audio spatialisation basics</a></li>
 	<li><a href="/en-US/docs/Web/API/Web_Audio_API/Controlling_multiple_parameters_with_ConstantSourceNode">Controlling multiple parameters with ConstantSourceNode</a></li>
-	<li><a href="http://www.html5rocks.com/tutorials/webaudio/positional_audio/">Mixing Positional Audio and WebGL</a></li>
-	<li><a href="http://www.html5rocks.com/tutorials/webaudio/games/">Developing Game Audio with the Web Audio API</a></li>
+	<li><a href="https://www.html5rocks.com/tutorials/webaudio/positional_audio/">Mixing Positional Audio and WebGL</a></li>
+	<li><a href="https://www.html5rocks.com/tutorials/webaudio/games/">Developing Game Audio with the Web Audio API</a></li>
 	<li><a href="/en-US/docs/Web/API/Web_Audio_API/Migrating_from_webkitAudioContext">Porting webkitAudioContext code to standards based AudioContext</a></li>
 </ul>
 

--- a/files/en-us/web/api/web_authentication_api/index.html
+++ b/files/en-us/web/api/web_authentication_api/index.html
@@ -194,23 +194,19 @@ navigator.credentials.create(createCredentialDefaultArgs)
 
 <ul>
  <li><a href="https://webauthn.bin.coffee/">Mozilla Demo</a> website and its <a href="https://github.com/jcjones/webauthn.bin.coffee">source code</a>.</li>
- <li><a href="http://webauthndemo.appspot.com/">Google Demo</a> website and its <a href="https://github.com/google/webauthndemo">source code</a>.</li>
+ <li><a href="https://webauthndemo.appspot.com/">Google Demo</a> website and its <a href="https://github.com/google/webauthndemo">source code</a>.</li>
  <li><a href="https://webauthn.org">webauthn.org</a> and its <a href="https://github.com/apowers313/webauthn-simple-app">client source code</a> and <a href="https://github.com/apowers313/fido2-lib">server source code</a></li>
 </ul>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('WebAuthn')}}</td>
-   <td>{{Spec2('WebAuthn')}}</td>
-   <td>Initial definition.</td>
+   <td><a href="https://w3c.github.io/webauthn/">Web Authentication: An API for accessing Public Key Credentials</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/web_crypto_api/index.html
+++ b/files/en-us/web/api/web_crypto_api/index.html
@@ -29,19 +29,15 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName("Web Crypto API")}}</td>
-   <td>{{Spec2("Web Crypto API")}}</td>
-   <td>Initial definition</td>
+   <td><a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/web_midi_api/index.html
+++ b/files/en-us/web/api/web_midi_api/index.html
@@ -92,7 +92,14 @@ function startLoggingMIDIInput( midiAccess, indexOfPort ) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<table>
+  <tr>
+    <th>Specification</th>
+  </tr>
+  <tr>
+    <td><a href="https://webaudio.github.io/web-midi-api/">Web MIDI API</a></td>
+  </tr>
+</table>
 
  <h2>See also</h2>
 

--- a/files/en-us/web/api/web_speech_api/index.html
+++ b/files/en-us/web/api/web_speech_api/index.html
@@ -13,9 +13,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Speech API")}}{{SeeCompatTable}}</div>
 
-<div class="summary">
-<p>The Web Speech API enables you to incorporate voice data into web apps. The Web Speech API has two parts: SpeechSynthesis (Text-to-Speech), and SpeechRecognition (Asynchronous Speech Recognition.)</p>
-</div>
+<p>The <strong>Web Speech API</strong> enables you to incorporate voice data into web apps. The Web Speech API has two parts: <code>SpeechSynthesis</code> (Text-to-Speech), and <code>SpeechRecognition</code> (Asynchronous Speech Recognition.)</p>
 
 <h2 id="Web_Speech_Concepts_and_Usage">Web Speech Concepts and Usage</h2>
 
@@ -74,17 +72,13 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('Web Speech API')}}</td>
-   <td>{{Spec2('Web Speech API')}}</td>
-   <td>Initial definition</td>
+   <td><a href="">Web Speech APII</a></td>
   </tr>
  </tbody>
 </table>
@@ -103,7 +97,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API">Using the Web Speech API</a></li>
- <li><a href="http://www.sitepoint.com/talking-web-pages-and-the-speech-synthesis-api/">SitePoint article</a></li>
+ <li><a href="https://www.sitepoint.com/talking-web-pages-and-the-speech-synthesis-api/">SitePoint article</a></li>
  <li><a href="http://updates.html5rocks.com/2014/01/Web-apps-that-talk---Introduction-to-the-Speech-Synthesis-API">HTML5Rocks article</a></li>
- <li><a href="http://aurelio.audero.it/demo/speech-synthesis-api-demo.html">Demo</a> [aurelio.audero.it]</li>
+ <li><a href="https://aurelio.audero.it/demo/speech-synthesis-api-demo.html">Demo</a> [aurelio.audero.it]</li>
 </ul>

--- a/files/en-us/web/api/web_storage_api/index.html
+++ b/files/en-us/web/api/web_storage_api/index.html
@@ -46,7 +46,7 @@ tags:
 </div>
 
 <div class="note">
-<p><strong>Note:</strong> Web Storage is not the same as <a href="/en-US/docs/Storage">mozStorage</a> (Mozilla's XPCOM interfaces to SQLite) or the <a href="/en-US/docs/Session_store_API">Session store API</a> (an <a href="/en-US/docs/XPCOM">XPCOM</a> storage utility for use by extensions).</p>
+<p><strong>Note:</strong> Web Storage is not the same as <code>mozStorage</code> (Mozilla's XPCOM interfaces to SQLite) or the <code>Session store API</code> (an XPCOM storage utility for use by extensions).</p>
 </div>
 
 <h2 id="Web_Storage_interfaces">Web Storage interfaces</h2>
@@ -55,7 +55,7 @@ tags:
  <dt>{{domxref("Storage")}}</dt>
  <dd>Allows you to set, retrieve and remove data for a specific domain and storage type (session or local.)</dd>
  <dt>{{domxref("Window")}}</dt>
- <dd>The Web Storage API extends the {{domxref("Window")}} object with two new properties — {{domxref("Window.sessionStorage")}} and {{domxref("Window.localStorage")}} — which provide access to the current domain's session and local {{domxref("Storage")}} objects respectively, and a {{domxref("Window.onstorage")}} event handler that fires when a storage area changes (e.g. a new item is stored.)</dd>
+ <dd>The Web Storage API extends the {{domxref("Window")}} object with two new properties — {{domxref("Window.sessionStorage")}} and {{domxref("Window.localStorage")}} — which provide access to the current domain's session and local {{domxref("Storage")}} objects respectively, and a {{domxref("WindowEventHandlers.onstorage")}} event handler that fires when a storage area changes (e.g. a new item is stored.)</dd>
  <dt>{{domxref("StorageEvent")}}</dt>
  <dd>The <code title="event-storage">storage</code> event is fired on a document's <code>Window</code> object when a storage area changes.</dd>
 </dl>
@@ -68,17 +68,16 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('HTML WHATWG', 'webstorage.html#webstorage')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
+   <td>
+    <a href="https://html.spec.whatwg.org/multipage/webstorage.html#webstorage">HTML Living Standard<br/>
+    # webstorage</a>
+   </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/web_workers_api/index.html
+++ b/files/en-us/web/api/web_workers_api/index.html
@@ -12,7 +12,7 @@ tags:
 <p class="summary"><strong>Web Workers</strong> makes it possible to run a script operation in a background thread separate from the main execution thread of a web application. The advantage of this is that laborious processing can be performed in a separate thread, allowing the main (usually the UI) thread to run without being blocked/slowed down.</p>
 
 <div class="notecard note">
-<p class="summary"><strong>Note:</strong> Web Workers can also use the Web Worker API (i.e. workers can spawn workers, provided they are hosted within the same <a href="/en-US/docs/Glossary/Origin">origin</a> as the parent page). </p>
+<p><strong>Note:</strong> Web Workers can also use the Web Worker API (i.e. workers can spawn workers, provided they are hosted within the same <a href="/en-US/docs/Glossary/Origin">origin</a> as the parent page).</p>
 </div>
 
 <h2 id="Web_Workers_concepts_and_usage">Web Workers concepts and usage</h2>
@@ -36,7 +36,7 @@ tags:
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: As per the <a href="https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2">Web workers Spec</a>, worker error events should not bubble (see {{bug(1188141)}}. This has been implemented in Firefox 42.</p>
+<p><strong>Note:</strong> As per the <a href="https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2">Web workers Spec</a>, worker error events should not bubble (see {{bug(1188141)}}. This has been implemented in Firefox 42.</p>
 </div>
 
 <h3 id="Worker_global_contexts_and_functions">Worker global contexts and functions</h3>
@@ -61,7 +61,7 @@ tags:
 <h3 id="Supported_Web_APIs">Supported Web APIs</h3>
 
 <div class="notecard note">
-<p>Note that if a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <a href="https://worker-playground.glitch.me/">https://worker-playground.glitch.me/</a></p>
+<p><strong>Note:</strong> If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <a href="https://worker-playground.glitch.me/">https://worker-playground.glitch.me/</a></p>
 </div>
 
 <p>The following Web APIs are available to workers: {{domxref("Barcode_Detection_API","Barcode Detection API")}}, {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}, {{domxref("Cache", "Cache API")}}, {{domxref("Channel_Messaging_API", "Channel Messaging API")}},{{domxref("Console API", "Console API")}}, <a href="/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a> ({{domxref("Crypto")}}), {{domxref("CustomEvent")}}, {{domxref("Data_Store_API", "Data Store")}} (Firefox only), {{domxref("DOMRequest")}} and {{domxref("DOMCursor")}}, {{domxref("Encoding_API", "Encoding API")}} ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}}, etc.), {{domxref("Fetch_API", "Fetch API")}}, {{domxref("FileReader")}}, {{domxref("FileReaderSync")}} (only works in workers!), {{domxref("FormData")}}, {{domxref("ImageData")}}, {{domxref("IndexedDB_API", "IndexedDB")}}, <a href="/en-US/docs/Web/API/Network_Information_API">Network Information API</a>, {{domxref("Notifications_API", "Notifications API")}}, {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}, {{domxref("PerformanceEntry")}}, {{domxref("PerformanceMeasure")}}, {{domxref("PerformanceMark")}}, {{domxref("PerformanceObserver")}}, {{domxref("PerformanceResourceTiming")}}), {{jsxref("Promise")}}, <a href="/en-US/docs/Web/API/Server-sent_events">Server-sent events</a>, {{domxref("ServiceWorkerRegistration")}}, {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }}), <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> with {{domxref("OffscreenCanvas")}} (enabled behind a feature preference setting <code>gfx.offscreencanvas.enabled</code>), {{domxref("WebSocket")}}, {{domxref("XMLHttpRequest")}}.</p>
@@ -100,17 +100,15 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName("HTML WHATWG", "workers.html#workers", "Web Workers")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition.</td>
+   <td>
+     <a href="https://html.spec.whatwg.org/multipage/workers.html#workers">HTML Living Standard<br/>
+     # workers</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -17,7 +17,7 @@ tags:
 <div>{{WebGLSidebar}}</div>
 
 <div class="summary">
-<p><span class="seoSummary">WebGL (Web Graphics Library) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics within any compatible web browser without the use of plug-ins. WebGL does so by introducing an API that closely conforms to OpenGL ES 2.0 that can be used in HTML5 {{HTMLElement("canvas")}} elements.</span> This conformance makes it possible for the API to take advantage of hardware graphics acceleration provided by the user's device.</p>
+<p><strong>WebGL</strong> (Web Graphics Library) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics within any compatible web browser without the use of plug-ins. WebGL does so by introducing an API that closely conforms to OpenGL ES 2.0 that can be used in HTML5 {{HTMLElement("canvas")}} elements. This conformance makes it possible for the API to take advantage of hardware graphics acceleration provided by the user's device.</p>
 </div>
 
 <p>Support for WebGL is present in <a href="/en-US/docs/Mozilla/Firefox" title="Firefox 4 for developers">Firefox</a> 4+, <a href="https://www.google.com/chrome/">Google Chrome</a> 9+, <a href="https://www.opera.com/">Opera</a> 12+, <a href="https://www.apple.com/safari/">Safari </a>5.1+, <a href="https://windows.microsoft.com/en-us/internet-explorer/browser-ie">Internet Explorer</a> 11+, and <a href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a> build 10240+; however, the user's device must also have hardware that supports these features.</p>
@@ -194,34 +194,24 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('OpenGL ES 3.0')}}</td>
-   <td>{{Spec2('OpenGL ES 3.0')}}</td>
-   <td></td>
+   <td><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/">WebGL Specification</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('OpenGL ES 2.0')}}</td>
-   <td>{{Spec2('OpenGL ES 2.0')}}</td>
-   <td></td>
+   <td><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2.0 Specification</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('WebGL2')}}</td>
-   <td>{{Spec2('WebGL2')}}</td>
-   <td>Builds on top of WebGL 1. Based on OpenGL ES 3.0.</td>
+   <td><a href="https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/">OpenGL ES 2.0</a></td>
   </tr>
   <tr>
-   <td>{{SpecName('WebGL')}}</td>
-   <td>{{Spec2('WebGL')}}</td>
-   <td>Initial definition. Based on OpenGL ES 2.0</td>
+   <td><a href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/">OpenGL ES 3.0</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/webrtc_api/index.html
+++ b/files/en-us/web/api/webrtc_api/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("WebRTC")}}</div>
 
-<p><span class="seoSummary"><strong>WebRTC</strong> (Web Real-Time Communication) is a technology which enables Web applications and sites to capture and optionally stream audio and/or video media, as well as to exchange arbitrary data between browsers without requiring an intermediary.</span> The set of standards that comprise WebRTC makes it possible to share data and perform teleconferencing peer-to-peer, without requiring that the user install plug-ins or any other third-party software.</p>
+<p><strong>WebRTC</strong> (Web Real-Time Communication) is a technology that enables Web applications and sites to capture and optionally stream audio and/or video media, as well as to exchange arbitrary data between browsers without requiring an intermediary. The set of standards that comprise WebRTC makes it possible to share data and perform teleconferencing peer-to-peer, without requiring that the user install plug-ins or any other third-party software.</p>
 
 <p>WebRTC consists of several interrelated APIs and protocols which work together to achieve this. The documentation you'll find here will help you understand the fundamentals of WebRTC, how to set up and use both data and media connections, and more.</p>
 
@@ -210,11 +210,28 @@ tags:
  <dd>This tutorial is a step-by-step guide on how to build a phone using Peer.js</dd>
 </dl>
 
-<h2 id="Resources">Resources</h2>
+<h2 id="Specifications">Specifications</h2>
 
-<h3 id="Protocols">Protocols</h3>
+<table>
+ <thead>
+  <tr>
+   <th>Specification</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><a href="https://w3c.github.io/webrtc-pc/">WebRTC: Real-Time Communication Between Browsers</a></td>
+  </tr>
+  <tr>
+   <td><a href="https://w3c.github.io/mediacapture-main/">Media Capture and Streams</a></td>
+  </tr>
+  <tr>
+   <td><a href="https://w3c.github.io/mediacapture-fromelement/">Media Capture from DOM Elements</a></td>
+  </tr>
+ </tbody>
+</table>
 
-<h4 id="WebRTC-proper_protocols">WebRTC-proper protocols</h4>
+<h3 id="WebRTC-proper_protocols">WebRTC-proper protocols</h4>
 
 <ul>
  <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/"><cite>Application Layer Protocol Negotiation for Web Real-Time Communications</cite></a></li>
@@ -226,7 +243,7 @@ tags:
  <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/"><cite>Transports for RTCWEB</cite></a></li>
 </ul>
 
-<h4 id="Related_supporting_protocols">Related supporting protocols</h4>
+<h3 id="Related_supporting_protocols">Related supporting protocols</h3>
 
 <ul>
  <li><a href="https://datatracker.ietf.org/doc/html/rfc5245">Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocol</a></li>
@@ -236,44 +253,6 @@ tags:
  <li><a href="https://datatracker.ietf.org/doc/html/rfc3264"><cite>An Offer/Answer Model with Session Description Protocol (SDP)</cite></a></li>
  <li><a href="https://datatracker.ietf.org/doc/draft-ietf-tram-turn-third-party-authz/"><cite>Session Traversal Utilities for NAT (STUN) Extension for Third Party Authorization</cite></a></li>
 </ul>
-
-<h4 id="WebRTC_statistics"><cite>WebRTC statistics</cite></h4>
-
-<ul>
- <li><a href="/en-US/docs/Web/API/WebRTC_Statistics_API">WebRTC Statistics API</a></li>
-</ul>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('WebRTC 1.0')}}</td>
-   <td>{{Spec2('WebRTC 1.0')}}</td>
-   <td>The initial definition of the API of WebRTC.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture')}}</td>
-   <td>{{Spec2('Media Capture')}}</td>
-   <td>The initial definition of the object conveying the stream of media content.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Capture DOM Elements')}}</td>
-   <td>{{Spec2('Media Capture DOM Elements')}}</td>
-   <td>The initial definition on how to obtain stream of content from DOM Elements</td>
-  </tr>
- </tbody>
-</table>
-
-<p>In additions to these specifications defining the API needed to use WebRTC, there are several protocols, listed under <a href="#protocols">resources</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -288,4 +267,5 @@ tags:
  <li><a href="https://hacks.mozilla.org/2015/04/peering-through-the-webrtc-fog-with-socketpeer/">Peering Through the WebRTC Fog with SocketPeer</a></li>
  <li><a href="https://hacks.mozilla.org/2014/04/inside-the-party-bus-building-a-web-app-with-multiple-live-video-streams-interactive-graphics/">Inside the Party Bus: Building a Web App with Multiple Live Video Streams + Interactive Graphics</a></li>
  <li><a href="/en-US/docs/Web/Media">Web media technologies</a></li>
+ <li><a href="/en-US/docs/Web/API/WebRTC_Statistics_API">WebRTC Statistics API</a></li>
 </ul>

--- a/files/en-us/web/api/webrtc_statistics_api/index.html
+++ b/files/en-us/web/api/webrtc_statistics_api/index.html
@@ -13,7 +13,7 @@ tags:
   - WebRTC
   - WebRTC Statistics API
 ---
-<p>{{DefaultAPISidebar("WebRTC")}}{{Draft}}</p>
+<p>{{DefaultAPISidebar("WebRTC")}}</p>
 
 <p>The WebRTC API has a vast array of statistics available, covering the entire breadth of the WebRTC connectivity system, from sender to receiver and peer to peer.</p>
 
@@ -401,24 +401,19 @@ function getConnectionStats() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
+<table>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th>Specification</th>
   </tr>
   <tr>
-   <td>{{SpecName('WebRTC Statistics Identifiers', '#dom-rtcstatstype', 'WebRTC statistics types')}}</td>
-   <td>{{Spec2('WebRTC Statistics Identifiers')}}</td>
-   <td>Compatibility for individual statistic types</td>
+   <td>
+     <a href="https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport">WebRTC: Real-Time Communication Between Browsers<br/>
+     # dom-rtcstatsreport</a>
+   </td>
   </tr>
   <tr>
-   <td>{{ SpecName('WebRTC 1.0', '#dom-rtcstatsreport', 'RTCStatsReport') }}</td>
-   <td>{{Spec2("WebRTC 1.0")}}</td>
-   <td>Compatibility of statistic reporting</td>
+   <td><a href="https://w3c.github.io/webrtc-stats/">Identifiers for WebRTC's Statistics API</td>
   </tr>
- </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -76,29 +76,21 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comments</th>
+   <th>Specification</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName("HTML WHATWG", "web-sockets.html", "WebSocket API")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
+   <td>
+     <a href="https://html.spec.whatwg.org/multipage/web-sockets.html#network">HTML Living Standard<br/>
+     # network</a>
+   </td>
   </tr>
   <tr>
-   <td><a href="https://www.w3.org/TR/websockets/">WebSockets</a></td>
-   <td><span class="spec-CR">Candidate Recommendation</span></td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{RFC(6455, "The WebSocket Protocol")}}</td>
-   <td><span class="spec-RFC">IETF RFC</span></td>
-   <td></td>
+   <td><a href="https://datatracker.ietf.org/doc/html/rfc6455">RFC 6455, The WebSocket Protocol</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/webvtt_api/index.html
+++ b/files/en-us/web/api/webvtt_api/index.html
@@ -17,7 +17,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("WebVTT")}}</div>
 
-<p><span class="seoSummary"><strong>Web Video Text Tracks Format</strong> (<strong>WebVTT</strong>) is a format for displaying timed text tracks (such as subtitles or captions) using the {{HTMLElement("track")}} element.</span> The primary purpose of WebVTT files is to add text overlays to a {{HTMLElement("video")}}. WebVTT is a text based format, which must be encoded using {{Glossary("UTF-8")}}. Where you can use spaces you can also use tabs. There is also a small API available to represent and manage these tracks and the data needed to perform the playback of the text at the correct times.</p>
+<p><strong>Web Video Text Tracks Format</strong> (<strong>WebVTT</strong>) is a format for displaying timed text tracks (such as subtitles or captions) using the {{HTMLElement("track")}} element. The primary purpose of WebVTT files is to add text overlays to a {{HTMLElement("video")}}. WebVTT is a text based format, which must be encoded using {{Glossary("UTF-8")}}. Where you can use spaces you can also use tabs. There is also a small API available to represent and manage these tracks and the data needed to perform the playback of the text at the correct times.</p>
 
 <h2 id="WebVTT_files">WebVTT files</h2>
 
@@ -870,17 +870,13 @@ Sur les &lt;i.foreignphrase&gt;&lt;lang en&gt;playground&lt;/lang&gt;&lt;/i&gt;,
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
    <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName("WebVTT")}}</td>
-   <td>{{Spec2("WebVTT")}}</td>
-   <td>Initial definition</td>
+   <td><a href="https://w3c.github.io/webvtt/">WebVTT: The Web Video Text Tracks Format</a></td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
For bookkeeping purposes: this is related to #1146 and #7387.

Fixes basic flaws and spec tables for API overview pages from W to Z. (+Notifications API where Web Notifications API was redirecting too).