### PR TITLE
Move links out of heading in Challenge solutions

### DIFF
--- a/files/en-us/web/guide/css/getting_started/challenge_solutions/index.html
+++ b/files/en-us/web/guide/css/getting_started/challenge_solutions/index.html
@@ -7,7 +7,9 @@ tags:
 ---
 <p>This page provides solutions to the challenges posed in the <a href="/en-US/docs/Learn/CSS/First_steps">CSS Getting Started</a> tutorial. These are not the only possible solutions. The sections below correspond to the titles of the tutorial sections.</p>
 
-<h2 id="Why_use_CSS"><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works" id="Why_use_CSS_Colors">Why use CSS</a></h2>
+<h2 id="Why_use_CSS">Why use CSS</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">Why use CSS</a> are:<p>
 
 <h3 id="Colors">Colors</h3>
 
@@ -18,7 +20,9 @@ tags:
  <dd>CSS supports common color names like <code>orange</code>, <code>yellow</code>, <code>blue</code>, <code>green</code>, or <code>black</code>. It also supports some more exotic color names like <code>chartreuse</code>, <code>fuschia</code>, or <code>burlywood</code>. See <a href="/en-US/docs/Web/CSS/color_value">CSS Color value</a> for a complete list as well as other ways of specifying colors.</dd>
 </dl>
 
-<h2 id="How_CSS_works"><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works" id="How_CSS_works_DOM_inspector">How CSS works</a></h2>
+<h2 id="How_CSS_works">How CSS works</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a> are:<p>
 
 <h3 id="DOM_inspector">DOM inspector</h3>
 
@@ -29,7 +33,9 @@ tags:
  <dd>In the menu above the right-hand pane, choose <strong>CSS Rules</strong>.  You see two items listed, one that references an internal resource and one that references your stylesheet file. The internal resource defines the <strong>font-weight</strong> property as <code>bolder</code>; your stylesheet defines the <strong>color</strong> property as <code>red</code>.</dd>
 </dl>
 
-<h2 id="Cascading_and_inheritance"><a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance">Cascading and inheritance</a></h2>
+<h2 id="Cascading_and_inheritance">Cascading and inheritance</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance">Cascading and inheritance</a> are:<p>
 
 <h3 id="Inherited_styles">Inherited styles</h3>
 
@@ -46,7 +52,9 @@ strong {color: orange; text-decoration: underline;}
 
 <p>Later sections of this tutorial describe style rules and declarations in greater detail.</p>
 
-<h2 id="Selectors"><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors">Selectors</a></h2>
+<h2 id="Selectors">Selectors</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors">Selectors</a> are:<p>
 
 <h3 id="Second_paragraph_blue">Second paragraph blue</h3>
 
@@ -138,6 +146,8 @@ p {
 
 <h2 id="Content">Content</h2>
 
+<p>The challenges on page are:<p>
+
 <h3 id="Add_an_image">Add an image</h3>
 
 <dl>
@@ -152,7 +162,9 @@ p {
  </dd>
 </dl>
 
-<h2 id="Lists"><a href="/en-US/docs/Learn/CSS/Styling_text/Styling_lists">Lists</a></h2>
+<h2 id="Lists">Lists</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/Styling_text/Styling_lists">Lists</a> are:<p>
 
 <h3 id="Lower_Roman_numerals">Lower Roman numerals</h3>
 
@@ -186,7 +198,9 @@ h3:before {
  </dd>
 </dl>
 
-<h2 id="Boxes"><a href="/en-US/docs/Learn/CSS/Building_blocks">Boxes</a></h2>
+<h2 id="Boxes">Boxes</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/Building_blocks">Boxes</a> are:<p>
 
 <h3 id="Ocean_border">Ocean border</h3>
 
@@ -204,7 +218,9 @@ h3:before {
  </dd>
 </dl>
 
-<h2 id="Layout"><a href="/en-US/docs/Learn/CSS/CSS_layout">Layout</a></h2>
+<h2 id="Layout">Layout</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/CSS_layout">Layout</a> are:<p>
 
 <h3 id="Default_image_position">Default image position</h3>
 
@@ -228,7 +244,9 @@ h3:before {
  </dd>
 </dl>
 
-<h2 id="Tables"><a href="/en-US/docs/Learn/CSS/Building_blocks/Styling_tables">Tables</a></h2>
+<h2 id="Tables">Tables</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Learn/CSS/Building_blocks/Styling_tables">Tables</a> are:<p>
 
 <h3 id="Borders_on_data_cells_only">Borders on data cells only</h3>
 
@@ -244,7 +262,9 @@ h3:before {
  </dd>
 </dl>
 
-<h2 id="Media"><a href="/en-US/docs/Web/Progressive_web_apps/Responsive/Media_types">Media</a></h2>
+<h2 id="Media">Media</h2>
+
+<p>The challenges on page <a href="/en-US/docs/Web/Progressive_web_apps/Responsive/Media_types">Media</a> are:<p>
 
 <h3 id="Separate_print_style_file">Separate print style file</h3>
 


### PR DESCRIPTION
The links in headings are unclickable. So I moved them below the heading, in a logical text.