### PR TITLE
updating links in CSS Scroll Snap pages.

### DIFF
--- a/files/en-us/web/css/scroll-margin-block-end/index.md
+++ b/files/en-us/web/css/scroll-margin-block-end/index.md
@@ -51,4 +51,4 @@ scroll-margin-block-end: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-block-start/index.md
+++ b/files/en-us/web/css/scroll-margin-block-start/index.md
@@ -53,4 +53,4 @@ scroll-margin-block-start: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-block/index.md
+++ b/files/en-us/web/css/scroll-margin-block/index.md
@@ -62,4 +62,4 @@ The scroll-margin values represent outsets defining the scroll snap area that is
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-bottom/index.md
+++ b/files/en-us/web/css/scroll-margin-bottom/index.md
@@ -56,4 +56,4 @@ scroll-margin-bottom: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-inline-end/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.md
@@ -135,4 +135,4 @@ Try it for yourself:
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-inline-start/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-start/index.md
@@ -138,4 +138,4 @@ Try it for yourself:
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-inline/index.md
+++ b/files/en-us/web/css/scroll-margin-inline/index.md
@@ -149,4 +149,4 @@ Try it for yourself:
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-left/index.md
+++ b/files/en-us/web/css/scroll-margin-left/index.md
@@ -56,4 +56,4 @@ scroll-margin-left: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-right/index.md
+++ b/files/en-us/web/css/scroll-margin-right/index.md
@@ -55,4 +55,4 @@ scroll-margin-right: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin-top/index.md
+++ b/files/en-us/web/css/scroll-margin-top/index.md
@@ -55,4 +55,4 @@ scroll-margin-top: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-margin/index.md
+++ b/files/en-us/web/css/scroll-margin/index.md
@@ -156,4 +156,4 @@ Try it for yourself:
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-block-end/index.md
+++ b/files/en-us/web/css/scroll-padding-block-end/index.md
@@ -61,4 +61,4 @@ scroll-padding-block-end: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-block-start/index.md
+++ b/files/en-us/web/css/scroll-padding-block-start/index.md
@@ -61,4 +61,4 @@ scroll-padding-block-start: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-block/index.md
+++ b/files/en-us/web/css/scroll-padding-block/index.md
@@ -70,4 +70,4 @@ scroll-padding-block: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-bottom/index.md
+++ b/files/en-us/web/css/scroll-padding-bottom/index.md
@@ -61,4 +61,4 @@ scroll-padding-bottom: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-inline-end/index.md
+++ b/files/en-us/web/css/scroll-padding-inline-end/index.md
@@ -60,4 +60,4 @@ scroll-padding-inline-end: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-inline-start/index.md
+++ b/files/en-us/web/css/scroll-padding-inline-start/index.md
@@ -60,4 +60,4 @@ scroll-padding-inline-start: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-inline/index.md
+++ b/files/en-us/web/css/scroll-padding-inline/index.md
@@ -71,4 +71,4 @@ scroll-padding-inline: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-left/index.md
+++ b/files/en-us/web/css/scroll-padding-left/index.md
@@ -60,4 +60,4 @@ scroll-padding-left: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-right/index.md
+++ b/files/en-us/web/css/scroll-padding-right/index.md
@@ -60,4 +60,4 @@ scroll-padding-right: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding-top/index.md
+++ b/files/en-us/web/css/scroll-padding-top/index.md
@@ -60,4 +60,4 @@ scroll-padding-top: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-padding/index.md
+++ b/files/en-us/web/css/scroll-padding/index.md
@@ -69,4 +69,4 @@ scroll-padding: unset;
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-align/index.md
+++ b/files/en-us/web/css/scroll-snap-align/index.md
@@ -61,4 +61,4 @@ Safari currently has the two value syntax in the wrong order, the first value be
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-coordinate/index.md
+++ b/files/en-us/web/css/scroll-snap-coordinate/index.md
@@ -148,4 +148,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-destination/index.md
+++ b/files/en-us/web/css/scroll-snap-destination/index.md
@@ -142,4 +142,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-points-x/index.md
+++ b/files/en-us/web/css/scroll-snap-points-x/index.md
@@ -103,4 +103,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-points-y/index.md
+++ b/files/en-us/web/css/scroll-snap-points-y/index.md
@@ -104,4 +104,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/p)

--- a/files/en-us/web/css/scroll-snap-stop/index.md
+++ b/files/en-us/web/css/scroll-snap-stop/index.md
@@ -219,4 +219,4 @@ This example is duplicated from {{cssxref("scroll-snap-type")}} with minor varia
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -241,4 +241,4 @@ html, body, .holster {
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)


### PR DESCRIPTION
Part of #7586 

Updates the links in the CSS Scroll Snap property pages to the new article on web.dev.