### PR TITLE
Remove pagemacro inclusion of image guide in HTML>Element>img

### DIFF
--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -63,7 +63,7 @@ browser-compat: html.elements.img
 </ul>
 
 
-<p>The newer formats like <a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a> and <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> are highly recommended as they are now broadly (and somewhat deeply) supported by web browsers, and perform much better than PNG, JPEG, GIF for both still and animated images. SVG remains the recommended format for images that that must be drawn accurately at different sizes.</p>
+<p>Formats like <a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a> and <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> are highly recommended as they are now broadly (and somewhat deeply) supported by web browsers, and perform much better than PNG, JPEG, GIF for both still and animated images. SVG remains the recommended format for images that must be drawn accurately at different sizes.</p>
 
 <h2 id="Image_loading_errors">Image loading errors</h2>
 

--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -44,19 +44,26 @@ browser-compat: html.elements.img
 
 <h2 id="Supported_image_formats">Supported image formats</h2>
 
-<p>The HTML standard doesn't list what image formats to support, so each {{glossary("user agent")}} supports different formats.</p>
-
-<p>{{page("/en-US/docs/Web/Media/Formats/Image_types", "Common_image_file_types")}}</p>
+<p>The HTML standard doesn't list what image formats to support, so {{glossary("user agent","user agents")}} may support different formats.</p>
 
 <div class="notecard note">
-	<h4>Tip</h4>
-	<p>Safari 11.1 added the ability to use a video format, as an animated gif replacement. No other browser supports this. See the <a href="https://crbug.com/791658">Chromium bug</a>, and <a href="http://bugzil.la/895131">Firefox bug</a> for more information.</p>
+	<p><strong>Note:</strong> The <a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a> provides comprehensive information about image formats and their web browser support.
+	This section is just a summary!</p>
 </div>
 
-<div class="notecard note">
-	<h4>Note</h4>
-	<p>See <a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a> for more comprehensive information about image formats supported by web browsers. This includes image formats that are supported but not recommended for web content (e.g. ICO, BMP, etc.)</p>
-</div>
+<p>The image file formats that are most commonly used on the web are:</p>
+<ul>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#apng">APNG (Animated Portable Network Graphics)</a> — Good choice for lossless animation sequences (GIF is less performant)</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF (AV1 Image File Format)</a> — Good choice for both images and animated images due to high performance.</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#gif">GIF (Graphics Interchange Format)</a> — Good choice for <em>simple</em> images and animations.</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#jpeg">JPEG (Joint Photographic Expert Group image)</a> — Good choice for lossy compression of still images (currently the most popular).</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#png">PNG (Portable Network Graphics)</a> — Good choice for lossy compression of still images (slightly better quality than JPEG).</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#svg">SVG (Scalable Vector Graphics)</a> — Vector image format. Use for images that must be drawn accurately at different sizes.</li>
+	<li><a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP (Web Picture format)</a> — Excellent choice for both images and animated images</li>
+</ul>
+
+
+<p>The newer formats like <a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a> and <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> are highly recommended as they are now broadly (and somewhat deeply) supported by web browsers, and perform much better than PNG, JPEG, GIF for both still and animated images. SVG remains the recommended format for images that that must be drawn accurately at different sizes.</p>
 
 <h2 id="Image_loading_errors">Image loading errors</h2>
 

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -46,7 +46,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#apng">APNG</a></th>
+   <th scope="row"><a href="#apng">APNG</a></th>
    <th scope="row">Animated Portable Network Graphics</th>
    <td><code>image/apng</code></td>
    <td><code>.apng</code></td>
@@ -54,7 +54,7 @@ tags:
     <strong>Supported</strong>: Chrome, Edge, Firefox, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a></th>
+   <th scope="row"><a href="#avif">AVIF</a></th>
    <th scope="row">AV1 Image File Format</th>
    <td><code>image/avif</code></td>
    <td><code>.avif</code></td>
@@ -64,7 +64,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#gif">GIF</a></th>
+   <th scope="row"><a href="#gif">GIF</a></th>
    <th scope="row">Graphics Interchange Format</th>
    <td><code>image/gif</code></td>
    <td><code>.gif</code></td>
@@ -72,7 +72,7 @@ tags:
     <strong>Supported:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#jpeg">JPEG</a></th>
+   <th scope="row"><a href="#jpeg">JPEG</a></th>
    <th scope="row">Joint Photographic Expert Group image</th>
    <td><code>image/jpeg</code></td>
    <td><code>.jpg</code>, <code>.jpeg</code>, <code>.jfif</code>, <code>.pjpeg</code>, <code>.pjp</code></td>
@@ -82,7 +82,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#png">PNG</a></th>
+   <th scope="row"><a href="#png">PNG</a></th>
    <th scope="row">Portable Network Graphics</th>
    <td><code>image/png</code></td>
    <td><code>.png</code></td>
@@ -92,7 +92,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#svg">SVG</a></th>
+   <th scope="row"><a href="#svg">SVG</a></th>
    <th scope="row">Scalable Vector Graphics</th>
    <td><code>image/svg+xml</code></td>
    <td><code>.svg</code></td>
@@ -100,7 +100,7 @@ tags:
     <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a></th>
+   <th scope="row"><a href="#webp">WebP</a></th>
    <th scope="row">Web Picture format</th>
    <td><code>image/webp</code></td>
    <td><code>.webp</code></td>
@@ -112,8 +112,7 @@ tags:
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
+  <p><strong>Note:</strong> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
 </div>
 
 <p>The following list includes image formats that appear on the web, but which should be avoided for web content (generally this is because either they do not have wide browser support, or because there are better alternatives).</p>
@@ -131,21 +130,21 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#bmp">BMP</a></th>
+   <th scope="row"><a href="#bmp">BMP</a></th>
    <th scope="row">Bitmap file</th>
    <td><code>image/bmp</code></td>
    <td><code>.bmp</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#ico">ICO</a></th>
+   <th scope="row"><a href="#ico">ICO</a></th>
    <th scope="row">Microsoft Icon</th>
    <td><code>image/x-icon</code></td>
    <td><code>.ico</code>, <code>.cur</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#tiff">TIFF</a></th>
+   <th scope="row"><a href="#tiff">TIFF</a></th>
    <th scope="row">Tagged Image File Format</th>
    <td><code>image/tiff</code></td>
    <td><code>.tif</code>, <code>.tiff</code></td>
@@ -156,8 +155,11 @@ tags:
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).</p>
+  <p><strong>Note:</strong> The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).</p>
+</div>
+
+<div class="notecard note">
+	<p><strong>Tip:</strong> Safari 11.1 added the ability to use a video format, as an animated gif replacement. No other browser supports this. See the <a href="https://crbug.com/791658">Chromium bug</a>, and <a href="https://bugzil.la/895131">Firefox bug</a> for more information.</p>
 </div>
 
 <h2 id="Image_file_type_details">Image file type details</h2>
@@ -242,7 +244,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Licensing</th>
-   <td>Free and open under the <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike license</a> (<a href="http://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>) version 3.0 or later.</td>
+   <td>Free and open under the <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike license</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>) version 3.0 or later.</td>
   </tr>
  </tbody>
 </table>
@@ -253,8 +255,7 @@ tags:
 <p>AV1 Image File Format (AVIF) is a powerful new, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container. </dfn></p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>AVIF has potential to become the "next big thing" for sharing images in web content. It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
+  <p><strong>Note:</strong> AVIF has potential to become the "next big thing" for sharing images in web content. It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
 </div>
 
 <p><dfn>AV1 is a coding format that was originally designed for video transmission over the Internet. The format benefits from the signficant advances in video encoding in recent years, and may potentially benefit from the associated support for hardware rendering. However it also has disadvantages for some cases, as video and image encoding have some different requirements.</dfn></p>
@@ -856,7 +857,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Licensing</th>
-   <td>©2003 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
+   <td>©2003 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
   </tr>
  </tbody>
 </table>
@@ -949,7 +950,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Licensing</th>
-   <td>©2018 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
+   <td>©2018 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
   </tr>
  </tbody>
 </table>
@@ -1187,8 +1188,7 @@ tags:
 </table>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
+  <p><strong>Note:</strong> Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
 </div>
 
 <a id="xbm"></a>


### PR DESCRIPTION
This removes the pagemacro inclusion of the Image guide and reference into HTML > Element > img topic on "supported image types". It further removes tidies up the image guide links to fix up some notes and links. This is part of #3196 

The change essentially just creates a smaller list and link to the relevant information.


It is also precursor to work I am going to do for #7744