### PR TITLE
Replace duplicate ID in Fx Experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -549,7 +549,7 @@ tags:
 
 <h2 id="SVG">SVG</h2>
 
-<h3 id="Property_math-style">Presentation attribute: d</h3>
+<h3 id="Presentation_attribute">Presentation attribute: d</h3>
 
 <p>The SVG {{SVGAttr('d')}} attribute, used to define a path to be drawn, is now a <a href="/en-US/docs/Web/SVG/Attribute/Presentation#attr-d">presentation attribute</a>. It can be used as a property in CSS and accepts the values <a href="/en-US/docs/Web/CSS/path()">path()</a> or <code>none</code>. (See {{bug(1340422)}} for more details.)</p>
 


### PR DESCRIPTION
Fixes a sectioning flaw: we should never have duplicate IDs.