### PR TITLE
Fix broken link in Audio for Web Games

### DIFF
--- a/files/en-us/games/techniques/audio_for_web_games/index.html
+++ b/files/en-us/games/techniques/audio_for_web_games/index.html
@@ -218,7 +218,7 @@ myAudio.addEventListener('timeupdate', function() {
 
 <p>Music in games can have a powerful emotional effect. You can mix and match various music samples and assuming you can control the volume of your audio element you could cross-fade different musical pieces. Using the <code><a href="/en-US/docs/Web/API/HTMLMediaElement/playbackRate">playbackRate()</a></code> method you can even adjust the speed of your music without affecting the pitch, to sync it up better with the action.</p>
 
-<p>All this is possible using the standard {{htmlelement("audio")}} element and associated {{domxref("HTMLMediaElement API")}}, but it becomes much easier and more flexible with the more advanced <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>. Let's look at this next.
+<p>All this is possible using the standard {{htmlelement("audio")}} element and associated {{domxref("HTMLMediaElement")}}, but it becomes much easier and more flexible with the more advanced <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>. Let's look at this next.
 
  <audio>element and associated HTMLMediaElement API, but it becomes much easier and more flexible with the more advanced Web Audio API. Let's look at this next.</audio>
 </p>


### PR DESCRIPTION
Fixes the following macro flaw:

MacroBrokenLinkError from domxref line 221:92
**Explanation:** /en-US/docs/Web/API/HTMLMediaElement_API does not exist