### PR TITLE
Use extension .md for a markdown file

### DIFF
--- a/files/en-us/web/api/hidinputreportevent/data/index.md
+++ b/files/en-us/web/api/hidinputreportevent/data/index.md
@@ -30,5 +30,3 @@ A {{domxref("DataView")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-


### PR DESCRIPTION
This makes the markdown syntax display the content properly.