### PR TITLE
Remove unnecessary parentheses in Offline_Service_workers doc

### DIFF
--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -182,7 +182,7 @@ self.addEventListener('install', (e) =&gt; {
       if (key === cacheName) { return; }
       caches.delete(key);
     }))
-  })());
+  }));
 });</pre>
 
 <p>This ensures we have only the files we need in the cache, so we don't leave any garbage behind; the <a href="/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria">available cache space in the browser is limited</a>, so it is a good idea to clean up after ourselves.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

```js
self.addEventListener('activate', (e) => {
  e.waitUntil(caches.keys().then((keyList) => {
    Promise.all(keyList.map((key) => {
      if (key === cacheName) { return; }
      caches.delete(key);
    }))
  })());
});
```

The above code is not IIFE, but parentheses are placed after calling `then(() => ...)`.
`then` method should not return function, because `Promise.all` inside of `then` is not return function.

> Anything else that could help us review it
