### PR TITLE
Fix redirected developers.google.com link in http/caching

### DIFF
--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -194,5 +194,5 @@ if (req.http.Accept-Encoding) {
 
 - [RFC 7234: Hypertext Transfer Protocol (HTTP/1.1): Caching](https://datatracker.ietf.org/doc/html/rfc7234)
 - [Caching Tutorial – Mark Nottingham](https://www.mnot.net/cache_docs)
-- [HTTP caching – Ilya Grigorik](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching)
+- [Prevent unnecessary network requests with the HTTP Cache – Jeff Posnick & Ilya Grigorik](https://web.dev/http-cache/)
 - [RedBot](https://redbot.org/), a tool to check your cache-related HTTP headers.


### PR DESCRIPTION
Part of #7586.