### PR TITLE
Fix broken link on WebHID API

### DIFF
--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>You can connect to a device with {{domxref("HID.requestDevices")}}. In this case, we select from all the available devices.</p>
+<p>You can connect to a device with {{domxref("HID.requestDevice()")}}. In this case, we select from all the available devices.</p>
 
 <pre class="brush: js">
 const device = await navigator.hid.requestDevice({filters: []})


### PR DESCRIPTION
This fixes the following flaw:

MacroBrokenLinkError from domxref line 35:37
**Explanation:** /en-US/docs/Web/API/HID/requestDevices does not exist