### PR TITLE
Clarify “How the Web works” section describing parse order

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -70,16 +70,13 @@ tags:
 
 <h2 id="Order_in_which_component_files_are_parsed">Order in which component files are parsed</h2>
 
-<p>Once the client’s request is approved, the server first sends back the HTML (index) file — index.html is commonly named as such, as it is the first file of a website to be parsed by the server.</p>
-
-<p>The HTML file can reference <a href="/en-US/docs/Learn/CSS">CSS</a> and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a>, either in external files via <code>&lt;link&gt;</code> and <code>&lt;script&gt;</code> elements respectively, or embedded in the HTML page via <code>&lt;style&gt;</code> and <code>&lt;script&gt;</code> elements.</p>
-
-<p>From a server standpoint it is important to know the order in which these files are parsed when the response is sent back:</p>
+<p>When browsers send requests to servers for HTML files, those HTML files often contain {{htmlelement("link")}} elements referencing external <a href="/en-US/docs/Learn/CSS">CSS</a> stylesheets and {{htmlelement("script")}} elements referencing external <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> scripts. It’s important to know the order in which those files are <a href="/en-US/docs/Web/Performance/How_browsers_work#parsing">parsed by the browser</a> as the browser loads the page:</p>
 
 <ul>
-  <li>The HTML file is parsed first and, by looking inside that file, the server recognises which CSS and JavaScript files are referenced.</li>
-  <li>After the HTML has been parsed and a DOM tree structure has been generated from it, the linked CSS is then parsed, and styles are applied to the appropriate parts of the DOM tree. At this point, the visual representation of the page is painted to the screen, and the user sees the page.</li>
-  <li>The JavaScript usually gets parsed and applied to the page after the HTML and CSS.</li>
+  <li>The browser parses the HTML file first, and that leads to the browser recognizing any <code>&lt;link&gt;</code>-element references to external CSS stylesheets and any <code>&lt;script&gt;</code>-element references to scripts.</li>
+  <li>As the browser parses the HTML, it sends requests back to the server for any CSS files it has found from <code>&lt;link&gt;</code> elements, and any JavaScript files it has found from <code>&lt;script&gt;</code> elements, and from those, then parses the CSS and JavaScript.</li>
+  <li>The browser generates an in-memory <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> tree from the parsed HTML, generates an in-memory <a href="/en-US/docs/Glossary/CSSOM">CSSOM</a> structure from the parsed CSS, and <a href="/en-US/docs/Web/Performance/How_browsers_work#javascript_compilation">complies and executes</a> the parsed JavaScript</a>.</li>
+  <li>As the browser builds the DOM tree and applies the styles from the CSSOM tree and executes the JavaScript, a visual representation of the page is painted to the screen, and the user sees the page content and can begin to interact with it.</li>
 </ul>
 
 <h2 id="DNS_explained">DNS explained</h2>


### PR DESCRIPTION
The existing “Order in which component files are parsed” section of the “How the Web works” article had a confused description that didn’t align with how things actually work. This change corrects it.

Fixes https://github.com/mdn/content/issues/8096