### PR TITLE
Fix notes about fetch abort exceptions

### DIFF
--- a/files/en-us/web/api/abortsignal/index.html
+++ b/files/en-us/web/api/abortsignal/index.html
@@ -78,12 +78,7 @@ function fetchVideo() {
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an <code>AbortError</code>.</p>
-</div>
-
-<div class="notecard warning">
-  <h4>Warning</h4>
-  <p>Current versions of Firefox rejects the promise with a <code>DOMException</code></p>
+  <p>When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an "<code>AbortError</code>" <code>DOMException</code>.</p>
 </div>
 
 <p>You can find a <a href="https://github.com/mdn/dom-examples/tree/master/abort-api">full working example on GitHub</a>; you can also see it  <a href="https://mdn.github.io/dom-examples/abort-api/">running live</a>.</p>


### PR DESCRIPTION
It seems the author was unaware that "AbortError" was a type of DOMException.