### PR TITLE
Fix live sample box size in font-synthesis

### DIFF
--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -79,7 +79,7 @@ em {
 
 #### Result
 
-{{ EmbedLiveSample('Disabling_font_synthesis', '', '50') }}
+{{ EmbedLiveSample('Disabling_font_synthesis', '', '75') }}
 
 ## Specifications
 


### PR DESCRIPTION
The live sample box in font-synthesis is too small. This makes it a bit larger so scrolling is no more necessary.