### PR TITLE
Add  WebXR Lighting Estimation reference docs - pt 1

### DIFF
--- a/files/en-us/web/api/xrsession/index.md
+++ b/files/en-us/web/api/xrsession/index.md
@@ -35,6 +35,8 @@ _In addition to the properties listed below, `XRSession` inherits properties fro
   - : Returns a list of this session's {{DOMxRef("XRInputSource")}}s, each representing an input device used to control the camera and/or scene.
 - {{DOMxRef("XRSession.interactionMode", "interactionMode")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns this session's interaction mode, which describes the best space (according to the user agent) for the application to draw interactive UI for the current session.
+- {{DOMxRef("XRSession.preferredReflectionFormat", "preferredReflectionFormat")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+  - : Returns this session's preferred reflection format used for lighting estimation texture data.
 - {{DOMxRef("XRSession.renderState", "renderState")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : An {{domxref("XRRenderState")}} object which contains options affecting how the imagery is rendered. This includes things such as the near and far clipping planes (distances defining how close and how far away objects can be and still get rendered), as well as field of view information.
 - {{DOMxRef("XRSession.visibilityState", "visibilityState")}} {{Experimental_Inline}}{{ReadOnlyInline}}
@@ -50,6 +52,8 @@ _`XRSession` provides the following methods in addition to those inherited from 
   - : Ends the WebXR session. Returns a {{jsxref("promise")}} which resolves when the session has been shut down.
 - {{DOMxRef("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}
   - : Schedules the specified method to be called the next time the {{glossary("user agent")}} is working on rendering an animation frame for the WebXR device. Returns an integer value which can be used to identify the request for the purposes of canceling the callback using `cancelAnimationFrame()`. This method is comparable to the {{domxref("Window.requestAnimationFrame()")}} method.
+- {{DOMxRef("XRSession.requestLightProbe", "requestLightProbe()")}}
+  - : Requests an {{domxref("XRLightProbe")}} that can be used to estimate lighting information at a given point in the user's environment.
 - {{DOMxRef("XRSession.requestReferenceSpace", "requestReferenceSpace()")}}
   - : Requests that a new {{domxref("XRReferenceSpace")}} of the specified type be created. Returns a promise which resolves with the `XRReferenceSpace` or {{domxref("XRBoundedReferenceSpace")}} which was requested, or throws a `NotSupportedError` if the requested space type isn't supported by the device.
 - {{DOMxRef("XRSession.updateRenderState", "updateRenderState()")}}

--- a/files/en-us/web/api/xrsession/index.md
+++ b/files/en-us/web/api/xrsession/index.md
@@ -53,7 +53,7 @@ _`XRSession` provides the following methods in addition to those inherited from 
 - {{DOMxRef("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}
   - : Schedules the specified method to be called the next time the {{glossary("user agent")}} is working on rendering an animation frame for the WebXR device. Returns an integer value which can be used to identify the request for the purposes of canceling the callback using `cancelAnimationFrame()`. This method is comparable to the {{domxref("Window.requestAnimationFrame()")}} method.
 - {{DOMxRef("XRSession.requestLightProbe", "requestLightProbe()")}}
-  - : Requests an {{domxref("XRLightProbe")}} that can be used to estimate lighting information at a given point in the user's environment.
+  - : Requests an {{domxref("XRLightProbe")}} that estimates lighting information at a given point in the user's environment.
 - {{DOMxRef("XRSession.requestReferenceSpace", "requestReferenceSpace()")}}
   - : Requests that a new {{domxref("XRReferenceSpace")}} of the specified type be created. Returns a promise which resolves with the `XRReferenceSpace` or {{domxref("XRBoundedReferenceSpace")}} which was requested, or throws a `NotSupportedError` if the requested space type isn't supported by the device.
 - {{DOMxRef("XRSession.updateRenderState", "updateRenderState()")}}

--- a/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
+++ b/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
@@ -30,7 +30,7 @@ A string representing the reflection format. Possible values:
 
 ### Requesting a light probe with the system's preferred format
 
-You can request a light probe with {{domxref("XRSession.requestLightProbe()")}} and specify the system's preferred format by setting the `reflectionFormat` option to `preferredReflectionFormat`.
+You can request a light probe with {{domxref("XRSession.requestLightProbe()")}} and specify the system's preferred format by setting the `reflectionFormat` option equal to `XRSession.preferredReflectionFormat`.
 
 ```js
 const lightProbe = await xrSession.requestLightProbe({

--- a/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
+++ b/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
@@ -1,0 +1,51 @@
+---
+title: XRSession.preferredReflectionFormat
+slug: Web/API/XRSession/preferredReflectionFormat
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRSession.preferredReflectionFormat
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`preferredReflectionFormat`** property of the {{DOMxRef("XRSession")}} interface returns this session's preferred reflection format used for lighting estimation texture data.
+
+### Value
+
+A string representing the reflection format. Possible values:
+
+| XRReflectionFormat | WebGL Format  | WebGL Internal Format  | WebGPU Format  | HDR  |
+|---|---|---|---|---|
+| "srgba8" | RGBA  | SRGB8_ALPHA8  | "rgba8unorm-srgb"  |  |
+| "rgba16f" | RGBA  | RGBA16F  | "rgba16float"  | ✓ |
+
+## Examples
+
+### Requesting a light probe with the system's preferred format
+
+You can request a light probe with {{domxref("XRSession.requestLightProbe()")}} and specify the system's preferred format by setting the `reflectionFormat` option to `preferredReflectionFormat`.
+
+```js
+const lightProbe = await xrSession.requestLightProbe({
+  reflectionFormat: xrSession.preferredReflectionFormat
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.requestLightProbe()")}}

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -1,0 +1,70 @@
+---
+title: XRSession.requestLightProbe()
+slug: Web/API/XRSession/requestLightProbe
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Method
+  - Reference
+  - VR
+  - Virtual Reality
+  - WebXR
+  - WebXR Device API
+  - XR
+  - XRSession
+browser-compat: api.XRSession.requestLightProbe
+---
+{{APIRef("WebXR Device API")}}
+
+The **`requestLightProbe()`** method of the
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves to an {{domxref("XRLightProbe")}} object that can be used to estimate lighting information at a given point in the user's environment.
+
+## Syntax
+
+```js
+requestLightProbe(options);
+```
+
+### Parameters
+
+- `options`
+  - : An optional object configuring the light probe. Properties:
+    - `reflectionFormat`: Internal reflection format indicating how the texture data is represented. Either `srgba8` (default value) or `rgba16f`. See also {{domxref("XRSession.preferredReflectionFormat")}}.
+
+### Exceptions
+
+Rather than throwing true exceptions, `requestLightProbe()` rejects the
+returned promise with a {{domxref("DOMException")}} whose name is found in the list
+below:
+
+- `NotSupportedError`
+  - : If `lighting-estimation` is not an enabled feature in {{domxref("XRSystem.requestSession()")}}.
+  - : If the `reflectionFormat` is not `srgb8` or the `preferredReflectionFormat`.
+- `InvalidStateError`
+  - : If the session has already ended.
+
+## Examples
+
+### Requesting a light probe with the system's preferred format
+
+The default format is `srgb8`, however, some runtimes may use other (high dynamic range) formats. You can request the light probe with {{domxref("XRSession.preferredReflectionFormat")}} which reports the preferred internal format.
+
+```js
+const lightProbe = await xrSession.requestLightProbe({
+  reflectionFormat: xrSession.preferredReflectionFormat
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.preferredReflectionFormat")}}

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -33,6 +33,10 @@ requestLightProbe(options);
   - : An optional object configuring the light probe. Properties:
     - `reflectionFormat`: Internal reflection format indicating how the texture data is represented. Either `srgba8` (default value) or `rgba16f`. See also {{domxref("XRSession.preferredReflectionFormat")}}.
 
+### Return value
+
+A {{jsxref("Promise")}} that resolves to an {{domxref("XRLightProbe")}} object.
+
 ### Exceptions
 
 Rather than throwing true exceptions, `requestLightProbe()` rejects the

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -52,7 +52,7 @@ returned promise with a {{domxref("DOMException")}}, specifically, one of the fo
 
 ### Requesting a light probe with the system's preferred format
 
-The default format is `srgb8`, however, some runtimes may use other (high dynamic range) formats. You can request the light probe with {{domxref("XRSession.preferredReflectionFormat")}} which reports the preferred internal format.
+The default format is `srgb8`, however, some rendering engines may use other (high dynamic range) formats. You can request the light probe with {{domxref("XRSession.preferredReflectionFormat")}} which reports the preferred internal format.
 
 ```js
 const lightProbe = await xrSession.requestLightProbe({

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -19,7 +19,7 @@ browser-compat: api.XRSession.requestLightProbe
 {{APIRef("WebXR Device API")}}
 
 The **`requestLightProbe()`** method of the
-{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves to an {{domxref("XRLightProbe")}} object that can be used to estimate lighting information at a given point in the user's environment.
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRLightProbe")}} object that estimates lighting information at a given point in the user's environment.
 
 ## Syntax
 
@@ -29,19 +29,18 @@ requestLightProbe(options);
 
 ### Parameters
 
-- `options`
-  - : An optional object configuring the light probe. Properties:
-    - `reflectionFormat`: Internal reflection format indicating how the texture data is represented. Either `srgba8` (default value) or `rgba16f`. See also {{domxref("XRSession.preferredReflectionFormat")}}.
+- `options` {{optional_inline}}
+  - : An object containing configuration options, specifically:
+    - `reflectionFormat`: The internal reflection format indicating how the texture data is represented, either `srgba8` (default value) or `rgba16f`. See also {{domxref("XRSession.preferredReflectionFormat")}}.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an {{domxref("XRLightProbe")}} object.
+A {{jsxref("Promise")}} that resolves with an {{domxref("XRLightProbe")}} object.
 
 ### Exceptions
 
 Rather than throwing true exceptions, `requestLightProbe()` rejects the
-returned promise with a {{domxref("DOMException")}} whose name is found in the list
-below:
+returned promise with a {{domxref("DOMException")}}, specifically, one of the following:
 
 - `NotSupportedError`
   - : If `lighting-estimation` is not an enabled feature in {{domxref("XRSystem.requestSession()")}}.

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -99,6 +99,8 @@ following:
   - : Enable the ability to obtain depth information using {{domxref("XRDepthInformation")}} objects.
 - `dom-overlay`
   - : Enable allowing to specify a DOM overlay element that will be displayed to the user.
+- `light-estimation`
+  - : Enable the ability to estimate environmental lighting conditions using {{domxref("XRLightEstimate")}} objects.
 - `local`
   - : Enable a tracking space whose native origin is located near the viewer's position at the time the session was created. The exact position depends on the underlying platform and implementation. The user isn't expected to move much if at all beyond their starting position, and tracking is optimized for this use case.
 - `local-floor`


### PR DESCRIPTION
Reference docs for https://immersive-web.github.io/lighting-estimation/ (part 1): Adding how to request a light probe to the `XRSession` docs.

Also: this is my first MDN markdown PR :)