### PR TITLE
Replace Intl/* with Intl.* in {{jsxref}} macros

### DIFF
--- a/files/en-us/web/javascript/guide/text_formatting/index.md
+++ b/files/en-us/web/javascript/guide/text_formatting/index.md
@@ -256,11 +256,11 @@ For more information, read about [Template literals](/en-US/docs/Web/JavaScript/
 
 ## Internationalization
 
-The {{jsxref("Intl")}} object is the namespace for the ECMAScript Internationalization API, which provides language sensitive string comparison, number formatting, and date and time formatting. The constructors for {{jsxref("Intl/Collator")}}, {{jsxref("Intl/NumberFormat")}}, and {{jsxref("Intl/DateTimeFormat")}} objects are properties of the `Intl` object.
+The {{jsxref("Intl")}} object is the namespace for the ECMAScript Internationalization API, which provides language sensitive string comparison, number formatting, and date and time formatting. The constructors for {{jsxref("Intl.Collator")}}, {{jsxref("Intl.NumberFormat")}}, and {{jsxref("Intl.DateTimeFormat")}} objects are properties of the `Intl` object.
 
 ### Date and time formatting
 
-The {{jsxref("Intl/DateTimeFormat")}} object is useful for formatting date and time. The following formats a date for English as used in the United States. (The result is different in another time zone.)
+The {{jsxref("Intl.DateTimeFormat")}} object is useful for formatting date and time. The following formats a date for English as used in the United States. (The result is different in another time zone.)
 
 ```js
 const msPerDay = 24 * 60 * 60 * 1000;
@@ -277,7 +277,7 @@ console.log(americanDateTime(july172014)); // 07/16/14, 5:00 PM PDT
 
 ### Number formatting
 
-The {{jsxref("Intl/NumberFormat")}} object is useful for formatting numbers, for example currencies.
+The {{jsxref("Intl.NumberFormat")}} object is useful for formatting numbers, for example currencies.
 
 ```js
 const gasPrice = new Intl.NumberFormat('en-US',
@@ -294,7 +294,7 @@ console.log(hanDecimalRMBInChina.format(1314.25)); // ￥ 一,三一四.二五
 
 ### Collation
 
-The {{jsxref("Intl/Collator")}} object is useful for comparing and sorting strings.
+The {{jsxref("Intl.Collator")}} object is useful for comparing and sorting strings.
 
 For example, there are actually two different sort orders in German, _phonebook_ and _dictionary_. Phonebook sort emphasizes sound, and it’s as if “ä”, “ö”, and so on were expanded to “ae”, “oe”, and so on prior to sorting.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.Collator.compare
 {{JSRef}}
 
 The **`Intl.Collator.prototype.compare()`** method compares two
-strings according to the sort order of this {{jsxref("Intl/Collator")}} object.
+strings according to the sort order of this {{jsxref("Intl.Collator")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-compare.html")}}
 
@@ -36,7 +36,7 @@ compare(string1, string2)
 
 The `compare` getter function returns a number indicating how
 `string1` and `string2` compare to each
-other according to the sort order of this {{jsxref("Intl/Collator")}} object: a negative
+other according to the sort order of this {{jsxref("Intl.Collator")}} object: a negative
 value if `string1` comes before `string2`;
 a positive value if `string1` comes after
 `string2`; 0 if they are considered equal.

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.Collator.resolvedOptions
 
 The **`Intl.Collator.prototype.resolvedOptions()`** method
 returns a new object with properties reflecting the locale and collation options
-computed during initialization of this {{jsxref("Intl/Collator")}} object.
+computed during initialization of this {{jsxref("Intl.Collator")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-resolvedoptions.html")}}
 
@@ -31,7 +31,7 @@ resolvedOptions()
 ### Return value
 
 A new object with properties reflecting the locale and collation options computed
-during the initialization of the given {{jsxref("Intl/Collator")}} object.
+during the initialization of the given {{jsxref("Intl.Collator")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.resolvedOptions
 
 The **`Intl.DateTimeFormat.prototype.resolvedOptions()`**
 method returns a new object with properties reflecting the locale and date and time
-formatting options computed during initialization of this {{jsxref("Intl/DateTimeFormat")}}
+formatting options computed during initialization of this {{jsxref("Intl.DateTimeFormat")}}
 object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-resolvedoptions.html")}}
@@ -32,7 +32,7 @@ resolvedOptions()
 ### Return value
 
 A new object with properties reflecting the locale and date and time formatting options
-computed during the initialization of the given {{jsxref("Intl/DateTimeFormat")}} object.
+computed during the initialization of the given {{jsxref("Intl.DateTimeFormat")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.DisplayNames.resolvedOptions
 
 The **`Intl.DisplayNames.prototype.resolvedOptions()`** method
 returns a new object with properties reflecting the locale and style formatting
-options computed during the construction of the current {{jsxref("Intl/DisplayNames")}}
+options computed during the construction of the current {{jsxref("Intl.DisplayNames")}}
 object.
 
 ## Syntax
@@ -28,7 +28,7 @@ resolvedOptions()
 ### Return value
 
 An object with properties reflecting the locale and formatting options computed during
-the construction of the given {{jsxref("Intl/DisplayNames")}} object.
+the construction of the given {{jsxref("Intl.DisplayNames")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -66,11 +66,11 @@ A locale identifier is a string that consists of:
 - "`zh-Hans-CN`": Chinese (language) written in simplified characters (script) as used in China (region)
 - "`en-emodeng`": English (language) in the "Early modern English" dialect (variant)
 
-Subtags identifying languages, scripts, regions (including countries), and (rarely used) variants are registered in the [IANA Language Subtag Registry](http://www.iana.org/assignments/language-subtag-registry). This registry is periodically updated over time, and implementations may not always be up to date, so don't rely too much on subtags being universally supported.
+Subtags identifying languages, scripts, regions (including countries), and (rarely used) variants are registered in the [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry). This registry is periodically updated over time, and implementations may not always be up to date, so don't rely too much on subtags being universally supported.
 
 BCP 47 extension sequences consist of a single digit or letter (other than `"x"`) and one or more two- to eight-letter or digit subtags separated by hyphens. Only one sequence is permitted for each digit or letter: "`de-a-foo-a-foo`" is invalid. BCP 47 extension subtags are defined in the [Unicode CLDR Project](https://github.com/unicode-org/cldr/tree/master/common/bcp47). Currently only two extensions have defined semantics:
 
-- The `"u"` (Unicode) extension can be used to request additional customization of {{jsxref("Intl/Collator")}}, {{jsxref("Intl/NumberFormat")}}, or {{jsxref("Intl/DateTimeFormat")}} objects. Examples:
+- The `"u"` (Unicode) extension can be used to request additional customization of {{jsxref("Intl.Collator")}}, {{jsxref("Intl.NumberFormat")}}, or {{jsxref("Intl.DateTimeFormat")}} objects. Examples:
 
   - "`de-DE-u-co-phonebk`": Use the phonebook variant of the German sort order, which interprets umlauted vowels as corresponding character pairs: ä → ae, ö → oe, ü → ue.
   - "`th-TH-u-nu-thai`": Use Thai digits (๐, ๑, ๒, ๓, ๔, ๕, ๖, ๗, ๘, ๙) in number formatting.
@@ -85,7 +85,7 @@ Finally, a private-use extension sequence using the letter `"x"` may appear, fol
 
 The list of locales specified by the `locales` argument, after Unicode extensions have been removed from them, is interpreted as a prioritized request from the application. The runtime compares it against the locales it has available and picks the best one available. Two matching algorithms exist: the "`lookup`" matcher follows the Lookup algorithm specified in [BCP 47](https://datatracker.ietf.org/doc/html/rfc4647#section-3.4); the "`best fit`" matcher lets the runtime provide a locale that's at least, but possibly more, suited for the request than the result of the Lookup algorithm. If the application doesn't provide a `locales` argument, or the runtime doesn't have a locale that matches the request, then the runtime's default locale is used. The matcher can be selected using a property of the `options` argument (see below).
 
-If the selected locale identifier had a Unicode extension sequence, that extension is now used to customize the constructed object or the behavior of the function. Each constructor or function supports only a subset of the keys defined for the Unicode extension, and the supported values often depend on the locale identifier. For example, the "`co`" key (collation) is only supported by {{jsxref("Intl/Collator")}}, and its "`phonebk`" value is only supported for German.
+If the selected locale identifier had a Unicode extension sequence, that extension is now used to customize the constructed object or the behavior of the function. Each constructor or function supports only a subset of the keys defined for the Unicode extension, and the supported values often depend on the locale identifier. For example, the "`co`" key (collation) is only supported by {{jsxref("Intl.Collator")}}, and its "`phonebk`" value is only supported for German.
 
 ### options argument
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.resolvedOptions
 
 The **`Intl.ListFormat.prototype.resolvedOptions()`** method
 returns a new object with properties reflecting the locale and style formatting
-options computed during the construction of the current {{jsxref("Intl/ListFormat")}}
+options computed during the construction of the current {{jsxref("Intl.ListFormat")}}
 object.
 
 ## Syntax
@@ -27,7 +27,7 @@ listFormat.resolvedOptions()
 ### Return value
 
 An object with properties reflecting the locale and formatting options computed during
-the construction of the given {{jsxref("Intl/ListFormat")}} object.
+the construction of the given {{jsxref("Intl.ListFormat")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.format
 
 The **`Intl.NumberFormat.prototype.format()`** method formats a
 number according to the locale and formatting options of this
-{{jsxref("Intl/NumberFormat")}} object.
+{{jsxref("Intl.NumberFormat")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-format.html",
 	"taller")}}
@@ -37,7 +37,7 @@ format(number)
 ## Description
 
 The `format` getter function formats a number into a string according to the
-locale and formatting options of this {{jsxref("Intl/NumberFormat")}} object.
+locale and formatting options of this {{jsxref("Intl.NumberFormat")}} object.
 
 ## Examples
 
@@ -56,7 +56,7 @@ console.log(numberFormat.format(654321.987));
 ### Using format with map
 
 Use the `format` getter function for formatting all numbers in an array.
-Note that the function is bound to the {{jsxref("Intl/NumberFormat")}} from which it was
+Note that the function is bound to the {{jsxref("Intl.NumberFormat")}} from which it was
 obtained, so it can be passed directly to {{jsxref("Array.prototype.map")}}. This is
 considered a historical artefact, as part of a convention which is no longer followed
 for new features, but is preserved to maintain compatibility with existing programs.

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -32,7 +32,7 @@ The **`Intl.NumberFormat`** object enables language-sensitive number formatting.
 ## Instance methods
 
 - {{jsxref("Intl/NumberFormat/format", "Intl.NumberFormat.prototype.format()")}}
-  - : Getter function that formats a number according to the locale and formatting options of this {{jsxref("Intl/NumberFormat")}} object.
+  - : Getter function that formats a number according to the locale and formatting options of this {{jsxref("Intl.NumberFormat")}} object.
 - {{jsxref("Intl/NumberFormat/formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}}
   - : Returns an {{jsxref("Array")}} of objects representing the number string in parts that can be used for custom locale-aware formatting.
 - {{jsxref("Intl/NumberFormat/resolvedOptions", "Intl.NumberFormat.prototype.resolvedOptions()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.resolvedOptions
 
 The **`Intl.NumberFormat.prototype.resolvedOptions()`** method
 returns a new object with properties reflecting the locale and number formatting
-options computed during initialization of this {{jsxref("Intl/NumberFormat")}} object.
+options computed during initialization of this {{jsxref("Intl.NumberFormat")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-resolvedoptions.html")}}
 
@@ -31,7 +31,7 @@ resolvedOptions()
 ### Return value
 
 A new object with properties reflecting the locale and number formatting options
-computed during the initialization of the given {{jsxref("Intl/NumberFormat")}} object.
+computed during the initialization of the given {{jsxref("Intl.NumberFormat")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.resolvedOptions
 
 The **`Intl.PluralRules.prototype.resolvedOptions()`** method
 returns a new object with properties reflecting the locale and plural formatting
-options computed during initialization of this {{jsxref("Intl/PluralRules")}} object.
+options computed during initialization of this {{jsxref("Intl.PluralRules")}} object.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ resolvedOptions()
 ### Return value
 
 A new object with properties reflecting the locale and plural formatting options
-computed during the initialization of the given {{jsxref("Intl/PluralRules")}} object.
+computed during the initialization of the given {{jsxref("Intl.PluralRules")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
@@ -37,7 +37,7 @@ of `zero`, `one`, `two`, `few`,
 ## Description
 
 This function selects a pluralization category according to the locale and formatting
-options of a {{jsxref("Intl/PluralRules")}} object.
+options of a {{jsxref("Intl.PluralRules")}} object.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions
 ---
 {{JSRef}}
 
-The **`Intl.RelativeTimeFormat.prototype.resolvedOptions()`** method returns a new object with properties reflecting the locale and relative time formatting options computed during initialization of this {{jsxref("Intl/RelativeTimeFormat")}} object.
+The **`Intl.RelativeTimeFormat.prototype.resolvedOptions()`** method returns a new object with properties reflecting the locale and relative time formatting options computed during initialization of this {{jsxref("Intl.RelativeTimeFormat")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-resolvedoptions.html")}}
 
@@ -29,7 +29,7 @@ resolvedOptions()
 
 ### Return value
 
-A new object with properties reflecting the locale and number formatting options computed during the initialization of the given {{jsxref("Intl/RelativeTimeFormat")}} object.
+A new object with properties reflecting the locale and number formatting options computed during the initialization of the given {{jsxref("Intl.RelativeTimeFormat")}} object.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -42,7 +42,7 @@ A string with a language-sensitive representation of the given number.
 ## Performance
 
 When formatting large numbers of numbers, it is better to create a
-{{jsxref("Intl/NumberFormat")}} object and use the function provided by its
+{{jsxref("Intl.NumberFormat")}} object and use the function provided by its
 {{jsxref("Intl/NumberFormat/format")}} property.
 
 ## Examples


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

Replace Intl/* with Intl.* in {{jsxref}} macros because Intl/* (ex. `Intl/Collator`) never appear in codes.

> Anything else that could help us review it
