### PR TITLE
Remove <div class="summary"> from Web/API

### DIFF
--- a/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
+++ b/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
@@ -12,11 +12,9 @@ tags:
 ---
 <p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
-<div class="summary">
   <p>The <code>AudioContext.createJavaScriptNode()</code> method creates a
     {{domxref("JavaScriptNode")}} which is used for directly manipulating audio data with
     JavaScript.</p>
-</div>
 
 <div class="note">
   <p><strong>Important</strong>: This method is obsolete, and has been renamed to

--- a/files/en-us/web/api/canvas_api/a_basic_ray-caster/index.html
+++ b/files/en-us/web/api/canvas_api/a_basic_ray-caster/index.html
@@ -11,9 +11,7 @@ tags:
 ---
 <div>{{CanvasSidebar}}</div>
 
-<div class="summary">
 <p>This article provides an interesting real-world example of using the {{HTMLElement("canvas")}} element to do software rendering of a 3D environment using ray-casting.</p>
-</div>
 
 <p>{{EmbedGHLiveSample("canvas-raycaster/index.html", 900, 300)}}</p>
 

--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.html
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.html
@@ -13,9 +13,7 @@ tags:
 ---
 <div>{{CanvasSidebar}}</div>
 
-<div class="summary">
 <p>By combining the capabilities of the <a class="internal" href="/en-US/docs/Web/HTML/Element/video"><code>video</code></a> element with a <a class="internal" href="/en-US/docs/Web/HTML/Element/canvas"><code>canvas</code></a>, you can manipulate video data in real time to incorporate a variety of visual effects to the video being displayed. This tutorial demonstrates how to perform chroma-keying (also known as the "green screen effect") using JavaScript code.</p>
-</div>
 
 <p>{{EmbedGHLiveSample('dom-examples/canvas/chroma-keying/index.html', 700, 400) }}</p>
 

--- a/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
@@ -8,9 +8,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}</div>
 
-<div class="summary">
 <p>In the last chapter we made some <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations">basic animations</a> and got to know ways to get things moving. In this part we will have a closer look at the motion itself and are going to add some physics to make our animations more advanced.</p>
-</div>
 
 <h2 id="Drawing_a_ball">Drawing a ball</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -11,9 +11,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}</div>
 
-<div class="summary">
 <p>In the chapter about <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">drawing shapes</a>, we used only the default line and fill styles. Here we will explore the canvas options we have at our disposal to make our drawings a little more attractive. You will learn how to add different colors, line styles, gradients, patterns and shadows to your drawings.</p>
-</div>
 
 <h2 id="Colors">Colors</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
@@ -11,9 +11,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/API/Canvas_API/Tutorial/Advanced_animations")}}</div>
 
-<div class="summary">
 <p>Since we're using JavaScript to control {{HTMLElement("canvas")}} elements, it's also very easy to make (interactive) animations. In this chapter we will take a look at how to do some basic animations.</p>
-</div>
 
 <p>Probably the biggest limitation is, that once a shape gets drawn, it stays that way. If we need to move it we have to redraw it and everything that was drawn before it. It takes a lot of time to redraw complex frames and the performance depends highly on the speed of the computer it's running on.</p>
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.html
@@ -10,9 +10,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}</div>
 
-<div class="summary">
 <p>Let's start this tutorial by looking at the {{HTMLElement("canvas")}} {{Glossary("HTML")}} element itself. At the end of this page, you will know how to set up a canvas 2D context and have drawn a first example in your browser.</p>
-</div>
 
 <h2 id="The_&lt;canvas&gt;_element">The <code>&lt;canvas&gt;</code> element</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
@@ -11,9 +11,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}</div>
 
-<div class="summary">
 <p>In all of our <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations">previous examples</a>, shapes were always drawn one on top of the other. This is more than adequate for most situations, but it limits the order in which composite shapes are built. We can, however, change this behavior by setting the <code>globalCompositeOperation</code> property. In addition, the <code>clip</code> property allows us to hide unwanted parts of shapes.</p>
-</div>
 
 <h2 id="globalCompositeOperation"><code>globalCompositeOperation</code></h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -12,9 +12,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}</div>
 
-<div class="summary">
 <p>Now that we have set up our <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_usage">canvas environment</a>, we can get into the details of how to draw on the canvas. By the end of this article, you will have learned how to draw rectangles, triangles, lines, arcs and curves, providing familiarity with some of the basic shapes. Working with paths is essential when drawing objects onto the canvas and we will see how that can be done.</p>
-</div>
 
 <h2 id="The_grid">The grid</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
@@ -9,9 +9,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}</div>
 
-<div class="summary">
 <p>After having seen how to <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors">apply styles and colors</a> in the previous chapter, we will now have a look at how to draw text onto the canvas.</p>
-</div>
 
 <h2 id="Drawing_text">Drawing text</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/finale/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/finale/index.html
@@ -8,9 +8,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}</div>
 
-<div class="summary">
 <p>Congratulations! You finished the <a href="/en-US/docs/Web/API/Canvas_API/Tutorial">Canvas tutorial</a>! This knowledge will help you to make great 2D graphics on the web.</p>
-</div>
 
 <h2 id="More_examples_and_tutorials">More examples and tutorials</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{ PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Optimizing_canvas") }}</div>
 
-<div class="summary">The {{HTMLElement("canvas")}} element on its own is just a bitmap and does not provide information about any drawn objects. Canvas content is not exposed to accessibility tools like semantic HTML is. In general, you should avoid using canvas in an accessible website or app. The following guidelines can help to make it more accessible.</div>
+<p>The {{HTMLElement("canvas")}} element on its own is just a bitmap and does not provide information about any drawn objects. Canvas content is not exposed to accessibility tools like semantic HTML is. In general, you should avoid using canvas in an accessible website or app. The following guidelines can help to make it more accessible.</p>
 
 <h2 id="Fallback_content">Fallback content</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.html
@@ -9,9 +9,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility")}}</div>
 
-<div class="summary">
 <p>Until now we haven't looked at the actual pixels of our canvas. With the <code>ImageData</code> object you can directly read and write a data array to manipulate pixel data. We will also look into how image smoothing (anti-aliasing) can be controlled and how to save images from your canvas.</p>
-</div>
 
 <h2 id="The_ImageData_object">The ImageData object</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}</div>
 
-<div class="summary">Earlier in this tutorial we've learned about the <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">canvas grid</a> and the <strong>coordinate space</strong>. Until now, we only used the default grid and changed the size of the overall canvas for our needs. With transformations there are more powerful ways to translate the origin to a different position, rotate the grid and even scale it.</div>
+<p>Earlier in this tutorial we've learned about the <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">canvas grid</a> and the <strong>coordinate space</strong>. Until now, we only used the default grid and changed the size of the overall canvas for our needs. With transformations there are more powerful ways to translate the origin to a different position, rotate the grid and even scale it.</p>
 
 <h2 id="Saving_and_restoring_state">Saving and restoring state</h2>
 

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
@@ -10,9 +10,7 @@ tags:
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Transformations" )}}</div>
 
-<div class="summary">
 <p>Until now we have created our own <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">shapes</a> and <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors">applied styles</a> to them. One of the more exciting features of {{HTMLElement("canvas")}} is the ability to use images.  These can be used to do dynamic photo compositing or as backdrops of graphs, for sprites in games, and so forth. External images can be used in any format supported by the browser, such as PNG, GIF, or JPEG. You can even use the image produced by other canvas elements on the same page as the source!</p>
-</div>
 
 <p>Importing images into a canvas is basically a two step process:</p>
 

--- a/files/en-us/web/api/fetch_api/basic_concepts/index.html
+++ b/files/en-us/web/api/fetch_api/basic_concepts/index.html
@@ -12,9 +12,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Fetch API")}}{{draft}}</p>
 
-<div class="summary">
 <p>The <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a> provides an interface for fetching resources (including across the network). It will seem familiar to anyone who has used {{domxref("XMLHttpRequest")}}, but it provides a more powerful and flexible feature set. This article explains some of the basic concepts of the Fetch API.</p>
-</div>
 
 <div class="note">
 <p><strong>Note:</strong> This article will be added to over time. If you find a Fetch concept that you feel needs explaining better, let someone know on the <a href="https://discourse.mozilla-community.org/c/mdn">MDN discussion forum</a>, or <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">MDN Web Docs room</a> on <a href="https://wiki.mozilla.org/Matrix">Matrix</a>.</p>

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -15,9 +15,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Fetch API")}}</p>
 
-<div class="summary">
 <p>The <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a> provides a JavaScript interface for accessing and manipulating parts of the HTTP pipeline, such as requests and responses. It also provides a global {{domxref("WindowOrWorkerGlobalScope/fetch","fetch()")}} method that provides an easy, logical way to fetch resources asynchronously across the network.</p>
-</div>
 
 <p>This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as {{domxref("Service_Worker_API", "Service Workers")}}. Fetch also provides a single logical place to define other HTTP-related concepts such as <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> and extensions to HTTP.</p>
 

--- a/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
@@ -8,9 +8,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("IndexedDB")}}</p>
 
-<div class="summary">
 <p>This article describes the key characteristics of IndexedDB, and introduces some essential terminology relevant to understanding the IndexedDB API.</p>
-</div>
 
 <p>You'll also find the following articles useful:</p>
 

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.html
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.html
@@ -9,9 +9,8 @@ tags:
   - IndexedDB
   - deadline
 ---
-<div>{{DefaultAPISidebar("IndexedDB")}}</div><div class="summary">
+<div>{{DefaultAPISidebar("IndexedDB")}}</div>
 <p>In this article we look at a complex example involving checking the current time and date against a deadline stored via IndexedDB. The main complication here is checking the stored deadline info (month, hour, day, etc.) against the current time and date taken from a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a> object.</p>
-</div>
 
 <img alt="A screenshot of the sample app. A red main title saying To do app, a test to-do item, and a red form for users to enter new tasks" src="to-do-app.png">
 

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -13,9 +13,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("IndexedDB")}}</p>
 
-<div class="summary">
 <p>IndexedDB is a way for you to persistently store data inside a user's browser. Because it lets you create web applications with rich query abilities regardless of network availability, your applications can work both online and offline. </p>
-</div>
 
 <h2 id="About_this_document">About this document</h2>
 

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.html
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.html
@@ -13,9 +13,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Server Sent Events")}}</p>
 
-<div class="summary">
 <p>Developing a web application that uses <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> is straightforward. You'll need a bit of code on the server to stream events to the front-end, but the client side code works almost identically to <a href="/en-US/docs/Web/API/WebSockets_API">websockets</a> in part of handling incoming events. This is a one-way connection, so you can't send events from a client to a server.</p>
-</div>
 
 <h2 id="Receiving_events_from_the_server">Receiving events from the server</h2>
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.html
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.html
@@ -10,9 +10,7 @@ tags:
 ---
 <p>{{ServiceWorkerSidebar}}</p>
 
-<div class="summary">
 <p>This article provides information on getting started with service workers, including basic architecture, registering a service worker, the install and activation process for a new service worker, updating your service worker, cache control and custom responses, all in the context of a simple app with offline functionality. </p>
-</div>
 
 <h2 id="The_premise_of_service_workers">The premise of service workers</h2>
 

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.html
@@ -10,9 +10,7 @@ tags:
   - visualization
   - waveform
 ---
-<div class="summary">
 <p>One of the most interesting features of the Web Audio API is the ability to extract frequency, waveform, and other data from your audio source, which can then be used to create visualizations. This article explains how, and provides a couple of basic use cases.</p>
-</div>
 
 <div class="note">
 <p><strong>Note</strong>: You can find working examples of all the code snippets in our <a href="https://mdn.github.io/voice-change-o-matic/">Voice-change-O-matic</a> demo.</p>

--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.html
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.html
@@ -8,9 +8,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Audio API")}}</div>
 
-<div class="summary">
 <p>As if its extensive variety of sound processing (and other) options wasn't enough, the Web Audio API also includes facilities to allow you to emulate the difference in sound as a listener moves around a sound source, for example panning as you move around a sound source inside a 3D game. The official term for this is <strong>spatialization</strong>, and this article will cover the basics of how to implement such a system.</p>
-</div>
 
 <h2 id="Basics_of_spatialization">Basics of spatialization</h2>
 

--- a/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
@@ -10,9 +10,7 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Basic_scissoring","Learn/WebGL/By_example/Boilerplate_1")}}</p>
 
-<div class="summary">
 <p>This WebGL example explores the effect of setting (or not setting) the canvas size to its element size in {{Glossary("CSS")}} pixels, as it appears in the browser window.</p>
-</div>
 
 <div id="canvas-size-and-webgl">
 <p>{{EmbedLiveSample("canvas-size-and-webgl-source",660,180)}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_with_colors","Learn/WebGL/By_example/Simple_color_animation")}}</p>
 
 <div id="clearing-by-clicking">
-<div class="summary">
 <p>This example demonstrates how to combine user interaction with WebGL graphics operations by clearing the rendering context with a random color when the user clicks.</p>
-</div>
 
 <p>{{EmbedLiveSample("clearing-by-clicking-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Detect_WebGL","Learn/WebGL/By_example/Clearing_by_clicking")}}</p>
 
 <div id="clearing-with-colors">
-<div class="summary">
 <p>An example showing how to clear a WebGL rendering context to a solid color.</p>
-</div>
 
 <p>{{EmbedLiveSample("clearing-with-colors-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Simple_color_animation","Learn/WebGL/By_example/Basic_scissoring")}}</p>
 
 <div id="color-masking">
-<div class="summary">
 <p>This WebGL example modifies random colors by applying color masking to limit the range of displayed colors to specific shades.</p>
-</div>
 
 <p>{{EmbedLiveSample("color-masking-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example","Learn/WebGL/By_example/Clearing_with_colors")}}</p>
 
 <div id="detect-webgl">
-<div class="summary">
 <p>This example demonstrates how to detect a {{Glossary("WebGL")}} rendering context and reports the result to the user.</p>
-</div>
 
 <p>{{EmbedLiveSample("detect-webgl-source",660,150)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
@@ -14,9 +14,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Raining_rectangles","Learn/WebGL/By_example/Hello_vertex_attributes")}}</p>
 
 <div id="hello-glsl">
-<div class="summary">
 <p id="hello-glsl-summary">This WebGL example demonstrates a very basic GLSL shader program that draws a solid color square.</p>
-</div>
 
 <div class="note">
 <p><strong>Note</strong>: This example will most likely work in all modern desktop browsers. But it may not work in some mobile or older browsers. If the canvas remains blank, you can check the output of the next example, which draws exactly the same thing. But remember to read through the explanations and code on this page, before moving on to the next.</p>

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_GLSL","Learn/WebGL/By_example/Textures_from_code")}}</p>
 
 <div id="hello-vertex-attributes">
-<div class="summary">
 <p id="hello-vertex-attributes-summary">This WebGL example demonstrates how to combine shader programming and user interaction by sending user input to the shader using vertex attributes.</p>
-</div>
 
 <p>{{EmbedLiveSample("hello-vertex-attributes-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
@@ -14,9 +14,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Scissor_animation","Learn/WebGL/By_example/Hello_GLSL")}}</p>
 
 <div id="raining-rectangles">
-<div class="summary">
 <p>A simple WebGL game that demonstrates clearing with solid colors, scissoring, animation, and user interaction.</p>
-</div>
 
 <p>{{EmbedLiveSample("raining-rectangles-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
@@ -14,9 +14,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Boilerplate_1","Learn/WebGL/By_example/Raining_rectangles")}}</p>
 
 <div id="scissor-animation">
-<div class="summary">
 <p>A simple WebGL example in which we have some animation fun using scissoring and clearing operations.</p>
-</div>
 
 <p>{{EmbedLiveSample("scissor-animation-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
@@ -12,9 +12,7 @@ tags:
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_by_clicking","Learn/WebGL/By_example/Color_masking")}}</p>
 
 <div id="simple-color-animation">
-<div class="summary">
 <p>A very basic color animation created using {{Glossary("WebGL")}}, performed by clearing the drawing buffer with a different random color every second.</p>
-</div>
 
 <p>{{EmbedLiveSample("simple-color-animation-source",660,425)}}</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
@@ -15,9 +15,7 @@ tags:
 <p>{{Previous("Learn/WebGL/By_example/Textures_from_code")}}</p>
 
 <div id="video-textures">
-<div class="summary">
 <p id="video-textures-summary">This example demonstrates how to use video files as textures for WebGL surfaces.</p>
-</div>
 
 <div id="video-textures-intro">
 <h3 id="Textures_from_video">Textures from video</h3>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -16,9 +16,7 @@ tags:
 ---
 <div>{{WebGLSidebar}}</div>
 
-<div class="summary">
 <p><strong>WebGL</strong> (Web Graphics Library) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics within any compatible web browser without the use of plug-ins. WebGL does so by introducing an API that closely conforms to OpenGL ES 2.0 that can be used in HTML5 {{HTMLElement("canvas")}} elements. This conformance makes it possible for the API to take advantage of hardware graphics acceleration provided by the user's device.</p>
-</div>
 
 <p>Support for WebGL is present in <a href="/en-US/docs/Mozilla/Firefox" title="Firefox 4 for developers">Firefox</a> 4+, <a href="https://www.google.com/chrome/">Google Chrome</a> 9+, <a href="https://www.opera.com/">Opera</a> 12+, <a href="https://www.apple.com/safari/">Safari </a>5.1+, <a href="https://windows.microsoft.com/en-us/internet-explorer/browser-ie">Internet Explorer</a> 11+, and <a href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a> build 10240+; however, the user's device must also have hardware that supports these features.</p>
 

--- a/files/en-us/web/api/webrtc_api/session_lifetime/index.html
+++ b/files/en-us/web/api/webrtc_api/session_lifetime/index.html
@@ -9,9 +9,7 @@ tags:
 ---
 <p>{{WebRTCSidebar}}{{draft}}</p>
 
-<div class="summary">
 <p>WebRTC lets you build peer-to-peer communication of arbitrary data, audio, or video—or any combination thereof—into a browser application. In this article, we'll look at the lifetime of a WebRTC session, from establishing the connection all the way through closing the connection when it's no longer needed.</p>
-</div>
 
 <p>This article doesn't get into details of the actual APIs involved in establishing and handling a WebRTC connection; it reviews the process in general with some information about why each step is required. See <a href="/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling">Signaling and video calling</a> for an actual example with a step-by-step explanation of what the code does.</p>
 


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8110.

It removes `class="summary"` from Web/API pages, in the cases where it was attached to a `<div>`.