### PR TITLE
Add Feature-Policy: speaker-selection docs

### DIFF
--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.html
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.html
@@ -11,31 +11,28 @@ browser-compat: api.MediaDevices.enumerateDevices
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
-<p><span class="seoSummary">The {{domxref("MediaDevices")}} method
-    <strong><code>enumerateDevices()</code></strong> requests a list of the available
-    media input and output devices, such as microphones, cameras, headsets, and so
-    forth.</span> The returned {{jsxref("Promise")}} is resolved with a
-  {{domxref("MediaDeviceInfo")}} array describing the devices.</p>
+<p>The {{domxref("MediaDevices")}} method <strong><code>enumerateDevices()</code></strong> requests a list of the available media input and output devices, such as microphones, cameras, headsets, and so forth.
+    The returned {{jsxref("Promise")}} is resolved with a {{domxref("MediaDeviceInfo")}} array describing the devices.</p>
+
+<p>Access to particular devices is gated by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.
+  The list of returned devices will omit any devices for which the corresponding permission has not been granted, including: <code>microphone</code>, <code>camera</code>, <code>speaker-selection</code> (for output devices), and so on.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>enumeratorPromise</em> = navigator.mediaDevices.enumerateDevices();
-</pre>
+<pre class="brush: js">navigator.mediaDevices.enumerateDevices()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{ jsxref("Promise") }} that receives an array of {{domxref("MediaDeviceInfo")}}
-  objects when the promise is fulfilled. Each object in the array describes one of the
-  available media input and output devices. The order is significant - the default capture
-  devices will be listed first.</p>
+<p>A {{ jsxref("Promise") }} that receives an array of {{domxref("MediaDeviceInfo")}} objects when the promise is fulfilled.
+  Each object in the array describes one of the available media input and output devices (only device-types for which permission has been granted are "available").
+  The order is significant - the default capture devices will be listed first.</p>
 
 <p>If enumeration fails, the promise is rejected.</p>
 
 <h2 id="Example">Example</h2>
 
 <p>Here's an example of using <code>enumerateDevices()</code>. It outputs a list of the <a
-    href="/en-US/docs/Web/API/MediaDeviceInfo/deviceId">device IDs</a>, with their labels
-  if available.</p>
+    href="/en-US/docs/Web/API/MediaDeviceInfo/deviceId">device IDs</a>, with their labels if available.</p>
 
 <pre class="brush: js">if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
   console.log("enumerateDevices() not supported.");
@@ -84,8 +81,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 <ul>
   <li>{{domxref("MediaDevices.getUserMedia")}}</li>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> - the introductory page to the API</li>
-  <li><a href="/en-US/docs/Web/API/Media_Streams_API">MediaStream API</a> - the API for the
-    media stream objects</li>
+  <li><a href="/en-US/docs/Web/API/Media_Streams_API">MediaStream API</a> - the API for the media stream objects</li>
   <li><a href="/en-US/docs/Web/API/WebRTC_API/Taking_still_photos">Taking webcam photos</a> - a
     tutorial on using <code>getUserMedia()</code> for taking photos rather than video.
   </li>

--- a/files/en-us/web/http/feature_policy/index.md
+++ b/files/en-us/web/http/feature_policy/index.md
@@ -29,7 +29,7 @@ With Feature Policy, you opt-in to a set of "policies" for the browser to enforc
 Examples of what you can do with Feature Policy:
 
 - Change the default behavior of autoplay on mobile and third party videos.
-- Restrict a site from using sensitive APIs like camera or microphone.
+- Restrict a site from using sensitive devices like the camera, microphone, or speakers.
 - Allow iframes to use the [fullscreen API](/en-US/docs/Web/API/Fullscreen_API).
 - Block the use of outdated APIs like [synchronous XHR](/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest) and {{domxref("document.write()")}}.
 - Ensure images are sized properly and are not too big for the viewport.
@@ -110,6 +110,7 @@ The features include (see [Features list](/en-US/docs/Web/HTTP/Headers/Feature-P
 - Midi
 - PaymentRequest
 - Picture-in-picture
+- Speakers
 - USB
 - Web Share API
 - VR / XR

--- a/files/en-us/web/http/headers/feature-policy/index.md
+++ b/files/en-us/web/http/headers/feature-policy/index.md
@@ -42,7 +42,7 @@ Feature-Policy: <directive> <allowlist>
 
 - `<directive>`
   - : The Feature Policy directive to apply the `allowlist` to. See [Directives](#directives) below for a list of the permitted directive names.
-- \<allowlist>
+- `<allowlist>`
 
   - : An `allowlist` is a list of origins that takes one or more of the following values, separated by spaces:
 
@@ -110,6 +110,8 @@ Feature-Policy: <directive> <allowlist>
   - : Controls whether the current document is allowed to play a video in a Picture-in-Picture mode via the corresponding API.
 - {{httpheader("Feature-Policy/publickey-credentials-get", "publickey-credentials-get")}}
   - : Controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve already stored public-key credentials, i.e. via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey: ..., ...})")}}.
+- {{httpheader("Feature-Policy/speaker-selection", "speaker-selection")}}
+  - : Controls whether the current document is allowed to use the [Audio Output Devices API](/en-US/docs/Web/API/Audio_Output_Devices_API) to list and select speakers.
 - {{httpheader('Feature-Policy/sync-xhr', 'sync-xhr')}}
   - : Controls whether the current document is allowed to make synchronous {{DOMxRef("XMLHttpRequest")}} requests.
 - {{httpheader('Feature-Policy/unoptimized-images', 'unoptimized-images')}} {{experimental_inline}}{{Non-standard_Inline}}
@@ -141,9 +143,7 @@ By specifying the `'none'` keyword for the origin list, the specified features w
 
 ## Specifications
 
-| Specification                                                                                                  |
-| -------------------------------------------------------------------------------------------------------------- |
-| [Permissions Policy](https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-http-header-field) |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/feature-policy/speaker-selection/index.md
+++ b/files/en-us/web/http/headers/feature-policy/speaker-selection/index.md
@@ -1,0 +1,48 @@
+---
+title: 'Feature-Policy: speaker-selection'
+slug: Web/HTTP/Headers/Feature-Policy/speaker-selection
+tags:
+  - Feature Policy
+  - Feature-Policy
+  - HTTP
+  - header
+  - microphone
+  - Experimental
+browser-compat: http.headers.Feature-Policy.speaker-selection
+---
+{{HTTPSidebar}} {{SeeCompatTable}}
+
+The HTTP {{HTTPHeader("Feature-Policy")}} header `speaker-selection` directive controls whether the current document is allowed to enumerate and select audio output devices (speakers, headphones, etc.).
+
+When this policy is enabled and the permission is denied:
+
+- {{domxref("MediaDevices.enumerateDevices()")}} won't return devices of type _audio output_.
+- {{domxref("MediaDevices.selectAudioOutput()")}} won't display the popup for selecting an audio output, and will reject the promise with a `NotAllowedError`.
+- {{domxref("HTMLMediaElement.setSinkId()")}} will throw a `NotAllowedError` if called for an audio output.
+
+## Syntax
+
+```
+Feature-Policy: speaker-selection <allowlist>;
+```
+
+- `<allowlist>`
+  - : A list of origins for which the feature is allowed. See [`Feature-Policy`](/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax).
+
+## Default policy
+
+The default allowlist for `speaker-selection` is `'self'`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{HTTPHeader("Feature-Policy")}} header
+- [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
+- [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)


### PR DESCRIPTION
FF92 delivers the `Feature-Policy: speaker-selection` (and corresponding permission) - https://bugzilla.mozilla.org/show_bug.cgi?id=1577199

This defines some of the documentation, as tracked in #7746

Note, there are other fixes to associated APIs I am explicitly not doing as part of _this_ PR. 
- documenting `MediaDevices.selectAudioOutput()` - will do in separate PR. 
- MediaDevices.enumerateDevices() returns the `MediaDeviceInfo` dictionary type. At some point that should be integrated where used, but that's out of scope for this particular fix. 


