### PR TITLE
fix documents of CSS gradient

### DIFF
--- a/files/en-us/web/css/gradient/conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/conic-gradient()/index.html
@@ -64,7 +64,7 @@ background: conic-gradient(
 
 <p>As with any gradient, a conic gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to, or size of the <code>&lt;image&gt;</code> is set to something other than the element size.</p>
 
-<p>To create a conic gradient that repeats so as to fill a 360 degree rotation, use the {{CSSxRef("gradient/repeating-conic-gradient()")}} function instead.</p>
+<p>To create a conic gradient that repeats so as to fill a 360 degree rotation, use the {{CSSxRef("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}} function instead.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>conic-gradient()</code> won't work on {{CSSxRef("background-color")}} and other properties that use the {{CSSxRef("&lt;color&gt;")}} data type.</p>
 
@@ -213,10 +213,10 @@ background-size: 25% 25%;
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Other gradient functions: {{CSSxRef("gradient/repeating-conic-gradient()")}}, {{CSSxRef("gradient/linear-gradient()")}}, {{CSSxRef("gradient/repeating-linear-gradient()")}}, {{CSSxRef("gradient/radial-gradient()")}}, {{CSSxRef("gradient/repeating-radial-gradient()")}}</li>
+ <li>Other gradient functions: {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}, {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}</li>
  <li>{{cssxref("&lt;image&gt;")}}</li>
- <li>{{cssxref("image()","image()")}}</li>
+ <li>{{cssxref("image/image()","image()")}}</li>
  <li>{{cssxref("element()")}}</li>
- <li>{{cssxref("image-set()","image-set()")}}</li>
+ <li>{{cssxref("image/image-set()","image-set()")}}</li>
  <li>{{cssxref("cross-fade()")}}</li>
 </ul>

--- a/files/en-us/web/css/gradient/index.html
+++ b/files/en-us/web/css/gradient/index.html
@@ -140,7 +140,7 @@ browser-compat: css.types.image.gradient
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Gradient functions: {{cssxref("gradient/linear-gradient()", "gradient/linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient()", "gradient/conic-gradient()")}}</li>
+ <li>Gradient functions: {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}</li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Types">CSS Basic Data Types</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Values_and_Units">CSS Units and Values</a></li>
  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Values_and_units">Introduction to CSS: Values and Units</a></li>

--- a/files/en-us/web/css/gradient/linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/linear-gradient()/index.html
@@ -72,7 +72,7 @@ linear-gradient(45deg, red 0 50%, blue 50% 100%);</pre>
 
 <p>As with any gradient, a linear gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
-<p>To create a linear gradient that repeats so as to fill its container, use the {{CSSxRef("gradient/repeating-linear-gradient()")}} function instead.</p>
+<p>To create a linear gradient that repeats so as to fill its container, use the {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}} function instead.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>linear-gradient()</code> won't work on {{CSSxRef("background-color")}} and other properties that use the {{CSSxRef("&lt;color&gt;")}} data type.</p>
 
@@ -174,10 +174,10 @@ linear-gradient(red 0%, orange 10% 30%, yellow 50% 70%, green 90% 100%);</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Other gradient functions: {{CSSxRef("gradient/repeating-linear-gradient()")}}, {{CSSxRef("gradient/radial-gradient()")}}, {{CSSxRef("gradient/repeating-radial-gradient()")}}, {{CSSxRef("gradient/conic-gradient()")}}, {{CSSxRef("gradient/repeating-conic-gradient()")}}</li>
+ <li>Other gradient functions: {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}</li>
  <li>{{CSSxRef("&lt;image&gt;")}}</li>
  <li>{{cssxref("element()")}}</li>
- <li>{{cssxref("image()","image()")}}</li>
- <li>{{cssxref("image-set()","image-set()")}}</li>
+ <li>{{cssxref("image/image()","image()")}}</li>
+ <li>{{cssxref("image/image-set()","image-set()")}}</li>
  <li>{{cssxref("cross-fade()")}}</li>
 </ul>

--- a/files/en-us/web/css/gradient/radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/radial-gradient()/index.html
@@ -66,7 +66,7 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
   </tbody>
  </table>
 
- <p>If <code>&lt;ending-shape&gt;</code> is specified as <code>circle</code> or is omitted, the size may be given explicitly as a <code><a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a></code>, which provides an explicit circle radius. Negative values are invalid.<br>
+ <p>If <code>&lt;ending-shape&gt;</code> is specified as <code>circle</code>, the size may be given explicitly as a <code><a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a></code>, which provides an explicit circle radius. Negative values are invalid.<br>
   <br>
   If <code>&lt;ending-shape&gt;</code> is specified as <code>ellipse</code> or is omitted, the size may be given as a <code><a href="/en-US/docs/Web/CSS/length-percentage">&lt;length-percentage&gt;</a></code> with two values to provide an explicit ellipse size. The first value represents the horizontal radius, the second the vertical radius. Percentages values are relative to the corresponding dimension of the gradient box. Negative values are invalid.</p>
  </dd>
@@ -80,7 +80,7 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <p>As with any gradient, a radial gradient has <a href="/en-US/docs/Web/CSS/image#description">no intrinsic dimensions</a>; i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.</p>
 
-<p>To create a radial gradient that repeats so as to fill its container, use the {{cssxref("gradient/repeating-radial-gradient()")}} function instead.</p>
+<p>To create a radial gradient that repeats so as to fill its container, use the {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}} function instead.</p>
 
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>radial-gradient()</code> won't work on {{Cssxref("background-color")}} and other properties that use the {{cssxref("&lt;color&gt;")}} data type.</p>
 
@@ -143,10 +143,10 @@ radial-gradient(circle at center, red 0, blue, green 100%)</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Other gradient functions: {{cssxref("gradient/repeating-radial-gradient()")}}, {{cssxref("gradient/linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()")}}, {{cssxref("gradient/conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()")}}</li>
+ <li>Other gradient functions: {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}, {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}</li>
  <li>{{cssxref("&lt;image&gt;")}}</li>
- <li>{{cssxref("image()","image()")}}</li>
+ <li>{{cssxref("image/image()","image()")}}</li>
  <li>{{cssxref("element()")}}</li>
- <li>{{cssxref("image-set()","image-set()")}}</li>
+ <li>{{cssxref("image/image-set()","image-set()")}}</li>
  <li>{{cssxref("cross-fade()")}}</li>
 </ul>

--- a/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient()/index.html
@@ -57,12 +57,12 @@ background: repeating-conic-gradient(
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>repeating-conic-gradient()</code> won't work on {{CSSxRef("background-color")}} and other properties that use the {{CSSxRef("&lt;color&gt;")}} data type.</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> To create a conic gradient that does not repeat, make the gradient a full 360 degree rotation, or use the {{CSSxRef("gradient/conic-gradient()")}} function instead.</p>
+<p><strong>Note:</strong> To create a conic gradient that does not repeat, make the gradient a full 360 degree rotation, or use the {{cssxref("gradient/conic-gradient()", "conic-gradient()")}} function instead.</p>
 </div>
 
 <h3 id="Understanding_repeating_conic_gradients">Understanding repeating conic gradients</h3>
 
-<p>The repeating-conic-gradient syntax is similar to the {{CSSxRef("gradient/conic-gradient()")}} and {{CSSxRef("gradient/repeating-radial-gradient()")}} syntax. Like the non-repeating conic-gradient, the color-stops are placed around a gradient arc. Like the repeating radial gradient, the size of the repeating section is the first color stop subtracted from the angle of the last color stop.</p>
+<p>The repeating-conic-gradient syntax is similar to the {{cssxref("gradient/conic-gradient()", "conic-gradient()")}} and {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}} syntax. Like the non-repeating conic-gradient, the color-stops are placed around a gradient arc. Like the repeating radial gradient, the size of the repeating section is the first color stop subtracted from the angle of the last color stop.</p>
 
 <p><img alt="Comparison of the color stops for repeating and non-repeating conic and radial gradients" src="repeatingconicgradient.png"></p>
 
@@ -165,10 +165,10 @@ repeating-conic-gradient(from -45deg, red 45deg, orange, yellow, green, blue 225
 
 <ul>
 	<li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
-	<li>Other gradient functions: {{CSSxRef("gradient/conic-gradient()")}}, {{CSSxRef("gradient/linear-gradient()")}}, {{CSSxRef("gradient/repeating-linear-gradient()")}}, {{CSSxRef("gradient/radial-gradient()")}}, {{CSSxRef("gradient/repeating-radial-gradient()")}}</li>
+	<li>Other gradient functions: {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}</li>
 	<li>{{cssxref("&lt;image&gt;")}}</li>
-	<li>{{cssxref("image()","image()")}}</li>
+	<li>{{cssxref("image/image()","image()")}}</li>
 	<li>{{cssxref("element()")}}</li>
-	<li>{{cssxref("image-set()","image-set()")}}</li>
+	<li>{{cssxref("image/image-set()","image-set()")}}</li>
 	<li>{{cssxref("cross-fade()")}}</li>
 </ul>

--- a/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient()/index.html
@@ -15,7 +15,7 @@ browser-compat: css.types.image.gradient.repeating-linear-gradient
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>repeating-linear-gradient()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> creates an image consisting of repeating linear gradients. It is similar to {{cssxref("gradient/linear-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container. The function's result is an object of the {{cssxref("&lt;gradient&gt;")}} data type, which is a special kind of {{cssxref("&lt;image&gt;")}}.</p>
+<p>The <strong><code>repeating-linear-gradient()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> creates an image consisting of repeating linear gradients. It is similar to {{cssxref("gradient/linear-gradient()", "linear-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container. The function's result is an object of the {{cssxref("&lt;gradient&gt;")}} data type, which is a special kind of {{cssxref("&lt;image&gt;")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/function-repeating-linear-gradient.html")}}</div>
 
@@ -138,10 +138,10 @@ where &lt;side-or-corner&gt; = [left | right] || [top | bottom]
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Other gradient functions: {{cssxref("gradient/linear-gradient()")}}, {{cssxref("gradient/radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()")}}</li>
+ <li>Other gradient functions: {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}</li>
  <li>{{cssxref("&lt;image&gt;")}}</li>
- <li>{{cssxref("image()","image()")}}</li>
+ <li>{{cssxref("image/image()","image()")}}</li>
  <li>{{cssxref("element()")}}</li>
- <li>{{cssxref("image-set()","image-set()")}}</li>
+ <li>{{cssxref("image/image-set()","image-set()")}}</li>
  <li>{{cssxref("cross-fade()")}}</li>
 </ul>

--- a/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient()/index.html
@@ -15,7 +15,7 @@ browser-compat: css.types.image.gradient.repeating-radial-gradient
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>repeating-radial-gradient()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> creates an image consisting of repeating gradients that radiate from an origin. It is similar to {{cssxref("gradient/radial-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container, similar to {{cssxref("gradient/repeating-linear-gradient()")}} . The function's result is an object of the {{cssxref("&lt;gradient&gt;")}} data type, which is a special kind of {{cssxref("&lt;image&gt;")}}.</p>
+<p>The <strong><code>repeating-radial-gradient()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> creates an image consisting of repeating gradients that radiate from an origin. It is similar to {{cssxref("gradient/radial-gradient()", "radial-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container, similar to {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}. The function's result is an object of the {{cssxref("&lt;gradient&gt;")}} data type, which is a special kind of {{cssxref("&lt;image&gt;")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/function-repeating-radial-gradient.html")}}</div>
 
@@ -156,10 +156,10 @@ where &lt;extent-keyword&gt; = closest-corner | closest-side | farthest-corner |
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">Using CSS gradients</a></li>
- <li>Other gradient functions: {{cssxref("gradient/radial-gradient()")}}, {{cssxref("gradient/linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()")}}, {{cssxref("gradient/conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()")}}</li>
+ <li>Other gradient functions: {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}, {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}, {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}, {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}</li>
  <li>{{cssxref("&lt;image&gt;")}}</li>
- <li>{{cssxref("image()","image()")}}</li>
+ <li>{{cssxref("image/image()","image()")}}</li>
  <li>{{cssxref("element()")}}</li>
- <li>{{cssxref("image-set()","image-set()")}}</li>
+ <li>{{cssxref("image/image-set()","image-set()")}}</li>
  <li>{{cssxref("cross-fade()")}}</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

- There is an inconsistent description in radial-gradient() -- `<ending-shape>` is never recognized as `circle` if it is omitted
- There are sub-directory names in some link texts
- Links to image() and image-set() should be corrected

> Anything else that could help us review it
