### PR TITLE
Fix sectioning flaw by removing useless div

### DIFF
--- a/files/en-us/web/guide/html/editable_content/rich-text_editing_in_mozilla/index.html
+++ b/files/en-us/web/guide/html/editable_content/rich-text_editing_in_mozilla/index.html
@@ -279,7 +279,6 @@ img.intLink { border: 0; }
  <li><a href="http://starkravingfinkle.org/blog/2007/07/firefox-3-contenteditable/">Firefox 3 and contentEditable</a></li>
 </ul>
 
-<div class="originaldocinfo">
 <h3 id="Original_Document_Information">Original Document Information</h3>
 
 <ul>
@@ -290,4 +289,3 @@ img.intLink { border: 0; }
  <li>Revised: 28 Nov 2006, <a class="link-mailto" href="mailto:kkuhns@ComputronicsUSA.com">Ken Kuhns</a>, <a href="http://www.ComputronicsUSA.com">ComputronicsUSA</a></li>
  <li>Revised: 19 Dec 2007, Mark Finkle</li>
 </ul>
-</div>


### PR DESCRIPTION
A `<div>` was used to put a special class over an `<h3>`section. The class is useless and this was creating a sectioning flaw puzzling React.

This fixes it.