### PR TITLE
Remove deleted children from XHR interface

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -81,10 +81,6 @@ browser-compat: api.XMLHttpRequest
  <dd>Is a boolean. If true, the same origin policy will not be enforced on the request.</dd>
  <dt>{{domxref("XMLHttpRequest.mozBackgroundRequest")}}</dt>
  <dd>Is a boolean. It indicates whether or not the object represents a background service request.</dd>
- <dt>{{domxref("XMLHttpRequest.mozResponseArrayBuffer")}} {{deprecated_inline}} {{ReadOnlyInline}}</dt>
- <dd>{{jsxref("ArrayBuffer")}}. The response to the request, as a JavaScript typed array.</dd>
- <dt>{{domxref("XMLHttpRequest.multipart")}} {{deprecated_inline}}</dt>
- <dd><strong>This Gecko-only feature, a boolean, was removed in Firefox/Gecko 22.</strong> Please use <a href="/en-US/docs/Web/API/Server-sent_events">Server-Sent Events</a>, <a href="/en-US/docs/Web/API/WebSockets_API">Web Sockets</a>, or <code>responseText</code> from progress events instead.</dd>
 </dl>
 
 <h3 id="Event_handlers">Event handlers</h3>


### PR DESCRIPTION
In #8144, we deleted 2 files that contained long outdated documents.

This update the XHR interface where they were still listed.