### PR TITLE
Fix the param passed to ServiceWorkerContainer.getRegistration()

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/getregistration/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/getregistration/index.html
@@ -15,20 +15,19 @@ browser-compat: api.ServiceWorkerContainer.getRegistration
 <p>The <strong><code>getRegistration()</code></strong> method of the
   {{domxref("ServiceWorkerContainer")}} interface gets a
   {{domxref("ServiceWorkerRegistration")}} object whose scope URL matches the provided
-  document URL.  The method returns a {{jsxref("Promise")}} that resolves to
+  client URL.  The method returns a {{jsxref("Promise")}} that resolves to
   a {{domxref("ServiceWorkerRegistration")}} or <code>undefined</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><em>serviceWorkerContainer</em>.getRegistration(<em>scope</em>).then(function(<em>serviceWorkerRegistration</em>) { ... });</pre>
+  class="brush: js"><em>serviceWorkerContainer</em>.getRegistration(<em>clientURL</em>).then(function(<em>serviceWorkerRegistration</em>) { ... });</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>scope</code> {{optional_inline}}</dt>
-  <dd>A unique identifier for a service worker registration — the scope URL of the
-    registration object you want to return. This is usually a relative URL.</dd>
+  <dt><code>clientURL</code> {{optional_inline}}</dt>
+  <dd>The registration whose scope matches this URL will be returned. Relative URLs are resolved with the current client as the base. If this parameter is not provided, the current client's URL will be used by default.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

n/a

> What was wrong/why is this fix needed? (quick summary only)

As per the [service worker specification](https://w3c.github.io/ServiceWorker/#navigator-service-worker-getRegistration), the parameter passed to `ServiceWorkerContainer.getRegistration()` is incorrectly described in the current documentation.

Currently, it's described as the scope of the registration you want to get back.

Instead, it should be described as the URL of a (hypothetical) client, and the registration that you get back is the registration whose scope would match that URL.

> Anything else that could help us review it
