### PR TITLE
Add WebXR Hit Test reference docs - pt2

### DIFF
--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -1,0 +1,49 @@
+---
+title: XRHitTestSource.cancel()
+slug: Web/API/XRHitTestSource/cancel
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - VR
+  - XR
+  - WebXR
+browser-compat: api.XRHitTestSource.cancel
+---
+{{APIRef("WebXR Device API")}}
+
+The **`cancel()`** method of the {{domxref("XRHitTestSource")}} interface unsubscribes a hit test.
+
+## Syntax
+
+```js
+cancel()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+Returns {{jsxref("undefined")}}.
+
+## Examples
+
+### Unsubscribe from hit test
+
+The `cancel` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+
+```js
+hitTestSource.cancel();
+hitTestSource = null;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -33,7 +33,7 @@ Returns {{jsxref("undefined")}}.
 
 ### Unsubscribe from hit test
 
-The `cancel` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+The `cancel()` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRHitTestSource
 
 The **`XRHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles hit test subscriptions. You can get an `XRHitTestSource` object by using the {{domxref("XRSession.requestHitTestSource()")}} method.
 
-This object doesn't itself contain hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} using {{domxref("XRFrame.getHitTestResults()")}} method which returns {{domxref("XRHitTestResult")}} objects.
+This object doesn't itself contain hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} by calling {{domxref("XRFrame.getHitTestResults()")}}, which returns {{domxref("XRHitTestResult")}} objects.
 
 ## Properties
 
@@ -30,7 +30,7 @@ None.
 
 ### Getting an `XRHitTestSource` object for a session
 
-Use the {{domxref("XRSession.requestHitTestSource()")}} method to get a hit test source.
+Call {{domxref("XRSession.requestHitTestSource()")}} to get a hit test source.
 
 ```js
 const xrSession = navigator.xr.requestSession("immersive-ar", {
@@ -56,7 +56,7 @@ function onXRFrame(time, xrFrame) {
 
 ### Unsubscribe from hit test
 
-To unsubscribe from a hit test source, use the {{domxref("XRHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to {{jsxref("null")}}.
+To unsubscribe from a hit test source, call {{domxref("XRHitTestSource.cancel()")}}. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to {{jsxref("null")}}.
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -1,0 +1,76 @@
+---
+title: XRHitTestSource
+slug: Web/API/XRHitTestSource
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRHitTestSource
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles hit test subscriptions. You can get an `XRHitTestSource` object by using the {{domxref("XRSession.requestHitTestSource()")}} method.
+
+This object doesn't itself contain hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} using {{domxref("XRFrame.getHitTestResults()")}} method which returns {{domxref("XRHitTestResult")}} objects.
+
+## Properties
+
+None.
+
+## Methods
+
+- {{domxref("XRHitTestSource.cancel()")}}
+  - : Unsubscribes from the hit test.
+
+## Examples
+
+### Getting an `XRHitTestSource` object for a session
+
+Use the {{domxref("XRSession.requestHitTestSource()")}} method to get a hit test source.
+
+```js
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let hitTestSource = null;
+
+xrSession.requestHitTestSource({
+  space : viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
+  offsetRay : new XRRay({y: 0.5})
+}).then((viewerHitTestSource) => {
+  hitTestSource = viewerHitTestSource;
+});
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+
+  // do things with the hit test results
+}
+```
+
+### Unsubscribe from hit test
+
+To unsubscribe from a hit test source, use the {{domxref("XRHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to {{jsxref("null")}}.
+
+```js
+hitTestSource.cancel();
+hitTestSource = null;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRTransientInputHitTestSource")}}

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -1,0 +1,49 @@
+---
+title: XRTransientInputHitTestSource.cancel()
+slug: Web/API/XRTransientInputHitTestSource/cancel
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - VR
+  - XR
+  - WebXR
+browser-compat: api.XRTransientInputHitTestSource.cancel
+---
+{{APIRef("WebXR Device API")}}
+
+The **`cancel()`** method of the {{domxref("XRTransientInputHitTestSource")}} interface unsubscribes a transient input hit test.
+
+## Syntax
+
+```js
+cancel()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+Returns {{jsxref("undefined")}}.
+
+## Examples
+
+### Unsubscribe from hit test
+
+The `cancel` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+
+```js
+transientHitTestSource.cancel();
+transientHitTestSource = null;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -33,7 +33,7 @@ Returns {{jsxref("undefined")}}.
 
 ### Unsubscribe from hit test
 
-The `cancel` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+The `cancel()` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
 
 ```js
 transientHitTestSource.cancel();

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -1,0 +1,76 @@
+---
+title: XRTransientInputHitTestSource
+slug: Web/API/XRTransientInputHitTestSource
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRTransientInputHitTestSource
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRTransientInputHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles transient input hit test subscriptions. You can get an `XRTransientInputHitTestSource` object by using the {{domxref("XRSession.requestHitTestSourceForTransientInput()")}} method.
+
+This object doesn't itself contain transient input hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} using {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method which returns {{domxref("XRTransientInputHitTestResult")}} objects.
+
+## Properties
+
+None.
+
+## Methods
+
+- {{domxref("XRTransientInputHitTestSource.cancel()")}}
+  - : Unsubscribes from the transient input hit test.
+
+## Examples
+
+### Getting an `XRTransientInputHitTestSource` object for a session
+
+Use the {{domxref("XRSession.requestHitTestSourceForTransientInput()")}} method to get a transient input hit test source.
+
+```js
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let transientHitTestSource = null;
+
+xrSession.requestHitTestSourceForTransientInput({
+  space : "generic-touchscreen",
+  offsetRay : new XRRay()
+}).then((touchScreenHitTestSource) => {
+  transientHitTestSource = touchScreenHitTestSource;
+});
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  // do things with the transient hit test results
+}
+```
+
+### Unsubscribe from a transient input hit test
+
+To unsubscribe from a transient input hit test source, use the {{domxref("XRTransientInputHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRTransientInputHitTestSource` object to {{jsxref("null")}}.
+
+```js
+transientHitTestSource.cancel();
+transientHitTestSource = null;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRTransientInputHitTestResult")}}

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -13,9 +13,9 @@ browser-compat: api.XRTransientInputHitTestSource
 ---
 {{APIRef("WebXR Device API")}} {{secureContext_header}}
 
-The **`XRTransientInputHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles transient input hit test subscriptions. You can get an `XRTransientInputHitTestSource` object by using the {{domxref("XRSession.requestHitTestSourceForTransientInput()")}} method.
+The **`XRTransientInputHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles transient input hit test subscriptions. You can get an `XRTransientInputHitTestSource` object by calling the {{domxref("XRSession.requestHitTestSourceForTransientInput()")}}.
 
-This object doesn't itself contain transient input hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} using {{domxref("XRFrame.getHitTestResultsForTransientInput()")}} method which returns {{domxref("XRTransientInputHitTestResult")}} objects.
+This object doesn't itself contain transient input hit test results, but it is used to compute hit tests for each {{domxref("XRFrame")}} by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}, which returns {{domxref("XRTransientInputHitTestResult")}} objects.
 
 ## Properties
 


### PR DESCRIPTION
This second part adds reference pages for `XRHitTestSource` and `XRTransientInputHitTestSource` and the `cancel` method on both interfaces.

Spec: https://immersive-web.github.io/hit-test/#hit-test-source