### PR TITLE
Update BSS example to match what Edge supports

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -120,9 +120,6 @@ browser-compat: webextensions.manifest.browser_specific_settings
     "strict_max_version": "50.*",
     "update_url": "https://example.com/updates.json"
   },
-  "edge": {
-    "browser_action_next_to_addressbar": true
-  },
   "safari": {
     "strict_min_version": "14",
     "strict_max_version": "20"


### PR DESCRIPTION
Edge no longer supports `browser_action_next_to_addressbar` 

Edge does not support the `browser_specific_settings` key in the manifest