### PR TITLE
Remove problatic section from Classes doc

### DIFF
--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -220,13 +220,6 @@ class Rectangle {
 }
 ```
 
-Static (class-side) data properties and prototype data properties must be defined outside of the ClassBody declaration:
-
-```js
-Rectangle.staticWidth = 20;
-Rectangle.prototype.prototypeWidth = 25;
-```
-
 ### Field declarations
 
 #### Public field declarations


### PR DESCRIPTION
I have removed the problem section because
1. A section titled `Instance Properties` shouldn't illustrate `static` especially when
2. There is a dedicated section for it above

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #6339 


> What was wrong/why is this fix needed? (quick summary only)
The code block illustrate old style static definitions under a section for Instance properties. There is already a dedicated section above for static.

> Anything else that could help us review it
No
