### PR TITLE
Add WebXR Hit Test reference docs - pt 3

### DIFF
--- a/files/en-us/web/api/xrframe/gethittestresults/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresults/index.md
@@ -1,0 +1,68 @@
+---
+title: XRFrame.getHitTestResults()
+slug: Web/API/XRFrame/getHitTestResults
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - XR
+  - WebXR
+browser-compat: api.XRFrame.getHitTestResults
+---
+{{APIRef("WebXR Device API")}}
+
+The **`getHitTestResults()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRHitResult")}} objects containing hit test results for a given {{domxref("XRHitTestSource")}}.
+
+## Syntax
+
+```js
+getHitTestResults(hitTestSource)
+```
+
+### Parameters
+
+- `hitTestSource`
+  - : An {{domxref("XRHitTestSource")}} object that contains hit test subscriptions.
+
+### Return value
+
+An array of {{domxref("XRHitResult")}} objects.
+
+## Examples
+
+### Getting hit test results
+
+To request a hit test source, start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Next, request a the hit test source with {{domxref("XRSession.requestHitTestSource()")}} and store it for later use in the frame loop. Finally, call `getHitTestResults()` to obtain the result.
+
+ ```js
+ const xrSession = navigator.xr.requestSession("immersive-ar", {
+    requiredFeatures: ["local", "hit-test"]
+ });
+ let hitTestSource = null;
+ xrSession.requestHitTestSource({
+   space : viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
+   offsetRay : new XRRay({y: 0.5})
+ }).then((viewerHitTestSource) => {
+   hitTestSource = viewerHitTestSource;
+ });
+ // frame loop
+ function onXRFrame(time, xrFrame) {
+   let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+   // do things with the hit test results
+ }
+ ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRHitTestResult")}}
+- {{domxref("XRHitTestSource")}}
+- {{domxref("XRRay")}}

--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -1,0 +1,70 @@
+---
+title: XRFrame.getHitTestResultsForTransientInput()
+slug: Web/API/XRFrame/getHitTestResultsForTransientInput
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - XR
+  - WebXR
+browser-compat: api.XRFrame.getHitTestResultsForTransientInput
+---
+{{APIRef("WebXR Device API")}}
+
+The **`getHitTestResultsForTransientInput()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRTransientInputHitResult")}} objects containing transient input hit test results for a given {{domxref("XRTransientInputHitTestSource")}}.
+
+## Syntax
+
+```js
+getHitTestResultsForTransientInput(hitTestSource)
+```
+
+### Parameters
+
+- `hitTestSource`
+  - : An {{domxref("XRTransientInputHitTestSource")}} object that contains transient input hit test subscriptions.
+
+### Return value
+
+An array of {{domxref("XRTransientInputHitResult")}} objects.
+
+## Examples
+
+### Getting transient input hit test results
+
+ To request a transient input hit test source, start an {{domxref("XRSession")}} with the `hit-test` session feature enabled. Next, request the hit test source with {{domxref("XRSession.requestHitTestSourceForTransientInput()")}} and store it for later use in the frame loop. Finally, call `getHitTestResultsForTransientInput()` to obtain the result.
+
+ ```js
+ const xrSession = navigator.xr.requestSession("immersive-ar", {
+    requiredFeatures: ["local", "hit-test"]
+ });
+
+ let transientHitTestSource = null;
+ xrSession.requestHitTestSourceForTransientInput({
+   space : "generic-touchscreen",
+   offsetRay : new XRRay()
+ }).then((touchScreenHitTestSource) => {
+   transientHitTestSource = touchScreenHitTestSource;
+ });
+
+ // frame loop
+ function onXRFrame(time, xrFrame) {
+   let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+   // do things with the transient hit test results
+ }
+ ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRTransientInputHitResult")}}
+- {{domxref("XRTransientInputHitTestSource")}}
+- {{domxref("XRRay")}}

--- a/files/en-us/web/api/xrframe/index.md
+++ b/files/en-us/web/api/xrframe/index.md
@@ -37,6 +37,10 @@ In addition to providing a reference to the {{domxref("XRSession")}} for which t
   - : Returns a {{jsxref("Promise")}} which resolves to a free-floating {{domxref("XRAnchor")}} object.
 - {{domxref("XRFrame.getDepthInformation()", "getDepthInformation()")}}
   - : Returns an {{domxref("XRCPUDepthInformation")}} object containing CPU depth information for the frame.
+- {{domxref("XRFrame.getHitTestResults()", "getHitTestResults()")}}
+  - : Returns an array of {{domxref("XRHitResult")}} objects containing hit test results for a given {{domxref("XRHitTestSource")}}.
+- {{domxref("XRFrame.getHitTestResultsForTransientInput()", "getHitTestResultsForTransientInput()")}}
+  - : Returns an array of {{domxref("XRTransientInputHitTestResult")}} objects containing hit test results for a given {{domxref("XRTransientInputHitTestSource")}}.
 - {{domxref("XRFrame.getLightEstimate()", "getLightEstimate()")}}
   - : Returns an {{domxref("XRLightEstimate")}} object containing estimated lighting values for an {{domxref("XRLightProbe")}}.
 - {{DOMxRef("XRFrame.getPose", "getPose()")}}


### PR DESCRIPTION
Part 3 adds reference pages for `XRFrame.getHitTestResults()` and `XRFrame.getHitTestResultsForTransientInput()`

https://immersive-web.github.io/hit-test/#obtaining-hit-test-results