### PR TITLE
Increase live-output height of “Getting started with HTML” example

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.html
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.html
@@ -459,7 +459,7 @@ textarea.onkeyup = function(){
 
 <pre class="brush: html">&lt;a href="https://www.example.com" title="Isn't this fun?"&gt;A link to my example.&lt;/a&gt;</pre>
 
-<p>To use quote marks inside other quote marks of the same type (single quote or double quote), use <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#entity_references_including_special_characters_in_html">HTML entities</a>. For example, this will break:</p>
+<p>To use quote marks inside other quote marks of the same type (single quote or double quote), use <a href="#entity_references_including_special_characters_in_html">HTML entities</a>. For example, this will break:</p>
 
 <pre class="example-bad brush: html">&lt;a href='https://www.example.com' title='Isn't this fun?'&gt;A link to my example.&lt;/a&gt;</pre>
 
@@ -520,8 +520,8 @@ textarea.onkeyup = function(){
  <li>Just below the opening tag of the {{htmlelement("body")}} element, add a main title for the document. This should be wrapped inside an <code>&lt;h1&gt;</code> opening tag and <code>&lt;/h1&gt;</code> closing tag.</li>
  <li>Edit the paragraph content to include text about a topic that you find interesting.</li>
  <li>Make important words stand out in bold by wrapping them inside a <code>&lt;strong&gt;</code> opening tag and <code>&lt;/strong&gt;</code> closing tag.</li>
- <li>Add a link to your paragraph, as <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#active_learning_adding_attributes_to_an_element">explained earlier in the article</a>.</li>
- <li>Add an image to your document. Place it below the paragraph, as <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#empty_elements">explained earlier in the article</a>. Earn bonus points if you manage to link to a different image (either locally on your computer, or somewhere else on the web).</li>
+ <li>Add a link to your paragraph, as <a href="#active_learning_adding_attributes_to_an_element">explained earlier in the article</a>.</li>
+ <li>Add an image to your document. Place it below the paragraph, as <a href="#empty_elements">explained earlier in the article</a>. Earn bonus points if you manage to link to a different image (either locally on your computer, or somewhere else on the web).</li>
 </ul>
 
 <p>If you make a mistake, you can always reset it using the <em>Reset</em> button. If you get really stuck, press the <em>Show solution</em> button to see the answer.</p>

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.html
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.html
@@ -653,7 +653,7 @@ textarea.onkeyup = function(){
 };</pre>
 </div>
 
-<p>{{ EmbedLiveSample('Playable_code3', 700, 600, "", "", "hide-codepen-jsfiddle") }}</p>
+<p>{{ EmbedLiveSample('Playable_code3', 700, 1075, "", "", "hide-codepen-jsfiddle") }}</p>
 
 <h3 id="Whitespace_in_HTML">Whitespace in HTML</h3>
 


### PR DESCRIPTION
This change increases the height of the “This is my page” embedded live sample in the “Getting started with HTML” article.

Otherwise, without this change, when the reader pushes the **Show solution** button, the **Editable code** area appears to be replaced by a large image.  However, in fact, the **Editable code** area isn’t replaced by the image; instead the image gets placed vertically before the **Editable code** area.  And because the height of the iframe for the embedded live sample is too small, the **Editable code** area seems to disappear. In fact, though, the **Editable code** area is still there, but the reader needs to scroll the iframe to view it — which is not immediately obvious to most readers.

So this change increases the height of the iframe for the embedded live sample such that the **Editable code** area doesn’t get cut off — and seemingly disappear — when the reader presses the **Show solution** button.

Fixes https://github.com/mdn/content/issues/7883