### PR TITLE
Remove {{draft}} from HTMLMediaElement.videoTracks

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/videotracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/videotracks/index.html
@@ -15,7 +15,7 @@ tags:
 - videoTracks
 browser-compat: api.HTMLMediaElement.videoTracks
 ---
-<div>{{APIRef("HTML DOM")}}{{draft}}</div>
+<div>{{APIRef("HTML DOM")}}</div>
 
 <p>The read-only <strong><code>videoTracks</code></strong>
     property on {{DOMxRef("HTMLMediaElement")}} objects returns a


### PR DESCRIPTION
The page is untouched in 2021 (besides technical fixes) and in a good enough shape; we can remove the `{{draft}}` banner.