### PR TITLE
Add clarity to the “Progressive Enhancement” glossary entry

### DIFF
--- a/files/en-us/glossary/progressive_enhancement/index.html
+++ b/files/en-us/glossary/progressive_enhancement/index.html
@@ -8,16 +8,20 @@ tags:
 ---
 <p><strong>Progressive enhancement</strong> is a design philosophy that provides a baseline of essential content and functionality to as many users as possible, while delivering the best possible experience only to users of the most modern browsers that can run all the required code.</p>
 
+<p>The word <em>progressive</em> in <em>progressive enhancement</em> means creating a design that achieves a simpler-but-still-usable experience for users of older browsers and devices with limited capabilities, while at the same time being a design that <strong>progresses the user experience up</strong> to a more-compelling, fully-featured experience for users of newer browsers and devices with richer capabilities.</p>
+
 <p><a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection">Feature detection</a> is generally used to determine whether browsers can handle more modern functionality, while <a href="/en-US/docs/Glossary/Polyfill">polyfills</a> are often used to add missing features with JavaScript.</p>
 
 <p>Special notice should be taken of accessibility. Acceptable alternatives should be provided where possible.</p>
 
 <p>Progressive enhancement is a useful technique that allows web developers to focus on developing the best possible websites while making those websites work on multiple unknown user agents. {{Glossary("Graceful degradation")}} is related but is not the same thing and is often seen as going in the opposite direction to progressive enhancement. In reality both approaches are valid and can often complement one another.</p>
 
-<h2 id="Learn_more">Learn more</h2>
-
-<h3 id="General_knowledge">General knowledge</h3>
+<h2>See also</h2>
 
 <ul>
- <li>{{Interwiki("wikipedia", "Progressive enhancement")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "Progressive enhancement")}} at Wikipedia</li>
+ <li><a href="https://www.freecodecamp.org/news/what-is-progressive-enhancement-and-why-it-matters-e80c7aaf834a/">What is Progressive Enhancement, and why it matters</a> at freeCodeCamp</li>
+ <li><a href="https://www.quirksmode.org/blog/archives/2021/02/progressive_enh_1.html">Progressive Enhancement reading list 2021</a> at QuirksMode</li>
+ <li><a href="https://alistapart.com/article/understandingprogressiveenhancement/">Understanding Progressive Enhancement</a> by Aaron Gustafson; a 2008 <em>A List Apart</em> article which first “placed progressive enhancement at the forefront of web developer thinking”</li>
+ <li><a href="http://hesketh.com/publications/inclusive_web_design_for_the_future/">Inclusive Web Design For the Future with Progressive Enhancement</a> (<a href="http://www.hesketh.com/progressive_enhancement_and_the_future_of_web_design.html">related article)</a> by Steve Champeon and Nick Finck; a 2003 SXSW presentation cited by Aaron Gustafson as “unveiling a blueprint for a new way of approaching web development”, and naming it “progressive ehancement”</li>
 </ul>


### PR DESCRIPTION
This change adds clarity about what the word *progressive* in “progressive enhancement” really means, while also adding links to four very high-quality sources where readers can learn in-depth about what progressive enhancement is — and about the history of the term. Fixes https://github.com/mdn/content/issues/8023.