### PR TITLE
Remove a redundant angle bracket

### DIFF
--- a/files/en-us/web/api/url_api/index.html
+++ b/files/en-us/web/api/url_api/index.html
@@ -69,7 +69,7 @@ try {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/URL"><code>URL</code></a></li>
- <li><<a href="/en-US/docs/Web/API/URLSearchParams"><code>URLSearchParams</code></a></li>
+ <li><a href="/en-US/docs/Web/API/URLSearchParams"><code>URLSearchParams</code></a></li>
 </ul>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There is a redundant opening angle bracket in a list of links.