### PR TITLE
Fix sectioning flaw in WebGL Boilerplate #1

### DIFF
--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
@@ -10,15 +10,11 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Canvas_size_and_WebGL","Learn/WebGL/By_example/Scissor_animation")}}</p>
 
-<div id="boilerplate-1">
-<div class="summary">
 <p>This example describes repeated pieces of code that will be hidden from now on, as well as defining a JavaScript utility function to make WebGL initialization easier.</p>
-</div>
 
-<p>{{EmbedLiveSample("boilerplate-1-source",660,400)}}</p>
+<p>{{EmbedLiveSample("Boilerplate_code_for_setting_up_WebGL_rendering_context",660,400)}}</p>
 
-<div id="boilerplate-1-intro">
-<h3 id="Boilerplate_code_for_setting_up_WebGL_rendering_context">Boilerplate code for setting up WebGL rendering context</h3>
+<h2 id="Boilerplate_code_for_setting_up_WebGL_rendering_context">Boilerplate code for setting up WebGL rendering context</h3>
 
 <p>By now you are quite used to seeing the same pieces of {{Glossary("HTML")}}, {{Glossary("CSS")}}, and {{Glossary("JavaScript")}} repeated again and again. So we are going to hide them from now on. This would allow us to focus on the interesting pieces of code that are most relevant for learning {{Glossary("WebGL")}}.</p>
 
@@ -27,9 +23,7 @@ tags:
 <p>In following examples, we will use a JavaScript helper function, <code>getRenderingContext()</code>, to initialize the {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}}. By now, you should be able to understand what the function does. Basically, it gets the WebGL rendering context from the canvas element, initializes the drawing buffer, clears it black, and returns the initialized context. In case of error, it displays an error message and returns {{jsxref("null")}}.</p>
 
 <p>Finally, all JavaScript code will run within an immediate function, which is a common JavaScript technique (see {{Glossary("Function")}}). The function declaration and invocation will also be hidden.</p>
-</div>
 
-<div id="boilerplate-1-source">
 <h3 id="HTML">HTML</h3>
 
 <pre class="brush: html">&lt;p&gt;[ Some descriptive text about the example. ]&lt;/p&gt;
@@ -83,7 +77,6 @@ button {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/boilerplate-1">GitHub</a>.</p>
-</div>
-</div>
+
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Canvas_size_and_WebGL","Learn/WebGL/By_example/Scissor_animation")}}</p>


### PR DESCRIPTION
Remove useless `<div>` that were creating sectioning flaws, and made sure the live example still works without them.