### PR TITLE
Fix sectioning error in KeyframeEffect.setKeyframes()

### DIFF
--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
@@ -27,7 +27,7 @@ browser-compat: api.KeyframeEffect.setKeyframes
  <dt>keyframes</dt>
  <dd>A keyframe object or <code>null</code>. If set to <code>null</code>, the keyframes are replaced with a sequence of empty keyframes.<br>
  <br>
- {{Page("/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats", "Syntax")}}</dd>
+ More information about a keyframe object's <a href="/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats#syntax">format</a>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>


### PR DESCRIPTION
The `{{page}}` macro on that page was:
1. generating a long transclusion
2. breaking the page by creating a sectioning flaw when transcluding an `<h3>`.

This PR fixes it by linking to the other article rather than including it.