### PR TITLE
Remove unmatched <span> tag that breaks the page

### DIFF
--- a/files/en-us/web/api/ndefrecord/encoding/index.html
+++ b/files/en-us/web/api/ndefrecord/encoding/index.html
@@ -2,16 +2,16 @@
 title: NDEFRecord.encoding
 slug: Web/API/NDEFRecord/encoding
 tags:
-- Encoding
-- NDEF
-- Reference
-- Web NFC
+  - Encoding
+  - NDEF
+  - Reference
+  - Web NFC
 browser-compat: api.NDEFRecord.encoding
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
-<span class="seoSummary">The <strong><code>encoding</code></strong>
+<div>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</div>
+<p>The <strong><code>encoding</code></strong>
     property of the {{DOMxRef("NDEFRecord")}} interface returns the encoding of
-    a textual payload, or <code>null</code> otherwise.
+    a textual payload, or <code>null</code> otherwise.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
A useless `<span>` without a closing tag was preventing spec and bcd tables to appear, and was creating a sectioning flaw.

This fixes it.
