### PR TITLE
FF92 AVIF: Remove experimental feature and update accept headers.

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1214,46 +1214,6 @@ tags:
 </table>
 
 
-<h4 id="AVIF_AV1_Image_File_format_support">AVIF (AV1 Image File format) support</h4>
-
-<p>With this feature enabled, Firefox supports the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a> format. This is a still image file format that leverages the capabilities of the AV1 video compression algorithms to reduce image size. (See {{bug(1443863)}} for more details.)</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>77</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>77</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>77</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>77</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>image.avif.enabled</code></th>
-  </tr>
- </tbody>
-</table>
-
 <h4 id="AV1_support_for_Firefox_on_Android">AV1 support for Firefox on Android</h4>
 
 <p>This feature allows Firefox on Android to use <a href="/en-US/docs/Web/Media/Formats/Video_codecs#av1">AV1 format media</a>. This feature is available in nightly builds effective in Firefox for Android 81 or later. It is enabled by default.</p>

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -17,7 +17,8 @@ These are the values sent when the context doesn't give better information. Note
 
 | User Agent                 | Value                                                                                                                                                                   |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Firefox 72 and later [1]   | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                                                            |
+| Firefox 91 and later [1]   | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                                                                 |
+| Firefox 72 to 91 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                                                            |
 | Firefox 66 to 71 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                                                       |
 | Firefox 65 [1]             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                                                            |
 | Firefox 64 and earlier [1] | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                                                       |
@@ -39,7 +40,8 @@ When requesting an image, like through an HTML {{HTMLElement("img")}} element, u
 
 | User Agent                                                                                                                     | Value                                                                      |
 | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Firefox 65 and later [1]                                                                                                       | `image/webp,*/*`                                                           |
+| Firefox 92 and later [1]                                                                                                       | `image/avif,image/webp,*/*`                                                 |
+| Firefox 65 to 91 [1]                                                                                                           | `image/webp,*/*`                                                           |
 | Firefox 47 to 63 [1]                                                                                                           | `*/*`                                                                      |
 | Firefox prior to 47 [1]                                                                                                        | `image/png,image/*;q=0.8,*/*;q=0.5`                                        |
 | Safari (since Mac OS Big Sur)                                                                                                  | `image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5` |
@@ -57,9 +59,9 @@ When a video is requested, via the {{HTMLElement("video")}} HTML element, most b
 | User Agent                     | Value                                                                              |
 | ------------------------------ | ---------------------------------------------------------------------------------- |
 | Firefox 3.6 and later          | `video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5` |
-| Firefox earlier than 3.6       | _no support for {{HTMLElement("video")}}_                                  |
+| Firefox earlier than 3.6       | _no support for {{HTMLElement("video")}}_                                          |
 | Chrome                         | `*/*`                                                                              |
-| Internet Explorer 8 or earlier | _no support for {{HTMLElement("video")}}_                                  |
+| Internet Explorer 8 or earlier | _no support for {{HTMLElement("video")}}_                                          |
 
 ## Values for audio resources
 


### PR DESCRIPTION
FF92 now supports AVIF: https://bugzilla.mozilla.org/show_bug.cgi?id=1682995. 
This removes the experimental feature and updates the accept headers.

This is part of docs work in #7744

