### PR TITLE
Fix typo in “Cache” API doc

### DIFF
--- a/files/en-us/web/api/cache/index.html
+++ b/files/en-us/web/api/cache/index.html
@@ -41,7 +41,7 @@ browser-compat: api.Cache
  <dt>{{domxref("Cache.match", "Cache.match(request, options)")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that resolves to the response associated with the first matching request in the <code>Cache</code> object.</dd>
  <dt>{{domxref("Cache.matchAll", "Cache.matchAll(request, options)")}}</dt>
- <dd>Returns a {{jsxref("Promise")}} that resolves to an array of all matching requests in the <code>Cache</code> object.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that resolves to an array of all matching responses in the <code>Cache</code> object.</dd>
  <dt>{{domxref("Cache.add", "Cache.add(request)")}}</dt>
  <dd>Takes a URL, retrieves it and adds the resulting response object to the given cache. This is functionally equivalent to calling <code>fetch()</code>, then using <code>put()</code> to add the results to the cache.</dd>
  <dt>{{domxref("Cache.addAll", "Cache.addAll(requests)")}}</dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
The correct type is **responses**

> Anything else that could help us review it
The [Cache.matchAll()](https://developer.mozilla.org/en-US/docs/Web/API/Cache/matchAll) webpage correctly describes the function as "...resolves to an array of all matching *responses*" but in the [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache) page it incorrectly says *requests*
