### PR TITLE
Remove XSLT and XPath compat sections

### DIFF
--- a/files/en-us/web/exslt/exsl/node-set/index.html
+++ b/files/en-us/web/exslt/exsl/node-set/index.html
@@ -31,7 +31,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/exsl/functions/node-set/index.html">EXSLT - EXSL:NODE-SET</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.exsl.node-set")}}</p>

--- a/files/en-us/web/exslt/exsl/object-type/index.html
+++ b/files/en-us/web/exslt/exsl/object-type/index.html
@@ -42,7 +42,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/exsl/functions/object-type/index.html">EXSLT - EXSL:OBJECT-TYPE</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.exsl.object-type")}}</p>

--- a/files/en-us/web/exslt/math/highest/index.html
+++ b/files/en-us/web/exslt/math/highest/index.html
@@ -31,7 +31,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/math/functions/highest/index.html">EXSLT - MATH:HIGHEST</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.math.highest")}}</p>

--- a/files/en-us/web/exslt/math/lowest/index.html
+++ b/files/en-us/web/exslt/math/lowest/index.html
@@ -31,7 +31,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/math/functions/lowest/index.html">EXSLT - MATH:LOWEST</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.math.lowest")}}</p>

--- a/files/en-us/web/exslt/math/max/index.html
+++ b/files/en-us/web/exslt/math/max/index.html
@@ -31,7 +31,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/math/functions/max/index.html">EXSLT - MATH:MAX</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.math.max")}}</p>

--- a/files/en-us/web/exslt/math/min/index.html
+++ b/files/en-us/web/exslt/math/min/index.html
@@ -32,7 +32,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/regexp/functions/min/index.html">EXSLT - MATH:MIN</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.math.min")}}</p>

--- a/files/en-us/web/exslt/regexp/match/index.html
+++ b/files/en-us/web/exslt/regexp/match/index.html
@@ -60,7 +60,3 @@ Part 5 = /en/docs/Firefox_3_for_developers
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/regexp/functions/match/index.html">EXSLT - REGEXP:MATCH</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.regexp.match")}}</p>

--- a/files/en-us/web/exslt/regexp/replace/index.html
+++ b/files/en-us/web/exslt/regexp/replace/index.html
@@ -44,7 +44,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/regexp/functions/replace/index.html">EXSLT - REGEXP:REPLACE</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.regexp.replace")}}</p>

--- a/files/en-us/web/exslt/regexp/test/index.html
+++ b/files/en-us/web/exslt/regexp/test/index.html
@@ -43,7 +43,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/regexp/functions/test/index.html">EXSLT - REGEXP:TEST</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.regexp.test")}}</p>

--- a/files/en-us/web/exslt/set/difference/index.html
+++ b/files/en-us/web/exslt/set/difference/index.html
@@ -32,7 +32,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/difference/index.html">EXSLT - SET:DIFFERENCE</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.difference")}}</p>

--- a/files/en-us/web/exslt/set/distinct/index.html
+++ b/files/en-us/web/exslt/set/distinct/index.html
@@ -28,7 +28,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/distinct/index.html">EXSLT - SET:DISTINCT</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.distinct")}}</p>

--- a/files/en-us/web/exslt/set/has-same-node/index.html
+++ b/files/en-us/web/exslt/set/has-same-node/index.html
@@ -30,7 +30,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/has-same-node/index.html">EXSLT - SET:HAS-SAME-NODE</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.has-same-node")}}</p>

--- a/files/en-us/web/exslt/set/intersection/index.html
+++ b/files/en-us/web/exslt/set/intersection/index.html
@@ -30,7 +30,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/intersection/index.html">EXSLT - SET:INTERSECTION</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.intersection")}}</p>

--- a/files/en-us/web/exslt/set/leading/index.html
+++ b/files/en-us/web/exslt/set/leading/index.html
@@ -35,7 +35,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/leading/index.html">EXSLT - SET:LEADING</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.leading")}}</p>

--- a/files/en-us/web/exslt/set/trailing/index.html
+++ b/files/en-us/web/exslt/set/trailing/index.html
@@ -34,7 +34,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/set/functions/trailing/index.html">EXSLT - SET:TRAILING</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.set.trailing")}}</p>

--- a/files/en-us/web/exslt/str/concat/index.html
+++ b/files/en-us/web/exslt/str/concat/index.html
@@ -28,7 +28,3 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <p><a href="http://www.exslt.org/str/functions/concat/index.html">EXSLT - STR:CONCAT</a></p>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.str.concat")}}</p>

--- a/files/en-us/web/exslt/str/split/index.html
+++ b/files/en-us/web/exslt/str/split/index.html
@@ -42,10 +42,6 @@ tags:
 
 <p><a href="http://www.exslt.org/str/functions/split/index.html">EXSLT - STR:SPLIT</a></p>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.str.split")}}</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/en-us/web/exslt/str/tokenize/index.html
+++ b/files/en-us/web/exslt/str/tokenize/index.html
@@ -44,10 +44,6 @@ tags:
 
 <p><a href="http://www.exslt.org/str/functions/tokenize/index.html">EXSLT - STR:TOKENIZE</a></p>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat("xslt.exslt.str.tokenize")}}</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/en-us/web/xpath/axes/self/index.html
+++ b/files/en-us/web/xpath/axes/self/index.html
@@ -4,7 +4,6 @@ slug: Web/XPath/Axes/self
 tags:
   - Axe
   - XPath
-browser-compat: xpath.axes.self
 ---
 <p>The <code>self</code> axis indicates the context node itself. It can be abbreviated as a single period (<code>.</code>).</p>
 
@@ -41,9 +40,5 @@ browser-compat: xpath.axes.self
   </tr>
  </tbody>
 </table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat}}</p>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}</p>

--- a/files/en-us/web/xslt/element/stylesheet/index.html
+++ b/files/en-us/web/xslt/element/stylesheet/index.html
@@ -6,7 +6,6 @@ tags:
   - Reference
   - StyleSheet
   - XSLT
-browser-compat: xslt.elements.stylesheet
 ---
 <div>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/XSLT")}}</div>
 
@@ -91,7 +90,3 @@ browser-compat: xslt.elements.stylesheet
   </tr>
  </tbody>
 </table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat}}</p>


### PR DESCRIPTION
This is the counterpart to https://github.com/mdn/browser-compat-data/pull/9830.

In BCD, we're dropping our largely incomplete and low-quality XPath and XSLT data. This makes the corresponding changes to content that refers to the features removed from BCD.