### PR TITLE
Remove summary class from paragraphs, part 1

### DIFF
--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -11,7 +11,7 @@ browser-compat: api.AbortSignal.abort
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).</p>
+<p>The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).</p>
 
 <p>This is shorthand for the following code:</p>
 

--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AnalyserNode.AnalyserNode
 ---
 <p>{{APIRef("'Web Audio API'")}}</p>
 
-<p class="summary">The <strong><code>AnalyserNode()</code></strong> constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new {{domxref("AnalyserNode")}} object instance.</p>
+<p>The <strong><code>AnalyserNode()</code></strong> constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> creates a new {{domxref("AnalyserNode")}} object instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/analysernode/fftsize/index.html
+++ b/files/en-us/web/api/analysernode/fftsize/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AnalyserNode.fftSize
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>fftSize</code></strong> property of the {{domxref("AnalyserNode")}} interface is an unsigned long value and represents the window size in samples that is used when performing a <a href="https://en.wikipedia.org/wiki/Fast_Fourier_transform">Fast Fourier Transform</a> (FFT) to get frequency domain data.</p>
+<p>The <strong><code>fftSize</code></strong> property of the {{domxref("AnalyserNode")}} interface is an unsigned long value and represents the window size in samples that is used when performing a <a href="https://en.wikipedia.org/wiki/Fast_Fourier_transform">Fast Fourier Transform</a> (FFT) to get frequency domain data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.html
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AnalyserNode.frequencyBinCount
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>frequencyBinCount</code></strong> read-only property of the {{domxref("AnalyserNode")}} interface is an unsigned integer half that of the {{domxref("AnalyserNode.fftSize")}}. This generally equates to the number of data values you will have to play with for the visualization.</p>
+<p>The <strong><code>frequencyBinCount</code></strong> read-only property of the {{domxref("AnalyserNode")}} interface is an unsigned integer half that of the {{domxref("AnalyserNode.fftSize")}}. This generally equates to the number of data values you will have to play with for the visualization.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.html
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AnalyserNode.maxDecibels
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>maxDecibels</code></strong> property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the maximum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
+<p>The <strong><code>maxDecibels</code></strong> property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the maximum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/analysernode/mindecibels/index.html
+++ b/files/en-us/web/api/analysernode/mindecibels/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AnalyserNode.minDecibels
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <strong><code>minDecibels</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the minimum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
+<p>The <strong><code>minDecibels</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the minimum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AnalyserNode.smoothingTimeConstant
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <strong><code>smoothingTimeConstant</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the averaging constant with the last analysis frame. It's basically an average between the current buffer and the last buffer the <code>AnalyserNode</code> processed, and results in a much smoother set of value changes over time.</p>
+<p>The <strong><code>smoothingTimeConstant</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the averaging constant with the last analysis frame. It's basically an average between the current buffer and the last buffer the <code>AnalyserNode</code> processed, and results in a much smoother set of value changes over time.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
@@ -19,7 +19,7 @@ browser-compat: api.AudioBuffer.copyFromChannel
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The
+<p>The
     <strong><code>copyFromChannel()</code></strong> method of the
     {{domxref("AudioBuffer")}} interface copies the audio sample data from the specified
     channel of the <code>AudioBuffer</code> to a specified

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AudioBufferSourceNode.detune
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>detune</code></strong> property of the
+<p>The <strong><code>detune</code></strong> property of the
   {{domxref("AudioBufferSourceNode")}} interface is a <a
     href="/en-US/docs/Web/API/AudioParam#k-rate">k-rate</a> {{domxref("AudioParam")}}
   representing detuning of oscillation in <a

--- a/files/en-us/web/api/audiocontext/baselatency/index.html
+++ b/files/en-us/web/api/audiocontext/baselatency/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AudioContext.baseLatency
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>baseLatency</code></strong> read-only property of the
+<p>The <strong><code>baseLatency</code></strong> read-only property of the
   {{domxref("AudioContext")}} interface returns a double that represents the number of
   seconds of processing latency incurred by the <code>AudioContext</code> passing an audio
   buffer from the {{domxref("AudioDestinationNode")}} — i.e. the end of the audio graph —

--- a/files/en-us/web/api/audiocontext/outputlatency/index.html
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AudioContext.outputLatency
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>outputLatency</code></strong> read-only property of
+<p>The <strong><code>outputLatency</code></strong> read-only property of
   the {{domxref("AudioContext")}} Interface provides an estimation of the output latency
   of the current audio context.</p>
 

--- a/files/en-us/web/api/audionode/context/index.html
+++ b/files/en-us/web/api/audionode/context/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AudioNode.context
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The read-only <code>context</code> property of the
+<p>The read-only <code>context</code> property of the
   {{domxref("AudioNode")}} interface returns the associated
   {{domxref("BaseAudioContext")}}, that is the object representing the processing graph
   the node is participating in.</p>

--- a/files/en-us/web/api/audioparam/defaultvalue/index.html
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AudioParam.defaultValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>defaultValue</code></strong>
+<p>The <strong><code>defaultValue</code></strong>
     read-only property of the {{ domxref("AudioParam") }} interface represents the initial
     value of the attributes as defined by the specific {{domxref("AudioNode")}} creating
     the <code>AudioParam</code>.</p>

--- a/files/en-us/web/api/audioparam/maxvalue/index.html
+++ b/files/en-us/web/api/audioparam/maxvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AudioParam.maxValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>maxValue</code></strong>
+<p>The <strong><code>maxValue</code></strong>
     read-only property of the {{domxref("AudioParam")}} interface represents the maximum
     possible value for the parameter's nominal (effective) range.</p>
 

--- a/files/en-us/web/api/audioparam/minvalue/index.html
+++ b/files/en-us/web/api/audioparam/minvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.AudioParam.minValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>minValue</code></strong>
+<p>The <strong><code>minValue</code></strong>
     read-only property of the {{domxref("AudioParam")}} interface represents the minimum
     possible value for the parameter's nominal (effective) range.</p>
 

--- a/files/en-us/web/api/audioparam/settargetattime/index.html
+++ b/files/en-us/web/api/audioparam/settargetattime/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AudioParam.setTargetAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <code>setTargetAtTime()</code> method of the
+<p>The <code>setTargetAtTime()</code> method of the
   {{domxref("AudioParam")}} interface schedules the start of a gradual change to the
   <code>AudioParam</code> value. This is useful for decay or release portions of ADSR
   envelopes.</p>

--- a/files/en-us/web/api/audioparam/setvalueattime/index.html
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.html
@@ -12,7 +12,7 @@ browser-compat: api.AudioParam.setValueAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <code>setValueAtTime()</code> method of the
+<p>The <code>setValueAtTime()</code> method of the
   {{domxref("AudioParam")}} interface schedules an instant change to the
   <code>AudioParam</code> value at a precise time, as measured against
   {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}. The new value is given in the value parameter.

--- a/files/en-us/web/api/audioworkletnode/parameters/index.html
+++ b/files/en-us/web/api/audioworkletnode/parameters/index.html
@@ -14,7 +14,7 @@ browser-compat: api.AudioWorkletNode.parameters
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The read-only <strong><code>parameters</code></strong> property of the
+<p>The read-only <strong><code>parameters</code></strong> property of the
   {{domxref("AudioWorkletNode")}} interface returns the associated
   {{domxref("AudioParamMap")}} — that is, a <code>Map</code>-like collection of
   {{domxref("AudioParam")}} objects. They are instantiated during creation of the

--- a/files/en-us/web/api/audioworkletnode/port/index.html
+++ b/files/en-us/web/api/audioworkletnode/port/index.html
@@ -12,13 +12,13 @@ browser-compat: api.AudioWorkletNode.port
 ---
 <div>{{APIRef("Web Audio API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The read-only <strong><code>port</code></strong> property of the
+<p>The read-only <strong><code>port</code></strong> property of the
   {{domxref("AudioWorkletNode")}} interface returns the associated
   {{domxref("MessagePort")}}. It can be used to communicate between the node and its
   associated {{domxref("AudioWorkletProcessor")}}.</p>
 
 <div class="notecard note">
-  <p class="summary"><strong>Note</strong>: The port at the other end of the channel is
+  <p><strong>Note</strong>: The port at the other end of the channel is
     available under the {{domxref("AudioWorkletProcessor.port", "port")}} property of the
     processor.</p>
 </div>

--- a/files/en-us/web/api/audioworkletprocessor/port/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/port/index.html
@@ -13,13 +13,13 @@ browser-compat: api.AudioWorkletProcessor.port
 ---
 <div>{{APIRef("Web Audio API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The read-only <strong><code>port</code></strong> property of the
+<p>The read-only <strong><code>port</code></strong> property of the
   {{domxref("AudioWorkletProcessor")}} interface returns the associated
   {{domxref("MessagePort")}}. It can be used to communicate between the processor and the
   {{domxref("AudioWorkletNode")}} to which it belongs.</p>
 
 <div class="notecard note">
-  <p class="summary"><strong>Note</strong>: The port at the other end of the channel is
+  <p><strong>Note</strong>: The port at the other end of the channel is
     available under the {{domxref("AudioWorkletNode.port", "port")}} property of the node.
   </p>
 </div>

--- a/files/en-us/web/api/background_fetch_api/index.html
+++ b/files/en-us/web/api/background_fetch_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong>Background Fetch API</strong> provides a method for managing downloads that may take a significant amount of time such as movies, audio files, and software.</p>
+<p>The <strong>Background Fetch API</strong> provides a method for managing downloads that may take a significant amount of time such as movies, audio files, and software.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchEvent.BackgroundFetchEvent
 ---
 <div>{{DefaultAPISidebar("null")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
+<p>The <strong><code>BackgroundFetchEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchEvent</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is the event type for background fetch events dispatched on the {{domxref("ServiceWorkerGlobalScope", "service worker global scope")}}.</p>
+<p>The <strong><code>BackgroundFetchEvent</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is the event type for background fetch events dispatched on the {{domxref("ServiceWorkerGlobalScope", "service worker global scope")}}.</p>
 
 <p>It is the event type passed to <code>onbackgroundfetchabort</code> and <code>onbackgroundfetchclick</code>.</p>
 

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchEvent.registration
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>registration</code></strong> read-only property of the {{domxref("BackgroundFetchEvent")}} interface returns a {{domxref("BackgroundFetchRegistration")}} object.</p>
+<p>The <strong><code>registration</code></strong> read-only property of the {{domxref("BackgroundFetchEvent")}} interface returns a {{domxref("BackgroundFetchRegistration")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -14,7 +14,7 @@ browser-compat: api.BackgroundFetchManager.fetch
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>fetch()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects. </p>
+<p>The <strong><code>fetch()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.html
@@ -14,7 +14,7 @@ browser-compat: api.BackgroundFetchManager.get
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>get()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided <code>id</code> or {{jsxref("undefined")}} if the <code>id</code> is not found. </p>
+<p>The <strong><code>get()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided <code>id</code> or {{jsxref("undefined")}} if the <code>id</code> is not found. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.html
@@ -14,7 +14,7 @@ browser-compat: api.BackgroundFetchManager.getIds
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>getIds()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches. </p>
+<p>The <strong><code>getIds()</code></strong> method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/index.html
@@ -13,7 +13,7 @@ browser-compat: api.BackgroundFetchManager
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchManager</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.</p>
+<p>The <strong><code>BackgroundFetchManager</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/backgroundfetchrecord/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchRecord
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchRecord</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual request and response.</p>
+<p>The <strong><code>BackgroundFetchRecord</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual request and response.</p>
 
 <p>A <code>BackgroundFetchRecord</code> is created by the {{domxref("BackgroundFetchManager.fetch()","BackgroundFetchManager.fetch()")}} method, therefore there is no constructor for this interface.</p>
 

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRecord.request
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>request</code></strong> read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns the details of the resource to be fetched.</p>
+<p>The <strong><code>request</code></strong> read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns the details of the resource to be fetched.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRecord.responseReady
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>responseReady</code></strong> read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.</p>
+<p>The <strong><code>responseReady</code></strong> read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.abort
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>abort()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface aborts an active background fetch.</p>
+<p>The <strong><code>abort()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface aborts an active background fetch.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.downloaded
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>downloaded</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes that has been downloaded, initially <code>0</code>.</p>
+<p>The <strong><code>downloaded</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes that has been downloaded, initially <code>0</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.downloadTotal
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>downloadTotal</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total size in bytes of this download. This is set when the background fetch was registered, or <code>0</code> if not set.</p>
+<p>The <strong><code>downloadTotal</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total size in bytes of this download. This is set when the background fetch was registered, or <code>0</code> if not set.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.failureReason
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>failureReason</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string with a value that indicates a reason for a background fetch failure.</p>
+<p>The <strong><code>failureReason</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string with a value that indicates a reason for a background fetch failure.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.id
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a copy of the background fetch's <code>ID</code>.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a copy of the background fetch's <code>ID</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchRegistration
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchRegistration</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual background fetch.</p>
+<p>The <strong><code>BackgroundFetchRegistration</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual background fetch.</p>
 
 <p>A <code>BackgroundFetchRegistration</code> instance is returned by the {{domxref("BackgroundFetchManager.fetch()")}} or {{domxref("BackgroundFetchManager.get()")}} methods, and therefore there has no constructor.</p>
 

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.match
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>match()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface returns the first matching {{domxref("BackgroundFetchRecord")}}.</p>
+<p>The <strong><code>match()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface returns the first matching {{domxref("BackgroundFetchRecord")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.matchAll
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>matchAll()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface returns an array of matching {{domxref("BackgroundFetchRecord")}} objects.</p>
+<p>The <strong><code>matchAll()</code></strong> method of the {{domxref("BackgroundFetchRegistration")}} interface returns an array of matching {{domxref("BackgroundFetchRecord")}} objects.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.onprogress
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>onprogress</code></strong> EventHandler of the {{domxref("BackgroundFetchRegistration")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes background fetch events.</p>
+<p>The <strong><code>onprogress</code></strong> EventHandler of the {{domxref("BackgroundFetchRegistration")}} interface is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes background fetch events.</p>
 
 <p> The event fires when any of the following properties change:</p>
 

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>recordsAvailable</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns <code>true</code> if there are requests and responses to be accessed. If this returns false then {{domxref("BackgroundFetchRegistration.match()","match()")}} and {{domxref("BackgroundFetchRegistration.matchAll()","matchAll()")}} can't be used.</p>
+<p>The <strong><code>recordsAvailable</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns <code>true</code> if there are requests and responses to be accessed. If this returns false then {{domxref("BackgroundFetchRegistration.match()","match()")}} and {{domxref("BackgroundFetchRegistration.matchAll()","matchAll()")}} can't be used.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.result
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>result</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string indicating whether the background fetch was successful or failed.</p>
+<p>The <strong><code>result</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string indicating whether the background fetch was successful or failed.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.uploaded
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>uploaded</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes successfully sent, initially <code>0</code>.</p>
+<p>The <strong><code>uploaded</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes successfully sent, initially <code>0</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchRegistration.uploadTotal
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>uploadTotal</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total number of bytes to be sent to the server.</p>
+<p>The <strong><code>uploadTotal</code></strong> read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total number of bytes to be sent to the server.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchUpdateUIEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchUpdateUIEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
+<p>The <strong><code>BackgroundFetchUpdateUIEvent()</code></strong> constructor creates a new {{domxref("BackgroundFetchUpdateUIEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>BackgroundFetchUpdateUIEvent</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is an event type passed to {{domxref("ServiceWorkerGlobalScope.onbackgroundfetchsuccess")}} and {{domxref("ServiceWorkerGlobalScope.onbackgroundfetchfail")}}, and provides a method for updating the title and icon of the app to inform a user of the success or failure of a background fetch. </p>
+<p>The <strong><code>BackgroundFetchUpdateUIEvent</code></strong> interface of the {{domxref('Background Fetch API','','',' ')}} is an event type passed to {{domxref("ServiceWorkerGlobalScope.onbackgroundfetchsuccess")}} and {{domxref("ServiceWorkerGlobalScope.onbackgroundfetchfail")}}, and provides a method for updating the title and icon of the app to inform a user of the success or failure of a background fetch. </p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BackgroundFetchUpdateUIEvent.updateUI
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
-<p class="summary">The <strong><code>updateUI()</code></strong> method of the {{domxref("BackgroundFetchUpdateUIEvent")}} interface updates the title and icon in the user interface to show the status of a background fetch.</p>
+<p>The <strong><code>updateUI()</code></strong> method of the {{domxref("BackgroundFetchUpdateUIEvent")}} interface updates the title and icon in the user interface to show the status of a background fetch.</p>
 
 <p>This method may only be run once, to notify the user on a failed or a successful fetch.</p>
 

--- a/files/en-us/web/api/badging_api/index.html
+++ b/files/en-us/web/api/badging_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Badging API")}}</div>
 
-<p class="summary">The <strong>Badging API</strong> gives web developers a method of setting a badge on a document or application, to act as a notification that state has changed without displaying a more distracting notification. A common use case for this would be an application with a messaging feature displaying a badge on the app icon to show that new messages have arrived.</p>
+<p>The <strong>Badging API</strong> gives web developers a method of setting a badge on a document or application, to act as a notification that state has changed without displaying a more distracting notification. A common use case for this would be an application with a messaging feature displaying a badge on the app icon to show that new messages have arrived.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detection API")}} {{AvailableInWorkers}}</div>
 
-<p class="summary">The Barcode Detection API detects linear and two-dimensional barcodes in images.</p>
+<p>The Barcode Detection API detects linear and two-dimensional barcodes in images.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 

--- a/files/en-us/web/api/barcodedetector/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/barcodedetector/index.html
@@ -12,7 +12,7 @@ browser-compat: api.BarcodeDetector.BarcodeDetector
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
-<p class="summary">The <strong><code>BarcodeDetector()</code></strong> constructor creates
+<p>The <strong><code>BarcodeDetector()</code></strong> constructor creates
   a new {{domxref("BarcodeDetector")}} object which detects linear and two-dimensional
   barcodes in images.</p>
 

--- a/files/en-us/web/api/barcodedetector/detect/index.html
+++ b/files/en-us/web/api/barcodedetector/detect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BarcodeDetector.detect
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
-<p class="summary">The <strong><code>detect()</code></strong> method of the
+<p>The <strong><code>detect()</code></strong> method of the
   {{domxref("BarcodeDetector")}} interface returns a {{jsxref('Promise')}} which fulfills
   with an {{jsxref('Array')}} of detected barcodes within an image.</p>
 

--- a/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BarcodeDetector.getSupportedFormats
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
-<p class="summary">The <strong><code>getSupportedFormats()</code></strong> static method
+<p>The <strong><code>getSupportedFormats()</code></strong> static method
   of the {{domxref("BarcodeDetector")}} interface returns a {{jsxref('Promise')}} which
   fulfills with an {{jsxref('Array')}} of supported barcode format types.</p>
 

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BarcodeDetector
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
-<p class="summary">The <strong><code>BarcodeDetector</code></strong> interface of the {{domxref('Barcode Detection API')}} allows detection of linear and two dimensional barcodes in images.</p>
+<p>The <strong><code>BarcodeDetector</code></strong> interface of the {{domxref('Barcode Detection API')}} allows detection of linear and two dimensional barcodes in images.</p>
 
 <h2 id="Constructors">Constructors</h2>
 

--- a/files/en-us/web/api/barprop/index.html
+++ b/files/en-us/web/api/barprop/index.html
@@ -10,7 +10,7 @@ browser-compat: api.BarProp
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p class="summary">The <strong><code>BarProp</code></strong> interface of the {{domxref('Document Object Model')}} represents the web browser user interface elements that are exposed to scripts in web pages. Each of the following interface elements are represented by a <code>BarProp</code> object.</p>
+<p>The <strong><code>BarProp</code></strong> interface of the {{domxref('Document Object Model')}} represents the web browser user interface elements that are exposed to scripts in web pages. Each of the following interface elements are represented by a <code>BarProp</code> object.</p>
 
 <dl>
   <dt>{{domxref("Window.locationbar")}}</dt>

--- a/files/en-us/web/api/barprop/visible/index.html
+++ b/files/en-us/web/api/barprop/visible/index.html
@@ -11,7 +11,7 @@ browser-compat: api.BarProp.visible
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p class="summary">The <strong><code>visible</code></strong> read-only property of the {{domxref("BarProp")}} interface returns <code>true</code> if the user interface element it represents is visible.</p>
+<p>The <strong><code>visible</code></strong> read-only property of the {{domxref("BarProp")}} interface returns <code>true</code> if the user interface element it represents is visible.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -13,7 +13,7 @@ browser-compat: api.BaseAudioContext.createAnalyser
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <code>createAnalyser()</code> method of the
+<p>The <code>createAnalyser()</code> method of the
   {{domxref("BaseAudioContext")}} interface creates an {{domxref("AnalyserNode")}}, which
   can be used to expose audio time and frequency data and create data visualisations.</p>
 

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -13,7 +13,7 @@ browser-compat: api.BaseAudioContext.createDelay
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <code>createDelay()</code> method of the
+<p>The <code>createDelay()</code> method of the
   {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("DelayNode")}},
   which is used to delay the incoming audio signal by a certain amount of time.</p>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.authenticatedSignedWrites
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>authenticatedSignedWrites</code></strong> read-only
+<p>The <strong><code>authenticatedSignedWrites</code></strong> read-only
   property of the {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if signed writing to the characteristic
   value is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.broadcast
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>broadcast</code></strong> read-only property of the
+<p>The <strong><code>broadcast</code></strong> read-only property of the
   {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if the broadcast of the characteristic
   value is permitted using the Server Characteristic Configuration Descriptor.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.indicate
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>indicate</code></strong> read-only property of the
+<p>The <strong><code>indicate</code></strong> read-only property of the
   {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if indications of the characteristic
   value with acknowledgement is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.notify
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("")}}</div>
 
-<p class="summary">The <strong><code>notify</code></strong> read-only property of the
+<p>The <strong><code>notify</code></strong> read-only property of the
   {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if notifications of the characteristic
   value without acknowledgement is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.read
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>read</code></strong> read-only property of the
+<p>The <strong><code>read</code></strong> read-only property of the
   {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if the reading of the characteristic
   value is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
@@ -16,7 +16,7 @@ browser-compat: api.BluetoothCharacteristicProperties.reliableWrite
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>reliableWrite</code></strong> read-only property of
+<p>The <strong><code>reliableWrite</code></strong> read-only property of
   the {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if reliable writes to the characteristic
   is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.writableAuxiliaries
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>writableAuxiliaries</code></strong> read-only
+<p>The <strong><code>writableAuxiliaries</code></strong> read-only
   property of the {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if reliable writes to the characteristic
   descriptor is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.write
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>write</code></strong> read-only property of the
+<p>The <strong><code>write</code></strong> read-only property of the
   {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if the writing to the characteristic with
   response is permitted.</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
@@ -15,7 +15,7 @@ browser-compat: api.BluetoothCharacteristicProperties.writeWithoutResponse
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
-<p class="summary">The <strong><code>writeWithoutResponse</code></strong> read-only
+<p>The <strong><code>writeWithoutResponse</code></strong> read-only
   property of the {{domxref("BluetoothCharacteristicProperties")}} interface returns a
   <code>boolean</code> that is <code>true</code> if the writing to the characteristic
   without response is permitted.</p>

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ByteLengthQueuingStrategy.ByteLengthQueuingStrategy
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>ByteLengthQueuingStrategy()</code></strong>
+<p>The <strong><code>ByteLengthQueuingStrategy()</code></strong>
   constructor creates and returns a <code>ByteLengthQueuingStrategy</code> object
   instance.</p>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ByteLengthQueuingStrategy.size
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>size()</code></strong> method of the
+<p>The <strong><code>size()</code></strong> method of the
   {{domxref("ByteLengthQueuingStrategy")}} interface returns the given chunk’s
   <code>byteLength</code> property.</p>
 

--- a/files/en-us/web/api/canvas_api/index.html
+++ b/files/en-us/web/api/canvas_api/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CanvasSidebar}}</div>
 
-<p class="summary">The <strong>Canvas API</strong> provides a means for drawing graphics via <a href="/en-US/docs/Web/JavaScript">JavaScript</a> and the <a href="/en-US/docs/Web/HTML">HTML</a> {{HtmlElement("canvas")}} element. Among other things, it can be used for animation, game graphics, data visualization, photo manipulation, and real-time video processing.</p>
+<p>The <strong>Canvas API</strong> provides a means for drawing graphics via <a href="/en-US/docs/Web/JavaScript">JavaScript</a> and the <a href="/en-US/docs/Web/HTML">HTML</a> {{HtmlElement("canvas")}} element. Among other things, it can be used for animation, game graphics, data visualization, photo manipulation, and real-time video processing.</p>
 
 <p>The Canvas API largely focuses on 2D graphics. The <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a>, which also uses the <code>&lt;canvas&gt;</code> element, draws hardware-accelerated 2D and 3D graphics.</p>
 

--- a/files/en-us/web/api/channel_messaging_api/index.html
+++ b/files/en-us/web/api/channel_messaging_api/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Channel Messaging API")}}</p>
 
-<p class="summary">The <strong>Channel Messaging API</strong> allows two separate scripts running in different browsing contexts attached to the same document (e.g., two IFrames, or the main document and an IFrame, two documents via a {{domxref("SharedWorker")}}, or two workers) to communicate directly, passing messages between one another through two-way channels (or pipes) with a port at each end.</p>
+<p>The <strong>Channel Messaging API</strong> allows two separate scripts running in different browsing contexts attached to the same document (e.g., two IFrames, or the main document and an IFrame, two documents via a {{domxref("SharedWorker")}}, or two workers) to communicate directly, passing messages between one another through two-way channels (or pipes) with a port at each end.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ClipboardItem.ClipboardItem
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p class="summary">The <code><strong>ClipboardItem()</strong></code> constructor of the {{domxref("Clipboard API")}} creates a new {{domxref("ClipboardItem")}} object which represents data to be stored or retrieved via the {{domxref("Clipboard API")}}, that is {{domxref("clipboard.write()")}} and {{domxref("clipboard.read()")}} respectively.</p>
+<p>The <code><strong>ClipboardItem()</strong></code> constructor of the {{domxref("Clipboard API")}} creates a new {{domxref("ClipboardItem")}} object which represents data to be stored or retrieved via the {{domxref("Clipboard API")}}, that is {{domxref("clipboard.write()")}} and {{domxref("clipboard.read()")}} respectively.</p>
 
 <div class="notecard note">
   <p><strong>Note</strong>: Image format support varies by browser. See the browser compatibility table for the {{domxref("Clipboard")}} interface.</p>

--- a/files/en-us/web/api/clipboarditem/gettype/index.html
+++ b/files/en-us/web/api/clipboarditem/gettype/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ClipboardItem.getType
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p class="summary">The <strong><code>getType()</code></strong> method of the {{domxref("ClipboardItem")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} of the requested  {{Glossary("MIME type")}} or an error if the MIME type is not found.</p>
+<p>The <strong><code>getType()</code></strong> method of the {{domxref("ClipboardItem")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} of the requested  {{Glossary("MIME type")}} or an error if the MIME type is not found.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ClipboardItem
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p class="summary">The <strong><code>ClipboardItem</code></strong> interface of the {{domxref('Clipboard API')}} represents a single item format, used when reading or writing data via the {{domxref('Clipboard API')}}. That is {{domxref("clipboard.read()")}} and {{domxref("clipboard.write()")}} respectively.</p>
+<p>The <strong><code>ClipboardItem</code></strong> interface of the {{domxref('Clipboard API')}} represents a single item format, used when reading or writing data via the {{domxref('Clipboard API')}}. That is {{domxref("clipboard.read()")}} and {{domxref("clipboard.write()")}} respectively.</p>
 
 <p>The benefit of having the <strong><code>ClipboardItem</code></strong> interface to represent data, is that it enables developers to cope with the varying scope of file types and data easily.</p>
 

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.html
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.html
@@ -17,7 +17,7 @@ browser-compat: api.ClipboardItem.presentationStyle
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p class="summary">The read-only
+<p>The read-only
     <strong><code>presentationStyle</code></strong> property of the {{domxref("ClipboardItem")}}
     interface returns a {{jsxref("String")}} indicating how an item should be presented.</p>
 

--- a/files/en-us/web/api/clipboarditem/types/index.html
+++ b/files/en-us/web/api/clipboarditem/types/index.html
@@ -17,7 +17,7 @@ browser-compat: api.ClipboardItem.types
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
-<p class="summary">The read-only
+<p>The read-only
     <strong><code>types</code></strong> property of the {{domxref("ClipboardItem")}}
     interface returns an {{jsxref("Array")}} of {{Glossary("MIME type", 'MIME types')}}
     available within the {{domxref("ClipboardItem")}}</p>

--- a/files/en-us/web/api/compressionstream/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CompressionStream.CompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>CompressionStream()</code></strong> constructor creates a new {{domxref("CompressionStream")}} object which compresses a stream of data.</p>
+<p>The <strong><code>CompressionStream()</code></strong> constructor creates a new {{domxref("CompressionStream")}} object which compresses a stream of data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>CompressionStream</code></strong> interface of the {{domxref('Compression Streams API','','',' ')}} is an API for compressing a stream of data.</p>
+<p>The <strong><code>CompressionStream</code></strong> interface of the {{domxref('Compression Streams API','','',' ')}} is an API for compressing a stream of data.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/compressionstream/readable/index.html
+++ b/files/en-us/web/api/compressionstream/readable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CompressionStream.readable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/compressionstream/writable/index.html
+++ b/files/en-us/web/api/compressionstream/writable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CompressionStream.writable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("WritableStream")}}.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("WritableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
-<p class="summary">The Contact Picker API allows users to select entries from their contact list and share limited details of the selected entries with a website or application.</p>
+<p>The Contact Picker API allows users to select entries from their contact list and share limited details of the selected entries with a website or application.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (not exposed via {{domxref("WorkerNavigator")}}).</p>

--- a/files/en-us/web/api/contactsmanager/getproperties/index.html
+++ b/files/en-us/web/api/contactsmanager/getproperties/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ContactsManager.getProperties
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
-<p class="summary">The <strong><code>getProperties()</code></strong> method of the
+<p>The <strong><code>getProperties()</code></strong> method of the
   {{domxref("ContactsManager")}} interface returns a {{jsxref('Promise')}} which resolves
   with an {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating which contact
   properties are available.</p>

--- a/files/en-us/web/api/contactsmanager/index.html
+++ b/files/en-us/web/api/contactsmanager/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ContactsManager
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
-<p class="summary">The <strong><code>ContactsManager</code></strong> interface of the {{domxref('Contact Picker API')}} allows users to select entries from their contact list and share limited details of the selected entries with a website or application.</p>
+<p>The <strong><code>ContactsManager</code></strong> interface of the {{domxref('Contact Picker API')}} allows users to select entries from their contact list and share limited details of the selected entries with a website or application.</p>
 
 <p>The <code>ContactsManager</code> is available through the global {{domxref('navigator.contacts')}} property.</p>
 

--- a/files/en-us/web/api/contactsmanager/select/index.html
+++ b/files/en-us/web/api/contactsmanager/select/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ContactsManager.select
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
-<p class="summary">The <strong><code>select()</code></strong> method of the
+<p>The <strong><code>select()</code></strong> method of the
   {{domxref("ContactsManager")}} interface returns a {{jsxref('Promise')}} which, when
   resolved, presents the user with a contact picker which allows them to select contact(s)
   they wish to share. This method requires a user gesture for the {{jsxref('Promise')}} to

--- a/files/en-us/web/api/content_index_api/index.html
+++ b/files/en-us/web/api/content_index_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The Content Index API allows developers to register their offline enabled content with the browser.</p>
+<p>The Content Index API allows developers to register their offline enabled content with the browser.</p>
 
 <h2 id="Concepts_and_Usage">Concepts and Usage</h2>
 

--- a/files/en-us/web/api/contentindex/add/index.html
+++ b/files/en-us/web/api/contentindex/add/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ContentIndex.add
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>add()</code></strong> method of the
+<p>The <strong><code>add()</code></strong> method of the
   {{domxref("ContentIndex")}} interface registers an item with the {{domxref('Content
   Index API','content index')}}.</p>
 

--- a/files/en-us/web/api/contentindex/delete/index.html
+++ b/files/en-us/web/api/contentindex/delete/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ContentIndex.delete
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>delete()</code></strong> method of the
+<p>The <strong><code>delete()</code></strong> method of the
   {{domxref("ContentIndex")}} interface unregisters an item from the currently indexed
   content.</p>
 

--- a/files/en-us/web/api/contentindex/getall/index.html
+++ b/files/en-us/web/api/contentindex/getall/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ContentIndex.getAll
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>getAll()</code></strong> method of the
+<p>The <strong><code>getAll()</code></strong> method of the
   {{domxref("ContentIndex")}} interface returns a {{jsxref('Promise')}} that resolves with
   an iterable list of content index entries.</p>
 

--- a/files/en-us/web/api/contentindex/index.html
+++ b/files/en-us/web/api/contentindex/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ContentIndex
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>ContentIndex</code></strong> interface of the {{domxref('Content Index API')}} allows developers to register their offline enabled content with the browser.</p>
+<p>The <strong><code>ContentIndex</code></strong> interface of the {{domxref('Content Index API')}} allows developers to register their offline enabled content with the browser.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ContentIndexEvent.ContentIndexEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>ContentIndexEvent()</code></strong> constructor
+<p>The <strong><code>ContentIndexEvent()</code></strong> constructor
   creates a new {{domxref("ContentIndexEvent")}} object whose type and other options are
   configured as specified.</p>
 

--- a/files/en-us/web/api/contentindexevent/id/index.html
+++ b/files/en-us/web/api/contentindexevent/id/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ContentIndexEvent.id
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The read-only <strong><code>id</code></strong> property of the
+<p>The read-only <strong><code>id</code></strong> property of the
   {{domxref("ContentIndexEvent")}} interface is a {{jsxref('String')}} which identifies
   the deleted content index via it's <code>id</code>.</p>
 

--- a/files/en-us/web/api/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ContentIndexEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
-<p class="summary">The <strong><code>ContentIndexEvent</code></strong> interface of the {{domxref('Content Index API')}} defines the object used to represent the {{Event('contentdelete')}} event.</p>
+<p>The <strong><code>ContentIndexEvent</code></strong> interface of the {{domxref('Content Index API')}} defines the object used to represent the {{Event('contentdelete')}} event.</p>
 
 <p>This event is sent to the {{domxref('ServiceWorkerGlobalScope','global scope')}} of a {{domxref('ServiceWorker')}}. It contains the id of the indexed content to be removed.</p>
 

--- a/files/en-us/web/api/cookie_store_api/index.html
+++ b/files/en-us/web/api/cookie_store_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The Cookie Store API provides an asychronous API for managing cookies, while also exposing cookies to {{domxref("Service Worker API", "service workers")}}. </p>
+<p>The Cookie Store API provides an asychronous API for managing cookies, while also exposing cookies to {{domxref("Service Worker API", "service workers")}}. </p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieChangeEvent.changed
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been changed.</p>
+<p>The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been changed.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CookieChangeEvent.CookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
+<p>The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieChangeEvent.deleted
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been deleted by the given <code>CookieChangeEvent</code> instance.</p>
+<p>The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been deleted by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("CookieStore.onchange()")}} when any cookie changes have occurred. A cookie change consists of a cookie and a type (either "changed" or "deleted").</p>
+<p>The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("CookieStore.onchange()")}} when any cookie changes have occurred. A cookie change consists of a cookie and a type (either "changed" or "deleted").</p>
 
 <p>Cookie changes that will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/cookiestore/delete/index.html
+++ b/files/en-us/web/api/cookiestore/delete/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStore.delete
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>delete()</code></strong> method of the {{domxref("CookieStore")}} interface deletes a cookie with the given name or options object. (See below.) The <code>delete()</code> method expires the cookie by changing the date to one in the past.</p>
+<p>The <strong><code>delete()</code></strong> method of the {{domxref("CookieStore")}} interface deletes a cookie with the given name or options object. (See below.) The <code>delete()</code> method expires the cookie by changing the date to one in the past.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStore.get
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>get()</code></strong> method of the {{domxref("CookieStore")}} interface returns a single cookie with the given name or options object. (See below.) The method will return the first matching cookie for the passed parameters.</p>
+<p>The <strong><code>get()</code></strong> method of the {{domxref("CookieStore")}} interface returns a single cookie with the given name or options object. (See below.) The method will return the first matching cookie for the passed parameters.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestore/getall/index.html
+++ b/files/en-us/web/api/cookiestore/getall/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStore.getAll
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>getAll()</code></strong> method of the {{domxref("CookieStore")}} interface returns a list of cookies that match the name or options passed to it. Passing no parameters will return all cookies for the current context.</p>
+<p>The <strong><code>getAll()</code></strong> method of the {{domxref("CookieStore")}} interface returns a list of cookies that match the name or options passed to it. Passing no parameters will return all cookies for the current context.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestore/index.html
+++ b/files/en-us/web/api/cookiestore/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CookieStore
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>CookieStore</code></strong> interface of the {{domxref('Cookie Store API')}} provides methods for getting and setting cookies asynchronously from either a page or a service worker.</p>
+<p>The <strong><code>CookieStore</code></strong> interface of the {{domxref('Cookie Store API')}} provides methods for getting and setting cookies asynchronously from either a page or a service worker.</p>
 
 <p>The <code>CookieStore</code> is accessed via attributes in the global scope in a {{domxref("Window")}} or {{domxref("ServiceWorkerGlobalScope")}} context. Therefore there is no constructor.</p>
 

--- a/files/en-us/web/api/cookiestore/onchange/index.html
+++ b/files/en-us/web/api/cookiestore/onchange/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStore.onchange
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>onchange</code></strong> EventHandler of the {{domxref("CookieStore")}} interface fires when a change is made to any cookie.</p>
+<p>The <strong><code>onchange</code></strong> EventHandler of the {{domxref("CookieStore")}} interface fires when a change is made to any cookie.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestore/set/index.html
+++ b/files/en-us/web/api/cookiestore/set/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStore.set
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
-<p class="summary">The <strong><code>set()</code></strong> method of the {{domxref("CookieStore")}} interface sets a cookie with the given name and value or options object. (See below.)</p>
+<p>The <strong><code>set()</code></strong> method of the {{domxref("CookieStore")}} interface sets a cookie with the given name and value or options object. (See below.)</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStoreManager.getSubscriptions
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>getSubscriptions()</code></strong> method of the {{domxref("CookieStoreManager")}} interface returns a list of all the cookie change subscriptions for this {{domxref("ServiceWorkerRegistration")}}.</p>
+<p>The <strong><code>getSubscriptions()</code></strong> method of the {{domxref("CookieStoreManager")}} interface returns a list of all the cookie change subscriptions for this {{domxref("ServiceWorkerRegistration")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/index.html
+++ b/files/en-us/web/api/cookiestoremanager/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CookieStoreManager
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieStoreManager</code></strong> interface of the {{domxref('Cookie Store')}} API allows service workers to subscribe to events for cookie changes. By using the {{domxref("CookieStoreManager.subscribe()","subscribe()")}} method a particular service worker registration can indicate that it is interested in change events.</p>
+<p>The <strong><code>CookieStoreManager</code></strong> interface of the {{domxref('Cookie Store')}} API allows service workers to subscribe to events for cookie changes. By using the {{domxref("CookieStoreManager.subscribe()","subscribe()")}} method a particular service worker registration can indicate that it is interested in change events.</p>
 
 <p>A <code>CookieStoreManager</code> has an associated {{domxref("ServiceWorkerRegistration")}}. Each service worker registration has a cookie change subscription list, which is a list of cookie change subscriptions each containing a name and url. The methods in this interface allow the service worker to add and remove subscriptions from this list, and to get a list of all subscriptions.</p>
 

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStoreManager.subscribe
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>subscribe()</code></strong> method of the {{domxref("CookieStoreManager")}} interface subscribes a {{domxref("ServiceWorkerRegistration")}} to cookie change events.</p>
+<p>The <strong><code>subscribe()</code></strong> method of the {{domxref("CookieStoreManager")}} interface subscribes a {{domxref("ServiceWorkerRegistration")}} to cookie change events.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CookieStoreManager.unsubscribe
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>unsubscribe()</code></strong> method of the {{domxref("CookieStoreManager")}} interface stops the {{domxref("ServiceWorkerRegistration")}} from receiving previously subscribed events.</p>
+<p>The <strong><code>unsubscribe()</code></strong> method of the {{domxref("CookieStoreManager")}} interface stops the {{domxref("ServiceWorkerRegistration")}} from receiving previously subscribed events.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CountQueuingStrategy.CountQueuingStrategy
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>CountQueuingStrategy()</code></strong> constructor
+<p>The <strong><code>CountQueuingStrategy()</code></strong> constructor
   creates and returns a <code>CountQueuingStrategy</code> object instance.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/countqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/size/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CountQueuingStrategy.size
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>size()</code></strong> method of the
+<p>The <strong><code>size()</code></strong> method of the
   {{domxref("CountQueuingStrategy")}} interface always returns <code>1</code>, so that the
   total queue size is a count of the number of chunks in the queue.</p>
 

--- a/files/en-us/web/api/crashreportbody/index.html
+++ b/files/en-us/web/api/crashreportbody/index.html
@@ -12,9 +12,9 @@ browser-compat: api.CrashReportBody
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>CrashReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of a crash report (the return value of its {{domxref("Report.body")}} property).</p>
+<p>The <code>CrashReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of a crash report (the return value of its {{domxref("Report.body")}} property).</p>
 
-<p class="summary">A crash report is generated when a document becomes unusable due to the browser (or one of its processes) crashing. For security reasons, no details of the crash are communicated in the body except for a general crash reason.</p>
+<p>A crash report is generated when a document becomes unusable due to the browser (or one of its processes) crashing. For security reasons, no details of the crash are communicated in the body except for a general crash reason.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/credential_management_api/index.html
+++ b/files/en-us/web/api/credential_management_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Credential Management API")}}{{ SeeCompatTable() }}</p>
 
-<p class="summary">The Credential Management API lets a website store and retrieve password, public key, and federated credentials. These capabilities allow users to sign in without typing passwords, see the federated account they used to sign in to a site, and resume a session without the explicit sign-in flow of an expired session.</p>
+<p>The Credential Management API lets a website store and retrieve password, public key, and federated credentials. These capabilities allow users to sign in without typing passwords, see the federated account they used to sign in to a site, and resume a session without the explicit sign-in flow of an expired session.</p>
 
 <h2 id="Credential_management_concepts_and_usage">Credential management concepts and usage</h2>
 

--- a/files/en-us/web/api/css_font_loading_api/index.html
+++ b/files/en-us/web/api/css_font_loading_api/index.html
@@ -12,10 +12,10 @@ tags:
 ---
 <div>{{DefaultAPISidebar("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The CSS Font Loading API provides events and interfaces for dynamically loading font resources.</p>
+<p>The CSS Font Loading API provides events and interfaces for dynamically loading font resources.</p>
 
 <div class="notecard note">
-<p class="summary"><strong>Note:</strong> This feature is available in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (<code>self.fonts</code> provides access to {{domxref('FontFaceSet')}}).</p>
+<p><strong>Note:</strong> This feature is available in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (<code>self.fonts</code> provides access to {{domxref('FontFaceSet')}}).</p>
 </div>
 
 <h2 id="Interfaces">Interfaces</h2>

--- a/files/en-us/web/api/css_object_model/css_declaration/index.html
+++ b/files/en-us/web/api/css_object_model/css_declaration/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
-<p class="summary">A <strong>CSS declaration</strong> is an abstract concept not exposed as an object in the DOM. It represents a CSS property and value pairing.</p>
+<p>A <strong>CSS declaration</strong> is an abstract concept not exposed as an object in the DOM. It represents a CSS property and value pairing.</p>
 
 <p>A CSS declaration has the following associated properties:</p>
 

--- a/files/en-us/web/api/css_object_model/css_declaration_block/index.html
+++ b/files/en-us/web/api/css_object_model/css_declaration_block/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
-<p class="summary">A <strong>CSS declaration block</strong> is an ordered collection of CSS properties and values. It is represented in the DOM as a {{domxref("CSSStyleDeclaration")}}.</p>
+<p>A <strong>CSS declaration block</strong> is an ordered collection of CSS properties and values. It is represented in the DOM as a {{domxref("CSSStyleDeclaration")}}.</p>
 
 <p>Each property and value pairing is known as a <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration">CSS declaration</a>. The CSS declaration block has the following associated properties:</p>
 

--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("CSSOM")}}</p>
 
-<p class="summary">The <strong>CSS Object Model</strong> is a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.</p>
+<p>The <strong>CSS Object Model</strong> is a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.</p>
 <p>The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects.</p>
 
 <h2 id="Reference">Reference</h2>

--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.html
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("CSSOM")}}</p>
 
-<p class="summary">The CSS Object Model (CSSOM), part of the DOM, exposes specific interfaces allowing manipulation of a wide amount of information regarding CSS. Initially defined in the <em>DOM Level 2 Style</em> recommendation, these interfaces forms now a specification, <em>CSS Object Model (CSSOM)</em> which aims at superseding it.</p>
+<p>The CSS Object Model (CSSOM), part of the DOM, exposes specific interfaces allowing manipulation of a wide amount of information regarding CSS. Initially defined in the <em>DOM Level 2 Style</em> recommendation, these interfaces forms now a specification, <em>CSS Object Model (CSSOM)</em> which aims at superseding it.</p>
 
 <p>In many cases, and where possible, it really is best practice to dynamically manipulate classes via the {{ domxref("element.className", "className") }} property since the ultimate appearance of all of the styling hooks can be controlled in a single stylesheet. One's JavaScript code also becomes cleaner since instead of being dedicated to styling details, it can focus on the overall semantics of each section it is creating or manipulating, leaving the precise style details to the stylesheet. However, there are cases where actually obtaining or manipulating the rules can be useful (whether for whole stylesheets or individual elements), and that is described in further detail below. Note also that, as with individual element's DOM styles, when speaking of manipulating the stylesheets, this is not actually manipulating the physical document(s), but merely the internal representation of the document.</p>
 

--- a/files/en-us/web/api/cssanimation/animationname/index.html
+++ b/files/en-us/web/api/cssanimation/animationname/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSAnimation.animationName
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>animationName</code></strong> property of the
+<p>The <strong><code>animationName</code></strong> property of the
   {{domxref("CSSAnimation")}} interface returns the {{CSSXref("animation-name")}}. This
   specifies one or more keyframe at-rules which describe the animation applied to the
   element.</p>

--- a/files/en-us/web/api/cssanimation/index.html
+++ b/files/en-us/web/api/cssanimation/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSAnimation
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSAnimation</code></strong> interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object.</p>
+<p>The <strong><code>CSSAnimation</code></strong> interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.html
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.additiveSymbols
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>additiveSymbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface  gets and sets the value of the {{cssxref("@counter-style/additive-symbols","additive-symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>additiveSymbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface  gets and sets the value of the {{cssxref("@counter-style/additive-symbols","additive-symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.html
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.fallback
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>fallback</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/fallback","fallback")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>fallback</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/fallback","fallback")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/name/index.html
+++ b/files/en-us/web/api/csscounterstylerule/name/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.name
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>name</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the <code>name</code> for the associated rule.</p>
+<p>The <strong><code>name</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the <code>name</code> for the associated rule.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/negative/index.html
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.negative
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>negative</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/negative","negative")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>negative</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/negative","negative")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/pad/index.html
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.pad
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>pad</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/pad", "pad")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>pad</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/pad", "pad")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.html
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.prefix
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>prefix</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/prefix","prefix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>prefix</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/prefix","prefix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/range/index.html
+++ b/files/en-us/web/api/csscounterstylerule/range/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.range
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>range</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/range","range")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>range</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/range","range")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.html
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.speakAs
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>speakAs</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/speak-as","speak-as")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>speakAs</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/speak-as","speak-as")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.html
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.suffix
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>suffix</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/suffix","suffix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>suffix</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/suffix","suffix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.html
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.symbols
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>symbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/symbols","symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>symbols</code></strong>  property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/symbols","symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/system/index.html
+++ b/files/en-us/web/api/csscounterstylerule/system/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSCounterStyleRule.system
 ---
 <div>{{DefaultAPISidebar("CSS Counter Styles")}}</div>
 
-<p class="summary">The <strong><code>system</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/system", "system")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
+<p>The <strong><code>system</code></strong> property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/system", "system")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssfontfacerule/style/index.html
+++ b/files/en-us/web/api/cssfontfacerule/style/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSFontFaceRule.style
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p class="summary">The read-only <strong><code>style</code></strong> property of the {{domxref("CSSFontFaceRule")}} interface returns the style information from the {{cssxref("@font-face")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. This will be in the form of a {{domxref("CSSStyleDeclaration")}} object.</p>
+<p>The read-only <strong><code>style</code></strong> property of the {{domxref("CSSFontFaceRule")}} interface returns the style information from the {{cssxref("@font-face")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. This will be in the form of a {{domxref("CSSStyleDeclaration")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.html
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSGroupingRule.cssRules
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>cssRules</code></strong> property of the
+<p>The <strong><code>cssRules</code></strong> property of the
   {{domxref("CSSGroupingRule")}} interface returns a {{domxref("CSSRuleList")}} containing
   a collection of {{domxref("CSSRule")}} objects.</p>
 

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSGroupingRule.deleteRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>deleteRule()</code></strong> method of the
+<p>The <strong><code>deleteRule()</code></strong> method of the
   {{domxref("CSSGroupingRule")}} interface removes a CSS rule from a list of child CSS
   rules.</p>
 

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSGroupingRule.insertRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>insertRule()</code></strong> method of the
+<p>The <strong><code>insertRule()</code></strong> method of the
   {{domxref("CSSGroupingRule")}} interface adds a new CSS rule to a list of CSS rules.</p>
 
 

--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSImportRule.href
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p class="summary">The read-only <strong><code>href</code></strong> property of the
+<p>The read-only <strong><code>href</code></strong> property of the
 	{{domxref("CSSImportRule")}} interface returns the URL specified by the
 	{{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>.</p>
 

--- a/files/en-us/web/api/cssimportrule/media/index.html
+++ b/files/en-us/web/api/cssimportrule/media/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSImportRule.media
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p class="summary">The read-only <strong><code>media</code></strong> property of the
+<p>The read-only <strong><code>media</code></strong> property of the
 	{{domxref("CSSImportRule")}} interface returns a {{domxref("MediaList")}} object,
 	containing the value of the <code>media</code> attribute of the associated stylesheet.
 </p>

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.html
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSImportRule.styleSheet
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p class="summary">The read-only <strong><code>styleSheet</code></strong> property of the
+<p>The read-only <strong><code>styleSheet</code></strong> property of the
 	{{domxref("CSSImportRule")}} interface returns the CSS Stylesheet specified by the
 	{{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. This will be
 	in the form of a {{domxref("CSSStyleSheet")}} object.</p>

--- a/files/en-us/web/api/csskeyframerule/keytext/index.html
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframeRule.keyText
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>keyText</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface represents the keyframe selector as a comma-separated list of percentage values. The from and to keywords map to 0% and 100%, respectively.</p>
+<p>The <strong><code>keyText</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface represents the keyframe selector as a comma-separated list of percentage values. The from and to keywords map to 0% and 100%, respectively.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/appendrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/appendrule/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.appendRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>appendRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface appends a {{domxref("CSSKeyFrameRule")}} to the end of the rules.</p>
+<p>The <strong><code>appendRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface appends a {{domxref("CSSKeyFrameRule")}} to the end of the rules.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.html
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.cssRules
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The read-only <strong><code>cssRules</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes {{cssxref("at-rule")}}.</p>
+<p>The read-only <strong><code>cssRules</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes {{cssxref("at-rule")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/deleterule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/deleterule/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.deleteRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>deleteRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface deletes the {{domxref("CSSKeyFrameRule")}} that matches the specified keyframe selector.</p>
+<p>The <strong><code>deleteRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface deletes the {{domxref("CSSKeyFrameRule")}} that matches the specified keyframe selector.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/findrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/findrule/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.findRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>findRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface finds the {{domxref("CSSKeyFrameRule")}} that matches the specified keyframe selector.</p>
+<p>The <strong><code>findRule()</code></strong> method of the {{domxref("CSSKeyframeRule")}} interface finds the {{domxref("CSSKeyFrameRule")}} that matches the specified keyframe selector.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/name/index.html
+++ b/files/en-us/web/api/csskeyframesrule/name/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.name
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>name</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface gets and sets the name of the animation as used by the {{cssxref("animation-name")}} property.</p>
+<p>The <strong><code>name</code></strong> property of the {{domxref("CSSKeyframeRule")}} interface gets and sets the name of the animation as used by the {{cssxref("animation-name")}} property.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathInvert.CSSMathInvert
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathInvert()</code></strong> constructor creates a
+<p>The <strong><code>CSSMathInvert()</code></strong> constructor creates a
   new {{domxref("CSSMathInvert")}} object which represents a CSS
   {{CSSXref('calc()','calc()')}} used as <code>calc(1 / value)</code></p>
 

--- a/files/en-us/web/api/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathInvert
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathInvert</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents a CSS {{CSSXref('calc()','calc()')}} used as <code>calc(1 / &lt;value&gt;).</code> It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathInvert</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents a CSS {{CSSXref('calc()','calc()')}} used as <code>calc(1 / &lt;value&gt;).</code> It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathinvert/value/index.html
+++ b/files/en-us/web/api/cssmathinvert/value/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathInvert.value
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The CSSMathInvert.value read-only property of the
+<p>The CSSMathInvert.value read-only property of the
   {{domxref("CSSMathInvert")}} interface returns a {{domxref('CSSNumericValue')}} object.
 </p>
 

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathMax.CSSMathMax
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathMax()</code></strong> constructor creates a
+<p>The <strong><code>CSSMathMax()</code></strong> constructor creates a
   new {{domxref("CSSMathMax")}} object which represents the CSS {{CSSXref('max()',
   'max()')}} function.</p>
 

--- a/files/en-us/web/api/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathMax
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathMax</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('max()','max()')}} function.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathMax</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('max()','max()')}} function.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathmax/values/index.html
+++ b/files/en-us/web/api/cssmathmax/values/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathMax.values
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The CSSMathMax.values read-only property of the
+<p>The CSSMathMax.values read-only property of the
   {{domxref("CSSMathMax")}} interface returns a {{domxref('CSSNumericArray')}} object
   which contains one or more {{domxref('CSSNumericValue')}} objects.</p>
 

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathMin.CSSMathMin
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathMin()</code></strong> constructor creates a
+<p>The <strong><code>CSSMathMin()</code></strong> constructor creates a
   new {{domxref("CSSMathMin")}} object which represents the CSS
   {{CSSXref('min()','min()')}} function.</p>
 

--- a/files/en-us/web/api/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathMin
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathMin</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('min()','min()')}} function.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathMin</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('min()','min()')}} function.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathmin/values/index.html
+++ b/files/en-us/web/api/cssmathmin/values/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMathMin.values
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The CSSMathMin.values read-only property of the
+<p>The CSSMathMin.values read-only property of the
   {{domxref("CSSMathMin")}} interface returns a {{domxref('CSSNumericArray')}} object
   which contains one or more {{domxref('CSSNumericValue')}} objects.</p>
 

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathNegate.CSSMathNegate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathNegate()</code></strong> constructor creates a
+<p>The <strong><code>CSSMathNegate()</code></strong> constructor creates a
   new {{domxref("CSSMathNegate")}} object which negates the value passed into it.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathNegate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMathNegate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} negates the value passed into it. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathNegate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} negates the value passed into it. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathnegate/value/index.html
+++ b/files/en-us/web/api/cssmathnegate/value/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathNegate.value
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The CSSMathNegate.value read-only property of the
+<p>The CSSMathNegate.value read-only property of the
   {{domxref("CSSMathNegate")}} interface returns a {{domxref('CSSNumericValue')}} object.
 </p>
 

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMathProduct.CSSMathProduct
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathProduct()</code></strong> constructor creates
+<p>The <strong><code>CSSMathProduct()</code></strong> constructor creates
   a new {{domxref("CSSMathProduct")}} object which creates a new
   {{domxref('CSSMathProduct')}} object which multiplies the arguments passed into it. </p>
 

--- a/files/en-us/web/api/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMathProduct
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathProduct</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathProduct</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.  It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathproduct/values/index.html
+++ b/files/en-us/web/api/cssmathproduct/values/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSMathProduct.values
 ---
 <p>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>CSSMathProduct.values</code></strong> read-only
+<p>The <strong><code>CSSMathProduct.values</code></strong> read-only
   property of the {{domxref("CSSMathProduct")}} interface returns a
   {{domxref('CSSNumericArray')}} object which contains one or more
   {{domxref('CSSNumericValue')}} objects.</p>

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMathSum.CSSMathSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathSum()</code></strong> constructor creates a
+<p>The <strong><code>CSSMathSum()</code></strong> constructor creates a
   new {{domxref("CSSMathSum")}} object which creates a new {{domxref('CSSKeywordValue')}}
   object which represents the result obtained by calling
   {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}},

--- a/files/en-us/web/api/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/index.html
@@ -13,9 +13,9 @@ browser-compat: api.CSSMathSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathSum</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.</p>
+<p>The <strong><code>CSSMathSum</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.</p>
 
-<p class="summary">A CSSMathSum is the object type returned when the  <code><a href="/en-US/docs/Web/API/StylePropertyMapReadOnly/get">StylePropertyMapReadOnly.get()</a></code> method is used on a CSS property whose value is created with a <code><a href="/en-US/docs/Web/CSS/calc()">calc()</a></code> function.</p>
+<p>A CSSMathSum is the object type returned when the  <code><a href="/en-US/docs/Web/API/StylePropertyMapReadOnly/get">StylePropertyMapReadOnly.get()</a></code> method is used on a CSS property whose value is created with a <code><a href="/en-US/docs/Web/CSS/calc()">calc()</a></code> function.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmathsum/values/index.html
+++ b/files/en-us/web/api/cssmathsum/values/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSMathSum.values
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathSum.values</code></strong> read-only property
+<p>The <strong><code>CSSMathSum.values</code></strong> read-only property
   of the {{domxref("CSSMathSum")}} interface returns a {{domxref('CSSNumericArray')}}
   object which contains one or more {{domxref('CSSNumericValue')}} objects.</p>
 

--- a/files/en-us/web/api/cssmathvalue/index.html
+++ b/files/en-us/web/api/cssmathvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSMathValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} a base class for classes representing complex numeric values.</p>
+<p>The <strong><code>CSSMathValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} a base class for classes representing complex numeric values.</p>
 
 <h2 id="Interfaces_based_on_CSSMathValue">Interfaces based on CSSMathValue</h2>
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.html
+++ b/files/en-us/web/api/cssmathvalue/operator/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMathValue.operator
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSMathValue.operator</code></strong> read-only
+<p>The <strong><code>CSSMathValue.operator</code></strong> read-only
   property of the {{domxref("CSSMathValue")}} interface indicates the operator that the
   current subtype represents. For example, if the current <code>CSSMathValue</code>
   subtype is <code>CSSMathSum</code>, this property will return the string

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMatrixComponent.CSSMatrixComponent
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMatrixComponent()</code></strong> constructor
+<p>The <strong><code>CSSMatrixComponent()</code></strong> constructor
   creates a new {{domxref("CSSMatrixComponent")}} object representing the <a
     href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix()</a> and <a
     href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix3d()</a> values of the

--- a/files/en-us/web/api/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSMatrixComponent
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSMatrixComponent</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix()</a> and <a href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix3d()</a> values of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
+<p>The <strong><code>CSSMatrixComponent</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix()</a> and <a href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix3d()</a> values of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
@@ -15,10 +15,10 @@ browser-compat: api.CSSMatrixComponent.matrix
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>matrix</code></strong> property of the
+<p>The <strong><code>matrix</code></strong> property of the
   {{domxref("CSSMatrixComponent")}} interface gets and sets a 2d or 3d matrix.</p>
 
-<p class="summary">See the <a
+<p>See the <a
     href="/en-US/docs/Web/CSS/transform-function/matrix()">matrix()</a> and <a
     href="/en-US/docs/Web/CSS/transform-function/matrix3d()">matrix3d()</a> pages for
   examples.</p>

--- a/files/en-us/web/api/cssmediarule/media/index.html
+++ b/files/en-us/web/api/cssmediarule/media/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSMediaRule.media
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
-<p class="summary">
+<p>
   The read-only <strong><code>media</code></strong> property of the
   {{domxref("CSSMediaRule")}} interface {{domxref("MediaList")}} represents the intended
   destination medium for style information.

--- a/files/en-us/web/api/cssnumericarray/index.html
+++ b/files/en-us/web/api/cssnumericarray/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSNumericArray
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSNumericArray</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}}  contains a list of {{domxref("CSSNumericValue")}} objects.</p>
+<p>The <strong><code>CSSNumericArray</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}}  contains a list of {{domxref("CSSNumericValue")}} objects.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/cssnumericarray/length/index.html
+++ b/files/en-us/web/api/cssnumericarray/length/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSNumericArray.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The read-only <strong><code>length</code></strong> property of the
+<p>The read-only <strong><code>length</code></strong> property of the
   {{domxref("CSSNumericArray")}} interface returns the number of
   {{domxref("CSSNumericValue")}} objects in the list.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/add/index.html
+++ b/files/en-us/web/api/cssnumericvalue/add/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.add
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>add()</code></strong> method of the
+<p>The <strong><code>add()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface adds a supplied number to the
   <code>CSSNumericValue</code>.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/div/index.html
+++ b/files/en-us/web/api/cssnumericvalue/div/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.div
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>div()</code></strong> method of the
+<p>The <strong><code>div()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface divides the <code>CSSNumericValue</code> by the
   supplied value.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/equals/index.html
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.equals
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>equals()</code></strong> method of the
+<p>The <strong><code>equals()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface returns a boolean indicating whether the passed
   value are strictly equal. To return a value of <code>true</code>, all passed values must
   be of the same type and value and must be in the same order. This allows structural

--- a/files/en-us/web/api/cssnumericvalue/index.html
+++ b/files/en-us/web/api/cssnumericvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSNumericValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSNumericValue</code></strong> interface of the <a href="/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model">CSS Typed Object Model API</a> represents operations that all numeric values can perform.</p>
+<p>The <strong><code>CSSNumericValue</code></strong> interface of the <a href="/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model">CSS Typed Object Model API</a> represents operations that all numeric values can perform.</p>
 
 <h2 id="Interfaces_based_on_CSSNumericValue">Interfaces based on CSSNumericValue</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/max/index.html
+++ b/files/en-us/web/api/cssnumericvalue/max/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.max
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>max()</code></strong> method of the
+<p>The <strong><code>max()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface returns the highest value from among the values
   passed. The passed values must be of the same type.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/min/index.html
+++ b/files/en-us/web/api/cssnumericvalue/min/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.min
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>min()</code></strong> method of the
+<p>The <strong><code>min()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface returns the lowest value from among those
   values passed. The passed values must be of the same type.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/mul/index.html
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.mul
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>mul()</code></strong> method of the
+<p>The <strong><code>mul()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface multiplies the <code>CSSNumericValue</code> by
   the supplied value.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/parse/index.html
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.parse
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>parse()</code></strong> method of the
+<p>The <strong><code>parse()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface converts a value string into an object whose
   members are value and the units.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/sub/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.sub
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>sub()</code></strong> method of the
+<p>The <strong><code>sub()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface subtracts a supplied number from the
   <code>CSSNumericValue</code>.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/to/index.html
+++ b/files/en-us/web/api/cssnumericvalue/to/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.to
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>to()</code></strong> method of the
+<p>The <strong><code>to()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface converts a numeric value from one unit to
   another.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.toSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>toSum()</code></strong> method of the
+<p>The <strong><code>toSum()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface converts the object's value to a
   {{domxref("CSSMathSum")}} object to values of the specified unit.</p>
 

--- a/files/en-us/web/api/cssnumericvalue/type/index.html
+++ b/files/en-us/web/api/cssnumericvalue/type/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSNumericValue.type
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>type()</code></strong> method of the
+<p>The <strong><code>type()</code></strong> method of the
   {{domxref("CSSNumericValue")}} interface returns the type of
   <code>CSSNumericValue</code>, one of <code>angle</code>, <code>flex</code>,
   <code>frequency</code>, <code>length</code>, <code>resolution</code>,

--- a/files/en-us/web/api/csspagerule/selectortext/index.html
+++ b/files/en-us/web/api/csspagerule/selectortext/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSPageRule.selectorText
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>selectorText</code></strong> property of the {{domxref("CSSPageRule")}} interface gets and sets the selectors associated with the <code>CSSPageRule</code>.</p>
+<p>The <strong><code>selectorText</code></strong> property of the {{domxref("CSSPageRule")}} interface gets and sets the selectors associated with the <code>CSSPageRule</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csspagerule/style/index.html
+++ b/files/en-us/web/api/csspagerule/style/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSPageRule.style
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>style</code></strong> read-only property of the {{domxref("CSSPageRule")}} interface returns a {{domxref("CSSStyleDeclaration")}} object. This represents an object that is a <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block">CSS declaration block</a>, and exposes style information and various style-related methods and properties.</p>
+<p>The <strong><code>style</code></strong> read-only property of the {{domxref("CSSPageRule")}} interface returns a {{domxref("CSSStyleDeclaration")}} object. This represents an object that is a <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block">CSS declaration block</a>, and exposes style information and various style-related methods and properties.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssperspective/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSPerspective.CSSPerspective
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSPerspective()</code></strong> constructor creates
+<p>The <strong><code>CSSPerspective()</code></strong> constructor creates
   a new {{domxref("CSSPerspective")}} object representing the <a
     href="/en-US/docs/Web/CSS/transform-function/perspective()">perspective()</a> value of
   the individual {{CSSXref('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSPerspective
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSPerspective</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/perspective()">perspective()</a> value of the individual {{CSSXRef('transform')}} property in CSS.  It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}. </p>
+<p>The <strong><code>CSSPerspective</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/perspective()">perspective()</a> value of the individual {{CSSXRef('transform')}} property in CSS.  It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}. </p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssperspective/length/index.html
+++ b/files/en-us/web/api/cssperspective/length/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSPerspective.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>length</code></strong> property of the
+<p>The <strong><code>length</code></strong> property of the
   {{domxref("CSSPerspective")}} interface sets the distance from z=0.</p>
 
 <p>It is used to apply a perspective transform to the element and its content. If the

--- a/files/en-us/web/api/csspropertyrule/inherits/index.html
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSPropertyRule.inherits
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
-<p class="summary">The read-only <strong><code>inherits</code></strong> property of the {{domxref("CSSPropertyRule")}} interface returns the inherit flag of the custom property registration represented by the {{cssxref("@property")}} rule, a boolean describing whether or not the property inherits by default.</p>
+<p>The read-only <strong><code>inherits</code></strong> property of the {{domxref("CSSPropertyRule")}} interface returns the inherit flag of the custom property registration represented by the {{cssxref("@property")}} rule, a boolean describing whether or not the property inherits by default.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.html
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSPropertyRule.initialValue
 ---
 <div>{{APIRef("CSS Properties and Values API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The read-only <strong><code>initialValue</code></strong> nullable property of the {{domxref("CSSPropertyRule")}} interface returns the initial value of the custom property registration represented by the {{cssxref("@property")}} rule, controlling the property’s initial value. </p>
+<p>The read-only <strong><code>initialValue</code></strong> nullable property of the {{domxref("CSSPropertyRule")}} interface returns the initial value of the custom property registration represented by the {{cssxref("@property")}} rule, controlling the property’s initial value. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csspropertyrule/name/index.html
+++ b/files/en-us/web/api/csspropertyrule/name/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSPropertyRule.name
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
-<p class="summary">The read-only <strong><code>name</code></strong> property of the {{domxref("CSSPropertyRule")}} interface represents the property name, this being the serialization of the name given to the custom property in the {{cssxref("@property")}} rule’s prelude.</p>
+<p>The read-only <strong><code>name</code></strong> property of the {{domxref("CSSPropertyRule")}} interface represents the property name, this being the serialization of the name given to the custom property in the {{cssxref("@property")}} rule’s prelude.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csspropertyrule/syntax/index.html
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSPropertyRule.syntax
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
-<p class="summary">The read-only <strong><code>syntax</code></strong> property of the {{domxref("CSSPropertyRule")}} interface returns the literal syntax of the custom property registration represented by the {{cssxref("@property")}} rule, controlling how the property’s value is parsed at computed-value time.</p>
+<p>The read-only <strong><code>syntax</code></strong> property of the {{domxref("CSSPropertyRule")}} interface returns the literal syntax of the custom property registration represented by the {{cssxref("@property")}} rule, controlling how the property’s value is parsed at computed-value time.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csspseudoelement/element/index.html
+++ b/files/en-us/web/api/csspseudoelement/element/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSPseudoElement.element
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>element</code></strong> read-only property of the
+<p>The <strong><code>element</code></strong> read-only property of the
   {{DOMxRef('CSSPseudoElement')}} interface returns a reference to the originating element
   of the pseudo-element, in other words its parent element.</p>
 

--- a/files/en-us/web/api/csspseudoelement/index.html
+++ b/files/en-us/web/api/csspseudoelement/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSPseudoElement
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>CSSPseudoElement</code></strong> interface represents a pseudo-element that may be the target of an event or animated using the {{DOMxRef('Web Animations API', '', '', 'true')}}. Instances of this interface may be obtained by calling {{DOMxRef('Element.pseudo()')}}.</p>
+<p>The <strong><code>CSSPseudoElement</code></strong> interface represents a pseudo-element that may be the target of an event or animated using the {{DOMxRef('Web Animations API', '', '', 'true')}}. Instances of this interface may be obtained by calling {{DOMxRef('Element.pseudo()')}}.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/csspseudoelement/type/index.html
+++ b/files/en-us/web/api/csspseudoelement/type/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSPseudoElement.type
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>type</code></strong> read-only property of the
+<p>The <strong><code>type</code></strong> read-only property of the
   {{DOMxRef('CSSPseudoElement')}} interface returns the type of the pseudo-element as a
   string, represented in the form of a <a
     href="/en-US/docs/Web/CSS/CSS_Selectors#pseudo-elements">CSS selector</a>.</p>

--- a/files/en-us/web/api/cssrotate/angle/index.html
+++ b/files/en-us/web/api/cssrotate/angle/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSRotate.angle
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>angle</code></strong> property of the
+<p>The <strong><code>angle</code></strong> property of the
   {{domxref("CSSRotate")}} interface gets and sets the angle of rotation. A positive angle
   denotes a clockwise rotation, a negative angle a counter-clockwise one.</p>
 

--- a/files/en-us/web/api/cssrotate/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSRotate.CSSRotate
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSRotate()</code></strong> constructor creates a new
+<p>The <strong><code>CSSRotate()</code></strong> constructor creates a new
   {{domxref("CSSRotate")}} object representing the <a
     href="/en-US/docs/Web/CSS/transform-function/rotate()">rotate()</a> value of the
   individual {{CSSXref('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSRotate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSRotate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the rotate value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
+<p>The <strong><code>CSSRotate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the rotate value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssrotate/x/index.html
+++ b/files/en-us/web/api/cssrotate/x/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSRotate.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>x</code></strong> property of the
+<p>The <strong><code>x</code></strong> property of the
   {{domxref("CSSRotate")}} interface gets and sets the abscissa or x-axis of the
   translating vector.</p>
 

--- a/files/en-us/web/api/cssrotate/y/index.html
+++ b/files/en-us/web/api/cssrotate/y/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSRotate.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>y</code></strong> property of the
+<p>The <strong><code>y</code></strong> property of the
   {{domxref("CSSRotate")}} interface gets and sets the ordinate or y-axis of the
   translating vector.</p>
 

--- a/files/en-us/web/api/cssrotate/z/index.html
+++ b/files/en-us/web/api/cssrotate/z/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSRotate.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>z</code></strong> property of the
+<p>The <strong><code>z</code></strong> property of the
   {{domxref("CSSRotate")}} interface representing the z-component of the translating
   vector. A positive value moves the element towards the viewer, and a negative value
   farther away.</p>

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSRule.type
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
-<p class="summary">The read-only <strong><code>type</code></strong> property of the
+<p>The read-only <strong><code>type</code></strong> property of the
   {{domxref("CSSRule")}} interface is a deprecated property that returns an integer
   indicating which type of rule the {{domxref("CSSRule")}} represents.</p>
 

--- a/files/en-us/web/api/cssrulelist/item/index.html
+++ b/files/en-us/web/api/cssrulelist/item/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSRuleList.item
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the {{domxref("CSSRule")}} object at the specified <code>index</code> or <code>null</code> if the specified <code>index</code> doesn't exist.</p>
+<p>The <strong><code>item()</code></strong> method of the {{domxref("CSSRuleList")}} interface returns the {{domxref("CSSRule")}} object at the specified <code>index</code> or <code>null</code> if the specified <code>index</code> doesn't exist.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssrulelist/length/index.html
+++ b/files/en-us/web/api/cssrulelist/length/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSRuleList.length
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p class="summary">The <strong><code>length</code></strong> property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.</p>
+<p>The <strong><code>length</code></strong> property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssscale/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/cssscale/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSScale.CSSScale
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSScale()</code></strong> constructor creates a new
+<p>The <strong><code>CSSScale()</code></strong> constructor creates a new
   {{domxref("CSSScale")}} object representing the <a
     href="/en-US/docs/Web/CSS/transform-function/scale()">scale()</a> and <a
     href="/en-US/docs/Web/CSS/transform-function/scale()">scale3d()</a> values of the

--- a/files/en-us/web/api/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSScale
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSScale</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/scale()">scale()</a> and <a href="/en-US/docs/Web/CSS/transform-function/scale()">scale3d()</a> values of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
+<p>The <strong><code>CSSScale</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/scale()">scale()</a> and <a href="/en-US/docs/Web/CSS/transform-function/scale()">scale3d()</a> values of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssscale/x/index.html
+++ b/files/en-us/web/api/cssscale/x/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSScale.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>x</code></strong> property of the
+<p>The <strong><code>x</code></strong> property of the
   {{domxref("CSSScale")}} interface gets and sets the abscissa or x-axis of the
   translating vector.</p>
 

--- a/files/en-us/web/api/cssscale/y/index.html
+++ b/files/en-us/web/api/cssscale/y/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSScale.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>y</code></strong> property of the
+<p>The <strong><code>y</code></strong> property of the
   {{domxref("CSSScale")}} interface gets and sets the ordinate or y-axis of the
   translating vector.</p>
 

--- a/files/en-us/web/api/cssscale/z/index.html
+++ b/files/en-us/web/api/cssscale/z/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSScale.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>z</code></strong> property of the
+<p>The <strong><code>z</code></strong> property of the
   {{domxref("CSSScale")}} interface representing the z-component of the translating
   vector. A positive value moves the element towards the viewer, and a negative value
   farther away.</p>

--- a/files/en-us/web/api/cssskew/ax/index.html
+++ b/files/en-us/web/api/cssskew/ax/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkew.ax
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>ax</code></strong> property of the
+<p>The <strong><code>ax</code></strong> property of the
 	{{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element
 	along the x-axis (or abscissa).</p>
 

--- a/files/en-us/web/api/cssskew/ay/index.html
+++ b/files/en-us/web/api/cssskew/ay/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkew.ay
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>ay</code></strong> property of the
+<p>The <strong><code>ay</code></strong> property of the
 	{{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element
 	along the y-axis (or ordinate).</p>
 

--- a/files/en-us/web/api/cssskew/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/cssskew/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSSkew.CSSSkew
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkew()</code></strong> constructor creates a new
+<p>The <strong><code>CSSSkew()</code></strong> constructor creates a new
 	{{domxref("CSSSkew")}} object which represents the
 	<code><a href="/en-US/docs/Web/CSS/transform-function/skew()">skew()</a></code> value
 	of the individual {{CSSXRef('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSSkew
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkew</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface. It represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skew()">skew()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS.</p>
+<p>The <strong><code>CSSSkew</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface. It represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skew()">skew()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssskewx/ax/index.html
+++ b/files/en-us/web/api/cssskewx/ax/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewX.ax
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>ax</code></strong> property of the
+<p>The <strong><code>ax</code></strong> property of the
 	{{domxref("CSSSkewX")}} interface gets and sets the angle used to distort the element
 	along the x-axis (or abscissa).</p>
 

--- a/files/en-us/web/api/cssskewx/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/cssskewx/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewX.CSSSkewX
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkewX()</code></strong> constructor creates a new
+<p>The <strong><code>CSSSkewX()</code></strong> constructor creates a new
 	{{domxref("CSSSkewX")}} object which represents the
 	<code><a href="/en-US/docs/Web/CSS/transform-function/skewX()">skewX()</a></code>
 	value of the individual {{CSSXRef('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewX
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkewX</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skewX()">skewX()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.</p>
+<p>The <strong><code>CSSSkewX</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skewX()">skewX()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssskewy/ay/index.html
+++ b/files/en-us/web/api/cssskewy/ay/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewY.ay
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>ay</code></strong> property of the
+<p>The <strong><code>ay</code></strong> property of the
 	{{domxref("CSSSkewY")}} interface gets and sets the angle used to distort the element
 	along the y-axis (or ordinate).</p>
 

--- a/files/en-us/web/api/cssskewy/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/cssskewy/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewY.CSSSkewY
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkewY()</code></strong> constructor creates a new
+<p>The <strong><code>CSSSkewY()</code></strong> constructor creates a new
   {{domxref("CSSSkewY")}} object which represents the
   <code><a href="/en-US/docs/Web/CSS/transform-function/skewY()">skewY()</a></code> value
   of the individual {{CSSXRef('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSSkewY
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSSkewY</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skewY()">skewY()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.</p>
+<p>The <strong><code>CSSSkewY</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <code><a href="/en-US/docs/Web/CSS/transform-function/skewY()">skewY()</a></code> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.html
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSStyleRule.selectorText
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
-<p class="summary">The <strong><code>selectorText</code></strong> property of the {{domxref("CSSStyleRule")}} interface gets and sets the selectors associated with the <code>CSSStyleRule</code>.</p>
+<p>The <strong><code>selectorText</code></strong> property of the {{domxref("CSSStyleRule")}} interface gets and sets the selectors associated with the <code>CSSStyleRule</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssstylerule/stylemap/index.html
+++ b/files/en-us/web/api/cssstylerule/stylemap/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CSSStyleRule.styleMap
 ---
 <div>{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>styleMap</code></strong> read-only property of the
+<p>The <strong><code>styleMap</code></strong> read-only property of the
     {{domxref("CSSStyleRule")}} interface returns a {{domxref('StylePropertyMap')}} object
     which provides access to the rule's property-value pairs.</p>
 

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.html
@@ -10,7 +10,7 @@ browser-compat: api.CSSStyleSheet.CSSStyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which represents a single <a href="/en-US/docs/Glossary/Stylesheet">Stylesheet</a>.</p>
+<p>The <strong><code>CSSStyleSheet()</code></strong> constructor creates a new {{domxref("CSSStyleSheet")}} object which represents a single <a href="/en-US/docs/Glossary/Stylesheet">Stylesheet</a>.</p>
 
 <p>After constructing a stylesheet the {{domxref("CSSStyleSheet.replace()")}} or {{domxref("CSSStyleSheet.replaceSync()")}} methods can be used to add rules to the new stylesheet.</p>
 

--- a/files/en-us/web/api/cssstylesheet/replace/index.html
+++ b/files/en-us/web/api/cssstylesheet/replace/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSStyleSheet.replace
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>replace()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface asynchronously replaces the content of the stylesheet with the content passed into it. The method returns a promise that resolves with a <code>CSSStyleSheet</code> object.</p>
+<p>The <strong><code>replace()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface asynchronously replaces the content of the stylesheet with the content passed into it. The method returns a promise that resolves with a <code>CSSStyleSheet</code> object.</p>
 
 <p>The <code>replace()</code> and {{domxref("CSSStyleSheet.replaceSync()")}} methods can only be used on a stylesheet created with the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</p>
 

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.html
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSStyleSheet.replaceSync
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>replaceSync()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface synchronously replaces the content of the stylesheet with the content passed into it.</p>
+<p>The <strong><code>replaceSync()</code></strong> method of the {{domxref("CSSStyleSheet")}} interface synchronously replaces the content of the stylesheet with the content passed into it.</p>
 
 <p>The <code>replaceSync()</code> and {{domxref("CSSStyleSheet.replace()")}} methods can only be used on a stylesheet created with the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.</p>
 

--- a/files/en-us/web/api/csstransformcomponent/index.html
+++ b/files/en-us/web/api/csstransformcomponent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformComponent
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
-<p class="summary">The <strong><code>CSSTransformComponent</code></strong> interface of the of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface.</p>
+<p>The <strong><code>CSSTransformComponent</code></strong> interface of the of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.html
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformComponent.is2D
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
-<p class="summary">The <strong><code>is2D</code></strong> read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.</p>
+<p>The <strong><code>is2D</code></strong> read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformComponent.toMatrix
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
-<p class="summary">The <strong><code>toMatrix()</code></strong> method of the
+<p>The <strong><code>toMatrix()</code></strong> method of the
   {{domxref("CSSTransformComponent")}} interface returns a {{domxref('DOMMatrix')}}
   object.</p>
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformComponent.toString
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
-<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("CSSTransformComponent")}} interface is a stringifier returning a <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a> function.</p>
+<p>The <strong><code>toString()</code></strong> method of the {{domxref("CSSTransformComponent")}} interface is a stringifier returning a <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a> function.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.CSSTransformValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue()</code></strong> constructor
+<p>The <strong><code>CSSTransformValue()</code></strong> constructor
   creates a new {{domxref("CSSTransformValue")}} object which represents a list of
   individual transform objects.</p>
 

--- a/files/en-us/web/api/csstransformvalue/entries/index.html
+++ b/files/en-us/web/api/csstransformvalue/entries/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.entries
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue.entries()</code></strong> method
+<p>The <strong><code>CSSTransformValue.entries()</code></strong> method
   returns an array of a given object's own enumerable
   property <code>[key, value]</code> pairs in the same order as that provided by a
   {{jsxref("for...in")}} loop (the difference being that a for-in loop enumerates

--- a/files/en-us/web/api/csstransformvalue/foreach/index.html
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.forEach
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue.forEach()</code></strong> method executes a provided function once for each element of the <code>CSSTransformValue</code>.</p>
+<p>The <strong><code>CSSTransformValue.forEach()</code></strong> method executes a provided function once for each element of the <code>CSSTransformValue</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents <code>transform-list</code> values as used by the CSS {{CSSxref('transform')}} property.</p>
+<p>The <strong><code>CSSTransformValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents <code>transform-list</code> values as used by the CSS {{CSSxref('transform')}} property.</p>
 
 <h2 id="Interfaces_based_on_CSSTransformValue">Interfaces based on CSSTransformValue</h2>
 

--- a/files/en-us/web/api/csstransformvalue/is2d/index.html
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.html
@@ -14,11 +14,11 @@ browser-compat: api.CSSTransformValue.is2D
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The read-only <strong><code>is2D</code></strong> property of the
+<p>The read-only <strong><code>is2D</code></strong> property of the
   {{domxref("CSSTransformValue")}} interface returns whether the transform is 2D or 3D.
 </p>
 
-<p class="summary">In the case of the <code>CSSTransformValue</code> this property returns
+<p>In the case of the <code>CSSTransformValue</code> this property returns
   true unless any of the individual functions return false for <code>Is2D</code>, in which
   case it returns false.</p>
 

--- a/files/en-us/web/api/csstransformvalue/keys/index.html
+++ b/files/en-us/web/api/csstransformvalue/keys/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.keys
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue.keys()</code></strong> method
+<p>The <strong><code>CSSTransformValue.keys()</code></strong> method
   returns a new <code><strong>Array Iterator</strong></code> object that contains the keys
   for each index in the array.</p>
 

--- a/files/en-us/web/api/csstransformvalue/length/index.html
+++ b/files/en-us/web/api/csstransformvalue/length/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The read-only <strong><code>length</code></strong> property of the
+<p>The read-only <strong><code>length</code></strong> property of the
   {{domxref("CSSTransformValue")}} interface returns the number of transform components in
   the list.</p>
 

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformValue.toMatrix
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>toMatrix()</code></strong> method of the
+<p>The <strong><code>toMatrix()</code></strong> method of the
   {{domxref("CSSTransformValue")}} interface returns a {{domxref('DOMMatrix')}} object.
 </p>
 

--- a/files/en-us/web/api/csstransformvalue/values/index.html
+++ b/files/en-us/web/api/csstransformvalue/values/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSTransformValue.values
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
-<p class="summary">The <strong><code>CSSTransformValue.values()</code></strong>  returns a
+<p>The <strong><code>CSSTransformValue.values()</code></strong>  returns a
   new <strong><code>Array Iterator</code></strong> object that contains the values for
   each index in the CSSTransformValue object.</p>
 

--- a/files/en-us/web/api/csstransition/index.html
+++ b/files/en-us/web/api/csstransition/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSTransition
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSTransition</code></strong> interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object used for a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS Transition</a>.</p>
+<p>The <strong><code>CSSTransition</code></strong> interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object used for a <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS Transition</a>.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/csstransition/transitionproperty/index.html
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.html
@@ -11,7 +11,7 @@ browser-compat: api.CSSTransition.transitionProperty
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>transitionProperty</code></strong> property of the
+<p>The <strong><code>transitionProperty</code></strong> property of the
   {{domxref("CSSTransition")}} interface returns the <strong>expanded transition property
     name</strong> of the transition. This is the longhand CSS property for which the
   transition was generated.</p>

--- a/files/en-us/web/api/csstranslate/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTranslate.CSSTranslate
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>CSSTranslate()</code></strong> constructor creates a
+<p>The <strong><code>CSSTranslate()</code></strong> constructor creates a
   new {{domxref("CSSTranslate")}} object representing the <a
     href="/en-US/docs/Web/CSS/transform-function/translate()">translate()</a> value of the
   individual {{CSSXref('transform')}} property in CSS.</p>

--- a/files/en-us/web/api/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTranslate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p class="summary">The <strong><code>CSSTranslate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/translate()">translate()</a> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
+<p>The <strong><code>CSSTranslate</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the <a href="/en-US/docs/Web/CSS/transform-function/translate()">translate()</a> value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/csstranslate/x/index.html
+++ b/files/en-us/web/api/csstranslate/x/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTranslate.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>x</code></strong> property of the
+<p>The <strong><code>x</code></strong> property of the
   {{domxref("CSSTranslate")}} interface gets and sets the abscissa or x-axis of the
   translating vector.</p>
 

--- a/files/en-us/web/api/csstranslate/y/index.html
+++ b/files/en-us/web/api/csstranslate/y/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTranslate.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>y</code></strong> property of the
+<p>The <strong><code>y</code></strong> property of the
 	{{domxref("CSSTranslate")}} interface gets and sets the ordinate or y-axis of the
 	translating vector.</p>
 

--- a/files/en-us/web/api/csstranslate/z/index.html
+++ b/files/en-us/web/api/csstranslate/z/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSTranslate.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
-<p class="summary">The <strong><code>z</code></strong> property of the
+<p>The <strong><code>z</code></strong> property of the
   {{domxref("CSSTranslate")}} interface representing the z-component of the translating
   vector. A positive value moves the element towards the viewer, and a negative value
   farther away.</p>

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSUnitValue.CSSUnitValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnitValue()</code></strong> constructor creates a
+<p>The <strong><code>CSSUnitValue()</code></strong> constructor creates a
 	new {{domxref("CSSUnitValue")}} object which returns a new {{domxref('CSSUnitValue')}}
 	object which represents values that contain a single unit type. For example, "42px"
 	would be represented by a <code>CSSNumericValue</code>.</p>

--- a/files/en-us/web/api/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSUnitValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnitValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents values that contain a single unit type. For example, "42px" would be represented by a <code>CSSNumericValue</code>.</p>
+<p>The <strong><code>CSSUnitValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents values that contain a single unit type. For example, "42px" would be represented by a <code>CSSNumericValue</code>.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssunitvalue/unit/index.html
+++ b/files/en-us/web/api/cssunitvalue/unit/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSUnitValue.unit
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnitValue.unit</code></strong> read-only property
+<p>The <strong><code>CSSUnitValue.unit</code></strong> read-only property
 	of the {{domxref("CSSUnitValue")}} interface returns a {{jsxref('USVString')}}
 	indicating the type of unit.</p>
 

--- a/files/en-us/web/api/cssunitvalue/value/index.html
+++ b/files/en-us/web/api/cssunitvalue/value/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSUnitValue.value
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnitValue.value</code></strong> property of the
+<p>The <strong><code>CSSUnitValue.value</code></strong> property of the
 	{{domxref("CSSUnitValue")}} interface returns a double indicating the number of units.
 </p>
 

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSUnparsedValue.CSSUnparsedValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue()</code></strong> constructor
+<p>The <strong><code>CSSUnparsedValue()</code></strong> constructor
   creates a new {{domxref("CSSUnparsedValue")}} object which represents property values
   that reference custom properties.</p>
 

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.entries
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue.entries()</code></strong> method
+<p>The <strong><code>CSSUnparsedValue.entries()</code></strong> method
   returns an array of a given object's own enumerable property <code>[key, value]</code>
   pairs in the same order as that provided by a {{jsxref("Statements/for...in",
   "for...in")}} loop (the difference being that a for-in loop enumerates properties in the

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.forEach
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue.forEach()</code></strong> method
+<p>The <strong><code>CSSUnparsedValue.forEach()</code></strong> method
   executes a provided function once for each element of the
   {{domxref('CSSUnparsedValue')}}.</p>
 

--- a/files/en-us/web/api/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/index.html
@@ -14,9 +14,9 @@ browser-compat: api.CSSUnparsedValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents property values that reference <a href="/en-US/docs/Web/CSS/CSS_Variables">custom properties</a>. It consists of a list of string fragments and variable references.</p>
+<p>The <strong><code>CSSUnparsedValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents property values that reference <a href="/en-US/docs/Web/CSS/CSS_Variables">custom properties</a>. It consists of a list of string fragments and variable references.</p>
 
-<p class="summary">Custom properties are represented by <code>CSSUnparsedValue</code> and {{cssxref('var()')}} references are represented using {{domxref('CSSVariableReferenceValue')}}.</p>
+<p>Custom properties are represented by <code>CSSUnparsedValue</code> and {{cssxref('var()')}} references are represented using {{domxref('CSSVariableReferenceValue')}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.keys
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue.keys()</code></strong> method
+<p>The <strong><code>CSSUnparsedValue.keys()</code></strong> method
   returns a new <code><strong>Array Iterator</strong></code> object that contains the keys
   for each index in the array.</p>
 

--- a/files/en-us/web/api/cssunparsedvalue/length/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.length
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>length</code></strong> read-only property of the
+<p>The <strong><code>length</code></strong> read-only property of the
   {{domxref("CSSUnparsedValue")}} interface returns the number of items in the object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/cssunparsedvalue/values/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSUnparsedValue.values
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSUnparsedValue.values()</code></strong> method
+<p>The <strong><code>CSSUnparsedValue.values()</code></strong> method
   returns a new <strong><code>Array Iterator</code></strong> object that contains the
   values for each index in the CSSUnparsedValue object.</p>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSVariableReferenceValue.CSSVariableReferenceValue
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">Creates a new {{domxref('CSSVariableReferenceValue')}}.</p>
+<p>Creates a new {{domxref('CSSVariableReferenceValue')}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSVariableReferenceValue.fallback
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>fallback</code></strong> read-only property of the
+<p>The <strong><code>fallback</code></strong> read-only property of the
   {{domxref("CSSVariableReferenceValue")}} interface returns the <a
     href="/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values">custom
     property fallback value</a> of the {{domxref("CSSVariableReferenceValue")}}.</p>

--- a/files/en-us/web/api/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CSSVariableReferenceValue
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>CSSVariableReferenceValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} allows you to create a custom name for a built-in CSS value. This object functionality is sometimes called a "CSS variable" and serves the same purpose as the {{cssxref('var()')}} function. The custom name must begin with two dashes.</p>
+<p>The <strong><code>CSSVariableReferenceValue</code></strong> interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} allows you to create a custom name for a built-in CSS value. This object functionality is sometimes called a "CSS variable" and serves the same purpose as the {{cssxref('var()')}} function. The custom name must begin with two dashes.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CSSVariableReferenceValue.variable
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>variable</code></strong> property of the
+<p>The <strong><code>variable</code></strong> property of the
   {{domxref("CSSVariableReferenceValue")}} interface returns the <a
     href="/en-US/docs/Web/CSS/--*">custom property name</a> of the
   {{domxref("CSSVariableReferenceValue")}}.</p>

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
@@ -12,7 +12,7 @@ browser-compat: api.DataTransferItem.getAsFileSystemHandle
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Drag and Drop API")}}
 </div>
 
-<p class="summary">The <strong><code>getAsFileSystemHandle()</code></strong> method of the
+<p>The <strong><code>getAsFileSystemHandle()</code></strong> method of the
   {{domxref("DataTransferItem")}} interface returns a {{domxref('FileSystemFileHandle')}}
   if the dragged item is a file, or a {{domxref('FileSystemDirectoryHandle')}} if the
   dragged item is a directory.</p>

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.DecompressionStream.DecompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>DecompressionStream()</code></strong> constructor creates a new {{domxref("DecompressionStream")}} object which decompresses a stream of data.</p>
+<p>The <strong><code>DecompressionStream()</code></strong> constructor creates a new {{domxref("DecompressionStream")}} object which decompresses a stream of data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.DecompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>DecompressionStream</code></strong> interface of the {{domxref('Compression Streams API','','',' ')}} is an API for decompressing a stream of data.</p>
+<p>The <strong><code>DecompressionStream</code></strong> interface of the {{domxref('Compression Streams API','','',' ')}} is an API for decompressing a stream of data.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/decompressionstream/readable/index.html
+++ b/files/en-us/web/api/decompressionstream/readable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DecompressionStream.readable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/decompressionstream/writable/index.html
+++ b/files/en-us/web/api/decompressionstream/writable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DecompressionStream.writable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("WritableStream")}}.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("WritableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/delaynode/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/delaynode/index.html
@@ -13,7 +13,7 @@ browser-compat: api.DelayNode.DelayNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<p class="summary">The <strong><code>DelayNode()</code></strong>
+<p>The <strong><code>DelayNode()</code></strong>
     constructor of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>
     creates a new {{domxref("DelayNode")}} object with a delay-line; an AudioNode
     audio-processing module that causes a delay between the arrival of an input data, and

--- a/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.html
+++ b/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.anticipatedRemoval
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>anticipatedRemoval</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the date that the browser version which removes the feature will ship. This value can be used to prioritize warnings. If this property returns <code>null</code> because the date is unknown, then the deprecation should be considered low priority.</p>
+<p>The <strong><code>anticipatedRemoval</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the date that the browser version which removes the feature will ship. This value can be used to prioritize warnings. If this property returns <code>null</code> because the date is unknown, then the deprecation should be considered low priority.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/deprecationreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/deprecationreportbody/columnnumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.columnNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
+<p>The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/deprecationreportbody/id/index.html
+++ b/files/en-us/web/api/deprecationreportbody/id/index.html
@@ -12,7 +12,7 @@ browser-compat: api.DeprecationReportBody.id
 
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns a string representing the feature or API that is deprecated. This can be used to group or count related reports.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns a string representing the feature or API that is deprecated. This can be used to group or count related reports.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/deprecationreportbody/index.html
+++ b/files/en-us/web/api/deprecationreportbody/index.html
@@ -12,7 +12,7 @@ browser-compat: api.DeprecationReportBody
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>DeprecationReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of a deprecation report.</p>
+<p>The <code>DeprecationReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of a deprecation report.</p>
 
 <p>A deprecation report is generated when a deprecated feature (for example a deprecated API method) is used on a document being observed by a {{domxref("ReportingObserver")}}. In addition to the support of this API, receiving useful deprecation warnings relies on browser vendors adding these warnings for deprecated features.</p>
 

--- a/files/en-us/web/api/deprecationreportbody/linenumber/index.html
+++ b/files/en-us/web/api/deprecationreportbody/linenumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.lineNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
+<p>The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/deprecationreportbody/message/index.html
+++ b/files/en-us/web/api/deprecationreportbody/message/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.message
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns a human-readable description of the deprecation. This typically matches the message a browser will display in its DevTools console regarding a deprecated feature.</p>
+<p>The <strong><code>message</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns a human-readable description of the deprecation. This typically matches the message a browser will display in its DevTools console regarding a deprecated feature.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.sourceFile
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the path to the source file where the deprecated feature was used.</p>
+<p>The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the path to the source file where the deprecated feature was used.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/deprecationreportbody/tojson/index.html
+++ b/files/en-us/web/api/deprecationreportbody/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.DeprecationReportBody.toJSON
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("DeprecationReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>InterventionReportBody</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("DeprecationReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>InterventionReportBody</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/device_memory_api/index.html
+++ b/files/en-us/web/api/device_memory_api/index.html
@@ -6,7 +6,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Device Memory API")}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
-<p class="summary">The capabilities of a client device largely depend on the amount of available RAM. Traditionally, developers had to use heuristics and either benchmark a device or infer device capabilities based on other factors like the device manufacturer or User Agent strings.</p>
+<p>The capabilities of a client device largely depend on the amount of available RAM. Traditionally, developers had to use heuristics and either benchmark a device or infer device capabilities based on other factors like the device manufacturer or User Agent strings.</p>
 
 <h2 id="Determining_device_memory">Determining device memory</h2>
 

--- a/files/en-us/web/api/element/ariaatomic/index.html
+++ b/files/en-us/web/api/element/ariaatomic/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAtomic
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaAtomic</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-atomic</code> attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.</p>
+<p>The <strong><code>ariaAtomic</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-atomic</code> attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariaautocomplete/index.html
+++ b/files/en-us/web/api/element/ariaautocomplete/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAutoComplete
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaAutoComplete</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-autocomplete</code> attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.</p>
+<p>The <strong><code>ariaAutoComplete</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-autocomplete</code> attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariabusy/index.html
+++ b/files/en-us/web/api/element/ariabusy/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaBusy
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaBusy</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-busy</code> attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.</p>
+<p>The <strong><code>ariaBusy</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-busy</code> attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariachecked/index.html
+++ b/files/en-us/web/api/element/ariachecked/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaChecked
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaChecked</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
+<p>The <strong><code>ariaChecked</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariacolcount/index.html
+++ b/files/en-us/web/api/element/ariacolcount/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColCount
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColCount</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colcount</code> attribute, which defines the number of columns in a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColCount</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colcount</code> attribute, which defines the number of columns in a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariacolindex/index.html
+++ b/files/en-us/web/api/element/ariacolindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndex
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColIndex</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colindex</code> attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColIndex</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colindex</code> attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariacolindextext/index.html
+++ b/files/en-us/web/api/element/ariacolindextext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndexText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColIndexText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colindextext</code> attribute, which defines a human readable text alternative of aria-colindex.</p>
+<p>The <strong><code>ariaColIndexText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colindextext</code> attribute, which defines a human readable text alternative of aria-colindex.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariacolspan/index.html
+++ b/files/en-us/web/api/element/ariacolspan/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColSpan
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColSpan</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colspan</code> attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColSpan</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-colspan</code> attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariacurrent/index.html
+++ b/files/en-us/web/api/element/ariacurrent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaCurrent
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaCurrent</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-current</code> attribute, which indicates the element that represents the current item within a container or set of related elements.</p>
+<p>The <strong><code>ariaCurrent</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-current</code> attribute, which indicates the element that represents the current item within a container or set of related elements.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariadescription/index.html
+++ b/files/en-us/web/api/element/ariadescription/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDescription
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-description</code> attribute, which defines a string value that describes or annotates the current element.</p>
+<p>The <strong><code>ariaDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-description</code> attribute, which defines a string value that describes or annotates the current element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDisabled
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaDisabled</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
+<p>The <strong><code>ariaDisabled</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> Where possible, use the {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element —  because those elements have built in semantics and do not require ARIA attributes.</p>

--- a/files/en-us/web/api/element/ariaexpanded/index.html
+++ b/files/en-us/web/api/element/ariaexpanded/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaExpanded
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaExpanded</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-expanded</code> attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
+<p>The <strong><code>ariaExpanded</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-expanded</code> attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaHasPopup
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaHasPopup</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-haspopup</code> attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.</p>
+<p>The <strong><code>ariaHasPopup</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-haspopup</code> attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariahidden/index.html
+++ b/files/en-us/web/api/element/ariahidden/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaHidden
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaHidden</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute"><code>aria-hidden</code></a> attribute, which indicates whether the element is exposed to an accessibility API.</p>
+<p>The <strong><code>ariaHidden</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute"><code>aria-hidden</code></a> attribute, which indicates whether the element is exposed to an accessibility API.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.html
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaKeyShortcuts
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaKeyShortcuts</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-keyshortcuts</code> attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
+<p>The <strong><code>ariaKeyShortcuts</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-keyshortcuts</code> attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/arialabel/index.html
+++ b/files/en-us/web/api/element/arialabel/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaLabel
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLabel</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute"><code>aria-label</code></a> attribute, which defines a string value that labels the current element.</p>
+<p>The <strong><code>ariaLabel</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute"><code>aria-label</code></a> attribute, which defines a string value that labels the current element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/arialevel/index.html
+++ b/files/en-us/web/api/element/arialevel/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaLevel
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLevel</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
+<p>The <strong><code>ariaLevel</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/arialive/index.html
+++ b/files/en-us/web/api/element/arialive/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Element.ariaLive
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLive</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">aria-live</a></code> attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.</p>
+<p>The <strong><code>ariaLive</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">aria-live</a></code> attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariamodal/index.html
+++ b/files/en-us/web/api/element/ariamodal/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaModal
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaModal</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-modal</code> attribute, which indicates whether an element is modal when displayed.</p>
+<p>The <strong><code>ariaModal</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-modal</code> attribute, which indicates whether an element is modal when displayed.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariamultiline/index.html
+++ b/files/en-us/web/api/element/ariamultiline/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiline
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaMultiline</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
+<p>The <strong><code>ariaMultiline</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariamultiselectable/index.html
+++ b/files/en-us/web/api/element/ariamultiselectable/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiSelectable
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
+<p>The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariaorientation/index.html
+++ b/files/en-us/web/api/element/ariaorientation/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaOrientation
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaOrientation</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute"><code>aria-orientation</code></a> attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
+<p>The <strong><code>ariaOrientation</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute"><code>aria-orientation</code></a> attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariaplaceholder/index.html
+++ b/files/en-us/web/api/element/ariaplaceholder/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPlaceholder
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
+<p>The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariaposinset/index.html
+++ b/files/en-us/web/api/element/ariaposinset/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPosInSet
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPosInSet</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-posinset</code> attribute, which defines an element's number or position in the current set of listitems or treeitems.</p>
+<p>The <strong><code>ariaPosInSet</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-posinset</code> attribute, which defines an element's number or position in the current set of listitems or treeitems.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariapressed/index.html
+++ b/files/en-us/web/api/element/ariapressed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPressed
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPressed</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
+<p>The <strong><code>ariaPressed</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariareadonly/index.html
+++ b/files/en-us/web/api/element/ariareadonly/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaReadOnly
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
+<p>The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariarelevant/index.html
+++ b/files/en-us/web/api/element/ariarelevant/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRelevant
 ---
 <div>{{DefaultAPISidebar("DOM")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>ariaRelevant</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
+<p>The <strong><code>ariaRelevant</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariarequired/index.html
+++ b/files/en-us/web/api/element/ariarequired/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRequired
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
+<p>The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
 
 <div class="notecard note">
   <h3>Note</h3>

--- a/files/en-us/web/api/element/ariaroledescription/index.html
+++ b/files/en-us/web/api/element/ariaroledescription/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRoleDescription
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRoleDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-roledescription</code> attribute, which defines a human-readable, author-localized description for the role of an element.</p>
+<p>The <strong><code>ariaRoleDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-roledescription</code> attribute, which defines a human-readable, author-localized description for the role of an element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariarowcount/index.html
+++ b/files/en-us/web/api/element/ariarowcount/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowCount
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowCount</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowcount</code> attribute, which defines the total number of rows in a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowCount</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowcount</code> attribute, which defines the total number of rows in a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariarowindex/index.html
+++ b/files/en-us/web/api/element/ariarowindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndex
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowIndex</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowindex</code> attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowIndex</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowindex</code> attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariarowindextext/index.html
+++ b/files/en-us/web/api/element/ariarowindextext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndexText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowIndexText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowindextext</code> attribute, which defines a human readable text alternative of aria-rowindex.</p>
+<p>The <strong><code>ariaRowIndexText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowindextext</code> attribute, which defines a human readable text alternative of aria-rowindex.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariarowspan/index.html
+++ b/files/en-us/web/api/element/ariarowspan/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowSpan
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowSpan</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowspan</code> attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowSpan</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-rowspan</code> attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariaselected/index.html
+++ b/files/en-us/web/api/element/ariaselected/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSelected
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSelected</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-selected</code> attribute, which indicates the current "selected" state of elements that have a selected state.</p>
+<p>The <strong><code>ariaSelected</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-selected</code> attribute, which indicates the current "selected" state of elements that have a selected state.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariasetsize/index.html
+++ b/files/en-us/web/api/element/ariasetsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSetSize
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSetSize</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-setsize</code> attribute, which defines the number of items in the current set of listitems or treeitems.</p>
+<p>The <strong><code>ariaSetSize</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-setsize</code> attribute, which defines the number of items in the current set of listitems or treeitems.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariasort/index.html
+++ b/files/en-us/web/api/element/ariasort/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSort
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSort</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-sort</code> attribute, which indicates if items in a table or grid are sorted in ascending or descending order.</p>
+<p>The <strong><code>ariaSort</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-sort</code> attribute, which indicates if items in a table or grid are sorted in ascending or descending order.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariavaluemax/index.html
+++ b/files/en-us/web/api/element/ariavaluemax/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaValueMax
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueMax</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attribute, which defines the maximum allowed value for a range widget.</p>
+<p>The <strong><code>ariaValueMax</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attribute, which defines the maximum allowed value for a range widget.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariavaluemin/index.html
+++ b/files/en-us/web/api/element/ariavaluemin/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaValueMin
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueMin</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> attribute, which defines the minimum allowed value for a range widget.</p>
+<p>The <strong><code>ariaValueMin</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> attribute, which defines the minimum allowed value for a range widget.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariavaluenow/index.html
+++ b/files/en-us/web/api/element/ariavaluenow/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaValueNow
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueNow</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> attribute, which defines the current value for a range widget.</p>
+<p>The <strong><code>ariaValueNow</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> attribute, which defines the current value for a range widget.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element/ariavaluetext/index.html
+++ b/files/en-us/web/api/element/ariavaluetext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaValueText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute, which defines the human readable text alternative of aria-valuenow for a range widget.</p>
+<p>The <strong><code>ariaValueText</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute, which defines the human readable text alternative of aria-valuenow for a range widget.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/element_timing_api/index.html
+++ b/files/en-us/web/api/element_timing_api/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong>Element Timing API</strong> provides features for monitoring the loading performance of large image elements and text nodes as they appear on screen.</p>
+<p>The <strong>Element Timing API</strong> provides features for monitoring the loading performance of large image elements and text nodes as they appear on screen.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.html
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAtomic
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaAtomic</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-atomic</code> attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the <code>aria-relevant</code> attribute.</p>
+<p>The <strong><code>ariaAtomic</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-atomic</code> attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the <code>aria-relevant</code> attribute.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.html
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAutoComplete
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaAutoComplete</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-autocomplete</code> attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.</p>
+<p>The <strong><code>ariaAutoComplete</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-autocomplete</code> attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariabusy/index.html
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaBusy
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaBusy</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-busy</code> attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.</p>
+<p>The <strong><code>ariaBusy</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-busy</code> attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariachecked/index.html
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaChecked
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaChecked</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
+<p>The <strong><code>ariaChecked</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColCount
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colcount</code> attribute, which defines the number of columns in a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colcount</code> attribute, which defines the number of columns in a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndex
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindex</code> attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindex</code> attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndexText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindextext</code> attribute, which defines a human readable text alternative of aria-colindex.</p>
+<p>The <strong><code>ariaColIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindextext</code> attribute, which defines a human readable text alternative of aria-colindex.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColSpan
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaColSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colspan</code> attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaColSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colspan</code> attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.html
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaCurrent
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaCurrent</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-current</code> attribute, which indicates the element that represents the current item within a container or set of related elements.</p>
+<p>The <strong><code>ariaCurrent</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-current</code> attribute, which indicates the element that represents the current item within a container or set of related elements.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariadescription/index.html
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDescription
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaDescription</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-description</code> attribute, which defines a string value that describes or annotates the current element.</p>
+<p>The <strong><code>ariaDescription</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-description</code> attribute, which defines a string value that describes or annotates the current element.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.html
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDisabled
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaDisabled</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
+<p>The <strong><code>ariaDisabled</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.html
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaExpanded
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaExpanded</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-expanded</code> attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
+<p>The <strong><code>ariaExpanded</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-expanded</code> attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.html
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaHasPopup
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaHasPopup</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-haspopup</code> attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.</p>
+<p>The <strong><code>ariaHasPopup</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-haspopup</code> attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariahidden/index.html
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaHidden
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaHidden</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute"><code>aria-hidden</code></a> attribute, which indicates whether the element is exposed to an accessibility API.</p>
+<p>The <strong><code>ariaHidden</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute"><code>aria-hidden</code></a> attribute, which indicates whether the element is exposed to an accessibility API.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.html
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaKeyShortcuts
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaKeyShortcuts</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-keyshortcuts</code> attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
+<p>The <strong><code>ariaKeyShortcuts</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-keyshortcuts</code> attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/arialabel/index.html
+++ b/files/en-us/web/api/elementinternals/arialabel/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaLabel
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLabel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute"><code>aria-label</code></a> attribute, which defines a string value that labels the current Element.</p>
+<p>The <strong><code>ariaLabel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute"><code>aria-label</code></a> attribute, which defines a string value that labels the current Element.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/arialevel/index.html
+++ b/files/en-us/web/api/elementinternals/arialevel/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaLevel
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLevel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
+<p>The <strong><code>ariaLevel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/arialive/index.html
+++ b/files/en-us/web/api/elementinternals/arialive/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ElementInternals.ariaLive
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaLive</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">aria-live</a></code> attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.</p>
+<p>The <strong><code>ariaLive</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">aria-live</a></code> attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariamodal/index.html
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaModal
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaModal</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-modal</code> attribute, which indicates whether an element is modal when displayed.</p>
+<p>The <strong><code>ariaModal</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-modal</code> attribute, which indicates whether an element is modal when displayed.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.html
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiline
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaMultiline</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
+<p>The <strong><code>ariaMultiline</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.html
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiSelectable
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
+<p>The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.html
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaOrientation
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaOrientation</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute"><code>aria-orientation</code></a> attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
+<p>The <strong><code>ariaOrientation</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute"><code>aria-orientation</code></a> attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.html
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPlaceholder
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
+<p>The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.html
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPosInSet
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPosInSet</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-posinset</code> attribute, which defines an element's number or position in the current set of listitems or treeitems.</p>
+<p>The <strong><code>ariaPosInSet</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-posinset</code> attribute, which defines an element's number or position in the current set of listitems or treeitems.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariapressed/index.html
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPressed
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaPressed</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
+<p>The <strong><code>ariaPressed</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.html
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaReadOnly
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
+<p>The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.html
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRelevant
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRelevant</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
+<p>The <strong><code>ariaRelevant</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarequired/index.html
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRequired
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
+<p>The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.html
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRoleDescription
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRoleDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-roledescription</code> attribute, which defines a human-readable, author-localized description for the role of an element.</p>
+<p>The <strong><code>ariaRoleDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-roledescription</code> attribute, which defines a human-readable, author-localized description for the role of an element.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowCount
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowcount</code> attribute, which defines the total number of rows in a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowcount</code> attribute, which defines the total number of rows in a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndex
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindex</code> attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindex</code> attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndexText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindextext</code> attribute, which defines a human readable text alternative of aria-rowindex.</p>
+<p>The <strong><code>ariaRowIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindextext</code> attribute, which defines a human readable text alternative of aria-rowindex.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowSpan
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaRowSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowspan</code> attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.</p>
+<p>The <strong><code>ariaRowSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowspan</code> attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariaselected/index.html
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSelected
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSelected</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-selected</code> attribute, which indicates the current "selected" state of elements that have a selected state.</p>
+<p>The <strong><code>ariaSelected</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-selected</code> attribute, which indicates the current "selected" state of elements that have a selected state.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.html
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSetSize
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSetSize</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-setsize</code> attribute, which defines the number of items in the current set of listitems or treeitems.</p>
+<p>The <strong><code>ariaSetSize</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-setsize</code> attribute, which defines the number of items in the current set of listitems or treeitems.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariasort/index.html
+++ b/files/en-us/web/api/elementinternals/ariasort/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSort
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaSort</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-sort</code> attribute, which indicates if items in a table or grid are sorted in ascending or descending order.</p>
+<p>The <strong><code>ariaSort</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-sort</code> attribute, which indicates if items in a table or grid are sorted in ascending or descending order.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaValueMax
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueMax</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attribute, which defines the maximum allowed value for a range widget.</p>
+<p>The <strong><code>ariaValueMax</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attribute, which defines the maximum allowed value for a range widget.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaValueMin
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueMin</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> attribute, which defines the minimum allowed value for a range widget.</p>
+<p>The <strong><code>ariaValueMin</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> attribute, which defines the minimum allowed value for a range widget.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaValueNow
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueNow</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> attribute, which defines the current value for a range widget.</p>
+<p>The <strong><code>ariaValueNow</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> attribute, which defines the current value for a range widget.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaValueText
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ariaValueText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute, which defines the human readable text alternative of aria-valuenow for a range widget.</p>
+<p>The <strong><code>ariaValueText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute, which defines the human readable text alternative of aria-valuenow for a range widget.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/elementinternals/checkvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/checkvalidity/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.checkValidity
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>checkValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface checks if the element meets any <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a> rules applied to it.</p>
+<p>The <strong><code>checkValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface checks if the element meets any <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a> rules applied to it.</p>
 
 <p>If <code>checkValidity</code> returns <code>false</code> then a cancelable <a href="/en-US/docs/Web/API/HTMLInputElement/invalid_event">invalid event</a> is fired on the element.</p>
 

--- a/files/en-us/web/api/elementinternals/form/index.html
+++ b/files/en-us/web/api/elementinternals/form/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.form
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>form</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("HTMLFormElement")}} associated with this element.</p>
+<p>The <strong><code>form</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("HTMLFormElement")}} associated with this element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/index.html
+++ b/files/en-us/web/api/elementinternals/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ElementInternals
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>ElementInternals</code></strong> interface of the {{domxref('Document_Object_Model','','',' ')}} gives web developers a way to allow custom elements to fully participate in HTML forms. It provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the <a href="https://wicg.github.io/aom/explainer.html">Accessibility Object Model</a> to the element.</p>
+<p>The <strong><code>ElementInternals</code></strong> interface of the {{domxref('Document_Object_Model','','',' ')}} gives web developers a way to allow custom elements to fully participate in HTML forms. It provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the <a href="https://wicg.github.io/aom/explainer.html">Accessibility Object Model</a> to the element.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/elementinternals/labels/index.html
+++ b/files/en-us/web/api/elementinternals/labels/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.labels
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>labels</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the labels associated with the element.</p>
+<p>The <strong><code>labels</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the labels associated with the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/reportvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/reportvalidity/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.reportValidity
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>reportValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface checks if the element meets any <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a> rules applied to it.</p>
+<p>The <strong><code>reportValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface checks if the element meets any <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a> rules applied to it.</p>
 
 <p>If <code>reportValidity</code> returns <code>false</code> then a cancelable <a href="/en-US/docs/Web/API/HTMLInputElement/invalid_event">invalid event</a> is fired on the element.</p>
 

--- a/files/en-us/web/api/elementinternals/role/index.html
+++ b/files/en-us/web/api/elementinternals/role/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.role
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>role</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">WAI-ARIA role</a> for the element. For example, a checkbox might have <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">role="checkbox</a></code></p>
+<p>The <strong><code>role</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">WAI-ARIA role</a> for the element. For example, a checkbox might have <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">role="checkbox</a></code></p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/setformvalue/index.html
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.setFormValue
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>setFormValue()</code></strong> method of the {{domxref("ElementInternals")}} interface sets the element's submission value and state, communicating these to the user agent.</p>
+<p>The <strong><code>setFormValue()</code></strong> method of the {{domxref("ElementInternals")}} interface sets the element's submission value and state, communicating these to the user agent.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/setvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.setValidity
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>setValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface sets the validity of the element.</p>
+<p>The <strong><code>setValidity()</code></strong> method of the {{domxref("ElementInternals")}} interface sets the validity of the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/shadowroot/index.html
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.shadowRoot
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>shadowRoot</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("ShadowRoot")}} for this element.</p>
+<p>The <strong><code>shadowRoot</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("ShadowRoot")}} for this element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/states/index.html
+++ b/files/en-us/web/api/elementinternals/states/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.states
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>states</code></strong> property of the {{domxref("ElementInternals")}} interface  </p>
+<p>The <strong><code>states</code></strong> property of the {{domxref("ElementInternals")}} interface  </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/validationmessage/index.html
+++ b/files/en-us/web/api/elementinternals/validationmessage/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.validationMessage
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>validationMessage</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the validation message for the element.</p>
+<p>The <strong><code>validationMessage</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns the validation message for the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/validity/index.html
+++ b/files/en-us/web/api/elementinternals/validity/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.validity
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>validity</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.</p>
+<p>The <strong><code>validity</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/elementinternals/willvalidate/index.html
+++ b/files/en-us/web/api/elementinternals/willvalidate/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ElementInternals.willValidate
 ---
 <div>{{DefaultAPISidebar("DOM")}}</div>
 
-<p class="summary">The <strong><code>willValidate</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns true if the element is a submittable element that is a candidate for <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>.</p>
+<p>The <strong><code>willValidate</code></strong> read-only property of the {{domxref("ElementInternals")}} interface returns true if the element is a submittable element that is a candidate for <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/encrypted_media_extensions_api/index.html
+++ b/files/en-us/web/api/encrypted_media_extensions_api/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Encrypted Media Extensions")}}</p>
 
-<p class="summary">The Encrypted Media Extensions API provides interfaces for controlling the playback of content which is subject to a digital restrictions management scheme.</p>
+<p>The Encrypted Media Extensions API provides interfaces for controlling the playback of content which is subject to a digital restrictions management scheme.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ExtendableCookieChangeEvent.changed
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+<p>The <strong><code>changed</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ExtendableCookieChangeEvent.deleted
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+<p>The <strong><code>deleted</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
+<p>The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ExtendableCookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occurred. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p>The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occurred. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)</p>
 
 <p>Cookie changes that cause the <code>ExtendableCookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/fetch_api/cross-global_fetch_usage/index.html
+++ b/files/en-us/web/api/fetch_api/cross-global_fetch_usage/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Fetch API")}}</p>
 
-<p class="summary">This article explains an edge case that occurs with fetch (and potentially other APIs exhibiting the same kind of resource retrieval behavior). When a cross-origin fetch involving a relative URL is initiated from an {{htmlelement("iframe")}}, the relative URL used to be resolved against the current global location, rather than the iframe's location.</p>
+<p>This article explains an edge case that occurs with fetch (and potentially other APIs exhibiting the same kind of resource retrieval behavior). When a cross-origin fetch involving a relative URL is initiated from an {{htmlelement("iframe")}}, the relative URL used to be resolved against the current global location, rather than the iframe's location.</p>
 
 <h2 id="The_edge_case">The edge case</h2>
 

--- a/files/en-us/web/api/fetch_api/index.html
+++ b/files/en-us/web/api/fetch_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Fetch API")}}</div>
 
-<p class="summary">The Fetch API provides an interface for fetching resources (including across the network). It will seem familiar to anyone who has used {{DOMxRef("XMLHttpRequest")}}, but the new API provides a more powerful and flexible feature set.</p>
+<p>The Fetch API provides an interface for fetching resources (including across the network). It will seem familiar to anyone who has used {{DOMxRef("XMLHttpRequest")}}, but the new API provides a more powerful and flexible feature set.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/en-us/web/api/file_system_access_api/index.html
+++ b/files/en-us/web/api/file_system_access_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
-<p class="summary">The File System Access API allows read, write and file management capabilities.</p>
+<p>The File System Access API allows read, write and file management capabilities.</p>
 
 <h2 id="Concepts_and_Usage">Concepts and Usage</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemDirectoryHandle.entries
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>entries()</code></strong> method of the
+<p>The <strong><code>entries()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns an array of a given object's
   own enumerable property <code>[key, value]</code> pairs, in the same order as that
   provided by a {{jsxref('for...in')}} loop (the difference being that a for-in loop

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemDirectoryHandle.getDirectoryHandle
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>getDirectoryHandle()</code></strong> method of the
+<p>The <strong><code>getDirectoryHandle()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns a
   {{domxref('FileSystemDirectoryHandle')}} for a subdirectory with the specified name
   within the directory handle on which the method is called.</p>

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemDirectoryHandle.getFileHandle
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>getFileHandle()</code></strong> method of the
+<p>The <strong><code>getFileHandle()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns a
   {{domxref('FileSystemFileHandle')}} for a file with the specified name, within the
   directory the method is called.</p>

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemDirectoryHandle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
-<p class="summary">The <strong><code>FileSystemDirectoryHandle</code></strong> interface of the {{domxref('File System Access API')}} provides a handle to a file system directory. The interface is accessed via the {{domxref('window.showDirectoryPicker()')}} method.</p>
+<p>The <strong><code>FileSystemDirectoryHandle</code></strong> interface of the {{domxref('File System Access API')}} provides a handle to a file system directory. The interface is accessed via the {{domxref('window.showDirectoryPicker()')}} method.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>keys()</code></strong> method of the
+<p>The <strong><code>keys()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns a new Array Iterator
   containing the keys for each item in <code>FileSystemDirectoryHandle</code>.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemDirectoryHandle.removeEntry
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>removeEntry()</code></strong> method of the
+<p>The <strong><code>removeEntry()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface attempts to remove an entry if the
   directory handle contains a file or directory called the name specified.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemDirectoryHandle.resolve
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>resolve()</code></strong> method of the
+<p>The <strong><code>resolve()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns an {{jsxref('Array')}} of
   directory names from the parent handle to the specified child entry, with the name of
   the child entry as the last array item.</p>

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemDirectoryHandle.values
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>values()</code></strong> method of the
+<p>The <strong><code>values()</code></strong> method of the
   {{domxref("FileSystemDirectoryHandle")}} interface returns a new Array Iterator
   containing the values for each index in the <code>FileSystemDirectoryHandle</code>
   object.</p>

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemFileHandle.createWritable
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>createWritable()</code></strong> method of the
+<p>The <strong><code>createWritable()</code></strong> method of the
   {{domxref("FileSystemFileHandle")}} interface creates
   a {{domxref('FileSystemWritableFileStream')}} that can be used to write to a file.</p>
 

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemFileHandle.getFile
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>getFile()</code></strong> method of the
+<p>The <strong><code>getFile()</code></strong> method of the
   {{domxref("FileSystemFileHandle")}} interface returns a {{domxref('File','file
   object')}} representing the state on disk of the entry represented by the handle.</p>
 

--- a/files/en-us/web/api/filesystemfilehandle/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemFileHandle
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
-<p class="summary">The <strong><code>FileSystemFileHandle</code></strong> interface of the {{domxref('File System Access API')}} represents a handle to a file system entry. The interface is accessed thought the {{domxref('window.showOpenFilePicker()')}} method.</p>
+<p>The <strong><code>FileSystemFileHandle</code></strong> interface of the {{domxref('File System Access API')}} represents a handle to a file system entry. The interface is accessed thought the {{domxref('window.showOpenFilePicker()')}} method.</p>
 
 <p>Note that read and write operations depend on file-access permissions that do not persist after a page refresh if no other tabs for that origin remain open. The {{domxref("FileSystemHandle.queryPermission()", "queryPermission")}} method of the {{domxref("FileSystemHandle")}} interface can be used to verify permission state before accessing a file.</p>
 

--- a/files/en-us/web/api/filesystemhandle/index.html
+++ b/files/en-us/web/api/filesystemhandle/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemHandle
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
-<p class="summary">The <strong><code>FileSystemHandle</code></strong> interface of the {{domxref('File System Access API')}} is an object which represents a file or directory entry. Multiple handles can represent the same entry. For the most part you do not work with <code>FileSystemHandle</code> directly but rather its child interfaces {{domxref('FileSystemFileHandle')}} and {{domxref('FileSystemDirectoryHandle')}}.</p>
+<p>The <strong><code>FileSystemHandle</code></strong> interface of the {{domxref('File System Access API')}} is an object which represents a file or directory entry. Multiple handles can represent the same entry. For the most part you do not work with <code>FileSystemHandle</code> directly but rather its child interfaces {{domxref('FileSystemFileHandle')}} and {{domxref('FileSystemDirectoryHandle')}}.</p>
 
 <h2 id="Interfaces_based_on_FileSystemHandle">Interfaces based on FileSystemHandle</h2>
 

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.html
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemHandle.isSameEntry
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>isSameEntry()</code></strong> method of the
+<p>The <strong><code>isSameEntry()</code></strong> method of the
   {{domxref("FileSystemHandle")}} interface compares two {{domxref("FileSystemHandle",
   "handles")}} to see if the associated entries (either a file or directory) match.</p>
 

--- a/files/en-us/web/api/filesystemhandle/kind/index.html
+++ b/files/en-us/web/api/filesystemhandle/kind/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemHandle.kind
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>kind</code></strong> read-only property of the
+<p>The <strong><code>kind</code></strong> read-only property of the
   {{domxref("FileSystemHandle")}} interface returns the type of entry. This is
   <code>'file'</code> if the associated entry is a file or <code>'directory'</code>. It is
   used to distinguish files from directories when iterating over the contents of a

--- a/files/en-us/web/api/filesystemhandle/name/index.html
+++ b/files/en-us/web/api/filesystemhandle/name/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemHandle.name
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>name</code></strong> read-only property of the
+<p>The <strong><code>name</code></strong> read-only property of the
   {{domxref("FileSystemHandle")}} interface returns the name of the entry represented by
   handle.</p>
 

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemHandle.queryPermission
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>queryPermission()</code></strong> method of the
+<p>The <strong><code>queryPermission()</code></strong> method of the
   {{domxref("FileSystemHandle")}} interface queries the current permission state of the
   current handle.</p>
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemHandle.requestPermission
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>requestPermission()</code></strong> method of the
+<p>The <strong><code>requestPermission()</code></strong> method of the
   {{domxref("FileSystemHandle")}} interface requests read or readwrite permissions for the
   file handle.</p>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.html
@@ -12,7 +12,7 @@ browser-compat: api.FileSystemWritableFileStream
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
-<p class="summary">The <strong><code>FileSystemWritableFileStream</code></strong> interface of the {{domxref('File System Access API')}} is a {{domxref('WritableStream')}} object with additional convenience methods, which operates on a single file on disk. The interface is accessed through the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
+<p>The <strong><code>FileSystemWritableFileStream</code></strong> interface of the {{domxref('File System Access API')}} is a {{domxref('WritableStream')}} object with additional convenience methods, which operates on a single file on disk. The interface is accessed through the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemWritableFileStream.seek
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>seek()</code></strong> method of the
+<p>The <strong><code>seek()</code></strong> method of the
   {{domxref("FileSystemWritableFileStream")}} interface updates the current file cursor
   offset to the position (in bytes) specified when calling the method.</p>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.FileSystemWritableFileStream.truncate
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>truncate()</code></strong> method of the
+<p>The <strong><code>truncate()</code></strong> method of the
   {{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with
   the stream to be the specified size in bytes.</p>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemWritableFileStream.write
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>write()</code></strong> method of the
+<p>The <strong><code>write()</code></strong> method of the
   {{domxref("FileSystemWritableFileStream")}} interface writes content into the file the
   method is called on, at the current file cursor offset.</p>
 

--- a/files/en-us/web/api/fontface/ascentoverride/index.html
+++ b/files/en-us/web/api/fontface/ascentoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.ascentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p>The <strong><code>ascentOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fontface/descentoverride/index.html
+++ b/files/en-us/web/api/fontface/descentoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.descentOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p>The <strong><code>descentOverride</code></strong>  property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fontface/featuresettings/index.html
+++ b/files/en-us/web/api/fontface/featuresettings/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.featureSettings
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>featureSettings</code></strong> property of the
+<p>The <strong><code>featureSettings</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets infrequently used font features that
   are not available from a font's variant properties. It is equivalent to the
   {{cssxref("@font-face/font-feature-settings", "font-feature-settings")}} descriptor.</p>

--- a/files/en-us/web/api/fontface/linegapoverride/index.html
+++ b/files/en-us/web/api/fontface/linegapoverride/index.html
@@ -11,7 +11,7 @@ browser-compat: api.FontFace.lineGapOverride
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>lineGapOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
+<p>The <strong><code>lineGapOverride</code></strong> property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are <code>normal</code>, indicating that the metric used should be obtained from the font file, or a percentage.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fontface/load/index.html
+++ b/files/en-us/web/api/fontface/load/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.load
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>load()</code></strong> method of the
+<p>The <strong><code>load()</code></strong> method of the
   {{domxref("FontFace")}} interface loads a font based on current object's
   constructor-passed requirements, including a location or source buffer, and returns a
   {{jsxref('Promise')}} that resolves with the current FontFace object.</p>

--- a/files/en-us/web/api/fontface/loaded/index.html
+++ b/files/en-us/web/api/fontface/loaded/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.loaded
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>loaded</code></strong> read-only property of the
+<p>The <strong><code>loaded</code></strong> read-only property of the
   {{domxref("FontFace")}} interface returns a {{jsxref('Promise')}} that resolves with the
   current <code>FontFace</code> object when the font specified in the object's constructor
   is done loading or rejects with a <code>SyntaxError</code>.</p>

--- a/files/en-us/web/api/fontface/status/index.html
+++ b/files/en-us/web/api/fontface/status/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.status
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>status</code></strong> read-only property of the
+<p>The <strong><code>status</code></strong> read-only property of the
   {{domxref("FontFace")}} interface returns an enumerated value indicating the status of
   the font, one of <code>"unloaded"</code>, <code>"loading"</code>, <code>"loaded"</code>,
   or <code>"error"</code>.</p>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8110.

It removes `class="summary"` from Web/API pages, in the cases where it was attached to a `<p>`. Because there are a lot of these, I'm doing it in 2 PRs. This is part 1.

In all these cases the marked-up paragraph was the first one anyway, so it's a no-op. Except for a few cases where a page contained more than one `<p class="summary">`, but that just seems to be an error in the page.
