### PR TITLE
Web Storage API only has 2 mechanism

### DIFF
--- a/files/en-us/web/api/web_storage_api/index.html
+++ b/files/en-us/web/api/web_storage_api/index.html
@@ -30,7 +30,7 @@ tags:
  <li><code>localStorage</code> does the same thing, but persists even when the browser is closed and reopened.
   <ul>
    <li>Stores data with no expiration date, and gets cleared only through JavaScript, or clearing the Browser cache / Locally Stored Data.</li>
-   <li>Storage limit is the maximum amongst the three.</li>
+   <li>Storage limit is the maximum amongst the two.</li>
   </ul>
  </li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

n/a

> What was wrong/why is this fix needed? (quick summary only)

Currently, web storage only has 2 mechanisms (sessionStorage and localStorage), but documentation says that there are 3. 

> Anything else that could help us review it
