### PR TITLE
Fix error in offline PWA cache clearing example

### DIFF
--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -182,7 +182,7 @@ self.addEventListener('install', (e) =&gt; {
       if (key === cacheName) { return; }
       caches.delete(key);
     }))
-  })());
+  }));
 });</pre>
 
 <p>This ensures we have only the files we need in the cache, so we don't leave any garbage behind; the <a href="/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria">available cache space in the browser is limited</a>, so it is a good idea to clean up after ourselves.</p>


### PR DESCRIPTION
The code worked, but there was an extraneous function call resulting in it throwing the error `caches.keys().then()... is not a function` afterwards.