### PR TITLE
Fix outdated information on extension publishing

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
@@ -224,13 +224,13 @@ tags:
     <p>Edge</p>
    </th>
    <td>
-    <p>Yes</p>
+    <p>No</p>
    </td>
    <td>
     <p>No</p>
    </td>
    <td>
-    <p>Manual, up to 72 hours<sup>2</sup></p>
+    <p>Manual, up to seven business days</p>
    </td>
    <td>
     <p>Yes</p>
@@ -240,8 +240,6 @@ tags:
 </table>
 
 <p><sup>1</sup> A manual review of the extension takes place after publication, which may result in the extension being suspended where issues that need fixing are found.</p>
-
-<p><sup>2</sup> At the time of writing, Microsoft was only allowing publication of preapproved extensions.</p>
 
 <h3 id="Other_considerations">Other considerations</h3>
 


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #7032 


> What was wrong/why is this fix needed? (quick summary only)
Outdated info on extension publishing

1. No registration fee for Edge Extension publishing
2. It may take up to 7 business days before approval [ref](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/publish-extension#notes-for-certification)

> Anything else that could help us review it
