### PR TITLE
FF92: AVIF - relnote and image updates

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1256,6 +1256,54 @@ tags:
 </table>
 
 
+<h4 id="AVIF_compliance_strictness">AVIF compliance strictness</h4>
+
+<p>The <code>image.avif.compliance_strictness</code> preference can be used to control the <em>strictness</em> appliied when processing <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images.
+  This allows Firefox users to display images that render on some other browsers, even if they are not strictly compliant.</p>
+
+<p>Permitted values are:</p>
+<ul>
+  <li><code>0</code>: Accept images with specification violations in both recommendations ("should" language) and requirements ("shall" language), provided they can be safely or unambigiously intepretted.</li>
+  <li><code>1</code> (default): Reject violations of requirements, but allow violations of recommendations.</li>
+  <li><code>2</code>: Strict. Reject any violations in requirements or recommendations.</li>
+</ul>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Default value</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>92</td>
+   <td>1</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>92</td>
+   <td>1</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>92</td>
+   <td>1</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>92</td>
+   <td>1</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>image.avif.compliance_strictness</code></th>
+  </tr>
+ </tbody>
+</table>
+
 <h4 id="AV1_support_for_Firefox_on_Android">AV1 support for Firefox on Android</h4>
 
 <p>This feature allows Firefox on Android to use <a href="/en-US/docs/Web/Media/Formats/Video_codecs#av1">AV1 format media</a>. This feature is available in nightly builds effective in Firefox for Android 81 or later. It is enabled by default.</p>

--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -41,6 +41,10 @@ tags:
 
 <h3 id="HTTP">HTTP</h3>
 
+<ul>
+  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format). ({{bug(1682995)}}).</li>
+</ul>
+
 <h4 id="removals_http">Removals</h4>
 
 <h3 id="Security">Security</h3>
@@ -66,6 +70,15 @@ tags:
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <h4 id="removals_webext">Removals</h4>
+
+<h3 id="Other">Other</h3>
+
+<ul>
+  <li>Support for <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images is now enabled by default ({{bug(1682995)}}).
+    This format has excellent compression and no patent restrictions ( it was developed by the <a href="http://aomedia.org/">Alliance for Open Media</a>).
+    Firefox can display still images, with colorspace support for both full and limited range colors, and image transforms for mirroring and rotation.
+    The preference <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a> can be used to adjust the compliance strictness with the specification. Animated images are not supported.</li>
+</ul>
 
 <h2 id="Older_versions">Older versions</h2>
 

--- a/files/en-us/web/http/headers/accept/index.md
+++ b/files/en-us/web/http/headers/accept/index.md
@@ -82,5 +82,6 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 ## See also
 
 - HTTP [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation)
+- [List of default Accept values](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values)
 - Header with the result of the content negotiation: {{HTTPHeader("Content-Type")}}
 - Other similar headers: {{HTTPHeader("TE")}}, {{HTTPHeader("Accept-Encoding")}}, {{HTTPHeader("Accept-Language")}}

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -22,12 +22,13 @@ tags:
   - Photos
   - SVG
   - WebP
+  - AVIF
   - gif
   - icon
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}</div>
 
-<p><span class="seoSummary">In this guide, we'll cover the image file types generally supported by web browsers, and provide insights that will help you select the most appropriate formats to use for your site's imagery.</span></p>
+<p>In this guide, we'll cover the image file types generally supported by web browsers, and provide insights that will help you select the most appropriate formats to use for your site's imagery.</p>
 
 <h2 id="Common_image_file_types">Common image file types</h2>
 
@@ -60,7 +61,7 @@ tags:
    <td><code>.avif</code></td>
    <td>
     <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
-     <strong>Supported:</strong> Chrome, Opera, Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>. Basic support only; advanced features like animated images and colorspace support yet to the implemented).</p>
+     <strong>Supported:</strong> Chrome, Opera, Firefox (still images only: animated images not implemented).</p>
    </td>
   </tr>
   <tr>
@@ -252,10 +253,11 @@ tags:
 <a id="avif"></a>
 <h3 id="AVIF_image">AVIF image</h3>
 
-<p>AV1 Image File Format (AVIF) is a powerful new, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container. </dfn></p>
+<p>AV1 Image File Format (AVIF) is a powerful, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container.</dfn></p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> AVIF has potential to become the "next big thing" for sharing images in web content. It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
+  <p><strong>Note:</strong> AVIF has potential to become the "next big thing" for sharing images in web content.
+    It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
 </div>
 
 <p><dfn>AV1 is a coding format that was originally designed for video transmission over the Internet. The format benefits from the signficant advances in video encoding in recent years, and may potentially benefit from the associated support for hardware rendering. However it also has disadvantages for some cases, as video and image encoding have some different requirements.</dfn></p>
@@ -272,10 +274,12 @@ tags:
  <li>Wide Color Gamut: Support for images that can contain a larger range of colors.</li>
 </ul>
 
-<p>AVIF does not support progressive rendering, so files must be fully downloaded before they can be displayed. This often has little impact on real-world user experience because AVIF files are much smaller than the equivalent JPEG or PNG files, and hence can be downloaded and displayed much faster. For larger file size the impact can become significant, and you should consider using a format that supports progressive rendering.</p>
+<p>AVIF does not support progressive rendering, so files must be fully downloaded before they can be displayed.
+  This often has little impact on real-world user experience because AVIF files are much smaller than the equivalent JPEG or PNG files, and hence can be downloaded and displayed much faster.
+  For larger file size the impact can become significant, and you should consider using a format that supports progressive rendering.</p>
 
-<p>AVIF is supported on desktop in Chrome, Opera and Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>).
-  As support is not yet comprehensive (and has no historical depth) you should provide a fallback in either {{anch("JPEG")}} or {{anch("PNG")}} format using <a href="/en-US/docs/Web/HTML/Element/picture">the <code>&lt;picture&gt;</code> element</a> (or some other approach).</p>
+<p>AVIF is supported on desktop in Chrome, Opera and Firefox (Firefox supports still images but not animations).
+  As support is not yet comprehensive (and has little historical depth) you should provide a fallback in  {{anch("WebP")}}, {{anch("JPEG")}} or {{anch("PNG")}} format using <a href="/en-US/docs/Web/HTML/Element/picture">the <code>&lt;picture&gt;</code> element</a> (or some other approach).</p>
 
 <table class="standard-table">
  <tbody>
@@ -295,9 +299,11 @@ tags:
   </tr>
   <tr>
    <th scope="row">Browser compatibility</th>
-   <td>Chrome 85, Opera 71, and Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>).
+   <td>Chrome 85, Opera 71, and Firefox 92.
     <ul>
-      <li>Firefox 77 and later require the preference <code>image.avif.enable</code> set <code>true</code>. Firefox provides <em>basic</em> support for AVIF images. More advanced features are still in development — including animated images and colorspace support ({{bug(1682995)}}).</li>
+      <li>Firefox 92 supports still images, with colorspace support for both full and limited range colors, image transforms for mirroring and rotation. The preference <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a> can be used to adjust the compliance strictness with the specification.
+        Animated images are not supported.</li>
+      <li>Firefox 77 to 91 require the preference <code>image.avif.enable</code> set <code>true</code> and provides only basic support.</li>
     </ul>
    </td>
   </tr>


### PR DESCRIPTION
This is final part of docs for AVIF support in FF92 - track in #7744
It includes
- release notes, 
- a new preference `image.avif.compliance_strictness` for controlling strictness of the parser. This is in experimental features.
- Updates to the image guide to remove the preference for enabling the feature, and note the level of support provided.
- Minor changes to HTTP accept header doc to cross link to the list of headers (opportunistic)

Think we're all done.