### PR TITLE
Make GitHub Action cache keys for node_modules unique per workflow

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/pr-check_redirects.yml') }}
 
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -29,6 +29,9 @@ jobs:
             node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Debug caching of node_modules
+        run: ${{ steps.cached-node_modules.outputs }}
+
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -29,14 +29,6 @@ jobs:
             node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/pr-test.yml') }}
 
-      - name: Debug caching of node_modules
-        run: |
-
-          echo ${{ steps.cached-node_modules.outputs }}
-
-          echo ${{ hashFiles('**/yarn.lock') }}
-          echo ${{ runner.os }}
-
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/pr-test.yml') }}
 
       - name: Debug caching of node_modules
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,7 +30,12 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Debug caching of node_modules
-        run: ${{ steps.cached-node_modules.outputs }}
+        run: |
+
+          echo ${{ steps.cached-node_modules.outputs }}
+
+          echo ${{ hashFiles('**/yarn.lock') }}
+          echo ${{ runner.os }}
 
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/preview.yml') }}
 
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fixes #8014

Now, the cache keys for caching `node_modules` is unique per each `.yml` file so you shouldn't be getting that error. 