### PR TITLE
Add experimental banner/flag to Object.hasOwn()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -6,9 +6,10 @@ tags:
   - Method
   - Object
   - hasOwn
+  - Experimental
 browser-compat: javascript.builtins.Object.hasOwn
 ---
-{{JSRef}}
+{{JSRef}}{{SeeCompatTable}}
 
 The **`Object.hasOwn()`** static method returns `true` if the specified object has the indicated property as its _own_ property.
 If the property is inherited, or does not exist, the method returns `false`.


### PR DESCRIPTION
Fixes #8086 

Even if this may change quickly, only one browser supports this feature, in its preview version; it is still experimental, even if the spec is likely pretty stable.