### PR TITLE
Align AudioScheduledSourceNode»start() params with spec

### DIFF
--- a/files/en-us/web/api/audioscheduledsourcenode/start/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/start/index.html
@@ -25,7 +25,9 @@ browser-compat: api.AudioScheduledSourceNode.start
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>AudioScheduledSourceNode</em>.start([<em>when</em> [, offset [, duration]]]);
+<pre class="brush: js">
+start()
+start(when)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -37,14 +39,6 @@ browser-compat: api.AudioScheduledSourceNode.start
     using for its {{domxref("BaseAudioContext/currentTime", "currentTime")}} attribute. A
     value of 0 (or omitting the <code>when</code> parameter entirely) causes the sound to
     start playback immediately.</dd>
-  <dt><code>offset</code> {{optional_inline}}</dt>
-  <dd>A floating-point number indicating the offset, in seconds, into the audio buffer
-    where playback should begin. If 0 is passed then the playback will start from the
-    beginning.</dd>
-  <dt><code>duration</code> {{optional_inline}}</dt>
-  <dd>A floating-point number indicating the duration, in seconds, to be played. If no
-    value is passed then the duration will be equal to the length of the audio buffer
-    minus the offset value</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/audioscheduledsourcenode/stop/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/stop/index.html
@@ -30,7 +30,9 @@ browser-compat: api.AudioScheduledSourceNode.stop
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>AudioScheduledSourceNode</em>.stop([<em>when</em>]);
+<pre class="brush: js">
+stop()
+stop(when)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>


### PR DESCRIPTION
This change aligns the `AudioScheduledSourceNode»start()` article’s Syntax and Parameters sections with the current spec. Fixes https://github.com/mdn/content/issues/8061.

The change also updates the `AudioScheduledSourceNode»stop()` article’s Syntax section to follow current MDN practice.