### PR TITLE
[webext] Clarify browser_specific_settings.gecko.id requirement

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 		</tr>
 		<tr>
 			<th scope="row">Mandatory</th>
-			<td>Usually, no (but see also <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when_do_you_need_an_add-on_id">When do you need an Add-on ID?</a>). Mandatory before Firefox 48 (desktop) and Firefox for Android.</td>
+			<td>Usually, no (but see also <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when-do-you-need-an-add-on-id">When do you need an Add-on ID?</a>). Mandatory if the extension ID cannot be determined, see <a href="#browser_specific_settings_gecko_id"><code>browser_specific_settings.gecko.id</code></a>.</td>
 		</tr>
 		<tr>
 			<th scope="row">Example</th>
@@ -45,8 +45,8 @@ browser-compat: webextensions.manifest.browser_specific_settings
 <p>Firefox stores is browser specific settings in the <code>gecko</code> subkey, which has the following properties:</p>
 
 <dl>
-	<dt><code>id</code></dt>
-	<dd>Is the extension ID. Optional from Firefox 48, mandatory before Firefox 48. See <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/">Extensions and the Add-on ID</a> to see when you need to specify an add-on ID.</dd>
+	<dt id="browser_specific_settings_gecko_id"><code>id</code></dt>
+	<dd>Is the extension ID. Optional since Firefox 48, where the extension ID is derived from the extension's signature. Mandatory if the extension is unsigned (and not loaded via <code>about:debugging</code>). See <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/">Extensions and the Add-on ID</a> to see when you need to specify an add-on ID.</dd>
 	<dt><code>strict_min_version</code></dt>
 	<dd>Minimum version of Gecko to support. Versions containing a "*" are not valid in this field. Defaults to "42a1".</dd>
 	<dt><code>strict_max_version</code></dt>


### PR DESCRIPTION
Complements https://github.com/mozilla/extension-workshop/pull/1078

Fixes broken links (anchor incorrectly used `_` instead of `-`), and be more clear about when the ID is needed, since the existing note caused confusion as seen at https://github.com/mdn/webextensions-examples/issues/473.