### PR TITLE
Drop “Success stories” section of “Intro to progressive web apps”

### DIFF
--- a/files/en-us/web/progressive_web_apps/introduction/index.html
+++ b/files/en-us/web/progressive_web_apps/introduction/index.html
@@ -66,20 +66,6 @@ tags:
 	<li>Re-engaging with users through the use of system notifications and push messages, leading to more engaged users and better conversion rates.</li>
 </ul>
 
-<h3 id="Success_stories">Success stories</h3>
-
-<p>There are many success stories of companies trying the PWA route, opting for an enhanced website experience rather than a native app, and seeing significant measurable benefits as a result. The website <a href="https://www.pwastats.com/"> PWA Stats</a> shares many case studies that indicate these benefits.</p>
-
-<p>The best-known success story is probably that of <a href="https://stories.flipkart.com/introducing-flipkart-lite/"> Flipkart Lite</a>. India's largest e-commerce site was rebuilt as a progressive web app in 2015, which resulted in 70% increase in conversions. The<a href="https://m.aliexpress.com/"> AliExpress</a> PWA has also seen much better results than either the web or the native app, with a 104% increase in conversion rates for new users. Given their profit increase, and the relatively low amount of work required for the conversion of these apps to PWAs, the advantage is clear.</p>
-
-<p>Early stage emerging startups like <a href="https://www.couponmoto.com/"> couponmoto</a> have also started using progressive web apps to drive more consumer engagement, showing that they can help small as well as big companies to (re-)engage users more effectively.</p>
-
-<p>Particularly worth mentioning is the<a href="https://hnpwa.com/"> hnpwa.com</a> page—this lists an example implementation of the Hacker News website (instead of the usual TodoMVC app), in which you can see the use of various front-end frameworks.</p>
-
-<p>You can even generate PWAs online using the<a href="https://www.pwabuilder.com/"> PWABuilder</a> website.</p>
-
-<p>For service worker and push specific information, be sure to check the<a href="https://serviceworke.rs/"> Service Worker Cookbook</a>, a collection of recipes using service workers in modern sites.</p>
-
 <p>It's well worth trying out a PWA approach, so you can see for yourself if it works for your app.</p>
 
 <h2 id="Advantages_of_web_applications">Advantages of web applications</h2>


### PR DESCRIPTION
The “Success stories” section of the “Introduction to progressive web apps” feels very dated, like reading a list of what the flagship PWA sites were 5 years ago — which is pretty much exactly what it is, so it’s not surprising it reads that way.

Among the problems with creating such a list of sites to begin with is that it invites others to do self-promotion by adding their own sites to the list — as in https://github.com/mdn/content/pull/7912. And even if it weren’t a vector for self-promotion and spam, such site lists generally end up rotting over time, because nobody has any interest in actively maintaining/updating/pruning them after they’re created.

For those reasons, this change removes the entire “Success stories” section of the “Introduction to progressive web apps” article.

(And hopefully our current review mechanism will cause any further site lists like that one to not be added again to the docs to begin with...)