### PR TITLE
Improve SVG `<view>` example

### DIFF
--- a/files/en-us/web/svg/element/view/example.svg
+++ b/files/en-us/web/svg/element/view/example.svg
@@ -1,19 +1,10 @@
-<svg width="600" height="200" viewBox="0 0 600 200"
-    xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 300 100" width="300" height="100" xmlns="http://www.w3.org/2000/svg">
+    <view id="one" viewBox="0 0 100 100" />
+    <circle cx="50" cy="50" r="40" fill="red" />
 
-  <circle r="50" cx="180" cy="50" fill="#8ca0ff"/>
+    <view id="two" viewBox="100 0 100 100" />
+    <circle cx="150" cy="50" r="40" fill="green" />
 
-  <view id="halfSizeView" viewBox="0 0 1200 400"/>
-  <view id="normalSizeView" viewBox="0 0 600 200"/>
-  <view id="doubleSizeView" viewBox="0 0 300 100"/>
-
-  <a href="#halfSizeView">
-    <text x="5" y="20" font-size="20">half size</text>
-  </a>
-  <a href="#normalSizeView">
-    <text x="5" y="40" font-size="20">normal size</text>
-  </a>
-  <a href="#doubleSizeView">
-    <text x="5" y="60" font-size="20">double size</text>
-  </a>
+    <view id="three" viewBox="200 0 100 100" />
+    <circle cx="250" cy="50" r="40" fill="blue" />
 </svg>

--- a/files/en-us/web/svg/element/view/example.svg
+++ b/files/en-us/web/svg/element/view/example.svg
@@ -1,0 +1,19 @@
+<svg width="600" height="200" viewBox="0 0 600 200"
+    xmlns="http://www.w3.org/2000/svg">
+
+  <circle r="50" cx="180" cy="50" fill="#8ca0ff"/>
+
+  <view id="halfSizeView" viewBox="0 0 1200 400"/>
+  <view id="normalSizeView" viewBox="0 0 600 200"/>
+  <view id="doubleSizeView" viewBox="0 0 300 100"/>
+
+  <a href="#halfSizeView">
+    <text x="5" y="20" font-size="20">half size</text>
+  </a>
+  <a href="#normalSizeView">
+    <text x="5" y="40" font-size="20">normal size</text>
+  </a>
+  <a href="#doubleSizeView">
+    <text x="5" y="60" font-size="20">double size</text>
+  </a>
+</svg>

--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -42,14 +42,8 @@ browser-compat: svg.elements.view
 <pre class="brush: svg">
 &lt;svg width="600" height="200" viewBox="0 0 600 200"
     xmlns="http://www.w3.org/2000/svg"&gt;
-  &lt;defs&gt;
-    &lt;radialGradient id="gradient"&gt;
-      &lt;stop offset="0%" stop-color="#8cffa0" /&gt;
-      &lt;stop offset="100%" stop-color="#8ca0ff" /&gt;
-    &lt;/radialGradient&gt;
-  &lt;/defs&gt;
 
-  &lt;circle r="50" cx="180" cy="50" style="fill:url(#gradient)"/&gt;
+  &lt;circle r="50" cx="180" cy="50" fill="#8ca0ff"/&gt;
 
   &lt;view id="halfSizeView" viewBox="0 0 1200 400"/&gt;
   &lt;view id="normalSizeView" viewBox="0 0 600 200"/&gt;
@@ -69,7 +63,7 @@ browser-compat: svg.elements.view
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">
-&lt;object data="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDYwMCAyMDAiCiAgICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzPgogICAgPHJhZGlhbEdyYWRpZW50IGlkPSJncmFkaWVudCI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiM4Y2ZmYTAiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhjYTBmZiIgLz4KICAgIDwvcmFkaWFsR3JhZGllbnQ+CiAgPC9kZWZzPgoKICA8Y2lyY2xlIHI9IjUwIiBjeD0iMTgwIiBjeT0iNTAiIHN0eWxlPSJmaWxsOnVybCgjZ3JhZGllbnQpIi8+CgogIDx2aWV3IGlkPSJoYWxmU2l6ZVZpZXciIHZpZXdCb3g9IjAgMCAxMjAwIDQwMCIvPgogIDx2aWV3IGlkPSJub3JtYWxTaXplVmlldyIgdmlld0JveD0iMCAwIDYwMCAyMDAiLz4KICA8dmlldyBpZD0iZG91YmxlU2l6ZVZpZXciIHZpZXdCb3g9IjAgMCAzMDAgMTAwIi8+CgogIDxhIGhyZWY9IiNoYWxmU2l6ZVZpZXciPgogICAgPHRleHQgeD0iNSIgeT0iMjAiIGZvbnQtc2l6ZT0iMjAiPmhhbGYgc2l6ZTwvdGV4dD4KICA8L2E+CiAgPGEgaHJlZj0iI25vcm1hbFNpemVWaWV3Ij4KICAgIDx0ZXh0IHg9IjUiIHk9IjQwIiBmb250LXNpemU9IjIwIj5ub3JtYWwgc2l6ZTwvdGV4dD4KICA8L2E+CiAgPGEgaHJlZj0iI2RvdWJsZVNpemVWaWV3Ij4KICAgIDx0ZXh0IHg9IjUiIHk9IjYwIiBmb250LXNpemU9IjIwIj5kb3VibGUgc2l6ZTwvdGV4dD4KICA8L2E+Cjwvc3ZnPg==" type="image/svg+xml"&gt;&lt;/object&gt;
+&lt;object data="example.svg" type="image/svg+xml"&gt;&lt;/object&gt;
 </pre>
 
 <h3 id="Result">Result</h3>

--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -41,8 +41,7 @@ browser-compat: svg.elements.view
 
 <pre class="brush: svg">
 &lt;svg width="600" height="200" viewBox="0 0 600 200"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
+    xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;radialGradient id="gradient"&gt;
       &lt;stop offset="0%" stop-color="#8cffa0" /&gt;
@@ -56,13 +55,13 @@ browser-compat: svg.elements.view
   &lt;view id="normalSizeView" viewBox="0 0 600 200"/&gt;
   &lt;view id="doubleSizeView" viewBox="0 0 300 100"/&gt;
 
-  &lt;a xlink:href="#halfSizeView"&gt;
+  &lt;a href="#halfSizeView"&gt;
     &lt;text x="5" y="20" font-size="20"&gt;half size&lt;/text&gt;
   &lt;/a&gt;
-  &lt;a xlink:href="#normalSizeView"&gt;
+  &lt;a href="#normalSizeView"&gt;
     &lt;text x="5" y="40" font-size="20"&gt;normal size&lt;/text&gt;
   &lt;/a&gt;
-  &lt;a xlink:href="#doubleSizeView"&gt;
+  &lt;a href="#doubleSizeView"&gt;
     &lt;text x="5" y="60" font-size="20"&gt;double size&lt;/text&gt;
   &lt;/a&gt;
 &lt;/svg&gt;</pre>
@@ -70,7 +69,7 @@ browser-compat: svg.elements.view
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">
-&lt;object data="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDYwMCAyMDAiDQogICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIg0KICAgIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgPGRlZnM%2BDQogICAgPHJhZGlhbEdyYWRpZW50IGlkPSJncmFkaWVudCI%2BDQogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjOGNmZmEwIiAvPg0KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjOGNhMGZmIiAvPg0KICAgIDwvcmFkaWFsR3JhZGllbnQ%2BDQogIDwvZGVmcz4NCg0KICA8Y2lyY2xlIHI9IjUwIiBjeD0iMTgwIiBjeT0iNTAiIHN0eWxlPSJmaWxsOnVybCgjZ3JhZGllbnQpIi8%2BDQoNCiAgPHZpZXcgaWQ9ImhhbGZTaXplVmlldyIgdmlld0JveD0iMCAwIDEyMDAgNDAwIi8%2BDQogIDx2aWV3IGlkPSJub3JtYWxTaXplVmlldyIgdmlld0JveD0iMCAwIDYwMCAyMDAiLz4NCiAgPHZpZXcgaWQ9ImRvdWJsZVNpemVWaWV3IiB2aWV3Qm94PSIwIDAgMzAwIDEwMCIvPg0KDQogIDxhIHhsaW5rOmhyZWY9IiNoYWxmU2l6ZVZpZXciPg0KICAgIDx0ZXh0IHg9IjUiIHk9IjIwIiBmb250LXNpemU9IjIwIj5oYWxmIHNpemU8L3RleHQ%2BDQogIDwvYT4NCiAgPGEgeGxpbms6aHJlZj0iI25vcm1hbFNpemVWaWV3Ij4NCiAgICA8dGV4dCB4PSI1IiB5PSI0MCIgZm9udC1zaXplPSIyMCI%2Bbm9ybWFsIHNpemU8L3RleHQ%2BDQogIDwvYT4NCiAgPGEgeGxpbms6aHJlZj0iI2RvdWJsZVNpemVWaWV3Ij4NCiAgICA8dGV4dCB4PSI1IiB5PSI2MCIgZm9udC1zaXplPSIyMCI%2BZG91YmxlIHNpemU8L3RleHQ%2BDQogIDwvYT4NCjwvc3ZnPg%3D%3D" type="image/svg+xml"&gt;&lt;/object&gt;
+&lt;object data="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDYwMCAyMDAiCiAgICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzPgogICAgPHJhZGlhbEdyYWRpZW50IGlkPSJncmFkaWVudCI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiM4Y2ZmYTAiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhjYTBmZiIgLz4KICAgIDwvcmFkaWFsR3JhZGllbnQ+CiAgPC9kZWZzPgoKICA8Y2lyY2xlIHI9IjUwIiBjeD0iMTgwIiBjeT0iNTAiIHN0eWxlPSJmaWxsOnVybCgjZ3JhZGllbnQpIi8+CgogIDx2aWV3IGlkPSJoYWxmU2l6ZVZpZXciIHZpZXdCb3g9IjAgMCAxMjAwIDQwMCIvPgogIDx2aWV3IGlkPSJub3JtYWxTaXplVmlldyIgdmlld0JveD0iMCAwIDYwMCAyMDAiLz4KICA8dmlldyBpZD0iZG91YmxlU2l6ZVZpZXciIHZpZXdCb3g9IjAgMCAzMDAgMTAwIi8+CgogIDxhIGhyZWY9IiNoYWxmU2l6ZVZpZXciPgogICAgPHRleHQgeD0iNSIgeT0iMjAiIGZvbnQtc2l6ZT0iMjAiPmhhbGYgc2l6ZTwvdGV4dD4KICA8L2E+CiAgPGEgaHJlZj0iI25vcm1hbFNpemVWaWV3Ij4KICAgIDx0ZXh0IHg9IjUiIHk9IjQwIiBmb250LXNpemU9IjIwIj5ub3JtYWwgc2l6ZTwvdGV4dD4KICA8L2E+CiAgPGEgaHJlZj0iI2RvdWJsZVNpemVWaWV3Ij4KICAgIDx0ZXh0IHg9IjUiIHk9IjYwIiBmb250LXNpemU9IjIwIj5kb3VibGUgc2l6ZTwvdGV4dD4KICA8L2E+Cjwvc3ZnPg==" type="image/svg+xml"&gt;&lt;/object&gt;
 </pre>
 
 <h3 id="Result">Result</h3>

--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -40,30 +40,26 @@ browser-compat: svg.elements.view
 <h3 id="SVG">SVG</h3>
 
 <pre class="brush: svg">
-&lt;svg width="600" height="200" viewBox="0 0 600 200"
-    xmlns="http://www.w3.org/2000/svg"&gt;
+&lt;svg viewBox="0 0 300 100" width="300" height="100"
+      xmlns="http://www.w3.org/2000/svg"&gt;
 
-  &lt;circle r="50" cx="180" cy="50" fill="#8ca0ff"/&gt;
+  &lt;view id="one" viewBox="0 0 100 100" /&gt;
+  &lt;circle cx="50" cy="50" r="40" fill="red" /&gt;
 
-  &lt;view id="halfSizeView" viewBox="0 0 1200 400"/&gt;
-  &lt;view id="normalSizeView" viewBox="0 0 600 200"/&gt;
-  &lt;view id="doubleSizeView" viewBox="0 0 300 100"/&gt;
+  &lt;view id="two" viewBox="100 0 100 100" /&gt;
+  &lt;circle cx="150" cy="50" r="40" fill="green" /&gt;
 
-  &lt;a href="#halfSizeView"&gt;
-    &lt;text x="5" y="20" font-size="20"&gt;half size&lt;/text&gt;
-  &lt;/a&gt;
-  &lt;a href="#normalSizeView"&gt;
-    &lt;text x="5" y="40" font-size="20"&gt;normal size&lt;/text&gt;
-  &lt;/a&gt;
-  &lt;a href="#doubleSizeView"&gt;
-    &lt;text x="5" y="60" font-size="20"&gt;double size&lt;/text&gt;
-  &lt;/a&gt;
-&lt;/svg&gt;</pre>
+  &lt;view id="three" viewBox="200 0 100 100" /&gt;
+  &lt;circle cx="250" cy="50" r="40" fill="blue" /&gt;
+&lt;/svg&gt;
+</pre>
 
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">
-&lt;object data="example.svg" type="image/svg+xml"&gt;&lt;/object&gt;
+&lt;img src="example.svg" alt="three circles" width="300" height="100" /&gt;
+&lt;br /&gt;
+&lt;img src="example.svg#three" alt="blue circle" width="100" height="100" /&gt;
 </pre>
 
 <h3 id="Result">Result</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

No issue.

> What was wrong/why is this fix needed? (quick summary only)

The SVG file was a base64 encoded data URI, I don't think this is well suited for examples. In my opinion the new example reflects a more common use case (choosing a specific detailed view in an external file).

> Anything else that could help us review it

Link to the current example: 
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/view#example