### PR TITLE
Fix macros and other technicalities in NDEFMessage and NDEFReader

### DIFF
--- a/files/en-us/web/api/ndefmessage/index.html
+++ b/files/en-us/web/api/ndefmessage/index.html
@@ -9,12 +9,12 @@ browser-compat: api.NDEFMessage
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p>The <strong><code>NDEFMessage</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the <code>NDEFMessage()</code> constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to {{domxrex("NDEFReader.onreading")}}.</p>
+<p>The <strong><code>NDEFMessage</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the <code>NDEFMessage()</code> constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to {{domxref("NDEFReader.onreading")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{DOMxRef("NDEFMessage.NDEFMessage", "NDEFMessage.NDEFMessage()")}}</dt>
+ <dt>{{DOMxRef("NDEFMessage.NDEFMessage", "NDEFMessage()")}}</dt>
  <dd>Creates a new <code>NDEFMessage</code> object, initialized with the given NDEF records.</dd>
 </dl>
 

--- a/files/en-us/web/api/ndefmessage/records/index.html
+++ b/files/en-us/web/api/ndefmessage/records/index.html
@@ -2,16 +2,17 @@
 title: NDEFMessage.records
 slug: Web/API/NDEFMessage/records
 tags:
-- NDEF
-- Reference
-- Web NFC
+  - NDEF
+  - Reference
+  - Web NFC
+  - Property
 browser-compat: api.NDEFMessage.records
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p><span class="seoSummary">The <code>records</code> property of
+<p>The <code>records</code> property of
     {{DOMxRef("NDEFMessage")}} interface represents a list of {{DOMxRef("NDEFRecord")}}s
-    present in the NDEF message.</span></p>
+    present in the NDEF message.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -25,7 +26,7 @@ browser-compat: api.NDEFMessage.records
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows how to read the contents of an NDEF message. It first sets up an event handler for {{domxrex("NDEFReader.onreading")}}, which is passed an instance of {{domxref("NDEFReadingEvent")}}. An <code>NDEFMessage</code> object is returned from {{domxref("NDEFReadingEvent.message")}}. It loops through <code>message.records</code> and processes each record based on its message type. The data member is a {{domxref("DataView")}}, which allows handling data encoded in UTF-16.</p>
+<p>The following example shows how to read the contents of an NDEF message. It first sets up an event handler for {{domxref("NDEFReader.onreading")}}, which is passed an instance of {{domxref("NDEFReadingEvent")}}. An <code>NDEFMessage</code> object is returned from {{domxref("NDEFReadingEvent.message")}}. It loops through <code>message.records</code> and processes each record based on its message type. The data member is a {{jsxref("DataView")}}, which allows handling data encoded in UTF-16.</p>
 
 <pre class="brush: js">ndefReaderInst.onreading = event => {
   const ndefMessage = event.message;

--- a/files/en-us/web/api/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/index.html
@@ -9,12 +9,12 @@ browser-compat: api.NDEFReader
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary"><span class="seoSummary">The <strong><code>NDEFReader</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> is used to read from and write data to compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</span></p>
+<p class="summary">The <strong><code>NDEFReader</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> is used to read from and write data to compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</p>
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{DOMxRef("NDEFReader.NDEFReader", "NDEFReader.NDEFReader()")}} {{Experimental_Inline}}</dt>
+ <dt>{{DOMxRef("NDEFReader.NDEFReader", "NDEFReader()")}} {{Experimental_Inline}}</dt>
  <dd>Returns a new <code>NDEFReader</code> object.</dd>
 </dl>
 
@@ -24,9 +24,9 @@ browser-compat: api.NDEFReader
 
 <dl>
  <dt>{{DOMxRef("NDEFReader.onreading")}} {{Experimental_Inline}}</dt>
- <dd>An {{domxref("EventHandler")}} called when the <code>reading</code> event is raised.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when the <code>reading</code> event is raised.</dd>
  <dt>{{DOMxRef("NDEFReader.onreadingerror")}} {{Experimental_Inline}}</dt>
- <dd>An {{domxref("EventHandler")}} called when when the <code>readingerror</code> event is raised. This occurs when a tag is in proximity of a reading device, but cannot be read.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when when the <code>readingerror</code> event is raised. This occurs when a tag is in proximity of a reading device, but cannot be read.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/ndefreader/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/ndefreader/index.html
@@ -5,15 +5,16 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+- Constructor
 browser-compat: api.NDEFReader.NDEFReader
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef()}}</p>
 
-<p class="summary"><span class="seoSummary">The <strong><code>NDEFReader()</code></strong>
+<p class="summary">The <strong><code>NDEFReader()</code></strong>
     constructor of the {{domxref("NDEFReader")}} interface returns a
     new <code>NDEFReader</code> object, which is used to read NDEF messages from
     compatible NFC devices, e.g. NDEF tags, within the reader's magnetic induction
-    field.</span></p>
+    field.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefreader/onreading/index.html
+++ b/files/en-us/web/api/ndefreader/onreading/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Property
 browser-compat: api.NDEFReader.onreading
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>

--- a/files/en-us/web/api/ndefreader/onreadingerror/index.html
+++ b/files/en-us/web/api/ndefreader/onreadingerror/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Property
 browser-compat: api.NDEFReader.onreadingerror
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>

--- a/files/en-us/web/api/ndefreader/scan/index.html
+++ b/files/en-us/web/api/ndefreader/scan/index.html
@@ -2,15 +2,15 @@
 title: NDEFReader.scan()
 slug: Web/API/NDEFReader/scan
 tags:
-- NDEF
-- Reference
-- Web NFC
+  - NDEF
+  - Reference
+  - Web NFC
+  - Method
 browser-compat: api.NDEFReader.scan
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p><span class="seoSummary">The <code>scan()</code> method of the {{DOMxRef("NDEFReader")}} interface activates a reading device and returns a {{jsxref("Promise")}} that either resolves when an NFC tag is read or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.</span>
-</p>
+<p>The <code>scan()</code> method of the {{DOMxRef("NDEFReader")}} interface activates a reading device and returns a {{jsxref("Promise")}} that either resolves when an NFC tag is read or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -2,9 +2,10 @@
 title: NDEFReader.write()
 slug: Web/API/NDEFReader/write
 tags:
-- NDEF
-- Reference
-- Web NFC
+  - NDEF
+  - Reference
+  - Web NFC
+  - Method
 browser-compat: api.NDEFReader.write
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>


### PR DESCRIPTION
There were a few macro errors:
- `domxrex` instead of `domxref`
- `DataView` is in JavaScript not in the Web APIs.
- `EventHandler` has no documentation as it is a callback "type" (replaced by a true HTML link)

I also:
- added a few missing `Property`, `Method` and `Constructor` tags that  preventing the page to show up in the sidebar,
- removed a `seoSummary` class we are getting rid of,
- corrected constructor names to remove the redundant interface in front of it, and make it coherent with the whole of MDN.