### PR TITLE
Fix the definition of integers in “Basic math in JavaScript” doc

### DIFF
--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -46,7 +46,7 @@ tags:
 <p>In programming, even the humble decimal number system that we all know so well is more complicated than you might think. We use different terms to describe different types of decimal numbers, for example:</p>
 
 <ul>
- <li><strong>Integers</strong> are whole numbers, e.g. 10, 400, or -5.</li>
+ <li><strong>Integers</strong> are floating-point numbers without a fraction. They can either be positive or negative, e.g. 10, 400, or -5.</li>
  <li><strong>Floating point numbers</strong> (floats) have decimal points and decimal places, for example 12.5, and 56.7786543.</li>
  <li><strong>Doubles</strong> are a specific type of floating point number that have greater precision than standard floating point numbers (meaning that they are accurate to a greater number of decimal places).</li>
 </ul>


### PR DESCRIPTION
I corrected the definition of integers on line 49...
The previous definition was wrong as it said that "Integers are whole numbers" and this statement was totally wrong because whole numbers are a set of numbers that include all positive numbers and 0, therefore whole numbers can't be negative but integers can be negative

Every whole number is an integer but every integer is not a whole number

