### PR TITLE
Fix typo in “protocol_handlers” doc

### DIFF
--- a/files/en-us/web/manifest/protocol_handlers/index.html
+++ b/files/en-us/web/manifest/protocol_handlers/index.html
@@ -62,7 +62,7 @@ tags:
   </tr>
   <tr>
    <td><code>url</code></td>
-   <td>Required HTTPS URL within the application <a href="/en-US/docs/Web/Manifest/scope">scope</a> that will handle the protocol. The <code>%s</code> token will be replaced by the URL starting with the protocol handler's scheme. <code>src</code> is a relative URL, the base URL will be the URL of the manifest.</td>
+   <td>Required HTTPS URL within the application <a href="/en-US/docs/Web/Manifest/scope">scope</a> that will handle the protocol. The <code>%s</code> token will be replaced by the URL starting with the protocol handler's scheme. If <code>url</code> is a relative URL, the base URL will be the URL of the manifest.</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
Fixes typo: the correct object property is `url` but it was incorrectly written as `src`