### PR TITLE
Drop outdated/404 links from “JavaScript shells” doc

### DIFF
--- a/files/en-us/web/javascript/shells/index.md
+++ b/files/en-us/web/javascript/shells/index.md
@@ -15,11 +15,8 @@ A JavaScript shell allows you to quickly test snippets of [JavaScript](/en-US/do
 
 The following JavaScript shells are stand-alone environments, like Perl or Python.
 
-- [Node.js](http://nodejs.org/) - Node.js is a platform for easily building fast, scalable network applications.
+- [Node.js](https://nodejs.org/) - Node.js is a platform for easily building fast, scalable network applications.
 - [GraalJS](https://www.graalvm.org/) - A high performance implementation of the JavaScript programming language. Built on the GraalVM by Oracle Labs.
-- [JSDB](http://www.jsdb.org/) - A standalone JavaScript shell, with compiled binaries for Windows, Mac, and Linux.
-- [JavaLikeScript](http://javalikescript.free.fr/) - A standalone, extensible JavaScript shell including both native and JavaScript libraries.
-- [GLUEscript](http://gluescript.sourceforge.net/) - A standalone JavaScript shell for writing cross-platform JavaScript applications.  It can use wxWidgets for GUI apps and was formerly called wxJavaScript.
 - [ShellJS](https://documentup.com/shelljs/shelljs) - Portable Unix shell commands for Node.js
 
 ## List of JavaScript shells
@@ -27,8 +24,7 @@ The following JavaScript shells are stand-alone environments, like Perl or Pytho
 The following JavaScript shells work with Mozilla.
 
 - Firefox has a [built-in JavaScript console](/en-US/docs/Tools/Web_Console/The_command_line_interpreter), which support multi-line editing.
-- [JavaScript Shell](/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell) (`js`) - A command line interpreter for JavaScript
-- [Babel REPL](http://babeljs.io/repl) - A browser-based [REPL](https://en.wikipedia.org/wiki/REPL) for experimenting with future JavaScript.
-- [ES6Console.com](http://es6console.com) - An open-source JavaScript console to test ECMAScript 2015 code inside the browser.
-- [jsconsole.com](http://jsconsole.com/) -- An open-source JavaScript console with the ability to easily link to particular expressions
-- [JavaScript Shell (web page)](http://www.squarefree.com/shell/) - also available as part of the [Extension Developer's Extension](https://addons.mozilla.org/en-US/firefox/addon/7434)
+- [Babel REPL](https://babeljs.io/repl) - A browser-based [REPL](https://en.wikipedia.org/wiki/REPL) for experimenting with future JavaScript.
+- [ES6Console.com](https://es6console.com) - An open-source JavaScript console to test ECMAScript 2015 code inside the browser.
+- [jsconsole.com](https://jsconsole.com/) -- An open-source JavaScript console with the ability to easily link to particular expressions
+- [JavaScript Shell (web page)](https://www.squarefree.com/shell/) - also available as part of the [Extension Developer's Extension](https://addons.mozilla.org/en-US/firefox/addon/7434)


### PR DESCRIPTION
This change drops a number of links in the “JavaScript shells” doc that are now 404 or are outdated/irrelevant to the degree that we don’t want to be pointing developers to them any longer.

The change also updates a few http URLs to https. Fixes https://github.com/mdn/content/issues/8085.