### PR TITLE
Align the “Object” glossary entry with formal definition

### DIFF
--- a/files/en-us/glossary/object/index.html
+++ b/files/en-us/glossary/object/index.html
@@ -7,14 +7,18 @@ tags:
   - Intro
   - Object
 ---
-<p><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> refers to a data structure containing data and instructions for working with the data. Objects sometimes refer to real-world things, for example a <code>car</code> or <code>map</code> object in a racing game. {{glossary("JavaScript")}}, Java, C++, Python, and Ruby are examples of {{glossary("OOP","object-oriented programming")}} languages.</p>
+
+<p>In JavaScript, objects can be seen as a collection of properties. With the <a href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals">object literal syntax</a>, a limited set of properties are initialized; then properties can be added and removed. Property values can be values of any type, including other objects, which enables building complex data structures. Properties are identified using <em>key</em> values. A <em>key</em> value is either a {{Glossary("String", "String value")}} or a {{Glossary("Symbol", "Symbol value")}}.</p>
+
+<p>There are two types of object properties: The <a href="/en-US/docs/Web/JavaScript/Data_structures#data_property"><em>data</em> property</a> and the <a href="/en-US/docs/Web/JavaScript/Data_structures#accessor_property"><em>accessor</em> property</a>.</p>
+
+<div class="notecard note">
+<p><strong>Note:</strong> It’s important to recognize it’s accessor <em>property</em> — not accessor <em>method</em>. We can give a JavaScript object class-<em>like</em> accessors by using a function as a value — but that doesn't make the object a class.</p>
+</div>
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_Knowledge">General knowledge</h3>
-
 <ul>
- <li>{{Interwiki("wikipedia", "Object-oriented programming")}} on Wikipedia</li>
+ <li><a href="/en-US/docs/Web/JavaScript/Data_structures#objects">Detailed explanation of JavaScript objects</a> in the <a href="/en-US/docs/Web/JavaScript/Data_structures">JavaScript data types and data structures</a> article</li>
  <li>{{jsxref("Object")}} in the <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Data_structures#objects">Object data structures in JavaScript</a></li>
 </ul>

--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -150,9 +150,9 @@ In computer science, an object is a value in memory which is possibly referenced
 
 ### Properties
 
-In JavaScript, objects can be seen as a collection of properties. With the [object literal syntax](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), a limited set of properties are initialized; then properties can be added and removed. Property values can be values of any type, including other objects, which enables building complex data structures. Properties are identified using _key_ values. A _key_ value is either a String or a Symbol value.
+In JavaScript, objects can be seen as a collection of properties. With the [object literal syntax](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), a limited set of properties are initialized; then properties can be added and removed. Property values can be values of any type, including other objects, which enables building complex data structures. Properties are identified using _key_ values. A _key_ value is either a {{Glossary("String", "String value")}} or a {{Glossary("Symbol", "Symbol value")}}.
 
-There are two types of object properties which have certain attributes: The _data_ property and the _accessor_ property.
+There are two types of object properties: The [_data_ property](#data_property) and the [_accessor_ property](#accessor_property).
 
 > **Note:** Each property has corresponding *attributes.* Attributes are used internally by the JavaScript engine, so you cannot directly access them. That's why attributes are listed in double square brackets, rather than single.
 >
@@ -228,7 +228,11 @@ Associates a key with a value, and has the following attributes:
 
 #### Accessor property
 
-Associates a key with one of two accessor functions (`get` and `set`) to retrieve or store a value, and has the following attributes:
+Associates a key with one of two accessor functions (`get` and `set`) to retrieve or store a value.
+
+> **Note:** It’s important to recognize it’s accessor _property_ — not accessor _method_. We can give a JavaScipt object class-like accessors by using a function as a value — but that doesn't make the object a class.
+
+An accessor property has the following attributes:
 
 | Attribute        | Type                           | Description                                                                                                                                                                                                              | Default value |
 | ---------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |


### PR DESCRIPTION
This change rewrites the “Object” glossary entry to largely just follow the more-accurate JavaScript-object-as-data-structure explanation at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#objects and to help preempt reader confusion about whether JavaScript objects are classes.

Otherwise, the glossary entry as currently written is misleading — because in so many words it’s basically describing classes, not objects; and it’s also not really very helpful to readers — because it’s not describing anything notable about *JavaScript* objects, as opposed to objects in other programming languages.

And given that MDN is a technical resource for developers working on a client platform whose programming language is JavaScript, it makes sense for the glossary to not just have a generic description of “objects” but to instead have a slightly more technical (but still succinct) description that’s specific to JavaScript objects and that’s framed in terms of their characteristics as data structures within the language.

Fixes https://github.com/mdn/content/issues/7895