### PR TITLE
it's Quick_links not Quick_Links

### DIFF
--- a/files/en-us/mdn/structures/quicklinks/index.html
+++ b/files/en-us/mdn/structures/quicklinks/index.html
@@ -12,9 +12,9 @@ tags:
 
 <h2 id="Quicklinks_syntax">Quicklinks syntax</h2>
 
-<p>The quicklinks for a page are provided by creating a {{HTMLElement("section")}} block with the ID "Quick_Links". Then you place the contents that go into the quicklinks box within the section. These should be formatted as an {{HTMLElement("ol")}} ordered list (optionally nested). You can do this by using the numbered list button in the editor toolbar. For example, your quicklinks HTML might look like this:</p>
+<p>The quicklinks for a page are provided by creating a {{HTMLElement("section")}} block with the ID "Quick_links". Then you place the contents that go into the quicklinks box within the section. These should be formatted as an {{HTMLElement("ol")}} ordered list (optionally nested). You can do this by using the numbered list button in the editor toolbar. For example, your quicklinks HTML might look like this:</p>
 
-<pre class="brush: html">&lt;section id="Quick_Links"&gt;
+<pre class="brush: html">&lt;section id="Quick_links"&gt;
   &lt;ol&gt;
     &lt;li&gt;&lt;a href="http://docs.ckeditor.com/"&gt;CKEditor documentation site&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="http://mxr.mozilla.org/"&gt;MXR: Mozilla source cross-reference&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none.

> What was wrong/why is this fix needed? (quick summary only)

Yari expects and looks for a `$('#Quick_links')` to extra a sidebar, not `$('#Quick_Links')` (where `$` is Node `cheerio`)

