### PR TITLE
Fixes #4292 by removing Interface sections/blocks

### DIFF
--- a/files/en-us/web/api/bluetooth/index.html
+++ b/files/en-us/web/api/bluetooth/index.html
@@ -17,21 +17,6 @@ browser-compat: api.Bluetooth
   {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object with the specified
   options.</p>
 
-<h2 id="Interface">Interface</h2>
-
-<pre class="brush: js">interface Bluetooth : EventTarget {
-  Promise&lt;boolean&gt; getAvailability();
-  attribute EventHandler onavailabilitychanged;
-  [SameObject]
-  readonly attribute BluetoothDevice? referringDevice;
-  Promise&lt;sequence&lt;BluetoothDevice&gt;&gt; getDevices();
-  Promise&lt;BluetoothDevice&gt; requestDevice(optional RequestDeviceOptions options = {});
-};
-Bluetooth includes BluetoothDeviceEventHandlers;
-Bluetooth includes CharacteristicEventHandlers;
-Bluetooth includes ServiceEventHandlers;
-</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <p><em>Inherits properties from its parent {{domxref("EventTarget")}}.</em></p>

--- a/files/en-us/web/api/bluetoothdevice/index.html
+++ b/files/en-us/web/api/bluetoothdevice/index.html
@@ -19,24 +19,6 @@ browser-compat: api.BluetoothDevice
 
 <p>{{InheritanceDiagram}}</p>
 
-<h2 id="Interface">Interface</h2>
-
-<pre class="brush: js">interface BluetoothDevice {
-  readonly attribute DOMString id;
-  readonly attribute DOMString? name;
-  readonly attribute BluetoothRemoteGATTServer? gatt;
-  readonly attribute FrozenArray uuids;
-
-  Promise watchAdvertisements();
-  void unwatchAdvertisements();
-  readonly attribute boolean watchingAdvertisements;
-};
-BluetoothDevice implements EventTarget;
-BluetoothDevice implements BluetoothDeviceEventHandlers;
-BluetoothDevice implements CharacteristicEventHandlers;
-BluetoothDevice implements ServiceEventHandlers;
-</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -15,26 +15,6 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic
 
 <p>The <code>BluetoothRemoteGattCharacteristic</code> interface of the <a href="/en-US/docs/Web/API/Web_Bluetooth_API">Web Bluetooth API</a> represents a GATT Characteristic, which is a basic data element that provides further information about a peripheral’s service.</p>
 
-<h2 id="Interface">Interface</h2>
-
-<pre>interface BluetoothRemoteGATTCharacteristic {
-  readonly attribute BluetoothRemoteGATTService service;
-  readonly attribute UUID uuid;
-  readonly attribute BluetoothCharacteristicProperties properties;
-  readonly attribute DataView? value;
-  Promise&lt;BluetoothRemoteGATTDescriptor&gt; getDescriptor(BluetoothDescriptorUUID <dfn>descriptor</dfn>);
-  Promise&lt;sequence&lt;BluetoothRemoteGATTDescriptor&gt;&gt;
-    getDescriptors(optional BluetoothDescriptorUUID <dfn>descriptor</dfn>);
-  Promise&lt;DataView&gt; readValue();
-  Promise&lt;void&gt; writeValue(BufferSource <dfn>value</dfn>);
-  Promise&lt;void&gt; writeValueWithResponse(BufferSource <dfn>value</dfn>);
-  Promise&lt;void&gt; writeValueWithoutResponse(BufferSource <dfn>value</dfn>);
-  Promise&lt;void&gt; startNotifications();
-  Promise&lt;void&gt; stopNotifications();
-};
-BluetoothRemoteGATTCharacteristic implements EventTarget;
-BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
@@ -24,16 +24,6 @@ browser-compat: api.BluetoothRemoteGATTDescriptor
       (Firefox OS)</a>.</p>
 </div>
 
-<h2 id="Interface">Interface</h2>
-
-<pre class="brush: js">interface BluetoothRemoteGATTDescriptor {
-  readonly attribute BluetoothGATTCharacteristic characteristic;
-  readonly attribute UUID uuid;
-  readonly attribute ArrayBuffer? value;
-  Promise&lt;ArrayBuffer&gt; readValue();
-  Promise&lt;void&gt; writeValue(BufferSource value);
-};</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>

--- a/files/en-us/web/api/bluetoothremotegattserver/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.html
@@ -24,18 +24,6 @@ browser-compat: api.BluetoothRemoteGATTServer
       (Firefox OS)</a>.</p>
 </div>
 
-<h2 id="Interface">Interface</h2>
-
-<pre class="brush: js">interface BluetoothRemoteGATTServer {
-  readonly attribute BluetoothDevice device;
-  readonly attribute boolean connected;
-
-  Promise&lt;BluetoothRemoteGATTServer&gt; connect();
-  void disconnect();
-  Promise&lt;BluetoothRemoteGATTService&gt; getPrimaryService(BluetoothServiceUUID service);
-  Promise&lt;sequence&lt;BluetoothRemoteGATTService&gt;&gt; getPrimaryServices(optional BluetoothServiceUUID service);
-};</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>

--- a/files/en-us/web/api/bluetoothremotegattservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.html
@@ -26,18 +26,6 @@ browser-compat: api.BluetoothRemoteGATTService
   service provided by a GATT server, including a device, a list of referenced services,
   and a list of the characteristics of this service.</p>
 
-<h2 id="Interface">Interface</h2>
-
-<pre class="brush: js">interface BluetoothRemoteGATTService : ServiceEventHandlers {
-  readonly attribute UUID uuid;
-  readonly attribute boolean isPrimary;
-  readonly attribute BluetoothDevice device;
-  Promise&lt;BluetoothGATTCharacteristic&gt; getCharacteristic(BluetoothCharacteristicUUID characteristic);
-  Promise&lt;sequence&lt;BluetoothGATTCharacteristic&gt;&gt; getCharacteristics(optional BluetoothCharacteristicUUID characteristic);
-  Promise&lt;BluetoothGATTService&gt; getIncludedService(BluetoothServiceUUID service);
-  Promise&lt;sequence&lt;BluetoothGATTService&gt;&gt; getIncludedServices(optional BluetoothServiceUUID service);
-};</pre>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>

--- a/files/en-us/web/api/mssitemodeevent/index.html
+++ b/files/en-us/web/api/mssitemodeevent/index.html
@@ -116,10 +116,7 @@ slug: Web/API/MSSiteModeEvent
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">interface MSSiteModeEvent extends Event {
-    buttonID: number;
-    actionURL: string;
-}
+<pre class="brush: js">
 declare var MSSiteModeEvent: {
     prototype: MSSiteModeEvent;
     new(): MSSiteModeEvent;

--- a/files/en-us/web/api/mssitemodeevent/index.html
+++ b/files/en-us/web/api/mssitemodeevent/index.html
@@ -116,7 +116,7 @@ slug: Web/API/MSSiteModeEvent
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">
+<pre>
 declare var MSSiteModeEvent: {
     prototype: MSSiteModeEvent;
     new(): MSSiteModeEvent;

--- a/files/en-us/web/api/webvtt_api/index.html
+++ b/files/en-us/web/api/webvtt_api/index.html
@@ -738,54 +738,6 @@ That's &lt;00:00:21.000&gt;amore
  </li>
 </ul>
 
-<h2 id="Interfaces">Interfaces</h2>
-
-<p>There are two interfaces or APIs used in WebVTT which are:</p>
-
-<h3 id="VTTCue_interface">VTTCue interface</h3>
-
-<p>It is used for providing an interface in Document Object Model API, where different attributes supported by it can be used to prepare and alter the cues in number of ways.</p>
-
-<p>Constructor is the first point for starting the Cue which is defined using the default constructor VTTCue(startTime, endTime, text) where starting time, ending time and text for cue can be adjusted. After that we can set the region for that particular cue to which this cue belongs using cue.region. Vertical, horizontal, line, lineAlign, Position, positionAlign, text, size and Align can be used to alter the cue and its formation, just like we can alter the objects form, shape and visibility in HTML using CSS. But the VTTCue interface is within the WebVTT provides the vast range of adjustment variables which can be used directly to alter the Cue. Following interface can be used to expose WebVTT cues in DOM API:</p>
-
-<pre class="brush: js">enum <dfn>AutoKeyword</dfn> { <dfn>"auto"</dfn> };
-enum <dfn>DirectionSetting</dfn> { <dfn>""</dfn> /* horizontal */, <dfn>"rl"</dfn>, <dfn>"lr"</dfn> };
-enum <dfn>LineAlignSetting</dfn> { <dfn>"start"</dfn>, <dfn>"center"</dfn>, <dfn>"end"</dfn> };
-enum <dfn>PositionAlignSetting</dfn> { <dfn>"line-left"</dfn>, <dfn>"center"</dfn>, <dfn>"line-right"</dfn>, <dfn>"auto"</dfn> };
-enum <dfn>AlignSetting</dfn> { <dfn>"start"</dfn>, <dfn>"center"</dfn>, <dfn>"end"</dfn>, <dfn>"left"</dfn>, <dfn>"right"</dfn> };
-[<a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue-1">Constructor</a>(double <dfn>startTime</dfn>, double <dfn>endTime</dfn>, DOMString <dfn>text</dfn>)]
-interface <dfn>VTTCue</dfn> : <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#texttrackcue">TextTrackCue</a> {
-  attribute <a href="https://w3c.github.io/webvtt/#vttregion" id="ref-for-vttregion-1">VTTRegion</a>? <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-region" id="ref-for-dom-vttcue-region-1">region</a>;
-  attribute <a href="https://w3c.github.io/webvtt/#enumdef-directionsetting" id="ref-for-enumdef-directionsetting-1">DirectionSetting</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical-1">vertical</a>;
-  attribute boolean <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-2">snapToLines</a>;
-  attribute (double or <a href="https://w3c.github.io/webvtt/#enumdef-autokeyword" id="ref-for-enumdef-autokeyword-1">AutoKeyword</a>) <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-line" id="ref-for-dom-vttcue-line-2">line</a>;
-  attribute <a href="https://w3c.github.io/webvtt/#enumdef-linealignsetting" id="ref-for-enumdef-linealignsetting-1">LineAlignSetting</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign-1">lineAlign</a>;
-  attribute (double or <a href="https://w3c.github.io/webvtt/#enumdef-autokeyword" id="ref-for-enumdef-autokeyword-2">AutoKeyword</a>) <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-position" id="ref-for-dom-vttcue-position-1">position</a>;
-  attribute <a href="https://w3c.github.io/webvtt/#enumdef-positionalignsetting" id="ref-for-enumdef-positionalignsetting-1">PositionAlignSetting</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign-1">positionAlign</a>;
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-size" id="ref-for-dom-vttcue-size-1">size</a>;
-  attribute <a href="https://w3c.github.io/webvtt/#enumdef-alignsetting" id="ref-for-enumdef-alignsetting-1">AlignSetting</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-align" id="ref-for-dom-vttcue-align-1">align</a>;
-  attribute DOMString <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-text" id="ref-for-dom-vttcue-text-1">text</a>;
-  <a href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-2">getCueAsHTML</a>();
-};</pre>
-
-<h3 id="VTT_Region_interface">VTT Region interface</h3>
-
-<p>This is the second interface in WebVTT API.</p>
-
-<p>The new keyword can be used for defining a new VTTRegion object which can then be used for containing the multiple cues. There are several properties of VTTRegion which are width, lines, regionAnchorX, RegionAnchorY, viewportAnchorX, viewportAnchorY and scroll that can be used to specify the look and feel of this VTT region. The interface code is given below which can be used to expose the WebVTT regions in DOM API:</p>
-
-<pre class="brush: js">enum <dfn>ScrollSetting</dfn> { <dfn>""</dfn> /* none */, <dfn>"up"</dfn> };
-[<a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion-1">Constructor</a>]
-interface <dfn>VTTRegion</dfn> {
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-width" id="ref-for-dom-vttregion-width-1">width</a>;
-  attribute long <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-lines" id="ref-for-dom-vttregion-lines-1">lines</a>;
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx-1">regionAnchorX</a>;
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory-1">regionAnchorY</a>;
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx-1">viewportAnchorX</a>;
-  attribute double <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory-1">viewportAnchorY</a>;
-  attribute <a href="https://w3c.github.io/webvtt/#enumdef-scrollsetting" id="ref-for-enumdef-scrollsetting-1">ScrollSetting</a> <a class="idl-code" href="https://w3c.github.io/webvtt/#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll-1">scroll</a>;
-};</pre>
-
 <h2 id="Methods_and_properties">Methods and properties</h2>
 
 <p>The methods used in WebVTT are those which are used to alter the cue or region as the attributes for both interfaces are different. We can categorize them for better understanding relating to each interface in WebVTT:</p>


### PR DESCRIPTION
…us/web directory in archived-content repo

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #4292


> What was wrong/why is this fix needed? (quick summary only)

The interface blocks are apparently only for browser implementors and hence not required in mdn docs


> Anything else that could help us review it

1. I have not removed the following files as the directory en-us/web was not present in archived-content repo. 
2. Also I have removed the Interface section where nothing was left after removing the Interface code blocks. 