### PR TITLE
Use the extension .md for some markdown files

### DIFF
--- a/files/en-us/web/api/hidinputreportevent/device/index.md
+++ b/files/en-us/web/api/hidinputreportevent/device/index.md
@@ -30,5 +30,3 @@ An {{domxref("HIDDevice")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-

--- a/files/en-us/web/api/hidinputreportevent/index.md
+++ b/files/en-us/web/api/hidinputreportevent/index.md
@@ -36,4 +36,3 @@ _This interface inherits methods from its parent, {{domxref("Event")}}._
 ## Browser compatibility
 
 {{Compat}}
-

--- a/files/en-us/web/api/hidinputreportevent/reportid/index.md
+++ b/files/en-us/web/api/hidinputreportevent/reportid/index.md
@@ -30,5 +30,3 @@ A one-byte identification prefix.
 ## Browser compatibility
 
 {{Compat}}
-
-


### PR DESCRIPTION
This makes the markdown syntax display the content properly.