### PR TITLE
Fix spec table of WebOTP API

### DIFF
--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -59,7 +59,7 @@ tags:
 
 <table>
   <tr>
-    <td>Specification</td>
+    <th>Specification</th>
   </tr>
   <tr>
     <td><a href="https://wicg.github.io/web-otp/">WebOTP API</a></td>

--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -57,7 +57,14 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<table>
+  <tr>
+    <td>Specification</td>
+  </tr>
+  <tr>
+    <td><a href="https://wicg.github.io/web-otp/">WebOTP API</a></td>
+  </tr>
+</table>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
There is a MacroExecutionError flaw on this page as `{{Specifications}}` uses a non-existent browser-compat key in the YAML head.

This updates the table to match what we do for the other overview table.