### PR TITLE
Update note in WebExtension CSP

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -108,7 +108,7 @@ browser-compat: webextensions.manifest.content_security_policy
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' 'unsafe-inline'; object-src 'self'"</pre>
 
-<p><span id="exampleNote_1">1. <em>Note: Valid examples display the correct use of keys in CSP. However, extensions with 'unsafe-eval', 'unsafe-inline', remote script, blob, or remote sources in their CSP are not allowed for extensions listed on addons.mozilla.org due to major security issues.</em></span></p>
+<p><span id="exampleNote_1">1. <em>Note: Valid examples display the correct use of keys in CSP. However, extensions with 'unsafe-eval', remote script, blob, or remote sources in their CSP are not allowed for Firefox extensions as per the <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">add-on policies</a> and due to major security issues.</em></span></p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This PR updates a note on WebExtensions CSP usage, specifically for overrides that are restricted per the add-on policies.