### PR TITLE
Fix erroneous page macros (wrong fragment)

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -59,8 +59,7 @@ Content-Security-Policy: connect-src <source> <source>;
 
 ### Sources
 
-{{page("/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src",
-  "common_sources")}}
+{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -47,8 +47,7 @@ Content-Security-Policy: prefetch-src <source> <source>;
 
 ### Sources
 
-{{page("/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src",
-  "common_sources")}}
+{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
 
 ## Example
 


### PR DESCRIPTION
Two pages had a `{{page}}` macro linking to a renamed fragment.

This fixes it, allows the transclusion to happen, and removes two MacroExecutionError flaws.