### PR TITLE
Directly link to Regexpr and String objects and methods

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -181,7 +181,7 @@ Parentheses around any part of the regular expression pattern causes that part o
 
 ## Using regular expressions in JavaScript
 
-Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("RegExp/test", "test()`")}} and {{jsxref("RegExp/exec", "exec()")}} and with the {{jsxref("String")}} methods {{jsxref("String/match", "match()")}}, {{jsxref("String/replace", "replace()"}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}}.
+Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("RegExp/test", "test()")}} and {{jsxref("RegExp/exec", "exec()")}} and with the {{jsxref("String")}} methods {{jsxref("String/match", "match()")}}, {{jsxref("String/replace", "replace()")}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}}.
 
 | Method                                                           | Description                                                                                                      |
 | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -181,7 +181,7 @@ Parentheses around any part of the regular expression pattern causes that part o
 
 ## Using regular expressions in JavaScript
 
-Regular expressions are used with the `RegExp` methods `test()` and `exec()` and with the `String` methods `match()`, `replace()`, `search()`, and `split()`. These methods are explained in detail in the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference).
+Regular expressions are used with the [`RegExp`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) methods [`test()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) and [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and with the [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) methods [`match()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match), [`replace()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), [`search()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search), and [`split()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split).
 
 | Method                                                           | Description                                                                                                      |
 | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -181,7 +181,7 @@ Parentheses around any part of the regular expression pattern causes that part o
 
 ## Using regular expressions in JavaScript
 
-Regular expressions are used with the [`RegExp`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) methods [`test()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) and [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and with the [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) methods [`match()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match), [`replace()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), [`search()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search), and [`split()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split).
+Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("RegExp/test", "test()`")}} and {{jsxref("RegExp/exec", "exec")}} and with the {{jsxref("String")}} methods {{jsxref("String/match", "match()")}}, {{jsxref("String/replace", "replace()}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}}.
 
 | Method                                                           | Description                                                                                                      |
 | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -181,7 +181,7 @@ Parentheses around any part of the regular expression pattern causes that part o
 
 ## Using regular expressions in JavaScript
 
-Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("RegExp/test", "test()`")}} and {{jsxref("RegExp/exec", "exec")}} and with the {{jsxref("String")}} methods {{jsxref("String/match", "match()")}}, {{jsxref("String/replace", "replace()}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}}.
+Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("RegExp/test", "test()`")}} and {{jsxref("RegExp/exec", "exec()")}} and with the {{jsxref("String")}} methods {{jsxref("String/match", "match()")}}, {{jsxref("String/replace", "replace()"}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}}.
 
 | Method                                                           | Description                                                                                                      |
 | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Directly link to Regexpr and String objects and methods instead of giving the link to the index of the docs

> What was wrong/why is this fix needed? (quick summary only)

If it was useful to say those methods were explained in details, then it's better to directly link to the explanation.

And it's "Much better" according to https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Writing_style_guide
