### PR TITLE
Add to nuance between isNaN and Number.isNaN

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -55,7 +55,7 @@ isNaN('hello world');        // true
 Number.isNaN('hello world'); // false
 ```
 
-For the same reason using a `bigint` value will throw an error with `isNaN()` and not with `Number.isNaN():
+For the same reason, using a `bigint` value will throw an error with `isNaN()` and not with `Number.isNaN():
 
 ```js
 isNaN(1n);        // TypeError: Conversion from 'BigInt' to 'number' is not allowed.

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -55,6 +55,13 @@ isNaN('hello world');        // true
 Number.isNaN('hello world'); // false
 ```
 
+For the same reason using a `bigint` value will throw an error with `isNaN()` and not with `Number.isNaN():
+
+```js
+isNaN(1n);        // TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+Number.isNaN(1n); // false
+```
+
 Additionally, some array methods cannot find `NaN`, while others can.
 
 ```js


### PR DESCRIPTION
Using a `bigint` value will throw an error with `isNaN()` and not with `Number.isNaN()
