### PR TITLE
Add notes regarding inline-formatting-context when deciding containing block

### DIFF
--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -40,7 +40,7 @@ The process for identifying the containing block depends entirely on the value o
 
 1.  If the `position` property is **`static`**, **`relative`**, or **`sticky`**, the containing block is formed by the edge of the _content box_ of the nearest ancestor element that is either **a block container** (such as an inline-block, block, or list-item element) or **establishes a formatting context** (such as a table container, flex container, grid container, or the block container itself).
 
-> **Note:** It is important to note that an inline element such as `<p>` **continues the [inline formatting context](https://www.w3.org/TR/css-display-3/#inline-formatting-context)** of its **block container** and does not establish an independent formatting context. Thus, inline elements cannot serve as containing blocks in the case above.
+> **Note:** It is important to note that an inline element such as `<span>` **continues the [inline formatting context](https://www.w3.org/TR/css-display-3/#inline-formatting-context)** of its **block container** and does not establish an independent formatting context. Thus, inline elements cannot serve as containing blocks in the case above.
 
 3.  If the `position` property is **`absolute`**, the containing block is formed by the edge of the _padding box_ of the nearest ancestor element that has a `position` value other than `static` (`fixed`, `absolute`, `relative`, or `sticky`).
 4.  If the `position` property is **`fixed`**, the containing block is established by the {{glossary("viewport")}} (in the case of continuous media) or the page area (in the case of paged media).

--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -39,9 +39,12 @@ The size and position of an element are often impacted by its containing block. 
 The process for identifying the containing block depends entirely on the value of the element's {{cssxref("position")}} property:
 
 1.  If the `position` property is **`static`**, **`relative`**, or **`sticky`**, the containing block is formed by the edge of the _content box_ of the nearest ancestor element that is either **a block container** (such as an inline-block, block, or list-item element) or **establishes a formatting context** (such as a table container, flex container, grid container, or the block container itself).
-2.  If the `position` property is **`absolute`**, the containing block is formed by the edge of the _padding box_ of the nearest ancestor element that has a `position` value other than `static` (`fixed`, `absolute`, `relative`, or `sticky`).
-3.  If the `position` property is **`fixed`**, the containing block is established by the {{glossary("viewport")}} (in the case of continuous media) or the page area (in the case of paged media).
-4.  If the `position` property is **`absolute`** or **`fixed`**, the containing block may also be formed by the edge of the _padding box_ of the nearest ancestor element that has the following:
+
+> **Note:** It is important to note that an inline element such as `<p>` **continues the [inline formatting context](https://www.w3.org/TR/css-display-3/#inline-formatting-context)** of its **block container** and does not establish an independent formatting context. Thus, inline elements cannot serve as containing blocks in the case above.
+
+3.  If the `position` property is **`absolute`**, the containing block is formed by the edge of the _padding box_ of the nearest ancestor element that has a `position` value other than `static` (`fixed`, `absolute`, `relative`, or `sticky`).
+4.  If the `position` property is **`fixed`**, the containing block is established by the {{glossary("viewport")}} (in the case of continuous media) or the page area (in the case of paged media).
+5.  If the `position` property is **`absolute`** or **`fixed`**, the containing block may also be formed by the edge of the _padding box_ of the nearest ancestor element that has the following:
 
     1.  A {{cssxref("transform")}} or {{cssxref("perspective")}} value other than `none`
     2.  A {{cssxref("will-change")}} value of `transform` or `perspective`


### PR DESCRIPTION
Hi,

First of all, thank you guys for the great article. Really helped me understand how containing blocks work.
However, while reading and trying to fully understand the mechanism,  

> 1.  If the `position` property is **`static`**, **`relative`**, or **`sticky`**, the containing block is formed by the edge of the _content box_ of the nearest ancestor element that is either **a block container** (such as an inline-block, block, or list-item element) or **establishes a formatting context** (such as a table container, flex container, grid container, or the block container itself).

the second part of the above explanation really got me confused. If an element that establishes a formatting context can serve as a containing block, can inline elements also serve as a containing block? Seemed really unlikely to me, so I searched through mdn and other sources for a while, but was not able to dig up any clear answers. 

At the end, I was able to find what I was looking for in w3c spec. 
Reading through [https://www.w3.org/TR/css-display-3/#formatting-context](https://www.w3.org/TR/css-display-3/#formatting-context), I was able to confirm that inline-formatting-context are not established by inline elements but by block elements, and that inline elements only continues the existing inline-formatting-context.

Maybe I am just being overly meticulous, but I thought it is possible others might get confused since it just seems likely that
block elements establishes block-formatting-context and
inline elements establishes inline-formatting-context,
when that actually is not the case.

Let me know what you guys think.
Thanks!

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
