### PR TITLE
Replace “Number” (object) w/ “number” in <input type=range> doc

### DIFF
--- a/files/en-us/web/html/element/input/range/index.html
+++ b/files/en-us/web/html/element/input/range/index.html
@@ -26,7 +26,7 @@ browser-compat: html.elements.input.input-range
  <tbody>
   <tr>
    <td><strong>{{anch("Value")}}</strong></td>
-   <td>A {{domxref("DOMString")}} containing the string representation of the selected numeric value; use {{domxref("HTMLInputElement.valueAsNumber", "valueAsNumber")}} to get the value as a {{jsxref("Number")}}.</td>
+   <td>A {{domxref("DOMString")}} containing the string representation of the selected numeric value; use {{domxref("HTMLInputElement.valueAsNumber", "valueAsNumber")}} to get the value as a number.</td>
   </tr>
   <tr>
    <td><strong>Events</strong></td>
@@ -100,7 +100,7 @@ browser-compat: html.elements.input.input-range
 
 <p id="attr-list">{{page("/en-US/docs/Web/HTML/Element/input/text", "attr-list", 0, 1, 2)}}</p>
 
-<p>See the <a href="#a_range_control_with_hash_marks">range control with hash marks</a> below for an example of how the options on a range are denoted in supported browsers</p>
+<p>See the <a href="#a_range_control_with_hash_marks">range control with hash marks</a> below for an example of how the options on a range are denoted in supported browsers.</p>
 
 <h3 id="attr-max"><code id="max">max</code></h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

This element doesn't have a `Number` wrapper object.

> Anything else that could help us review it
