### PR TITLE
Incorrect link in the "Type" article of the glossary

### DIFF
--- a/files/en-us/glossary/type/index.html
+++ b/files/en-us/glossary/type/index.html
@@ -6,13 +6,13 @@ tags:
   - Glossary
   - JavaScript
 ---
-<p><strong>Type</strong> is a characteristic of a {{glossary("value")}} affecting what kind of data it can store, and the structure that the data will adhere to. For example, a {{jsxref("Boolean")}} <a href="/en-US/docs/Web/JavaScript/Data_structures">Data Type</a> can hold only a <code>true</code> or <code>false</code> value at any given time, whereas a {{jsxref("String")}} has the ability to hold a string or a sequence of characters, a {{jsxref("Number")}} can hold numerical values of any kind, and so on.</p>
+<p><strong>Type</strong> is a characteristic of a {{glossary("value")}} affecting what kind of data it can store, and the structure that the data will adhere to. For example, a {{Glossary("boolean")}} <a href="/en-US/docs/Web/JavaScript/Data_structures">Data Type</a> can hold only a <code>true</code> or <code>false</code> value at any given time, whereas a {{Glossary("string")}} has the ability to hold a string or a sequence of characters, a {{Glossary("number")}} can hold numerical values of any kind, and so on.</p>
 
 <p>A value's data type also affects the operations that are valid on that value. For example, a value of type number can be multiplied by another number, but not by a string - even if that string contains <em>only</em> a number, such as the string "2".</p>
 
 <p>Types also provides us with useful knowledge about the comparison between different values. Comparison between structured types is not always an easy assumption, as even if the previous data structure is the same, there could be inherited structures inside of the <a href="/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain">Prototype Chain</a>.</p>
 
-<p>If you are unsure of the type of a value, you can use the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a> operator.</p>
+<p>If you are unsure of the type of a value, you can use the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/typeof"><code>typeof</code></a> operator.</p>
 
 <section id="Quick_links">
 <ol>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The {{jsxref("Boolean")}}, {{jsxref("Number")}} and {{jsxref("Stirng")}} produce links to wrapper objects. However this article mentions about primitive types there.

> Anything else that could help us review it

They should be links to explanations of primitive types. I attempted to fix them as links to the glossary articles.