### PR TITLE
Remove https://developer.mozilla.org in link

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.html
@@ -55,7 +55,7 @@ browser-compat: api.ServiceWorkerContainer.register
         <ul>
           <li><code>'classic'</code>: The loaded service worker is in a standard script. This is the default.</li>
           <li><code>module</code>: The loaded service worker is in an
-          <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules">ES module</a>
+          <a href="/en-US/docs/Web/JavaScript/Guide/Modules">ES module</a>
           and the import statement is available on
             worker contexts.
           </li>


### PR DESCRIPTION
We don't need to hardcode the prod domain inside links. (This may even be annoying when testing)