### PR TITLE
Delete useless generated Web/API/Index

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7865,6 +7865,7 @@
 /en-US/docs/Web/API/ImageData.data	/en-US/docs/Web/API/ImageData/data
 /en-US/docs/Web/API/ImageData.height	/en-US/docs/Web/API/ImageData/height
 /en-US/docs/Web/API/ImageData.width	/en-US/docs/Web/API/ImageData/width
+/en-US/docs/Web/API/Index	/en-US/docs/Web/API
 /en-US/docs/Web/API/IndexSync	/en-US/docs/Web/API/IDBIndexSync
 /en-US/docs/Web/API/IndexedDB	/en-US/docs/Web/API/IndexedDB_API
 /en-US/docs/Web/API/IndexedDB_API/Basic_Concepts_Behind_IndexedDB	/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -57329,13 +57329,6 @@
       "jpmedley"
     ]
   },
-  "Web/API/Index": {
-    "modified": "2019-10-10T16:43:11.819Z",
-    "contributors": [
-      "kscarfone",
-      "fscholz"
-    ]
-  },
   "Web/API/IndexedDB_API": {
     "modified": "2020-12-09T03:15:23.621Z",
     "contributors": [

--- a/files/en-us/web/api/index/index.html
+++ b/files/en-us/web/api/index/index.html
@@ -1,8 +1,0 @@
----
-title: Index
-slug: Web/API/Index
-tags:
-  - API
-  - Landing
----
-<p>{{Index("/en-US/docs/Web/API")}}</p>


### PR DESCRIPTION
Web/API/Index was created to work around the inability to run recursive grep in the wiki era. It allowed checking tags and summaries of all API files at a glance.

A table of >9000 is useless nowadays.

RIP. Even if we won't miss you.