### PR TITLE
run pr-test CI on main branch too

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,6 +7,15 @@
 name: PR Test
 
 on:
+  # The reason for building once it's pushed to `main`, too, is an
+  # optimization. This way, when workflow is built on the `main` branch
+  # anything that's stored in the cache (e.g. node_modules) can be
+  # re-used by consecutive PRs in other branches.
+  # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  # and https://github.community/t/how-come-the-actions-cache-is-failing-so-much-often/196279/3
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
See https://github.community/t/how-come-the-actions-cache-is-failing-so-much-often/196279/3
The objective is to speed up PR CI by making sure that the cache is more often hot for PRs. PRs, won't be able to access the cache (e.g. `node_modules`) unless it was stored when built on the default branch (`main`). 