### PR TITLE
Fix a MD typo in user-agent/firefox

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -182,7 +182,7 @@ Here is a JavaScript regular expression that will detect all mobile devices, inc
 
 ```
 /mobi/i
-!!
+```
 
 The `i` makes it case-insensitive, and `mobi` matches all mobile browsers.
 


### PR DESCRIPTION
There was a `!!` instead of a triple-tick in this page.

This fixes it.