### PR TITLE
Updating intro paragraph language

### DIFF
--- a/files/en-us/web/api/mutationobserver/takerecords/index.html
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.html
@@ -24,7 +24,7 @@ browser-compat: api.MutationObserver.takeRecords
     that have been detected but not yet processed by the observer's callback function,
     leaving the mutation queue empty.</span> The most common use case for this is to
   immediately fetch all pending mutation records immediately prior to disconnecting the
-  observer, so that any pending mutations can be processed when stopping down the
+  observer, so that any pending mutations can be processed when shutting down the
   observer.</p>
 
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
Updating MutationObserver.takeRecords() intro paragraph slightly by saying "`shutting` down the observer" as opposed to "`stopping` down the observer"

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Didn't find any open issues regarding this fix

> What was wrong/why is this fix needed? (quick summary only)
The wording didn't seem to fit how the sentence was constructed - I think saying `shutting` instead of `stopping` in the context is more common

> Anything else that could help us review it
This is obviously driven by personal preference and how I think sentences like this are commonly worded so please feel free to reject if you feel the current word choice fits better! An alternative could also be to remove `down`- so it would read "... so that any pending mutations can be processed when stopping the observer."