### PR TITLE
Fixed small grammatical error on the Clipping and Masking page

### DIFF
--- a/files/en-us/web/svg/tutorial/clipping_and_masking/index.html
+++ b/files/en-us/web/svg/tutorial/clipping_and_masking/index.html
@@ -82,6 +82,6 @@ tags:
 
 <h2 id="Using_well-known_CSS_techniques">Using well-known CSS techniques</h2>
 
-<p>One of the most powerful tools in a web developer's toolbox is <code>display: none</code>. It is therefore little surprise, that it was decided to take this CSS property into SVG as well, together with <code>visibility</code> and <code>clip</code> as defined by CSS 2. For reverting a previously set <code>display: none</code> it is important to know, that the initial value for all SVG elements is <code>inline</code>.</p>
+<p>One of the most powerful tools in a web developer's toolbox is <code>display: none</code>. It is therefore a little surprising, that it was decided to take this CSS property into SVG as well, together with <code>visibility</code> and <code>clip</code> as defined by CSS 2. For reverting a previously set <code>display: none</code> it is important to know, that the initial value for all SVG elements is <code>inline</code>.</p>
 
 <p>{{ PreviousNext("Web/SVG/Tutorial/Basic_Transformations", "Web/SVG/Tutorial/Other_content_in_SVG") }}</p>

--- a/files/en-us/web/svg/tutorial/clipping_and_masking/index.html
+++ b/files/en-us/web/svg/tutorial/clipping_and_masking/index.html
@@ -82,6 +82,6 @@ tags:
 
 <h2 id="Using_well-known_CSS_techniques">Using well-known CSS techniques</h2>
 
-<p>One of the most powerful tools in a web developer's toolbox is <code>display: none</code>. It is therefore a little surprising, that it was decided to take this CSS property into SVG as well, together with <code>visibility</code> and <code>clip</code> as defined by CSS 2. For reverting a previously set <code>display: none</code> it is important to know, that the initial value for all SVG elements is <code>inline</code>.</p>
+<p>One of the most powerful tools in a web developer's toolbox is <code>display: none</code>. It is therefore not a surprise that it was decided to take this CSS property into SVG as well, together with <code>visibility</code> and <code>clip</code> as defined by CSS 2. For reverting a previously set <code>display: none</code> it is important to know, that the initial value for all SVG elements is <code>inline</code>.</p>
 
 <p>{{ PreviousNext("Web/SVG/Tutorial/Basic_Transformations", "Web/SVG/Tutorial/Other_content_in_SVG") }}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
N/A


> What was wrong/why is this fix needed? (quick summary only)
"It is therefore little surprise, that (...)" is not grammatically correct. I figured it's meant to say "(...) a little surprising, that (...)".  


> Anything else that could help us review it
It's beyond me to try to interpret the intended meaning besides a small grammatical error, but it seems to me that it's not surprising for "One of the most powerful tools in a web developer's toolbox" to be put into SVG. This PR makes it grammatically correct, but someone might want to check if the sentence itself makes sense.
