### PR TITLE
Radically streamline the PWA landing page

### DIFF
--- a/files/en-us/web/progressive_web_apps/index.html
+++ b/files/en-us/web/progressive_web_apps/index.html
@@ -10,85 +10,46 @@ tags:
   - Web app
   - Web applications
 ---
-<div>{{draft}}</div>
+<p><strong>Progressive Web Apps</strong> (PWAs) are web apps that use <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a>, <a href="/en-US/docs/Web/Manifest">manifests</a>, and other web-platform features in combination with {{glossary("progressive enhancement")}} to give users an experience on par with native apps.</p>
 
-<p class="summary"><img alt="PWA community logo" src="pwa.png" style="display: block; float: left; margin: 0px auto; padding-bottom: 1em; padding-right: 2em;"><strong>Progressive Web Apps</strong> are web apps that use emerging web browser APIs and features along with traditional progressive enhancement strategy to bring a native app-like user experience to cross-platform web applications. Progressive Web Apps are a useful design pattern, though they aren't a formalized standard. PWA can be thought of as similar to AJAX or other similar patterns that encompass a set of application attributes, including use of specific web technologies and techniques. This set of docs tells you all you need to know about them.</p>
+<p>PWAs provide a number of <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#advantages_of_web_applications">advantages</a> to users — including being <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#installability">installable</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#progressive_enhancement_support">progressively enhanced</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#responsiveness">responsively designed</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#re-engageability">re-engageable</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#linkability">linkable</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#discoverability">discoverable</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#network_independence">network independent</a>, and <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#safety">secure</a>.</p>
 
-<p>In order to call a Web App a PWA, technically speaking it should have the following features: <a href="/en-US/docs/Web/Security/Secure_Contexts">Secure contexts</a> (<strong>{{Glossary("HTTPS")}}</strong>), one or more <a href="/en-US/docs/Web/API/Service_Worker_API">Service Workers</a>, and a <a href="/en-US/docs/Web/Manifest">manifest file</a>.</p>
+<h2>PWA how-to guides and other documentation</h2>
 
-<dl>
- <dt><a href="/en-US/docs/Web/Security/Secure_Contexts">Secure contexts</a> ({{Glossary("HTTPS")}})</dt>
- <dd>The web application must be served over a secure network. Being a secure site is not only a best practice, but it also establishes your web application as a trusted site especially if users need to make secure transactions. Most of the features related to a PWA such as geolocation and even service workers are available only once the app has been loaded using HTTPS.</dd>
- <dt><a href="/en-US/docs/Web/API/Service_Worker_API">Service workers</a></dt>
- <dd>A service worker is a script that allows intercepting and control of how a web browser handles its network requests and asset caching. With service workers, web developers can create reliably fast web pages and offline experiences.</dd>
- <dt><a href="/en-US/docs/Web/Manifest">Manifest file</a></dt>
- <dd>A {{Glossary("JSON")}} file that controls how your app appears to the user and ensures that progressive web apps are discoverable. It describes the name of the app, the start URL, icons, and all of the other details necessary to transform the website into an app-like format.</dd>
-</dl>
+<p>These introductory materials and step-by-step guides walk you through key aspects of building PWAs:</p>
 
-<h2 id="PWA_advantages">PWA advantages</h2>
-
-<p>PWAs should be discoverable, installable, linkable, network independent, progressive, re-engageable, responsive, and safe. To find out more about what these mean, read <a href="/en-US/docs/Web/Progressive_web_apps/Introduction#advantages_of_web_applications">Progressive web app advantages</a>.</p>
-
-<h2 id="Documentation">Documentation</h2>
-
-<p><strong>&lt;-- The temporary automatic list below will be replaced soon --&gt;</strong></p>
-
-<p>{{LandingPageListSubpages}}</p>
-
-<div class="notecard warning">
-<p><strong>Everything below this point is left over from the old version of this page and will be revamped as other content is overhauled.</strong></p>
-</div>
-
-<h2 id="Core_PWA_guides">Core PWA guides</h2>
-
-<p>The following guides show you what need to do to implement a PWA, by examining a simple example and showing you how all the pieces work.</p>
-
-<ol>
+<ul>
  <li><a href="/en-US/docs/Web/Progressive_web_apps/Introduction">Introduction to progressive web apps</a></li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/App_structure">Progressive web app structure</a></li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers">Making PWAs work offline with Service workers</a></li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Installable_PWAs">How to make PWAs installable</a></li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Re-engageable_Notifications_Push">How to make PWAs re-engageable using Notifications and Push</a></li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Loading">Progressive loading</a></li>
-</ol>
-
-<h2 id="Technology_guides">Technology guides</h2>
-
-<ul>
- <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage">Client-side storage</a> — A lengthy guide showing how and when to use web storage, IndexedDB, and service workers.</li>
- <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using service workers</a> — A more in-depth guide covering the Service Worker API.</li>
- <li><a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a> — The fundamentals of IndexedDB, explained in detail.</li>
- <li><a href="/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API">Using the Web Storage API</a> — The Web storage API made simple.</li>
- <li><a class="external external-icon" href="https://developers.google.com/web/updates/2015/11/app-shell" rel="noopener">Instant Loading Web Apps with An Application Shell Architecture</a> — A guide to using the App Shell coding pattern to create apps that load quickly.</li>
- <li><a href="/en-US/docs/Web/API/Push_API">Using the Push API</a> — Learn the essentials behind the Web Push API.</li>
- <li><a href="/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API">Using the Notifications API</a> — Web notifications in a nutshell.</li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/responsive_design_building_blocks">The building blocks of responsive design</a> — Learn the basics of responsive design, an essential topic for modern app layout.</li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/Mobile_first">Mobile first</a> — Often when creating responsive application layouts, it makes sense to create the mobile layout as the default, and build wider layouts on top.</li>
- <li><a href="/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen">Add to home screen guide</a> — Learn how your apps can take advantage of Add to home screen (A2HS).</li>
-</ul>
-
-<h2 id="Tools">Tools</h2>
-
-<ul>
- <li><a class="external external-icon" href="https://localforage.github.io/localForage/" rel="noopener">localForage</a> — A nice simple JavaScript library for making client-side data storage really simple; it uses IndexedDB by default and falls back to Web SQL/Web Storage if necessary.</li>
- <li><a class="external external-icon" href="https://github.com/fxos-components/serviceworkerware" rel="noopener">ServiceWorkerWare</a> — An <em>Express-like</em> microframework for easy Service Worker development.</li>
- <li><a class="external external-icon" href="https://github.com/mozilla/oghliner" rel="noopener">oghliner</a> — Not only a template but a tool for deploying Offline Web Apps to GitHub Pages.</li>
- <li><a class="external external-icon" href="https://developers.google.com/web/tools/workbox" rel="noopener">workbox</a> — Spiritual successor to sw-precache with more advanced caching strategies and easy precaching.</li>
- <li><a class="external external-icon" href="https://www.talater.com/upup/" rel="noopener">upup</a> — A tiny script that makes sure your site is always there for your users.</li>
- <li><a class="external external-icon" href="https://serviceworke.rs/" rel="noopener">The service worker cookbook</a> — A series of excellent service worker/push recipes, showing how to implement an offline app, but also much more.</li>
- <li><a href="https://marketplace.visualstudio.com/items?itemName=mayeedwin.vscode-pwa">PWA VS Code extension</a> - A collection of all essential code snippets you need to build Progressive Web Apps right there in your VS Code environment.</li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/App_structure">Progressive web app structure</a> and <a href="/en-US/docs/Web/Progressive_web_apps/Structural_overview">structural overview</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/responsive_design_building_blocks">Understanding the building blocks of responsive design</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers">How to make PWAs work offline (using service workers)</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Installable_PWAs">How to make PWAs installable</a>, <a href="/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen">enable “add to home screen”</a>, and <a href="/en-US/docs/Web/Progressive_web_apps/Installing">further details on installing PWAs</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Re-engageable_Notifications_Push">How to make PWAs “re-engageable” (using the Notifications API and Push API)</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Loading">How to enable progressive loading</a></li>
+ <li><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/Mobile_first">How to build “mobile first” PWAs</a></li>
 </ul>
 
 <ul>
- <li><a href="https://web.dev/progressive-web-apps/">Progressive web apps</a> on Google Developers.</li>
- <li><a href="https://medium.com/@slightlylate/progressive-apps-escaping-tabs-without-losing-our-soul-3b93a8561955#.6czgj0myh">Progressive Web Apps: Escaping Tabs Without Losing Our Soul</a> by Alex Russell.</li>
- <li><a href="https://web.dev/pwa-checklist/">Progressive Web Apps Check List</a>.</li>
- <li><a href="https://developers.google.com/web/tools/lighthouse">The Lighthouse Tool</a> by Google.</li>
- <li><a href="https://pokedex.org/">Offline-capable Pokédex web site</a>.</li>
- <li><a href="https://hnpwa.com/">Hacker News readers as Progressive Web Apps</a>.</li>
+ <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using service workers</a></li>
+ <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage">Using client-side storage</a>, <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">IndexedDB</a>, and the <a href="/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API">the Web Storage API</a></li>
+ <li><a href="/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API">Using the Notifications API</a> and <a href="/en-US/docs/Web/API/Push_API">the Push API</a></li>
+</ul>
+
+<h2>See also</h2>
+
+<ul>
+ <li><a href="https://web.dev/progressive-web-apps/">Progressive Web Apps landing page</a> and <a href="https://web.dev/pwa-checklist/">check list</a> on <a href="https://web.dev/">web.dev</a></li>
  <li><a href="https://www.csschopper.com/blog/progressive-web-apps-everything-you-need-to-know/">Progressive Web Apps: Everything You Need To Know</a></li>
- <li><a href="https://pwafire.org">Collection of resources, codelabs and tools you need to build PWAs by the team at pwafire.org</a></li>
- <li><a href="https://github.com/pwafire/pwadev-tips">Setting up your Progressive Web App Development environment</a></li>
+ <li><a href="https://medium.com/@slightlylate/progressive-apps-escaping-tabs-without-losing-our-soul-3b93a8561955#.6czgj0myh">Progressive Web Apps: Escaping Tabs Without Losing Our Soul</a></li>
+ <li><a href="https://developers.google.com/web/updates/2015/11/app-shell">Instant Loading Web Apps with An Application Shell Architecture</a></li>
+ <li><a href="https://developers.google.com/web/ilt/pwa/introduction-to-progressive-web-app-architectures">Introduction to Progressive Web App Architectures</a></li>
+ <li><a href="https://serviceworke.rs/">Service worker cookbook</a></li>
 </ul>
+<ul>
+ <li><a href="https://developers.google.com/web/tools/workbox">Workbox</a> — set of libraries to power a “production-ready” service worker for your PWA</li>
+ <li><a href="https://developers.google.com/web/tools/lighthouse">Lighthouse</a> — web-app auditing tool that includes PWA-auditing features</li>
+ <li><a href="https://localforage.github.io/localForage/">localForage</a> — <code>localStorage</code>-like <em>async</em> storage, to improve your PWA’s offline experience</li>
+</ul>
+
 
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Progressive_web_apps/")}}</div>

--- a/files/en-us/web/progressive_web_apps/index.html
+++ b/files/en-us/web/progressive_web_apps/index.html
@@ -27,9 +27,6 @@ tags:
  <li><a href="/en-US/docs/Web/Progressive_web_apps/Re-engageable_Notifications_Push">How to make PWAs “re-engageable” (using the Notifications API and Push API)</a></li>
  <li><a href="/en-US/docs/Web/Progressive_web_apps/Loading">How to enable progressive loading</a></li>
  <li><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/Mobile_first">How to build “mobile first” PWAs</a></li>
-</ul>
-
-<ul>
  <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using service workers</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage">Using client-side storage</a>, <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">IndexedDB</a>, and the <a href="/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API">the Web Storage API</a></li>
  <li><a href="/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API">Using the Notifications API</a> and <a href="/en-US/docs/Web/API/Push_API">the Push API</a></li>
@@ -44,8 +41,6 @@ tags:
  <li><a href="https://developers.google.com/web/updates/2015/11/app-shell">Instant Loading Web Apps with An Application Shell Architecture</a></li>
  <li><a href="https://developers.google.com/web/ilt/pwa/introduction-to-progressive-web-app-architectures">Introduction to Progressive Web App Architectures</a></li>
  <li><a href="https://serviceworke.rs/">Service worker cookbook</a></li>
-</ul>
-<ul>
  <li><a href="https://developers.google.com/web/tools/workbox">Workbox</a> — set of libraries to power a “production-ready” service worker for your PWA</li>
  <li><a href="https://developers.google.com/web/tools/lighthouse">Lighthouse</a> — web-app auditing tool that includes PWA-auditing features</li>
  <li><a href="https://localforage.github.io/localForage/">localForage</a> — <code>localStorage</code>-like <em>async</em> storage, to improve your PWA’s offline experience</li>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps is a landing/portal page that should just serve as a gateway to attract users into the reading the subpages where all the useful content actually is.

But that existing page has so much content on it — and so much clutter — that it’s not serving its purpose well at all.

So this change pares that down to just a well-structured, slim list of links for quickly getting readers over to the where the meat of the content is.

Among the changes:

- Drop huge PWA logo taking up 25% of screen real estate above the fold
- Copy-edit/rewrite intro paragraphs down to just two sentences
- Drop link redundancy/wordiness caused by {{LandingPageListSubpages}} macro
- Assemble links to subpages into a better order/structure for readers
- Discard cruft from list of links to external sites
- Distill external-sites list down to a curated set of just the best stuff

Fixes https://github.com/mdn/content/issues/8023