### PR TITLE
FF92 - MediaDevices.selectAudioOutput() docs

### DIFF
--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -1,0 +1,26 @@
+---
+title: Transient activation
+slug: Glossary/Transient_activation
+tags:
+  - Transient activation
+  - Glossary
+  - JavaScript
+---
+**Transient activation** (or "transient user activation") is a window state that indicates a user has recently pressed a button, moved a mouse, used a menu, or performed some other user interaction.
+
+This state is sometimes used as a mechanism for ensuring that a web API can only function if triggered by user interaction.
+For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠—it must be triggered from a UI element's event handler.
+
+Examples of APIs that require _transient activation_ are:
+- {{domxref("MediaDevices.selectAudioOutput()")}} 
+
+> **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs.
+
+
+
+<section id="Quick_links">
+<ul>
+  <li>{{domxref("MediaDevices.selectAudioOutput()")}}</li>
+  <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">HTML Living Standard > Transient activation</a></li>
+</ul>
+</section>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -760,6 +760,48 @@ tags:
  </tbody>
 </table>
 
+<h3 id="javascript_dom_api">Audio Output API</h3>
+
+<h4 id="">MediaDevices.selectAudioOutput()</h4>
+
+<p>{{domxref("MediaDevices.selectAudioOutput()")}} displays a prompt from which users can select their desired audio output. See {{bug(1699026)}}.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>88</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>88</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>88</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>88</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>media.setsinkid.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
 <h3 id="HTML_DOM_API">HTML DOM API</h3>
 
 <h4 id="HTMLMediaElement_method_setSinkId">HTMLMediaElement method: setSinkId()</h4>

--- a/files/en-us/web/api/mediadevices/index.html
+++ b/files/en-us/web/api/mediadevices/index.html
@@ -48,6 +48,8 @@ browser-compat: api.MediaDevices
 	<dd>Prompts the user to select a display or portion of a display (such as a window) to capture as a {{domxref("MediaStream")}} for sharing or recording purposes. Returns a promise that resolves to a <code>MediaStream</code>.</dd>
 	<dt>{{ domxref("MediaDevices.getUserMedia", "getUserMedia()") }}</dt>
 	<dd>With the user's permission through a prompt, turns on a camera and/or a microphone on the system and provides a {{domxref("MediaStream")}} containing a video track and/or an audio track with the input.</dd>
+	<dt>{{domxref("MediaDevices.selectAudioOutput", "selectAudioOutput()") }}</dt>
+	<dd>Prompts the user to select a specific audio output device.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
@@ -1,0 +1,107 @@
+---
+title: MediaDevices.selectAudioOutput()
+slug: Web/API/MediaDevices/selectAudioOutput
+tags:
+  - API
+  - MediaDevices
+  - Method
+  - Reference
+  - WebRTC
+  - selectAudioOutput
+  - Experimental
+browser-compat: api.MediaDevices.selectAudioOutput
+---
+<div>{{APIRef("WebRTC")}} {{SeeCompatTable}}</div>
+
+<p>The {{domxref("MediaDevices")}} method <strong><code>selectAudioOutput()</code></strong> prompts the user to select a specific audio output device, for example a speaker or headset.
+  On success, the returned {{jsxref("Promise")}} is resolved with a {{domxref("MediaDeviceInfo")}} describing the selected device.</p>
+
+<p>The method must be triggered from some UI interaction like a button click (more precisely, it <em>requires</em> "transient user activation" to reduce the chance that the prompt is popped up at arbitrary points by a script).</p>
+
+<p>Access to audio output devices is gated by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.
+    The prompt will not be displayed if the <code>speaker-selection</code> permission has not been granted.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">navigator.mediaDevices.selectAudioOutput()
+navigator.mediaDevices.selectAudioOutput(options)
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+ <dt><code>options</code> {{Optional_Inline}}</dt>
+ <dd><p>An object that configures what device(s) may be offered in the user prompt.</p>
+
+  <dl>
+    <dt><code>deviceId</code> {{Optional_Inline}}</dt>
+    <dd>A {{domxref("DOMString")}} representing the id of the (only) device to display in the prompt (with default value: "").
+      
+      <div class="notecard note">
+        <p><strong>Note:</strong> A user agent may choose to skip prompting the user if a specified non-null id was previously exposed to the user by <code>selectAudioOutput()</code> in an earlier session. 
+          In this case the user agent may simply resolve with this device id, or a new id for the same device if it has changed.</p>
+
+        <p>This intended for applications that want to use persisted device ids.
+          The ids <em>must be passed</em> through <code>selectAudioOutput()</code> successfully before they will work with {{domxref("HTMLMediaElement.setSinkId","setSinkId()")}}.</p>
+      </div>
+    </dd>
+   </dl>
+
+ </dd>
+</dl>
+
+
+<h3 id="Return_value">Return value</h3>
+
+<p>A {{ jsxref("Promise") }} that receives a {{domxref("MediaDeviceInfo")}} object when the promise is fulfilled.
+  The object describes the user-selected audio output device.</p>
+
+<p>The promise may be rejected with one of the following errors:</p>
+<dl>
+ <dt><code>NotAllowedError</code></dt>
+ <dd>The current page has not been granted the {{HTTPHeader("Feature-Policy/speaker-selection","speaker-selection")}} permission or the user closed the selection prompt without choosing a device.</dd>
+ <dt><code>NotFoundError</code></dt>
+ <dd>There are no available audio output devices.</dd>
+ <dt><code>NotFoundError</code></dt>
+ <dd>There are no available audio output devices.</dd>
+ <dt><code>InvalidStateError</code></dt>
+ <dd><code>selectAudioOutput</code> requires transient user activation (you must trigger it from some kind of UI event).</dd>
+</dl>
+
+<h2 id="Example">Example</h2>
+
+<p>Here's an example of using <code>selectAudioOutput()</code>, which you might call within a function that is triggered by a button click.
+  It outputs the selected <a href="/en-US/docs/Web/API/MediaDeviceInfo/deviceId">device IDs</a> and labels (if available) or an error message.</p>
+
+<pre class="brush: js">if (!navigator.mediaDevices.selectAudioOutput) {
+  console.log("selectAudioOutput() not supported.");
+  return;
+}
+
+//Display prompt and log selected device or error
+navigator.mediaDevices.selectAudioOutput()
+.then( (device) => {
+    console.log(device.kind + ": " + device.label + " id = " + device.deviceId);
+  })
+.catch(function(err) {
+  console.log(err.name + ": " + err.message);
+});
+</pre>
+
+<p>On selection of an output this might produce:</p>
+
+<pre class="brush: bash">audiooutput: Realtek Digital Output (Realtek(R) Audio) id = 0wE6fURSZ20H0N2NbxqgowQJLWbwo+5ablCVVJwRM3k=</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> - the introductory page to the API</li>
+</ul>

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
@@ -41,7 +41,7 @@ navigator.mediaDevices.selectAudioOutput(options)
         <p><strong>Note:</strong> A user agent may choose to skip prompting the user if a specified non-null id was previously exposed to the user by <code>selectAudioOutput()</code> in an earlier session. 
           In this case the user agent may simply resolve with this device id, or a new id for the same device if it has changed.</p>
 
-        <p>This intended for applications that want to use persisted device ids.
+        <p>This is intended for applications that want to use persisted device ids.
           The ids <em>must be passed</em> through <code>selectAudioOutput()</code> successfully before they will work with {{domxref("HTMLMediaElement.setSinkId","setSinkId()")}}.</p>
       </div>
     </dd>

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
@@ -62,8 +62,6 @@ navigator.mediaDevices.selectAudioOutput(options)
  <dd>The current page has not been granted the {{HTTPHeader("Feature-Policy/speaker-selection","speaker-selection")}} permission or the user closed the selection prompt without choosing a device.</dd>
  <dt><code>NotFoundError</code></dt>
  <dd>There are no available audio output devices.</dd>
- <dt><code>NotFoundError</code></dt>
- <dd>There are no available audio output devices.</dd>
  <dt><code>InvalidStateError</code></dt>
  <dd><code>selectAudioOutput</code> requires {{Glossary("transient activation")}} (you must trigger it from some kind of UI event).</dd>
 </dl>

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.html
@@ -16,7 +16,7 @@ browser-compat: api.MediaDevices.selectAudioOutput
 <p>The {{domxref("MediaDevices")}} method <strong><code>selectAudioOutput()</code></strong> prompts the user to select a specific audio output device, for example a speaker or headset.
   On success, the returned {{jsxref("Promise")}} is resolved with a {{domxref("MediaDeviceInfo")}} describing the selected device.</p>
 
-<p>The method must be triggered from some UI interaction like a button click (more precisely, it <em>requires</em> "transient user activation" to reduce the chance that the prompt is popped up at arbitrary points by a script).</p>
+<p>The method must be triggered from some UI interaction like a button click (more precisely, it <em>requires</em> {{Glossary("transient activation")}}).</p>
 
 <p>Access to audio output devices is gated by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.
     The prompt will not be displayed if the <code>speaker-selection</code> permission has not been granted.</p>
@@ -65,7 +65,7 @@ navigator.mediaDevices.selectAudioOutput(options)
  <dt><code>NotFoundError</code></dt>
  <dd>There are no available audio output devices.</dd>
  <dt><code>InvalidStateError</code></dt>
- <dd><code>selectAudioOutput</code> requires transient user activation (you must trigger it from some kind of UI event).</dd>
+ <dd><code>selectAudioOutput</code> requires {{Glossary("transient activation")}} (you must trigger it from some kind of UI event).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
This follows on from #7875 (part of documenting https://github.com/mdn/content/issues/7746).

Essentially the permission `speaker-selection` rolls out in FF92. This controls access to `MediaDevices.selectAudioOutput()`, which is undocumented on MDN (and protected behind a preference on FF). 

This adds docs so that the dependency can be added.
- Doc for page
- Glossary for new term "transient activation"
- Experimental features page addition
- 
BCD is done in https://github.com/mdn/browser-compat-data/pull/12029