### PR TITLE
Rolling back content: none on elements

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -385,46 +385,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Value_content_none">Value of the <code>content</code> property: none</h3>
-
-<p>The <code>none</code> value of the {{cssxref("content")}} property inhibits the children of the element from being rendered, as if the element was empty. (See {{bug(1699964)}} for more details.)</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>91</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>91</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>91</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>91</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>layout.css.element-content-none.enabled</code></th>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="Fit_content_function">The <code>fit-content()</code> function for <code>width</code> and other sizing properties</h3>
 
 <p>The {{cssxref("fit-content()")}} function as it applies to {{cssxref("width")}} and other sizing properties. This function is already well-supported for CSS Grid Layout track sizing. (See {{bug(1312588)}} for more details.)</p>

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -60,7 +60,7 @@ content: unset;
 ### Values
 
 - `none`
-  - : The pseudo-element is not generated.
+  - : When applied to a pseudo-element, the pseudo-element is not generated. If applied to an element, the value has no effect.
 - `normal`
   - : Computes to `none` for the `::before` and `::after` pseudo-elements.
 - {{cssxref("&lt;string&gt;")}}


### PR DESCRIPTION
Firefox 91 had an experimental implementation of `content: none` for elements. This caused issues and the CSSWG resolved to make `content: none` have no effect on elements in https://github.com/w3c/csswg-drafts/issues/6503.

This PR removes the entry in experimental features, and adds a clarification to the `content` docs.