### PR TITLE
Add WebXR Hit Test reference docs - pt 1

### DIFF
--- a/files/en-us/web/api/xrsession/index.md
+++ b/files/en-us/web/api/xrsession/index.md
@@ -52,6 +52,10 @@ _`XRSession` provides the following methods in addition to those inherited from 
   - : Ends the WebXR session. Returns a {{jsxref("promise")}} which resolves when the session has been shut down.
 - {{DOMxRef("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}
   - : Schedules the specified method to be called the next time the {{glossary("user agent")}} is working on rendering an animation frame for the WebXR device. Returns an integer value which can be used to identify the request for the purposes of canceling the callback using `cancelAnimationFrame()`. This method is comparable to the {{domxref("Window.requestAnimationFrame()")}} method.
+- {{DOMxRef("XRSession.requestHitTestSource", "requestHitTestSource()")}}
+  - : Requests an {{domxref("XRHitTestSource")}} object that handles hit test subscription.
+- {{DOMxRef("XRSession.requestHitTestSourceForTransientInput", "requestHitTestSourceForTransientInput()")}}
+  - : Requests an {{domxref("XRTransientInputHitTestSource")}} object that handles hit test subscription for a transient input source.
 - {{DOMxRef("XRSession.requestLightProbe", "requestLightProbe()")}}
   - : Requests an {{domxref("XRLightProbe")}} that estimates lighting information at a given point in the user's environment.
 - {{DOMxRef("XRSession.requestReferenceSpace", "requestReferenceSpace()")}}

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -70,10 +70,9 @@ let hitTestSource = null;
 
 xrSession.requestHitTestSource({
   space : viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
-  entityTypes: ["point"],
   offsetRay : new XRRay({y: 0.5})
-}).then((pointHitTestSource) => {
-  hitTestSource = pointHitTestSource;
+}).then((viewerHitTestSource) => {
+  hitTestSource = viewerHitTestSource;
 });
 
 // frame loop

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -1,0 +1,97 @@
+---
+title: XRSession.requestHitTestSource()
+slug: Web/API/XRSession/requestHitTestSource
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Method
+  - Reference
+  - VR
+  - Virtual Reality
+  - WebXR
+  - WebXR Device API
+  - XR
+  - XRSession
+browser-compat: api.XRSession.requestHitTestSource
+---
+{{APIRef("WebXR Device API")}}
+
+The **`requestHitTestSource()`** method of the
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRHitTestSource")}} object that can be used to obtain hit test results using the {{domxref("XRFrame.getHitTestResults()")}} method.
+
+## Syntax
+
+```js
+requestHitTestSource(options);
+```
+
+### Parameters
+
+- `options`
+  - : An object containing configuration options, specifically:
+    - `space`: The {{domxref("XRSpace")}} that will be tracked by the hit test source.
+    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities that should be used for the purposes of hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
+      - `point`: Compute hit test results based on characteristic points detected.
+      - `plane`: Compute hit test results based on real-world planes detected.
+      - `mesh`: Compute hit test results based on meshes detected.
+    - `offsetRay`: {{optional_inline}} The {{domxref("XRRay")}} object that will be used to perform hit test. If no `XRRay` object has been provided, a new `XRRay` object is constructed without any parameters.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an {{domxref("XRHitTestSource")}} object.
+
+### Exceptions
+
+Rather than throwing true exceptions, `requestHitTestSource()` rejects the
+returned promise with a {{domxref("DOMException")}}, specifically, one of the following:
+
+- `NotSupportedError`
+  - : If `hit-test` is not an enabled feature in {{domxref("XRSystem.requestSession()")}}.
+- `InvalidStateError`
+  - : If the session has already ended.
+- `NotAllowedError`
+  - : If there is an unreasonable amount of requests (some user agents might limit usage due to privacy reasons).
+
+## Examples
+
+### Requesting a hit test source
+
+To request a hit test source, make sure to start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Then you can configure the hit test source and store it for later use in the frame loop where you can use the {{domxref("XRFrame.getHitTestResults()")}} method to obtain the hit test result.
+
+```js
+
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let hitTestSource = null;
+
+xrSession.requestHitTestSource({
+  space : viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
+  entityTypes: ["point"],
+  offsetRay : new XRRay({y: 0.5})
+}).then((pointHitTestSource) => {
+  hitTestSource = pointHitTestSource;
+});
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+
+  // do things with the hit test results
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.requestHitTestSourceForTransientInput()")}}

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -19,7 +19,7 @@ browser-compat: api.XRSession.requestHitTestSource
 {{APIRef("WebXR Device API")}}
 
 The **`requestHitTestSource()`** method of the
-{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRHitTestSource")}} object that can be used to obtain hit test results using the {{domxref("XRFrame.getHitTestResults()")}} method.
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRHitTestSource")}} object that can be passed to {{domxref("XRFrame.getHitTestResults()")}}.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ requestHitTestSource(options);
 - `options`
   - : An object containing configuration options, specifically:
     - `space`: The {{domxref("XRSpace")}} that will be tracked by the hit test source.
-    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities that should be used for the purposes of hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
+    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities to be used for hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
       - `point`: Compute hit test results based on characteristic points detected.
       - `plane`: Compute hit test results based on real-world planes detected.
       - `mesh`: Compute hit test results based on meshes detected.
@@ -52,13 +52,13 @@ returned promise with a {{domxref("DOMException")}}, specifically, one of the fo
 - `InvalidStateError`
   - : If the session has already ended.
 - `NotAllowedError`
-  - : If there is an unreasonable amount of requests (some user agents might limit usage due to privacy reasons).
+  - : If there is an unreasonable amount of requests. Some user agents might limit usage for privacy reasons.
 
 ## Examples
 
 ### Requesting a hit test source
 
-To request a hit test source, make sure to start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Then you can configure the hit test source and store it for later use in the frame loop where you can use the {{domxref("XRFrame.getHitTestResults()")}} method to obtain the hit test result.
+To request a hit test source, start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Next, configure the hit test source and store it for later use in the frame loop and call {{domxref("XRFrame.getHitTestResults()")}} to obtain the result.
 
 ```js
 

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -19,7 +19,7 @@ browser-compat: api.XRSession.requestHitTestSourceForTransientInput
 {{APIRef("WebXR Device API")}}
 
 The **`requestHitTestSourceForTransientInput()`** method of the
-{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRTransientInputHitTestSource")}} object that can be used to obtain hit test results using the {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method.
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRTransientInputHitTestSource")}} object that can be passed to {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ requestHitTestSourceForTransientInput(options);
 - `options`
   - : An object containing configuration options, specifically:
     - `profile`: A string specifying the [input profile name](/en-US/docs/Web/API/XRInputSource) of the transient input source that will be used to compute hit test results.
-    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities that should be used for the purposes of hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
+    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities to be used for hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
       - `point`: Compute hit test results based on characteristic points detected.
       - `plane`: Compute hit test results based on real-world planes detected.
       - `mesh`: Compute hit test results based on meshes detected.
@@ -52,13 +52,13 @@ returned promise with a {{domxref("DOMException")}}, specifically, one of the fo
 - `InvalidStateError`
   - : If the session has already ended.
 - `NotAllowedError`
-  - : If there is an unreasonable amount of requests (some user agents might limit usage due to privacy reasons).
+  - : If there is an unreasonable amount of requests. Some user agents might limit usage for privacy reasons.
 
 ## Examples
 
 ### Requesting a transient hit test source
 
-To request a hit test source, make sure to start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Then you can configure the hit test source and store it for later use in the frame loop where you can use the {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method to obtain the hit test result.
+To request a hit test source, start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Next, configure the hit test source and store it for later use in the frame loop and call {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} to obtain the result.
 
 ```js
 

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -1,0 +1,96 @@
+---
+title: XRSession.requestHitTestSourceForTransientInput()
+slug: Web/API/XRSession/requestHitTestSourceForTransientInput
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Method
+  - Reference
+  - VR
+  - Virtual Reality
+  - WebXR
+  - WebXR Device API
+  - XR
+  - XRSession
+browser-compat: api.XRSession.requestHitTestSourceForTransientInput
+---
+{{APIRef("WebXR Device API")}}
+
+The **`requestHitTestSourceForTransientInput()`** method of the
+{{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRTransientInputHitTestSource")}} object that can be used to obtain hit test results using the {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method.
+
+## Syntax
+
+```js
+requestHitTestSourceForTransientInput(options);
+```
+
+### Parameters
+
+- `options`
+  - : An object containing configuration options, specifically:
+    - `profile`: A string specifying the [input profile name](/en-US/docs/Web/API/XRInputSource) of the transient input source that will be used to compute hit test results.
+    - `entityTypes`: {{optional_inline}} An {{jsxref("Array")}} specifying the types of entities that should be used for the purposes of hit test source creation. If no no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
+      - `point`: Compute hit test results based on characteristic points detected.
+      - `plane`: Compute hit test results based on real-world planes detected.
+      - `mesh`: Compute hit test results based on meshes detected.
+    - `offsetRay`: {{optional_inline}} The {{domxref("XRRay")}} object that will be used to perform hit test. If no `XRRay` object has been provided, a new `XRRay` object is constructed without any parameters.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an {{domxref("XRTransientInputHitTestSource")}} object.
+
+### Exceptions
+
+Rather than throwing true exceptions, `requestHitTestSourceForTransientInput()` rejects the
+returned promise with a {{domxref("DOMException")}}, specifically, one of the following:
+
+- `NotSupportedError`
+  - : If `hit-test` is not an enabled feature in {{domxref("XRSystem.requestSession()")}}.
+- `InvalidStateError`
+  - : If the session has already ended.
+- `NotAllowedError`
+  - : If there is an unreasonable amount of requests (some user agents might limit usage due to privacy reasons).
+
+## Examples
+
+### Requesting a transient hit test source
+
+To request a hit test source, make sure to start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Then you can configure the hit test source and store it for later use in the frame loop where you can use the {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method to obtain the hit test result.
+
+```js
+
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let transientHitTestSource = null;
+
+xrSession.requestHitTestSourceForTransientInput({
+  space : "generic-touchscreen",
+  offsetRay : new XRRay()
+}).then((touchScreenHitTestSource) => {
+  transientHitTestSource = touchScreenHitTestSource;
+});
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  // do things with the transient hit test results
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.requestHitTestSource()")}}

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -99,6 +99,8 @@ following:
   - : Enable the ability to obtain depth information using {{domxref("XRDepthInformation")}} objects.
 - `dom-overlay`
   - : Enable allowing to specify a DOM overlay element that will be displayed to the user.
+- `hit-test`
+  - : Enable hit testing features for performing hit tests against real world geometry.
 - `light-estimation`
   - : Enable the ability to estimate environmental lighting conditions using {{domxref("XRLightEstimate")}} objects.
 - `local`
@@ -120,6 +122,7 @@ Each reference space or feature type has minimum safety requirements. By session
 | --------------- | ----------------------------------- | -------------------------- |
 | `bounded-floor` | Always required                     | `xr-spatial-tracking`      |
 | `depth-sensing` | —                                   | `xr-spatial-tracking`      |
+| `hit-test`      | —                                   | `xr-spatial-tracking`      |
 | `local`         | Always required for inline sessions | `xr-spatial-tracking`      |
 | `local-floor`   | Always required                     | `xr-spatial-tracking`      |
 | `unbounded`     | Always required                     | `xr-spatial-tracking`      |


### PR DESCRIPTION
This talks about Hit testing initialization and adds reference pages for `XRSession.requestHitTestSource()` and `XRSession.requestHitTestSourceForTransientInput()`. 

Spec: https://immersive-web.github.io/hit-test