### PR TITLE
Drop empty Example section from WebDriver » Capabilities doc

### DIFF
--- a/files/en-us/web/webdriver/capabilities/index.html
+++ b/files/en-us/web/webdriver/capabilities/index.html
@@ -152,10 +152,6 @@ tags:
 
 <pre class="brush: json">{"capabilities": {"alwaysMatch": {"browserName": "firefox"}}}</pre>
 
-<h2 id="Example">Example</h2>
-
-<p>asd</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
This change removes an empty Example section in the article at https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities.  The section had no actual content but appears to be of the kind that somebody added essentially as a TODO (and then forgot about).

---

This was reported by a user in the Matrix MDN Web Docs room:

> Team, example section on this page isn't available.
> https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities#example

https://view.matrix.org/room/%21cGYYDEJwjktUBMSTQT:matrix.org/ should be where the logs show up, but right now it’s 504 and in general seems to maybe not be reliably available.

So maybe we should consider setting up separate logging for the MDN Web Docs room.