### PR TITLE
Add Crypto.randomUUID page

### DIFF
--- a/files/en-us/web/api/crypto/randomuuid/index.html
+++ b/files/en-us/web/api/crypto/randomuuid/index.html
@@ -10,6 +10,7 @@ tags:
 - UUID
 - Web Crypto API
 - randomUUID
+browser-compat: api.Crypto.randomUUID
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
 
@@ -34,7 +35,13 @@ let uuid = self.crypto.randomUUID();
 console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 </pre>
 
-<!-- TODO(lucacasonato): Add "Specifications" and "Compat" tables when https://github.com/mdn/browser-compat-data/pull/12048 is released. -->
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility_2">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/crypto/randomuuid/index.html
+++ b/files/en-us/web/api/crypto/randomuuid/index.html
@@ -39,7 +39,7 @@ console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 
 <p>{{Specifications}}</p>
 
-<h2 id="Browser_compatibility_2">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/crypto/randomuuid/index.html
+++ b/files/en-us/web/api/crypto/randomuuid/index.html
@@ -10,18 +10,17 @@ tags:
 - UUID
 - Web Crypto API
 - randomUUID
-browser-compat: api.Crypto.randomUUID
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
 
-<p>The <code><strong>Crypto.randomUUID()</strong></code> method lets you generate
-  a V4 UUID using a cryptographically secure random number generator, like is
-  used for {{domxref("Crypto.getRandomValues", "getRandomValues()")}}.</p>
+<p><p>The <code><strong>randomUUID()</strong></code> method of the {{domxref("Crypto")}}
+  interface lets you generate a v4 UUID using a cryptographically secure random
+  number generator, like is used for
+  {{domxref("Crypto.getRandomValues", "getRandomValues()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>uuid</var> = <var>crypto</var>.randomUUID();</pre>
+<pre class="brush: js">crypto.randomUUID();</pre>
 
 <h3 id="Return_value">Return value</h3>
 
@@ -29,9 +28,9 @@ browser-compat: api.Crypto.randomUUID
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">/* Assuming that self.crypto.randomUUID is available */
+<pre class="brush: js">/* Assuming that self.crypto.randomUUID() is available */
 
-let uuid = self.crypto.getRandomValues();
+let uuid = self.crypto.randomUUID();
 console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 </pre>
 
@@ -40,7 +39,7 @@ console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a></li>
+  <li>{{ domxref("Web Crypto API") }}</li>
   <li>{{ domxref("Window.crypto") }} to get a {{domxref("Crypto")}} object.</li>
   <li>{{ domxref("Crypto.getRandomValues") }}, a source for arbitrary amounts of secure random bytes.</li>
 </ul>

--- a/files/en-us/web/api/crypto/randomuuid/index.html
+++ b/files/en-us/web/api/crypto/randomuuid/index.html
@@ -1,0 +1,46 @@
+---
+title: Crypto.randomUUID()
+slug: Web/API/Crypto/randomUUID
+tags:
+- API
+- Crypto
+- Method
+- Pseudorandom
+- Reference
+- UUID
+- Web Crypto API
+- randomUUID
+browser-compat: api.Crypto.randomUUID
+---
+<p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
+
+<p>The <code><strong>Crypto.randomUUID()</strong></code> lets you generate a V4 UUID
+  using a cryptographically secure random number generator, like is used for 
+  {{domxref("Crypto.getRandomValues", "getRandomValues()")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre
+  class="brush: js"><var>uuid</var> = <var>crypto</var>.randomUUID();</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>A randomly generated, 36 character long v4 UUID.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">/* Assuming that self.crypto.randomUUID is available */
+
+let uuid = self.crypto.getRandomValues();
+console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
+</pre>
+
+<!-- TODO(lucacasonato): Add "Specifications" and "Compat" tables when https://github.com/mdn/browser-compat-data/pull/12048 is released. -->
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a></li>
+  <li>{{ domxref("Window.crypto") }} to get a {{domxref("Crypto")}} object.</li>
+  <li>{{ domxref("Crypto.getRandomValues") }}, a source for arbitrary amounts of secure random bytes.</li>
+</ul>

--- a/files/en-us/web/api/crypto/randomuuid/index.html
+++ b/files/en-us/web/api/crypto/randomuuid/index.html
@@ -14,9 +14,9 @@ browser-compat: api.Crypto.randomUUID
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
 
-<p>The <code><strong>Crypto.randomUUID()</strong></code> lets you generate a V4 UUID
-  using a cryptographically secure random number generator, like is used for 
-  {{domxref("Crypto.getRandomValues", "getRandomValues()")}}.</p>
+<p>The <code><strong>Crypto.randomUUID()</strong></code> method lets you generate
+  a V4 UUID using a cryptographically secure random number generator, like is
+  used for {{domxref("Crypto.getRandomValues", "getRandomValues()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
This adds a page for the new Crypto.randomUUID API, proposed in this
spec: https://wicg.github.io/uuid.

It is shipped in Chrome 92, Deno 1.11 and Node 16.7.0.
