### PR TITLE
Fix a link in Global_Objects/Object/propertyIsEnumerable

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
@@ -30,7 +30,7 @@ propertyIsEnumerable(prop)
 
 ### Return value
 
-A {{jsxref("Boolean")}} indicating whether the specified property is enumerable and is
+A `true` or `false` value indicating whether the specified property is enumerable and is
 the object's own property.
 
 ## Description


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

{{jsxref("Boolean")}} produces a link to the Boolean wrapper object, but it is incorrect.

> Anything else that could help us review it
