### PR TITLE
Fixed error in compare function of sort() behavior

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -75,7 +75,8 @@ elements are sorted according to the return value of the compare function (all
 being compared, then:
 
 - If `compareFunction(a, b)` returns a value > than 0, sort `b` before `a`.
-- If `compareFunction(a, b)` returns a value ≤ 0, leave `a` and `b` in the same order.
+- If `compareFunction(a, b)` returns a value < than 0, sort `a` before `b`.
+- If `compareFunction(a, b)` returns 0, `a` and `b` are considered equal.
 
   > **Note:** The [ECMAScript Standard, 10th edition](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-intro) (2019)
   > algorithm mandates stable sorting, which means elements that compare equal must remain in their original order with respect to each other.


### PR DESCRIPTION
This PR is an update of this one: https://github.com/mdn/content/pull/6255 with the new MD format.

> What was wrong/why is this fix needed? (quick summary only)

Correct me if I'm wrong but I think the description of the effect of the return value is wrong and this is the correct description of the compareFunction behaviour.

> Anything else that could help us review it

The french version seams to be correct: https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

Discussion and examples are available here: https://github.com/mdn/content/pull/6255
