### PR TITLE
Correct navigator.credentials.store to match implementations and spec

### DIFF
--- a/files/en-us/web/api/credentialscontainer/store/index.html
+++ b/files/en-us/web/api/credentialscontainer/store/index.html
@@ -36,7 +36,7 @@ browser-compat: api.CredentialsContainer.store
 
 <h3 id="Returns">Returns</h3>
 
-<p>A {{jsxref("Promise")}}, resolving to the passed {{domxref("Credential")}} instance.
+<p>A {{jsxref("Promise")}} that resolves to <code>undefined</code>.
 </p>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
Documentation currently states `navigator.credentials.store(credential)` returns a Promise that resolves with `credential`, but it actually resolves with `undefined`.

Implementations match the spec:
> When store() is called, the user agent MUST return the result of executing Store a Credential on credential.
> ... The Store a Credential algorithm accepts a Credential (credential), and returns a Promise which resolves once the object is persisted to the credential store

The Promise resolves with 
> ... the result of executing credential’s interface object's [[Store]](credential, sameOriginWithAncestors) 

and
> Credential's default implementation of [[Store]](credential, sameOriginWithAncestors):
> Return undefined.


References:
- https://w3c.github.io/webappsec-credential-management/#abstract-opdef-store-a-credential
- https://w3c.github.io/webappsec-credential-management/#dom-credential-store-slot
