### PR TITLE
Add WebXR Lighting Estimation reference docs - pt 2

### DIFF
--- a/files/en-us/web/api/xrlightprobe/index.md
+++ b/files/en-us/web/api/xrlightprobe/index.md
@@ -13,16 +13,16 @@ browser-compat: api.XRLightProbe
 ---
 {{APIRef("WebXR Device API")}} {{secureContext_header}}
 
-The **`XRLightProbe`** interface contains lighting information at a given point in the user's environment. You can get an `XRLighting` object using the {{domxref("XRSession.requestLightProbe()")}} method.
+The **`XRLightProbe`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) contains lighting information at a given point in the user's environment. You can get an `XRLighting` object using the {{domxref("XRSession.requestLightProbe()")}} method.
 
-This object doesn't itself contain lighting values, but it is used to collect lighting state for each {{domxref("XRFrame")}}. See {{domxref("XRLightEstimate")}} for the estimated lighting values for an `XRLightProbe`.
+This object doesn't itself contain lighting values, but it is used to collect lighting states for each {{domxref("XRFrame")}}. See {{domxref("XRLightEstimate")}} for the estimated lighting values for an `XRLightProbe`.
 
 ## Properties
 
 - {{domxref("XRLightProbe.onreflectionchange")}}
   - : Event handler property for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
 - {{domxref("XRLightProbe.probeSpace")}} {{ReadOnlyInline}}
-  - : An {{domxref("XRSpace")}} tracking the position and orientation the lighting estimations are being generated relative to.
+  - : An {{domxref("XRSpace")}} tracking the position and orientation the lighting estimations are relative to.
 
 ## Methods
 
@@ -31,7 +31,7 @@ None.
 ## Events
 
 - {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}}
-  - : Fired each time the estimated reflection cube map has changed (happens when the user moves around and the environment's lighting changes).
+  - : Fired each time the estimated reflection cube map changes. (This happens when the user moves around and the environment's lighting changes.)
 
 ## Examples
 

--- a/files/en-us/web/api/xrlightprobe/index.md
+++ b/files/en-us/web/api/xrlightprobe/index.md
@@ -1,0 +1,74 @@
+---
+title: XRLightProbe
+slug: Web/API/XRLightProbe
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRLightProbe
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRLightProbe`** interface contains lighting information at a given point in the user's environment. You can get an `XRLighting` object using the {{domxref("XRSession.requestLightProbe()")}} method.
+
+This object doesn't itself contain lighting values, but it is used to collect lighting state for each {{domxref("XRFrame")}}. See {{domxref("XRLightEstimate")}} for the estimated lighting values for an `XRLightProbe`.
+
+## Properties
+
+- {{domxref("XRLightProbe.onreflectionchange")}}
+  - : Event handler property for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
+- {{domxref("XRLightProbe.probeSpace")}} {{ReadOnlyInline}}
+  - : An {{domxref("XRSpace")}} tracking the position and orientation the lighting estimations are being generated relative to.
+
+## Methods
+
+None.
+
+## Events
+
+- {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}}
+  - : Fired each time the estimated reflection cube map has changed (happens when the user moves around and the environment's lighting changes).
+
+## Examples
+
+Typical use cases of the `XRLightProbe` interface:
+
+Get an `XRLightProbe` object for a session.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+```
+
+Use `probeSpace` for getting a probe pose within an {{domxref("XRFrame")}}.
+
+```js
+const probePose = xrFrame.getPose(lightProbe.probeSpace, xrReferenceSpace);
+```
+
+Pass `XRLightProbe` to get a reflection cube map whenever the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event fires. See also {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}.
+
+```js
+const glBinding = new XRWebGLBinding(xrSession, gl);
+const lightProbe = await xrSession.requestLightProbe();
+const glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+
+lightProbe.addEventListener('reflectionchange', () => {
+  glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.requestLightProbe()")}}

--- a/files/en-us/web/api/xrlightprobe/index.md
+++ b/files/en-us/web/api/xrlightprobe/index.md
@@ -35,19 +35,23 @@ None.
 
 ## Examples
 
-Typical use cases of the `XRLightProbe` interface:
+### Getting an `XRLightProbe` object for a session
 
-Get an `XRLightProbe` object for a session.
+Use the {{domxref("XRSession.requestLightProbe()")}} method to get a light probe.
 
 ```js
 const lightProbe = await xrSession.requestLightProbe();
 ```
 
-Use `probeSpace` for getting a probe pose within an {{domxref("XRFrame")}}.
+### Getting a probe pose within an `XRFrame`
+
+Pass the light probe's `probeSpace` to {{domxref("XRFrame.getPose()")}} to get a light probe for a pose.
 
 ```js
 const probePose = xrFrame.getPose(lightProbe.probeSpace, xrReferenceSpace);
 ```
+
+### Using the `reflectionchange` event
 
 Pass `XRLightProbe` to get a reflection cube map whenever the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event fires. See also {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}.
 

--- a/files/en-us/web/api/xrlightprobe/index.md
+++ b/files/en-us/web/api/xrlightprobe/index.md
@@ -54,7 +54,7 @@ Pass `XRLightProbe` to get a reflection cube map whenever the {{domxref("XRLight
 ```js
 const glBinding = new XRWebGLBinding(xrSession, gl);
 const lightProbe = await xrSession.requestLightProbe();
-const glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+let glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
 
 lightProbe.addEventListener('reflectionchange', () => {
   glCubeMap = glBinding.getReflectionCubeMap(lightProbe);

--- a/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
+++ b/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
@@ -24,8 +24,11 @@ A function to be invoked whenever the {{domxref("XRLightProbe")}} receives a {{d
 
 ## Examples
 
+Whenever the `reflectionchange` event fires on a light probe, you can retrieve an updated cube map by calling {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}. This is less expensive than retrieving lighting information with every {{domxref("XRFrame")}}.
 
 ```js
+const glBinding = new XRWebGLBinding(xrSession, gl);
+
 lightProbe.onreflectionchange = event => {
   glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
 });

--- a/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
+++ b/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
@@ -16,7 +16,7 @@ browser-compat: api.XRLightProbe.onreflectionchange
 ---
 {{APIRef("WebXR Device API")}}
 
-The **`onreflectionchange`** property of the {{DOMxRef("XRLightProbe")}} interface is and event handler property for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
+The **`onreflectionchange`** property of the {{DOMxRef("XRLightProbe")}} interface is and event handler for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
 
 ### Value
 

--- a/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
+++ b/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
@@ -1,0 +1,46 @@
+---
+title: XRLightProbe.onreflectionchange
+slug: Web/API/XRLightProbe/onreflectionchange
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Event handler
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightProbe.onreflectionchange
+---
+{{APIRef("WebXR Device API")}}
+
+The **`onreflectionchange`** property of the {{DOMxRef("XRLightProbe")}} interface is and event handler property for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
+
+### Value
+
+A function to be invoked whenever the {{domxref("XRLightProbe")}} receives a {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
+
+## Examples
+
+
+```js
+lightProbe.onreflectionchange = event => {
+  glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+});
+```
+
+See the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event page for an example using {{domxref("EventTarget.addEventListener", "addEventListener()")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event

--- a/files/en-us/web/api/xrlightprobe/probespace/index.md
+++ b/files/en-us/web/api/xrlightprobe/probespace/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRLightProbe.probeSpace
 ---
 {{APIRef("WebXR Device API")}}
 
-The _read-only_ **`probeSpace`** property of the {{DOMxRef("XRLightProbe")}} interface returns an {{domxref("XRSpace")}} tracking the position and orientation the lighting estimations are being generated relative to.
+The _read-only_ **`probeSpace`** property of the {{DOMxRef("XRLightProbe")}} interface returns an {{domxref("XRSpace")}} tracking the position and orientation that the lighting estimations are relative to.
 
 ### Value
 
@@ -23,7 +23,7 @@ An {{domxref("XRSpace")}} object.
 
 ## Examples
 
-The position and orientation in space that the lighting is estimated relative to is communicated with the `probeSpace` property (it may update over time as the user moves around). The {{domxref("XRFrame.getPose()")}} method can be used to get the current lighting state with each frame.
+The `probeSpace` property returns the position and orientation in space that the lighting estimate is relative to. It may update over time as the user moves around. Use the {{domxref("XRFrame.getPose()")}} method to get the current lighting state with each frame.
 
 ```js
 const lightProbe = await xrSession.requestLightProbe();

--- a/files/en-us/web/api/xrlightprobe/probespace/index.md
+++ b/files/en-us/web/api/xrlightprobe/probespace/index.md
@@ -1,0 +1,44 @@
+---
+title: XRLightProbe.probeSpace
+slug: Web/API/XRLightProbe/probeSpace
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightProbe.probeSpace
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`probeSpace`** property of the {{DOMxRef("XRLightProbe")}} interface returns an {{domxref("XRSpace")}} tracking the position and orientation the lighting estimations are being generated relative to.
+
+### Value
+
+An {{domxref("XRSpace")}} object.
+
+## Examples
+
+The position and orientation in space that the lighting is estimated relative to is communicated with the `probeSpace` property (it may update over time as the user moves around). The {{domxref("XRFrame.getPose()")}} method can be used to get the current lighting state with each frame.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+const probePose = xrFrame.getPose(lightProbe.probeSpace, xrReferenceSpace);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSpace()")}}
+- {{domxref("XRFrame.getPose()")}}

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRLightProbe.reflectionchange_event
 ---
 {{APIRef("WebXR Device API")}}
 
-The WebXR **`reflectionchange`** event is sent to an {{domxref("XRLightProbe")}} fires each time the estimated reflection cube map has changed (happens when the user moves around and the environment's lighting changes).
+The WebXR **`reflectionchange`** event is passed to an {{domxref("XRLightProbe")}} each time the estimated reflection cube map changes. This happens in response to use movements through different lighting conditions or to direct changes to lighting itself.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -42,7 +42,7 @@ You can pass an `XRLightProbe` to get a reflection cube map whenever the `reflec
 ```js
 const glBinding = new XRWebGLBinding(xrSession, gl);
 const lightProbe = await xrSession.requestLightProbe();
-const glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+let glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
 
 lightProbe.addEventListener('reflectionchange', () => {
   glCubeMap = glBinding.getReflectionCubeMap(lightProbe);

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -1,0 +1,63 @@
+---
+title: 'XRLightProbe: reflectionchange event'
+slug: Web/API/XRLightProbe/reflectionchange_event
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Event
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightProbe.reflectionchange_event
+---
+{{APIRef("WebXR Device API")}}
+
+The WebXR **`reflectionchange`** event is sent to an {{domxref("XRLightProbe")}} fires each time the estimated reflection cube map has changed (happens when the user moves around and the environment's lighting changes).
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th>Cancelable</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Interface</th>
+      <td>{{domxref("Event")}}</td>
+    </tr>
+    <tr>
+      <th>Event handler property</th>
+      <td>{{domxref("XRLightProbe.onreflectionchange", "onreflectionchange")}}</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Examples
+
+You can pass an `XRLightProbe` to get a reflection cube map whenever the `reflectionchange` event fires to retrieve an updated cube map. This is less expensive than retrieving lighting information with every {{domxref("XRFrame")}}. See also {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}.
+
+```js
+const glBinding = new XRWebGLBinding(xrSession, gl);
+const lightProbe = await xrSession.requestLightProbe();
+const glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+
+lightProbe.addEventListener('reflectionchange', () => {
+  glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("EventTarget.addEventListener", "addEventListener()")}}
+- {{domxref("XRLightProbe.onreflectionchange")}}

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -37,7 +37,7 @@ The WebXR **`reflectionchange`** event is passed to an {{domxref("XRLightProbe")
 
 ## Examples
 
-You can pass an `XRLightProbe` to get a reflection cube map whenever the `reflectionchange` event fires to retrieve an updated cube map. This is less expensive than retrieving lighting information with every {{domxref("XRFrame")}}. See also {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}.
+Whenever the `reflectionchange` event fires on a light probe, you can retrieve an updated cube map by calling {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}. This is less expensive than retrieving lighting information with every {{domxref("XRFrame")}}.
 
 ```js
 const glBinding = new XRWebGLBinding(xrSession, gl);

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -1,0 +1,58 @@
+---
+title: XRWebGLBinding.getReflectionCubeMap()
+slug: Web/API/XRWebGLBinding/getReflectionCubeMap
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - XR
+  - WebXR
+browser-compat: api.XRWebGLBinding.getReflectionCubeMap
+---
+{{APIRef("WebXR Device API")}}
+
+The **`getReflectionCubeMap()`** method of the {{domxref("XRWebGLBinding")}} interface returns a {{domxref("WebGLTexture")}} object containing a reflection cube map texture.
+
+The texture format is specified by the session's `reflectionFormat`. See the `options` parameter on {{domxref("XRSession.requestLightProbe()")}} and {{domxref("XRSession.preferredReflectionFormat")}} for more details. By default, the `srgba8` format is used. When using a `rgba16f` format, you need to be within a WebGL 2.0 context or enable the {{domxref("OES_texture_half_float")}} extension within WebGL 1.0 contexts.
+
+## Syntax
+
+```js
+getReflectionCubeMap(lightProbe)
+```
+
+### Parameters
+
+- `lightProbe`
+  - : An {{domxref("XRLightProbe")}} object obtained from the session.
+
+### Return value
+
+A {{domxref("WebGLTexture")}} object.
+
+## Examples
+
+```js
+const glBinding = new XRWebGLBinding(xrSession, gl);
+gl.getExtension('OES_texture_half_float'); // if rgba16f is the preferredReflectionFormat
+
+xrSession.requestLightProbe().then(function (lightProbe) {
+  lightProbe.addEventListener('reflectionchange', () => {
+    glBinding.getReflectionCubeMap(lightProbe);
+  });
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRLightProbe")}}
+- {{domxref("OES_texture_half_float")}}

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -25,7 +25,7 @@ getReflectionCubeMap(lightProbe)
 ### Parameters
 
 - `lightProbe`
-  - : An {{domxref("XRLightProbe")}} object obtained from the session.
+  - : An {{domxref("XRLightProbe")}} object returned by calling {{domxref("XRSession.requestLightProbe()")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -33,6 +33,10 @@ A {{domxref("WebGLTexture")}} object.
 
 ## Examples
 
+You typically call `getReflectionCubeMap()` whenever the `reflectionchange` event fires on a light probe to retrieve an updated cube map. This is less expensive than retrieving lighting information with every {{domxref("XRFrame")}}.
+
+If the `rgba16f` format is used, enable the {{domxref("OES_texture_half_float")}} extension within WebGL 1.0 contexts.
+
 ```js
 const glBinding = new XRWebGLBinding(xrSession, gl);
 gl.getExtension('OES_texture_half_float'); // if rgba16f is the preferredReflectionFormat

--- a/files/en-us/web/api/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/index.md
@@ -24,6 +24,8 @@ The **`XRWebGLBinding`** interface is used to create layers that have a GPU bac
 
 - {{domxref("XRWebGLBinding.getDepthInformation()")}}
   - : Returns an {{domxref("XRWebGLDepthInformation")}} object containing WebGL depth information.
+- {{domxref("XRWebGLBinding.getReflectionCubeMap()")}}
+  - : Returns a {{domxref("WebGLTexture")}} object containing a reflection cube map texture.
 
 ## Specifications
 


### PR DESCRIPTION
Part 2 adds reference docs for the `XRLightProbe` object and `XRWebGLBinding.getReflectionCubeMap()`

I haven't documented events in a while, but I made pages for the event itself and the event handler property. Will follow-up with BCD later.