### PR TITLE
Add WebXR Lighting Estimation reference docs - pt 3

### DIFF
--- a/files/en-us/web/api/xrframe/getlightestimate/index.md
+++ b/files/en-us/web/api/xrframe/getlightestimate/index.md
@@ -1,0 +1,65 @@
+---
+title: XRFrame.getLightEstimate()
+slug: Web/API/XRFrame/getLightEstimate
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - XR
+  - WebXR
+browser-compat: api.XRFrame.getLightEstimate
+---
+{{APIRef("WebXR Device API")}}
+
+The **`getLightEstimate()`** method of the {{domxref("XRFrame")}} interface returns an {{domxref("XRLightEstimate")}} object containing estimated lighting values for a given {{domxref("XRLightProbe")}}.
+
+## Syntax
+
+```js
+getLightEstimate(lightProbe)
+```
+
+### Parameters
+
+- `lightProbe`
+  - : An {{domxref("XRLightProbe")}} object containing the current lighting state for the frame.
+
+### Return value
+
+An {{domxref("XRLightEstimate")}} object or {{jsxref("null")}} if the device cannot estimate lighting for this frame.
+
+## Examples
+
+### Getting light estimates for each frame
+
+Given a session's {{domxref("XRLightProbe")}}, the `getLightEstimate()` method gets an {{domxref("XRLightEstimate")}} object containing the lighting values for each frame.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let lightEstimate = xrFrame.getLightEstimate(lightProbe);
+
+  // Use light estimate data to light the scene
+
+  // Available properties
+  lightEstimate.sphericalHarmonicsCoefficients;
+  lightEstimate.primaryLightDirection;
+  lightEstimate.primaryLightIntensity;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRLightEstimate")}}
+- {{domxref("XRLightProbe")}}

--- a/files/en-us/web/api/xrframe/index.md
+++ b/files/en-us/web/api/xrframe/index.md
@@ -37,6 +37,8 @@ In addition to providing a reference to the {{domxref("XRSession")}} for which t
   - : Returns a {{jsxref("Promise")}} which resolves to a free-floating {{domxref("XRAnchor")}} object.
 - {{domxref("XRFrame.getDepthInformation()", "getDepthInformation()")}}
   - : Returns an {{domxref("XRCPUDepthInformation")}} object containing CPU depth information for the frame.
+- {{domxref("XRFrame.getLightEstimate()", "getLightEstimate()")}}
+  - : Returns an {{domxref("XRLightEstimate")}} object containing estimated lighting values for an {{domxref("XRLightProbe")}}.
 - {{DOMxRef("XRFrame.getPose", "getPose()")}}
   - : Returns an {{domxref("XRPose")}} object representing the spatial relationship between the two specified {{domxref("XRSpace")}} objects.
 - {{DOMxRef("XRFrame.getViewerPose", "getViewerPose()")}}

--- a/files/en-us/web/api/xrlightestimate/index.md
+++ b/files/en-us/web/api/xrlightestimate/index.md
@@ -35,7 +35,7 @@ None.
 ### Getting an `XRLightProbe` object
 
 First, use the {{domxref("XRSession.requestLightProbe()")}} method to get a light probe from a session.
-Then, within an {{domxref("XRFrame")}} loop, the {{domxref("XRFrame.getLightEstimate", "getLightEstimate()")}} method will return `XRLightEstimate` object containing the lighting values for each frame.
+Then, within an {{domxref("XRFrame")}} loop, the {{domxref("XRFrame.getLightEstimate", "getLightEstimate()")}} method will return a `XRLightEstimate` object containing the lighting values for each frame.
 
 ```js
 const lightProbe = await xrSession.requestLightProbe();

--- a/files/en-us/web/api/xrlightestimate/index.md
+++ b/files/en-us/web/api/xrlightestimate/index.md
@@ -1,0 +1,66 @@
+---
+title: XRLightEstimate
+slug: Web/API/XRLightEstimate
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRLightEstimate
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRLightEstimate`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) provides the estimated lighting values for an {{domxref("XRLightProbe")}} at the time represented by an {{domxref("XRFrame")}}.
+
+To get an `XRLightEstimate`object, call the {{domxref("XRFrame.getLightEstimate()")}} method.
+
+## Properties
+
+- {{domxref("XRLightEstimate.primaryLightDirection")}} {{ReadOnlyInline}}
+  - : A {{domxref("DOMPointReadOnly")}} representing the direction to the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
+- {{domxref("XRLightEstimate.primaryLightIntensity")}} {{ReadOnlyInline}}
+  - : A {{domxref("DOMPointReadOnly")}} (with the `x`, `y`, `z` values mapped to RGB) representing the intensity of the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
+- {{domxref("XRLightEstimate.sphericalHarmonicsCoefficients")}} {{ReadOnlyInline}}
+  - : A {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients.
+
+## Methods
+
+None.
+
+## Examples
+
+### Getting an `XRLightProbe` object
+
+First, use the {{domxref("XRSession.requestLightProbe()")}} method to get a light probe from a session.
+Then, within an {{domxref("XRFrame")}} loop, the {{domxref("XRFrame.getLightEstimate", "getLightEstimate()")}} method will return `XRLightEstimate` object containing the lighting values for each frame.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let lightEstimate = xrFrame.getLightEstimate(lightProbe);
+
+  // Use light estimate data to light the scene
+
+  // Available properties
+  lightEstimate.sphericalHarmonicsCoefficients;
+  lightEstimate.primaryLightDirection;
+  lightEstimate.primaryLightIntensity;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRFrame.getLightEstimate()")}}

--- a/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
@@ -1,0 +1,55 @@
+---
+title: XRLightEstimate.primaryLightDirection
+slug: Web/API/XRLightEstimate/primaryLightDirection
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightEstimate.primaryLightDirection
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`primaryLightDirection`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the direction to the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
+
+### Value
+
+A {{domxref("DOMPointReadOnly")}} object. If no estimated values from the user's environment are available, the point will be `{ x: 0.0, y: 1.0, z: 0.0, w: 0.0 }`, representing a light shining straight down from above.
+
+## Examples
+
+Within an {{domxref("XRFrame")}} loop, you can use the `primaryLightDirection` and  `primaryLightIntensity` properties
+to render shadows based on the most prominent light source, for example.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let lightEstimate = xrFrame.getLightEstimate(lightProbe);
+
+  // Render lights ...
+
+  // Available properties
+  lightEstimate.primaryLightDirection;
+  lightEstimate.primaryLightIntensity;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRLightEstimate.primaryLightIntensity")}}
+- {{domxref("XRLightProbe.probeSpace")}}

--- a/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
@@ -1,0 +1,55 @@
+---
+title: XRLightEstimate.primaryLightIntensity
+slug: Web/API/XRLightEstimate/primaryLightIntensity
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightEstimate.primaryLightIntensity
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`primaryLightIntensity`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the intensity of the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
+
+### Value
+
+A {{domxref("DOMPointReadOnly")}} object where an RGB value is mapped to the `x`, `y`, and `z` values. The `w` value is always `1.0`. If no estimated values from the user's environment are available, the point will be `{x: 0.0, y: 0.0, z: 0.0, w: 1.0}`, representing no illumination.
+
+## Examples
+
+Within an {{domxref("XRFrame")}} loop, you can use the `primaryLightDirection` and  `primaryLightIntensity` properties
+to render shadows based on the most prominent light source, for example.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let lightEstimate = xrFrame.getLightEstimate(lightProbe);
+
+  // Render lights ...
+
+  // Available properties
+  lightEstimate.primaryLightDirection;
+  lightEstimate.primaryLightIntensity;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRLightEstimate.primaryLightDirection")}}
+- {{domxref("XRLightProbe.probeSpace")}}

--- a/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
+++ b/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
@@ -23,7 +23,7 @@ Spheral harmonic lighting is a technique that uses spherical functions instead o
 
 A {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients. The array contains 27 elements in total, with every 3 elements defining red, green, and blue components for each coefficient.
 
-The first 3 elements must be a valid lighting estimate component, the rest may be 0 due to privacy settings or limitations of the device to provide more data.
+The first 3 elements must be a valid lighting estimate component; the rest may be 0 due to privacy settings or limitations of the device to provide more data.
 
 ## Examples
 

--- a/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
+++ b/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
@@ -1,0 +1,53 @@
+---
+title: XRLightEstimate.sphericalHarmonicsCoefficients
+slug: Web/API/XRLightEstimate/sphericalHarmonicsCoefficients
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRLightEstimate.sphericalHarmonicsCoefficients
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`sphericalHarmonicsCoefficients`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients.
+
+Spheral harmonic lighting is a technique that uses spherical functions instead of standard lighting equations. See [Wikipedia](https://en.wikipedia.org/wiki/Spherical_harmonic_lighting) for more information.
+
+### Value
+
+A {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients. The array contains 27 elements in total, with every 3 elements defining red, green, and blue components for each coefficient.
+
+The first 3 elements must be a valid lighting estimate component, the rest may be 0 due to privacy settings or limitations of the device to provide more data.
+
+## Examples
+
+Within an {{domxref("XRFrame")}} loop, you can use the `sphericalHarmonicsCoefficients` property to light the scene.
+
+```js
+const lightProbe = await xrSession.requestLightProbe();
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let lightEstimate = xrFrame.getLightEstimate(lightProbe);
+
+  // Render lights using lightEstimate.sphericalHarmonicsCoefficients ...
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRFrame.getLightEstimate()")}}


### PR DESCRIPTION
Final part to add reference docs for https://immersive-web.github.io/lighting-estimation

In this part, I'm documenting `XRFrame.getLightEstimate()` and the `XRLightEstimate` object.

The examples for `XRLightEstimate.sphericalHarmonicsCoefficients`, `XRLightEstimate.primaryLightDirection`, and `XRLightEstimate.primaryLightIntensity` are a bit weak as I don't know how to actually demonstrate lighting a scene using the light estimation data in a short code snippet (and without using 3rd party libraries like THREE).

