### PR TITLE
Fix grammar and description

### DIFF
--- a/files/en-us/web/api/idbindex/getall/index.html
+++ b/files/en-us/web/api/idbindex/getall/index.html
@@ -38,8 +38,8 @@ var getAllKeysRequest = <em>IDBIndex</em>.getAll(<em>query</em>, <em>count</em>)
   <dd>A key or an {{domxref("IDBKeyRange")}} identifying the records to retrieve. If this
     value is null or missing, the browser will use an unbound key range.</dd>
   <dt><em>count</em> {{optional_inline}}</dt>
-  <dd>The number records to return. If this value exceeds the number of records in the
-    query, the browser will only retrieve the first item. If it is lower than
+  <dd>The number of records to return. If this value exceeds the number of records in the
+    query, the browser will only retrieve the queried records. If it is lower than
     <code>0</code> or greater than <code>2^32 - 1</code> a {{jsxref("TypeError")}}
     exception will be thrown.</dd>
 </dl>


### PR DESCRIPTION
>  If this value exceeds the number of records in the query, the browser will only retrieve the first item.

If I pass `count=5`, and there are only 3 records, then the browser will only retrieve 1 record (the first item)?

No, this "first item" phrasing is confusing and wrong. The browser will retrieve 3 records.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
