### PR TITLE
Remove summary class from paragraphs, part 2

### DIFF
--- a/files/en-us/web/api/fontface/stretch/index.html
+++ b/files/en-us/web/api/fontface/stretch/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.stretch
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>stretch</code></strong> property of the
+<p>The <strong><code>stretch</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets how the font stretches. It is
   equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.</p>
 

--- a/files/en-us/web/api/fontface/style/index.html
+++ b/files/en-us/web/api/fontface/style/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.style
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>style</code></strong> property of the
+<p>The <strong><code>style</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the font's style. It is equivalent
   to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.</p>
 

--- a/files/en-us/web/api/fontface/unicoderange/index.html
+++ b/files/en-us/web/api/fontface/unicoderange/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.unicodeRange
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>unicodeRange</code></strong> property of the
+<p>The <strong><code>unicodeRange</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the range of unicode codepoints
   encompassing the font. It is equivalent to the {{cssxref("@font-face/unicode-range",
   "unicode-range")}} descriptor.</p>

--- a/files/en-us/web/api/fontface/variant/index.html
+++ b/files/en-us/web/api/fontface/variant/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.variant
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>variant</code></strong> property of the
+<p>The <strong><code>variant</code></strong> property of the
   {{domxref("FontFace")}} interface programmatically retrieves or sets font variant
   values. It is equivalent to the {{cssxref("@font-face/font-variant", "font-variant")}}
   descriptor.</p>

--- a/files/en-us/web/api/fontface/variationsettings/index.html
+++ b/files/en-us/web/api/fontface/variationsettings/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.variationSettings
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>variationSettings</code></strong> property of the
+<p>The <strong><code>variationSettings</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets low-level OpenType or TrueType font variations.
   It is equivalent to the
   {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.</p>

--- a/files/en-us/web/api/fontface/weight/index.html
+++ b/files/en-us/web/api/fontface/weight/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FontFace.weight
 ---
 <div>{{APIRef("CSS Font Loading API")}}</div>
 
-<p class="summary">The <strong><code>weight</code></strong> property of the
+<p>The <strong><code>weight</code></strong> property of the
   {{domxref("FontFace")}} interface retrieves or sets the weight of the font. It is
   equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.</p>
 

--- a/files/en-us/web/api/formdata/using_formdata_objects/index.html
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{APIRef("XMLHttpRequest")}}</div>
 
-<p class="summary">The <code><a href="/en-US/docs/Web/API/FormData">FormData</a></code> object lets you compile a set of key/value pairs to send using <code><a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a></code>. It is primarily intended for use in sending form data, but can be used independently from forms in order to transmit keyed data. The transmitted data is in the same format that the form's {{domxref("HTMLFormElement.submit","submit()")}} method would use to send the data if the form's encoding type were set to <code>multipart/form-data</code>.</p>
+<p>The <code><a href="/en-US/docs/Web/API/FormData">FormData</a></code> object lets you compile a set of key/value pairs to send using <code><a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a></code>. It is primarily intended for use in sending form data, but can be used independently from forms in order to transmit keyed data. The transmitted data is in the same format that the form's {{domxref("HTMLFormElement.submit","submit()")}} method would use to send the data if the form's encoding type were set to <code>multipart/form-data</code>.</p>
 
 <h2 id="Creating_a_FormData_object_from_scratch">Creating a FormData object from scratch</h2>
 

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -11,7 +11,7 @@ browser-compat: api.GainNode
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <code>GainNode</code> interface represents a change in volume. It is an {{domxref("AudioNode")}} audio-processing module that causes a given gain to be applied to the input data before its propagation to the output. A <code>GainNode</code> always has exactly one input and one output, both with the same number of channels.</p>
+<p>The <code>GainNode</code> interface represents a change in volume. It is an {{domxref("AudioNode")}} audio-processing module that causes a given gain to be applied to the input data before its propagation to the output. A <code>GainNode</code> always has exactly one input and one output, both with the same number of channels.</p>
 
 <p>The gain is a unitless value, changing with time, that is multiplied to each corresponding sample of all input channels. If modified, the new gain is instantly applied, causing unaesthetic 'clicks' in the resulting audio. To prevent this from happening, never change the value directly but use the exponential interpolation methods on the {{domxref("AudioParam")}} interface.</p>
 

--- a/files/en-us/web/api/hid/getdevices/index.html
+++ b/files/en-us/web/api/hid/getdevices/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.getDevices
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>getDevices()</code></strong> method of the {{domxref("HID")}} interface gets a list of the connected HID devices.</p>
+<p>The <strong><code>getDevices()</code></strong> method of the {{domxref("HID")}} interface gets a list of the connected HID devices.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hid/onconnect/index.html
+++ b/files/en-us/web/api/hid/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.onconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events fired when the user agent connects to the HID device.</p>
+<p>The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events fired when the user agent connects to the HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hid/ondisconnect/index.html
+++ b/files/en-us/web/api/hid/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.ondisconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events when the user agent disconnects from the HID device.</p>
+<p>The <strong><code>ondisconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("HID")}} interface processes the events when the user agent disconnects from the HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hid/requestdevice/index.html
+++ b/files/en-us/web/api/hid/requestdevice/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HID.requestDevice
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>requestDevice()</code></strong> method of the {{domxref("HID")}} interface requests access to a HID device.</p>
+<p>The <strong><code>requestDevice()</code></strong> method of the {{domxref("HID")}} interface requests access to a HID device.</p>
 
 <p>The user agent will present a permission dialog including a list of connected devices, and ask the user to select and grant permission to one of these devices.</p>
 

--- a/files/en-us/web/api/hidconnectionevent/device/index.html
+++ b/files/en-us/web/api/hidconnectionevent/device/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDConnectionEvent.device
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>device</code></strong> read-only property of the {{domxref("HIDConnectionEvent")}} interface returns the {{domxref("HIDDevice")}} associated with this connection event.</p>
+<p>The <strong><code>device</code></strong> read-only property of the {{domxref("HIDConnectionEvent")}} interface returns the {{domxref("HIDDevice")}} associated with this connection event.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
+++ b/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.HIDConnectionEvent.HIDConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>HIDConnectionEvent()</code></strong> constructor creates a new {{domxref("HIDConnectionEvent")}} object. Typically this constructor is not used as events are created when an input report is received.</p>
+<p>The <strong><code>HIDConnectionEvent()</code></strong> constructor creates a new {{domxref("HIDConnectionEvent")}} object. Typically this constructor is not used as events are created when an input report is received.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hidconnectionevent/index.html
+++ b/files/en-us/web/api/hidconnectionevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.HIDConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>HIDConnectionEvent</code></strong> interface of the {{domxref('WebHID API')}} represents HID connection events, and is the event type passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when an input report is received.</p>
+<p>The <strong><code>HIDConnectionEvent</code></strong> interface of the {{domxref('WebHID API')}} represents HID connection events, and is the event type passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when an input report is received.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/hiddevice/close/index.html
+++ b/files/en-us/web/api/hiddevice/close/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.close
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>close()</code></strong> method of the {{domxref("HIDDevice")}} interface closes the connection to the HID device.</p>
+<p>The <strong><code>close()</code></strong> method of the {{domxref("HIDDevice")}} interface closes the connection to the HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hiddevice/collections/index.html
+++ b/files/en-us/web/api/hiddevice/collections/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.collections
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>collections</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns an array of report formats </p>
+<p>The <strong><code>collections</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns an array of report formats </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hiddevice/index.html
+++ b/files/en-us/web/api/hiddevice/index.html
@@ -10,7 +10,7 @@ browser-compat: api.HIDDevice
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>HIDDevice</code></strong> interface of the {{domxref('WebHID API')}} represents a HID Device. It provides properties for accessing information about the device, methods for opening and closing the connection, and the sending and receiving of reports.</p>
+<p>The <strong><code>HIDDevice</code></strong> interface of the {{domxref('WebHID API')}} represents a HID Device. It provides properties for accessing information about the device, methods for opening and closing the connection, and the sending and receiving of reports.</p>
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/hiddevice/oninputreport/index.html
+++ b/files/en-us/web/api/hiddevice/oninputreport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.oninputreport
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>oninputreport</code></strong> event handler of the {{domxref("HIDDevice")}} interface processes inputreport events.</p>
+<p>The <strong><code>oninputreport</code></strong> event handler of the {{domxref("HIDDevice")}} interface processes inputreport events.</p>
 
 <p> The event fires when a new report is received from the HID device.</p>
 

--- a/files/en-us/web/api/hiddevice/open/index.html
+++ b/files/en-us/web/api/hiddevice/open/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.open
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>open()</code></strong> method of the {{domxref("HIDDevice")}} interface requests that the operating sytem opens the HID device.</p>
+<p>The <strong><code>open()</code></strong> method of the {{domxref("HIDDevice")}} interface requests that the operating sytem opens the HID device.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/hiddevice/opened/index.html
+++ b/files/en-us/web/api/hiddevice/opened/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.opened
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>opened</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns true if the connection to the {{domxref("HIDDevice")}} is open and ready to transfer data.</p>
+<p>The <strong><code>opened</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns true if the connection to the {{domxref("HIDDevice")}} is open and ready to transfer data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hiddevice/productid/index.html
+++ b/files/en-us/web/api/hiddevice/productid/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.productId
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>productId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product ID of the connected HID device.</p>
+<p>The <strong><code>productId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product ID of the connected HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hiddevice/productname/index.html
+++ b/files/en-us/web/api/hiddevice/productname/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.productName
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>productName</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product name of the connected HID device.</p>
+<p>The <strong><code>productName</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the product name of the connected HID device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.receiveFeatureReport
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>receiveFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface receives a feature report from the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
+<p>The <strong><code>receiveFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface receives a feature report from the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
 
 <p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
 

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.sendFeatureReport
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>sendFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends a feature report to the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
+<p>The <strong><code>sendFeatureReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends a feature report to the HID device. Feature reports are a way for HID devices and applications to exchange non-standardized HID data.</p>
 
 <p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
 

--- a/files/en-us/web/api/hiddevice/sendreport/index.html
+++ b/files/en-us/web/api/hiddevice/sendreport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.sendReport
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>sendReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends an output report to the HID device.</p>
+<p>The <strong><code>sendReport()</code></strong> method of the {{domxref("HIDDevice")}} interface sends an output report to the HID device.</p>
 
 <p>The <code>reportId</code> for each of the report formats that this device supports can be retrieved from {{domxref("HIDDevice.collections")}}.</p>
 

--- a/files/en-us/web/api/hiddevice/vendorid/index.html
+++ b/files/en-us/web/api/hiddevice/vendorid/index.html
@@ -11,7 +11,7 @@ browser-compat: api.HIDDevice.vendorId
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p class="summary">The <strong><code>vendorId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the vendor ID of the connected HID device. This identifies the vendor of the device.</p>
+<p>The <strong><code>vendorId</code></strong> read-only property of the {{domxref("HIDDevice")}} interface returns the vendor ID of the connected HID device. This identifies the vendor of the device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/html_sanitizer_api/index.html
+++ b/files/en-us/web/api/html_sanitizer_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}</div>
 
-<p class="summary">The HTML Sanitizer API allow developers to take untrusted strings of HTML, and sanitize them for safe insertion into a document’s DOM.</p>
+<p>The HTML Sanitizer API allow developers to take untrusted strings of HTML, and sanitize them for safe insertion into a document’s DOM.</p>
 
 <h2 id="Sanitizer_API_Concepts_and_Usage">Sanitizer API Concepts and Usage</h2>
 

--- a/files/en-us/web/api/htmlimageelement/image/index.html
+++ b/files/en-us/web/api/htmlimageelement/image/index.html
@@ -15,7 +15,7 @@ browser-compat: api.HTMLImageElement.Image
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>Image()</code></strong>
+<p>The <strong><code>Image()</code></strong>
     constructor creates a new {{DOMxRef("HTMLImageElement")}} instance. It is functionally
     equivalent to {{DOMxRef("Document.createElement()",
     "document.createElement('img')")}}.</p>

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLMediaElement.ratechange_event
 ---
 <p>{{APIRef("HTMLMediaElement")}}</p>
 
-<p class="summary">The <code>ratechange</code> event is fired when the playback rate has changed.</p>
+<p>The <code>ratechange</code> event is fired when the playback rate has changed.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/htmlmenuitemelement/index.html
+++ b/files/en-us/web/api/htmlmenuitemelement/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLMenuItemElement
 ---
 <p>{{APIRef("HTML DOM")}}{{Deprecated_Header}}</p>
 
-<p class="summary">The <strong><code>HTMLMenuItemElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menuitem")}} elements.</p>
+<p>The <strong><code>HTMLMenuItemElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menuitem")}} elements.</p>
 
 <p>{{InheritanceDiagram(600,120)}}</p>
 

--- a/files/en-us/web/api/htmlobjectelement/checkvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/checkvalidity/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.checkValidity
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
-<p class="summary">The <strong><code>checkValidity()</code></strong> method of the
+<p>The <strong><code>checkValidity()</code></strong> method of the
   {{domxref("HTMLObjectElement")}} interface returns a boolean value that always
   is true, because object objects are never candidates for constraint validation.</p>
 

--- a/files/en-us/web/api/htmlobjectelement/contentdocument/index.html
+++ b/files/en-us/web/api/htmlobjectelement/contentdocument/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.contentDocument
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>contentDocument</code></strong> read-only property of
+<p>The <strong><code>contentDocument</code></strong> read-only property of
   the {{domxref("HTMLObjectElement")}} interface Returns a {{domxref("Document")}}
   representing the active document of the object element's nested browsing context, if
   any; otherwise null.</p>

--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.html
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.contentWindow
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>contentWindow</code></strong> read-only property of
+<p>The <strong><code>contentWindow</code></strong> read-only property of
   the {{domxref("HTMLObjectElement")}} interface returns a {{domxref("WindowProxy")}}
   representing the window proxy of the object element's nested browsing context, if any;
   otherwise null.</p>

--- a/files/en-us/web/api/htmlobjectelement/data/index.html
+++ b/files/en-us/web/api/htmlobjectelement/data/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.data
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>data</code></strong> property of the
+<p>The <strong><code>data</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address
   of a resource's data.</p>

--- a/files/en-us/web/api/htmlobjectelement/form/index.html
+++ b/files/en-us/web/api/htmlobjectelement/form/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.form
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>form</code></strong> read-only property of the
+<p>The <strong><code>form</code></strong> read-only property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("HTMLFormElement")}}
   representing the object element's form owner, or null if there isn't one.</p>
 

--- a/files/en-us/web/api/htmlobjectelement/height/index.html
+++ b/files/en-us/web/api/htmlobjectelement/height/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.height
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>height</code></strong> property of the
+<p>The <strong><code>height</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface Returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("height", "object")}} HTML attribute, specifying the
   displayed height of the resource in CSS pixels.</p>

--- a/files/en-us/web/api/htmlobjectelement/name/index.html
+++ b/files/en-us/web/api/htmlobjectelement/name/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.name
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>name</code></strong> property of the
+<p>The <strong><code>name</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of
   the browsing context.</p>

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.setCustomValidity
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>setCustomValidity()</code></strong> method of the
+<p>The <strong><code>setCustomValidity()</code></strong> method of the
 	{{domxref("HTMLObjectElement")}} interface sets a custom validity message for the
 	element.</p>
 

--- a/files/en-us/web/api/htmlobjectelement/type/index.html
+++ b/files/en-us/web/api/htmlobjectelement/type/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.type
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>type</code></strong> property of the
+<p>The <strong><code>type</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type
   of the resource.</p>

--- a/files/en-us/web/api/htmlobjectelement/usemap/index.html
+++ b/files/en-us/web/api/htmlobjectelement/usemap/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.useMap
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>useMap</code></strong> property of the
+<p>The <strong><code>useMap</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("usemap", "object")}} HTML attribute, specifying a
   {{HTMLElement("map")}} element to use.</p>

--- a/files/en-us/web/api/htmlobjectelement/validationmessage/index.html
+++ b/files/en-us/web/api/htmlobjectelement/validationmessage/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.validationMessage
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>validationMessage</code></strong> read-only property
+<p>The <strong><code>validationMessage</code></strong> read-only property
   of the {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}}
   representing a localized message that describes the validation constraints that the
   control does not satisfy (if any). This is the empty string if the control is not a

--- a/files/en-us/web/api/htmlobjectelement/validity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/validity/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.validity
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>validity</code></strong> read-only property of the
+<p>The <strong><code>validity</code></strong> read-only property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("ValidityState")}} with
   the validity states that this element is in.</p>
 

--- a/files/en-us/web/api/htmlobjectelement/width/index.html
+++ b/files/en-us/web/api/htmlobjectelement/width/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.width
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>width</code></strong> property of the
+<p>The <strong><code>width</code></strong> property of the
   {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
   reflects the {{htmlattrxref("width", "object")}} HTML attribute, specifying the
   displayed width of the resource in CSS pixels.</p>

--- a/files/en-us/web/api/htmlobjectelement/willvalidate/index.html
+++ b/files/en-us/web/api/htmlobjectelement/willvalidate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLObjectElement.willValidate
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>willValidate</code></strong> read-only property of
+<p>The <strong><code>willValidate</code></strong> read-only property of
   the {{domxref("HTMLObjectElement")}} interface returns a boolean value that
   indicates whether the element is a candidate for constraint validation. Always false for
   HTMLObjectElement objects.</p>

--- a/files/en-us/web/api/idbtransaction/durability/index.html
+++ b/files/en-us/web/api/idbtransaction/durability/index.html
@@ -14,7 +14,7 @@ browser-compat: api.IDBTransaction.durability
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}</div>
 
-<p class="summary">The <strong><code>durability</code></strong> read-only property of the
+<p>The <strong><code>durability</code></strong> read-only property of the
   {{domxref("IDBTransaction")}} interface returns the durability hint the transaction was
   created with. This is a hint to the user agent of whether to prioritize performance or
   durability when committing the transaction.</p>

--- a/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.IDBVersionChangeEvent.IDBVersionChangeEvent
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}</div>
 
-<p class="summary">The <strong><code>IDBVersionChangeEvent()</code></strong> constructor
+<p>The <strong><code>IDBVersionChangeEvent()</code></strong> constructor
   creates a new {{domxref("IDBVersionChangeEvent")}} object, which is used to represent
   when a version of the database has changed, as a result of the
   {{domxref('IDBOpenDBRequest.onupgradeneeded')}} event handler.</p>

--- a/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.html
+++ b/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("IndexedDB")}}</div>
 
-<p class="summary">There are a number of web technologies that store data of one kind or another on the client-side (i.e., on your local disk). The process by which the browser works out how much space to allocate to web data storage and what to delete when that limit is reached is not simple, and differs between browsers. This article describes how browsers determine what local content to purge and when in order to free up needed local storage space.</p>
+<p>There are a number of web technologies that store data of one kind or another on the client-side (i.e., on your local disk). The process by which the browser works out how much space to allocate to web data storage and what to delete when that limit is reached is not simple, and differs between browsers. This article describes how browsers determine what local content to purge and when in order to free up needed local storage space.</p>
 
 <div class="note">
 <p><strong>Note</strong>: The information below should be fairly accurate for most modern browsers, but browser specifics are called out where known. Opera and Chrome should behave the same in all cases. <a href="http://www.opera.com/mobile/mini">Opera Mini</a> (still presto-based, server-side rendering) doesn't store any data on the client.</p>

--- a/files/en-us/web/api/inputdevicecapabilities_api/index.html
+++ b/files/en-us/web/api/inputdevicecapabilities_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("InputDeviceCapabilities API")}}{{SeeCompatTable}}</p>
 
-<p class="summary">The InputDeviceCapabilities API provides details about the underlying sources of input events. The API attempts to describe how the device behaves rather than what it is. For example, the first version of the API indicates whether a device fires touch events rather than whether it is a touch screen.</p>
+<p>The InputDeviceCapabilities API provides details about the underlying sources of input events. The API attempts to describe how the device behaves rather than what it is. For example, the first version of the API indicates whether a device fires touch events rather than whether it is a touch screen.</p>
 
 <h2 id="Input_device_capabilities_concepts_and_usage">Input device capabilities concepts and usage</h2>
 

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InputDeviceInfo.getCapabilities
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
-<p class="summary">The <strong><code>getCapabilities()</code></strong> method of the {{domxref("InputDeviceInfo")}} interface returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of the device's {{domxref("MediaStream")}}.</p>
+<p>The <strong><code>getCapabilities()</code></strong> method of the {{domxref("InputDeviceInfo")}} interface returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of the device's {{domxref("MediaStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/inputdeviceinfo/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InputDeviceInfo
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
-<p class="summary">The <strong><code>InputDeviceInfo</code></strong> interface of the {{domxref('Media Streams API','','',' ')}} gives access to the capabilities of the input device that it represents.</p>
+<p>The <strong><code>InputDeviceInfo</code></strong> interface of the {{domxref('Media Streams API','','',' ')}} gives access to the capabilities of the input device that it represents.</p>
 
 <p><code>InputDeviceInfo</code> objects are returned by {{domxref("MediaDevices.enumerateDevices()")}} if the returned device is an audio or video input device.</p>
 

--- a/files/en-us/web/api/intersection_observer_api/index.html
+++ b/files/en-us/web/api/intersection_observer_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Intersection Observer API")}}</div>
 
-<p class="summary">The Intersection Observer API provides a way to asynchronously observe changes in the intersection of a target element with an ancestor element or with a top-level document's {{Glossary("viewport")}}.</p>
+<p>The Intersection Observer API provides a way to asynchronously observe changes in the intersection of a target element with an ancestor element or with a top-level document's {{Glossary("viewport")}}.</p>
 
 <p>Historically, detecting visibility of an element, or the relative visibility of two elements in relation to each other, has been a difficult task for which solutions have been unreliable and prone to causing the browser and the sites the user is accessing to become sluggish. As the web has matured, the need for this kind of information has grown. Intersection information is needed for many reasons, such as:</p>
 

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.columnNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
+<p>The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/interventionreportbody/id/index.html
+++ b/files/en-us/web/api/interventionreportbody/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.id
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a string identifying the intervention that generated the report. This can be used to group reports.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a string identifying the intervention that generated the report. This can be used to group reports.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -12,7 +12,7 @@ browser-compat: api.InterventionReportBody
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>InterventionReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of an intervention report.</p>
+<p>The <code>InterventionReportBody</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents the body of an intervention report.</p>
 
 <p>An intervention report is generated when usage of a feature in a web document has been blocked by the browser for reasons such as security, performance, or user annoyance. So for example, a script was been stopped because it was significantly slowing down the browser, or the browser's autoplay policy blocked audio from playing without a user gesture to trigger it.</p>
 

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.lineNumber
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
+<p>The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/interventionreportbody/message/index.html
+++ b/files/en-us/web/api/interventionreportbody/message/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.message
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a human-readable description of the intervention, including information such as how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
+<p>The <strong><code>message</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns a human-readable description of the intervention, including information such as how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.sourceFile
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.</p>
+<p>The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/interventionreportbody/tojson/index.html
+++ b/files/en-us/web/api/interventionreportbody/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.InterventionReportBody.toJSON
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("InterventionReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>InterventionReportBody</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("InterventionReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>InterventionReportBody</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/keyframeeffectoptions/index.html
+++ b/files/en-us/web/api/keyframeeffectoptions/index.html
@@ -16,7 +16,7 @@ browser-compat: api.KeyframeEffectOptions
 ---
 <p>{{APIRef("Web Animations")}}{{Draft}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>KeyframeEffectOptions</code></strong> dictionary, part of the {{DOMxRef('Web Animations API', '', '', 'true')}}, is used by {{DOMxRef('Element.animate()')}} and {{DOMxRef('KeyframeEffect.KeyframeEffect', 'KeyframeEffect()')}} to describe timing properties for animation effects. These properties are all optional, although without setting a <code>duration</code> the animation will not play.</p>
+<p>The <strong><code>KeyframeEffectOptions</code></strong> dictionary, part of the {{DOMxRef('Web Animations API', '', '', 'true')}}, is used by {{DOMxRef('Element.animate()')}} and {{DOMxRef('KeyframeEffect.KeyframeEffect', 'KeyframeEffect()')}} to describe timing properties for animation effects. These properties are all optional, although without setting a <code>duration</code> the animation will not play.</p>
 
 <p>In other words, these properties describe how the {{Glossary("user agent")}} should go about making the transition from keyframe to keyframe, and how to behave when the animation begins and ends.</p>
 

--- a/files/en-us/web/api/largest_contentful_paint_api/index.html
+++ b/files/en-us/web/api/largest_contentful_paint_api/index.html
@@ -10,7 +10,7 @@ browser-compat: api.LargestContentfulPaint
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong>Largest Contentful Paint (LCP) API</strong> enables monitoring the largest paint element triggered on screen.</p>
+<p>The <strong>Largest Contentful Paint (LCP) API</strong> enables monitoring the largest paint element triggered on screen.</p>
 
 <h2> Concepts and Usage</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/element/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/element/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.element
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>element</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns an object representing the {{domxref("Element")}} that is the largest contentful paint.</p>
+<p>The <strong><code>element</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns an object representing the {{domxref("Element")}} that is the largest contentful paint.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.id
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the ID of the element that is the largest contentful paint.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the ID of the element that is the largest contentful paint.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/loadtime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.loadTime
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>loadTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the time that the element was loaded.</p>
+<p>The <strong><code>loadTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the time that the element was loaded.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.renderTime
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>renderTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface represents the time that the element was rendered to the screen.</p>
+<p>The <strong><code>renderTime</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface represents the time that the element was rendered to the screen.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.size
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>size</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the intrinsic size of the element that is the largest contentful paint.</p>
+<p>The <strong><code>size</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the intrinsic size of the element that is the largest contentful paint.</p>
 
 <p>The <code>size</code> of the element is the <code>width</code> times <code>height</code> of the {{domxref("DOMRectReadOnly","rectangle")}} that this element creates on the screen.</p>
 

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.toJSON
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LargestContentfulPaint")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>LargestContentfulPaint</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("LargestContentfulPaint")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>LargestContentfulPaint</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LargestContentfulPaint.url
 ---
 <div>{{DefaultAPISidebar("Largest Contentful Paint API")}}</div>
 
-<p class="summary">The <strong><code>url</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the request url of the element, if the element is an image.</p>
+<p>The <strong><code>url</code></strong> read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the request url of the element, if the element is an image.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/layout_instability_api/index.html
+++ b/files/en-us/web/api/layout_instability_api/index.html
@@ -10,7 +10,7 @@ browser-compat: api.LayoutShift
 ---
 <div>{{DefaultAPISidebar("Layout Instability API")}}</div>
 
-<p class="summary">The <strong>Layout Instability API</strong> provides interfaces for measuring and reporting layout shifts.</p>
+<p>The <strong>Layout Instability API</strong> provides interfaces for measuring and reporting layout shifts.</p>
 
 <h2> Concepts and Usage</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LayoutShiftAttribution.currentRect
 ---
 <div><div>{{APIRef("Layout Instability API")}}</div></div>
 
-<p class="summary">The <strong><code>currentRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
+<p>The <strong><code>currentRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/node/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LayoutShiftAttribution.node
 ---
 <div><div>{{APIRef("Layout Instability API")}}</div></div>
 
-<p class="summary">The <strong><code>node</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("node")}} representing the object that has shifted.</p>
+<p>The <strong><code>node</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("node")}} representing the object that has shifted.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LayoutShiftAttribution.previousRect
 ---
 <div><div>{{APIRef("Layout Instability API")}}</div></div>
 
-<p class="summary">The <strong><code>previousRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
+<p>The <strong><code>previousRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.LayoutShiftAttribution.toJSON
 ---
 <div><div>{{APIRef("Layout Instability API")}}</div></div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em> that returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em> that returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mathmlelement/index.html
+++ b/files/en-us/web/api/mathmlelement/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MathMLElement
 ---
 <div>{{APIRef("MathML")}}</div>
 
-<p class="summary">The <strong><code>MathMLElement</code></strong> interface represents any <a href="/en-US/docs/Web/MathML">MathML</a> element.</p>
+<p>The <strong><code>MathMLElement</code></strong> interface represents any <a href="/en-US/docs/Web/MathML">MathML</a> element.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/media_capabilities_api/index.html
+++ b/files/en-us/web/api/media_capabilities_api/index.html
@@ -11,7 +11,7 @@ tags:
 <p>{{DefaultAPISidebar("Media Capabilities API")}}</p>
 
 <div>
-<p class="summary">The <strong>Media Capabilities API</strong> allows developers to determine decoding and encoding abilities of the device, exposing information such as whether media is supported and whether playback should be smooth and power efficient, with real time feedback about playback to better enable adaptive streaming, and access to display property information.</p>
+<p>The <strong>Media Capabilities API</strong> allows developers to determine decoding and encoding abilities of the device, exposing information such as whether media is supported and whether playback should be smooth and power efficient, with real time feedback about playback to better enable adaptive streaming, and access to display property information.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/media_session_api/index.html
+++ b/files/en-us/web/api/media_session_api/index.html
@@ -13,11 +13,11 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Media Session API")}}</p>
 
-<p class="summary">The Media Session API provides a way to customize media notifications. It does this by providing metadata for display by the user agent for the media your web app is playing.</p>
+<p>The Media Session API provides a way to customize media notifications. It does this by providing metadata for display by the user agent for the media your web app is playing.</p>
 
-<p class="summary">It also provides action handlers that the browser can use to access platform media keys such as hardware keys found on keyboards, headsets, remote controls, and software keys found in notification areas and on lock screens of mobile devices. So you can seamlessly control web-provided media via your device, even when not looking at the web page.</p>
+<p>It also provides action handlers that the browser can use to access platform media keys such as hardware keys found on keyboards, headsets, remote controls, and software keys found in notification areas and on lock screens of mobile devices. So you can seamlessly control web-provided media via your device, even when not looking at the web page.</p>
 
-<p class="summary">The aim is to allow users to know what's playing and to control it, without needing to open the specific page that launched it. To be able to support the Media Session API, a browser first needs a mechanism by which to access and be controlled by the OS-level media controls (such as Firefox's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1648100">MediaControl</a>).</p>
+<p>The aim is to allow users to know what's playing and to control it, without needing to open the specific page that launched it. To be able to support the Media Session API, a browser first needs a mechanism by which to access and be controlled by the OS-level media controls (such as Firefox's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1648100">MediaControl</a>).</p>
 
 <h2 id="Media_Session_concepts_and_usage">Media Session concepts and usage</h2>
 

--- a/files/en-us/web/api/media_source_extensions_api/index.html
+++ b/files/en-us/web/api/media_source_extensions_api/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Media Source Extensions")}}{{ Draft}}</p>
 
-<p class="summary">The <strong>Media Source API</strong>, formally known as <strong>Media Source Extensions</strong> (<strong>MSE</strong>), provides functionality enabling plugin-free web-based streaming media. Using MSE, media streams can be created via JavaScript, and played using {{htmlelement("audio")}} and {{htmlelement("video")}} elements.</p>
+<p>The <strong>Media Source API</strong>, formally known as <strong>Media Source Extensions</strong> (<strong>MSE</strong>), provides functionality enabling plugin-free web-based streaming media. Using MSE, media streams can be created via JavaScript, and played using {{htmlelement("audio")}} and {{htmlelement("video")}} elements.</p>
 
 <h2 id="Media_Source_Extensions_concepts_and_usage">Media Source Extensions concepts and usage</h2>
 

--- a/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.html
+++ b/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.html
@@ -9,7 +9,7 @@ tags:
   - Media Source Extensions
   - adaptive
 ---
-<p class="summary">When working with Media Source Extensions, it is likely that you need to condition your assets before you can stream them. This article takes you through the requirements and shows you a toolchain you can use to encode your assets appropriately.</p>
+<p>When working with Media Source Extensions, it is likely that you need to condition your assets before you can stream them. This article takes you through the requirements and shows you a toolchain you can use to encode your assets appropriately.</p>
 
 <h2 id="Getting_started">Getting started</h2>
 

--- a/files/en-us/web/api/mediastream_image_capture_api/index.html
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Image Capture API")}}{{SeeCompatTable}}</p>
 
-<p class="summary">The <strong>MediaStream Image Capture API</strong> is an API for capturing images or videos from a photographic device. In addition to capturing data, it also allows you to retrieve information about device capabilities such as image size, red-eye reduction and whether or not there is a flash and what they are currently set to. Conversely, the API allows the capabilities to be configured within the constraints what the device allows.</p>
+<p>The <strong>MediaStream Image Capture API</strong> is an API for capturing images or videos from a photographic device. In addition to capturing data, it also allows you to retrieve information about device capabilities such as image size, red-eye reduction and whether or not there is a flash and what they are currently set to. Conversely, the API allows the capabilities to be configured within the constraints what the device allows.</p>
 
 <h2 id="MediaStream_image_capture_concepts_and_usage">MediaStream image capture concepts and usage</h2>
 

--- a/files/en-us/web/api/midiaccess/inputs/index.html
+++ b/files/en-us/web/api/midiaccess/inputs/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIAccess.inputs
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>inputs</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface provides access to any available MIDI input ports.</p>
+<p>The <strong><code>inputs</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface provides access to any available MIDI input ports.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiaccess/onstatechange/index.html
+++ b/files/en-us/web/api/midiaccess/onstatechange/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIAccess.onstatechange
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>onstatechange</code></strong> {{event("Event_handlers", "Event Handler")}} of the {{domxref("MIDIAccess")}} interface processes statechange events.</p>
+<p>The <strong><code>onstatechange</code></strong> {{event("Event_handlers", "Event Handler")}} of the {{domxref("MIDIAccess")}} interface processes statechange events.</p>
 
 <p>The event fires when a new MIDI port is added or when an existing port changes state.</p>
 

--- a/files/en-us/web/api/midiaccess/outputs/index.html
+++ b/files/en-us/web/api/midiaccess/outputs/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIAccess.outputs
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>outputs</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface provides access to any available MIDI output ports.</p>
+<p>The <strong><code>outputs</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface provides access to any available MIDI output ports.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiaccess/sysexenabled/index.html
+++ b/files/en-us/web/api/midiaccess/sysexenabled/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIAccess.sysexEnabled
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>sysexEnabled</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface indicates whether system exclusive support is enabled on the current MIDIAccess instance.</p>
+<p>The <strong><code>sysexEnabled</code></strong> read-only property of the {{domxref("MIDIAccess")}} interface indicates whether system exclusive support is enabled on the current MIDIAccess instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.MIDIConnectionEvent.MIDIConnectionEvent
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>MIDIConnectionEvent()</code></strong> constructor creates a new {{domxref("MIDIConnectionEvent")}} object. Typically this constructor is not used as events are created when a new port becomes available, and the object is passed to the {{domxref("MIDIAccess.onstagechange")}} event handler.</p>
+<p>The <strong><code>MIDIConnectionEvent()</code></strong> constructor creates a new {{domxref("MIDIConnectionEvent")}} object. Typically this constructor is not used as events are created when a new port becomes available, and the object is passed to the {{domxref("MIDIAccess.onstagechange")}} event handler.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiconnectionevent/port/index.html
+++ b/files/en-us/web/api/midiconnectionevent/port/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIConnectionEvent.port
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>port</code></strong> read-only property of the {{domxref("MIDIConnectionEvent")}} interface returns the port that has been disconnected or connected.</p>
+<p>The <strong><code>port</code></strong> read-only property of the {{domxref("MIDIConnectionEvent")}} interface returns the port that has been disconnected or connected.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiinput/onmidimessage/index.html
+++ b/files/en-us/web/api/midiinput/onmidimessage/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIInput.onmidimessage
 ---
 <div>{{APIRef("Web MIDI API")}}{{securecontext_header}}</div>
 
-<p class="summary">The <strong><code>onmidimessage</code></strong> {{event("Event_handlers", "event handler")}} of the {{domxref("MIDIInput")}} interface processes <code>midimessage</code> events.</p>
+<p>The <strong><code>onmidimessage</code></strong> {{event("Event_handlers", "event handler")}} of the {{domxref("MIDIInput")}} interface processes <code>midimessage</code> events.</p>
 
 <p> The event fires when the MIDI port corresponding to this {{domxref("MIDIInput")}} finishes receiving one or more MIDI messages. An instance of {{domxref("MIDIMessageEvent")}} containing the message that was received is passed to this event handler.</p>
 

--- a/files/en-us/web/api/midimessageevent/data/index.html
+++ b/files/en-us/web/api/midimessageevent/data/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIMessageEvent.data
 ---
 <p>{{securecontext_header}}{{APIRef("Web MIDI API")}}</p>
 
-<p class="summary">The <strong><code>data</code></strong> read-only property of the {{domxref("MIDIMessageEvent")}} interface returns the MIDI data bytes of a single MIDI message.</p>
+<p>The <strong><code>data</code></strong> read-only property of the {{domxref("MIDIMessageEvent")}} interface returns the MIDI data bytes of a single MIDI message.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midimessageevent/midimessageevent/index.html
+++ b/files/en-us/web/api/midimessageevent/midimessageevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.MIDIMessageEvent.MIDIMessageEvent
 ---
 <p>{{securecontext_header}}{{APIRef("Web MIDI API")}}</p>
 
-<p class="summary">The <strong><code>MIDIMessageEvent()</code></strong> constructor creates a new {{domxref("MIDIMessageEvent")}} object. Typically this constructor is not used as events are created when a {{domxref("MIDIInput")}} finishes receiving one or more MIDI messages.</p>
+<p>The <strong><code>MIDIMessageEvent()</code></strong> constructor creates a new {{domxref("MIDIMessageEvent")}} object. Typically this constructor is not used as events are created when a {{domxref("MIDIInput")}} finishes receiving one or more MIDI messages.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midioutput/clear/index.html
+++ b/files/en-us/web/api/midioutput/clear/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIOutput.clear
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>clear()</code></strong> method of the {{domxref("MIDIOutput")}} interface clears the queue of messages being sent to the output device.</p>
+<p>The <strong><code>clear()</code></strong> method of the {{domxref("MIDIOutput")}} interface clears the queue of messages being sent to the output device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midioutput/index.html
+++ b/files/en-us/web/api/midioutput/index.html
@@ -10,7 +10,7 @@ browser-compat: api.MIDIOutput
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>MIDIOutput</code></strong> interface of the {{domxref('Web MIDI API','','',' ')}} provides methods to add messages to the queue of an output device, and to clear the queue of messages.</p>
+<p>The <strong><code>MIDIOutput</code></strong> interface of the {{domxref('Web MIDI API','','',' ')}} provides methods to add messages to the queue of an output device, and to clear the queue of messages.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIOutput.send
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>send()</code></strong> method of the {{domxref("MIDIOutput")}} interface queues messages for the corresponding MIDI port. The message can be sent immediately, or with an optional timestamp to delay sending.</p>
+<p>The <strong><code>send()</code></strong> method of the {{domxref("MIDIOutput")}} interface queues messages for the corresponding MIDI port. The message can be sent immediately, or with an optional timestamp to delay sending.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/close/index.html
+++ b/files/en-us/web/api/midiport/close/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.close
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>close()</code></strong> method of the {{domxref("MIDIPort")}} interface makes the access to the MIDI device connected to this <code>MIDIPort</code> unavailable.</p>
+<p>The <strong><code>close()</code></strong> method of the {{domxref("MIDIPort")}} interface makes the access to the MIDI device connected to this <code>MIDIPort</code> unavailable.</p>
 
 <p>If the port is successfully closed a new {{domxref("MIDICOnnectionEvent")}} is queued to the {{domxref("MIDIPort.onstatechange")}} and {{domxref("MIDIAccess.onstatechange")}} event handlers, and the {{domxref("MIDIPort.connection")}} property is changed to <code>"closed"</code>.</p>
 

--- a/files/en-us/web/api/midiport/connection/index.html
+++ b/files/en-us/web/api/midiport/connection/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.connection
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>connection</code></strong> property of the {{domxref("MIDIPort")}} interface returns the connection state of the port.</p>
+<p>The <strong><code>connection</code></strong> property of the {{domxref("MIDIPort")}} interface returns the connection state of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/id/index.html
+++ b/files/en-us/web/api/midiport/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.id
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the unique ID of the port.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the unique ID of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/index.html
+++ b/files/en-us/web/api/midiport/index.html
@@ -10,7 +10,7 @@ browser-compat: api.MIDIPort
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>MIDIPort</code></strong> interface of the {{domxref('Web MIDI API','','',' ')}} represents a MIDI input or output port.</p>
+<p>The <strong><code>MIDIPort</code></strong> interface of the {{domxref('Web MIDI API','','',' ')}} represents a MIDI input or output port.</p>
 
 <p>A <code>MIDIPort</code> instance is created when a new MIDI device is connected. Therefore it has no constructor.</p>
 

--- a/files/en-us/web/api/midiport/manufacturer/index.html
+++ b/files/en-us/web/api/midiport/manufacturer/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.manufacturer
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>manufacturer</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the manufacturer of the port.</p>
+<p>The <strong><code>manufacturer</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the manufacturer of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/name/index.html
+++ b/files/en-us/web/api/midiport/name/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.name
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>name</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the system name of the port.</p>
+<p>The <strong><code>name</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the system name of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/onstatechange/index.html
+++ b/files/en-us/web/api/midiport/onstatechange/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.onstatechange
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>onstatechange</code></strong> event handler of the {{domxref("MIDIPort")}} interface processes {{domxref("MIDIPort/statechange_event", "statechange")}} events.</p>
+<p>The <strong><code>onstatechange</code></strong> event handler of the {{domxref("MIDIPort")}} interface processes {{domxref("MIDIPort/statechange_event", "statechange")}} events.</p>
 
 <p> The event fires when a port changes from open to closed, or closed to open.</p>
 

--- a/files/en-us/web/api/midiport/open/index.html
+++ b/files/en-us/web/api/midiport/open/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.open
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>open()</code></strong> method of the {{domxref("MIDIPort")}} interface makes the MIDI device connected to this <code>MIDIPort</code> explicitly available.</p>
+<p>The <strong><code>open()</code></strong> method of the {{domxref("MIDIPort")}} interface makes the MIDI device connected to this <code>MIDIPort</code> explicitly available.</p>
 
 <p>If the port is successfully opened a new {{domxref("MIDICOnnectionEvent")}} is queued to the {{domxref("MIDIPort.onstatechange")}} and {{domxref("MIDIAccess.onstatechange")}} event handlers, and the {{domxref("MIDIPort.connection")}} property is changed to <code>"open"</code>.</p>
 

--- a/files/en-us/web/api/midiport/state/index.html
+++ b/files/en-us/web/api/midiport/state/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.state
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>state</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the state of the port.</p>
+<p>The <strong><code>state</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the state of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/type/index.html
+++ b/files/en-us/web/api/midiport/type/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.type
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>type</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the type of the port, indicating whether this is an input or output MIDI port.</p>
+<p>The <strong><code>type</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the type of the port, indicating whether this is an input or output MIDI port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midiport/version/index.html
+++ b/files/en-us/web/api/midiport/version/index.html
@@ -11,7 +11,7 @@ browser-compat: api.MIDIPort.version
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}</div>
 
-<p class="summary">The <strong><code>version</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the version of the port.</p>
+<p>The <strong><code>version</code></strong> read-only property of the {{domxref("MIDIPort")}} interface returns the version of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Navigator.canShare
 <div>{{APIRef("HTML
   DOM")}}{{Non-standard_Header}}{{SeeCompatTable}}{{securecontext_header}}</div>
 
-<p class="summary">The <strong><code>Navigator.canShare()</code></strong> method of the
+<p>The <strong><code>Navigator.canShare()</code></strong> method of the
   Web Share API returns <code>true</code> if a call to {{domxref("navigator.share()")}}
   would succeed.</p>
 

--- a/files/en-us/web/api/navigator/clearappbadge/index.html
+++ b/files/en-us/web/api/navigator/clearappbadge/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Navigator.clearAppBadge
 ---
 <div>{{DefaultAPISidebar("Badging API")}}</div>
 
-<p class="summary">The <strong><code>clearAppBadge()</code></strong> method of the {{domxref("Navigator")}} interface clears a badge on the current app's icon by setting it to <code>nothing</code>. The value <code>nothing</code> indictes that no badge is currently set, and the status of the badge is <em>cleared</em>.</p>
+<p>The <strong><code>clearAppBadge()</code></strong> method of the {{domxref("Navigator")}} interface clears a badge on the current app's icon by setting it to <code>nothing</code>. The value <code>nothing</code> indictes that no badge is currently set, and the status of the badge is <em>cleared</em>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigator/contacts/index.html
+++ b/files/en-us/web/api/navigator/contacts/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.contacts
 ---
 <div>{{draft}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
-<p class="summary">The <strong><code>contacts</code></strong> read-only property of the
+<p>The <strong><code>contacts</code></strong> read-only property of the
   {{domxref("Navigator")}} interface returns a {{domxref('ContactsManager')}} interface
   which allows users to select entries from their contact list and share limited details
   of the selected entries with a website or application.</p>

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Navigator.serial
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p class="summary">The <strong><code>serial</code></strong> read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
+<p>The <strong><code>serial</code></strong> read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
 
 <p>When getting, the same instance of the {{domxref("Serial")}} object will always be returned.</p>
 

--- a/files/en-us/web/api/navigator/setappbadge/index.html
+++ b/files/en-us/web/api/navigator/setappbadge/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Navigator.setAppBadge
 ---
 <div>{{DefaultAPISidebar("Badging API")}}</div>
 
-<p class="summary">The <strong><code>setAppBadge()</code></strong> method of the {{domxref("Navigator")}} interface a badge on the icon associated with this app. If a value is passed to the method, this will be set as the value of the badge. Otherwise the badge will display as a dot, or other indicator as defined by the platform.</p>
+<p>The <strong><code>setAppBadge()</code></strong> method of the {{domxref("Navigator")}} interface a badge on the icon associated with this app. If a value is passed to the method, this will be set as the value of the badge. Otherwise the badge will display as a dot, or other indicator as defined by the platform.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigatoruadata/brands/index.html
+++ b/files/en-us/web/api/navigatoruadata/brands/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NavigatorUAData.brands
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>brands</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns an array of brand information.</p>
+<p>The <strong><code>brands</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns an array of brand information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.html
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NavigatorUAData.getHighEntropyValues
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>getHighEntropyValues()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the <em>high entropy</em> values the user-agent returns.</p>
+<p>The <strong><code>getHighEntropyValues()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the <em>high entropy</em> values the user-agent returns.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/navigatoruadata/index.html
+++ b/files/en-us/web/api/navigatoruadata/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NavigatorUAData
 ---
 <div>{{DefaultAPISidebar("User-Agent Client Hints API")}}</div>
 
-<p class="summary">The <strong><code>NavigatorUAData</code></strong> interface of the {{domxref('User-Agent Client Hints API')}} returns information about the browser and operating system of a user.</p>
+<p>The <strong><code>NavigatorUAData</code></strong> interface of the {{domxref('User-Agent Client Hints API')}} returns information about the browser and operating system of a user.</p>
 
 <p>An instance of this object is returned by calling {{domxref("Navigator.userAgentData")}}. Therefore, this interface has no constructor.</p>
 

--- a/files/en-us/web/api/navigatoruadata/mobile/index.html
+++ b/files/en-us/web/api/navigatoruadata/mobile/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NavigatorUAData.mobile
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>mobile</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns a value indicating whether the device is a mobile device.</p>
+<p>The <strong><code>mobile</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns a value indicating whether the device is a mobile device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigatoruadata/platform/index.html
+++ b/files/en-us/web/api/navigatoruadata/platform/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NavigatorUAData.platform
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>platform</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns the platform brand information.</p>
+<p>The <strong><code>platform</code></strong> read-only property of the {{domxref("NavigatorUAData")}} interface returns the platform brand information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigatoruadata/tojson/index.html
+++ b/files/en-us/web/api/navigatoruadata/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NavigatorUAData.toJSON
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a <em>serializer</em> that returns a JSON representation of the <em>low entropy</em> properties of the <code>NavigatorUAData</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a <em>serializer</em> that returns a JSON representation of the <em>low entropy</em> properties of the <code>NavigatorUAData</code> object.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/ndefmessage/ndefmessage/index.html
+++ b/files/en-us/web/api/ndefmessage/ndefmessage/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFMessage.NDEFMessage
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>NDEFMessage()</code></strong> constructor creates a new {{domxref("NDEFMessage")}} object, initialized with the given NDEF records.</p>
+<p>The <strong><code>NDEFMessage()</code></strong> constructor creates a new {{domxref("NDEFMessage")}} object, initialized with the given NDEF records.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFReader
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>NDEFReader</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> is used to read from and write data to compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</p>
+<p>The <strong><code>NDEFReader</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> is used to read from and write data to compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/ndefreader/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/ndefreader/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFReader.NDEFReader
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>NDEFReader()</code></strong>
+<p>The <strong><code>NDEFReader()</code></strong>
     constructor of the {{domxref("NDEFReader")}} interface returns a
     new <code>NDEFReader</code> object, which is used to read NDEF messages from
     compatible NFC devices, e.g. NDEF tags, within the reader's magnetic induction

--- a/files/en-us/web/api/ndefreader/onreading/index.html
+++ b/files/en-us/web/api/ndefreader/onreading/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFReader.onreading
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <code>onreading</code> property of the {{DOMxRef("NDEFReader")}} interface is called whenever a new reading is available from compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</p>
+<p>The <code>onreading</code> property of the {{DOMxRef("NDEFReader")}} interface is called whenever a new reading is available from compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/ndefreader/onreadingerror/index.html
+++ b/files/en-us/web/api/ndefreader/onreadingerror/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFReader.onreadingerror
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <code>onreadingerror</code> property of the {{DOMxRef("NDEFReader")}} interface is called whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.</p>
+<p>The <code>onreadingerror</code> property of the {{DOMxRef("NDEFReader")}} interface is called whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/ndefreadingevent/message/index.html
+++ b/files/en-us/web/api/ndefreadingevent/message/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NDEFReadingEvent.message
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>message</code></strong> property of the {{domxref("NDEFReadingEvent")}} interface returns an {{DOMxRef("NDEFMessage")}} object containing the received message.</p>
+<p>The <strong><code>message</code></strong> property of the {{domxref("NDEFReadingEvent")}} interface returns an {{DOMxRef("NDEFMessage")}} object containing the received message.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.html
+++ b/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFReadingEvent.NDEFReadingEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>NDEFReadingEvent()</code></strong> constructor creates a new {{domxref("NDEFReadingEvent")}} object which represents events dispatched on new NFC readings obtained by {{DOMxRef("NDEFReader")}}.</p>
+<p>The <strong><code>NDEFReadingEvent()</code></strong> constructor creates a new {{domxref("NDEFReadingEvent")}} object which represents events dispatched on new NFC readings obtained by {{DOMxRef("NDEFReader")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefreadingevent/serialnumber/index.html
+++ b/files/en-us/web/api/ndefreadingevent/serialnumber/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NDEFReadingEvent.serialNumber
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>serialNumber</code></strong> property of the {{domxref("NDEFReadingEvent")}} interface returns the serial number of the device, which is used for anti-collision and identification, or an empty string if no serial number is available. </p>
+<p>The <strong><code>serialNumber</code></strong> property of the {{domxref("NDEFReadingEvent")}} interface returns the serial number of the device, which is used for anti-collision and identification, or an empty string if no serial number is available. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ndefrecord/data/index.html
+++ b/files/en-us/web/api/ndefrecord/data/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.data
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>data</code></strong>
+<p>The <strong><code>data</code></strong>
     property of the {{DOMxRef("NDEFRecord")}} interface returns a
     {{jsxref("DataView")}} containing the raw bytes of the record's payload.</p>
 

--- a/files/en-us/web/api/ndefrecord/id/index.html
+++ b/files/en-us/web/api/ndefrecord/id/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NDEFRecord.id
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>id</code></strong> property of the
+<p>The <strong><code>id</code></strong> property of the
 {{DOMxRef("NDEFRecord")}} interface returns the record identifier, which is an
 absolute or relative URL used to identify the record.</p>
 

--- a/files/en-us/web/api/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>NDEFRecord</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> provides data that can be read from, or written to, compatible NFC devices, e.g. NFC tags supporting NDEF.</p>
+<p>The <strong><code>NDEFRecord</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_NFC_API">Web NFC API</a> provides data that can be read from, or written to, compatible NFC devices, e.g. NFC tags supporting NDEF.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/ndefrecord/lang/index.html
+++ b/files/en-us/web/api/ndefrecord/lang/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.lang
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>lang</code></strong>
+<p>The <strong><code>lang</code></strong>
     property of the {{DOMxRef("NDEFRecord")}} interface returns the language of
     a textual payload, or <code>null</code> if one was not supplied.</p>
 

--- a/files/en-us/web/api/ndefrecord/mediatype/index.html
+++ b/files/en-us/web/api/ndefrecord/mediatype/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.mediaType
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>mediaType</code></strong>
+<p>The <strong><code>mediaType</code></strong>
     property of the {{DOMxRef("NDEFRecord")}} interface returns the {{Glossary("MIME type")}} of the record. This value will be <code>null</code> if <code>recordType</code> is not equal to <code>"mime"</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.NDEFRecord
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>NDEFRecord()</code></strong>
+<p>The <strong><code>NDEFRecord()</code></strong>
     constructor of the <a href="/en-US/docs/Web/API/WebNFC_API">Web NFC API</a> returns a
     newly constructed {{DOMxRef("NDEFRecord")}} object that represents data that can be
     read from, or written to, compatible NFC devices; e.g. NFC tags supporting NDEF.

--- a/files/en-us/web/api/ndefrecord/recordtype/index.html
+++ b/files/en-us/web/api/ndefrecord/recordtype/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.recordType
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>recordType</code></strong>
+<p>The <strong><code>recordType</code></strong>
     property of the {{DOMxRef("NDEFRecord")}} interface returns the record type of the record.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/ndefrecord/torecords/index.html
+++ b/files/en-us/web/api/ndefrecord/torecords/index.html
@@ -9,7 +9,7 @@ browser-compat: api.NDEFRecord.toRecords
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
-<p class="summary">The <strong><code>toRecords()</code></strong>
+<p>The <strong><code>toRecords()</code></strong>
     method of the {{DOMxRef("NDEFRecord")}} interface converts
     {{DOMxRef("NDEFRecord.data")}} to a sequence of records based on
     {{DOMxRef("NDEFRecord.recordType")}}, and returns the result. This allows

--- a/files/en-us/web/api/networkinformation/savedata/index.html
+++ b/files/en-us/web/api/networkinformation/savedata/index.html
@@ -14,7 +14,7 @@ browser-compat: api.NetworkInformation.saveData
 ---
 <div>{{APIRef("Network Information API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>NetworkInformation.saveData</code></strong> read-only
+<p>The <strong><code>NetworkInformation.saveData</code></strong> read-only
   property of the {{domxref("NetworkInformation")}} interface returns <code>true</code> if
   the user has set a reduced data usage option on the user agent.</p>
 

--- a/files/en-us/web/api/nodelist/item/index.html
+++ b/files/en-us/web/api/nodelist/item/index.html
@@ -11,7 +11,7 @@ browser-compat: api.NodeList.item
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p class="summary">Returns a node from a <a
+<p>Returns a node from a <a
     href="/en-US/docs/Web/API/NodeList"><code>NodeList</code></a> by index. This method
   doesn't throw exceptions as long as you provide arguments. A value of <code>null</code>
   is returned if the index is out of range, and a <code>TypeError</code> is thrown if no

--- a/files/en-us/web/api/notifications_api/index.html
+++ b/files/en-us/web/api/notifications_api/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
-<p class="summary">The Notifications API allows web pages to control the display of system notifications to the end user. These are outside the top-level browsing context viewport, so therefore can be displayed even when the user has switched tabs or moved to a different app. The API is designed to be compatible with existing notification systems, across different platforms.</p>
+<p>The Notifications API allows web pages to control the display of system notifications to the end user. These are outside the top-level browsing context viewport, so therefore can be displayed even when the user has switched tabs or moved to a different app. The API is designed to be compatible with existing notification systems, across different platforms.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
-<p class="summary">The <a href="/en-US/docs/Web/API/Notifications_API">Notifications API</a> lets a web page or app send notifications that are displayed outside the page at the system level; this lets web apps send information to a user even if the application is idle or in the background. This article looks at the basics of using this API in your own apps.</p>
+<p>The <a href="/en-US/docs/Web/API/Notifications_API">Notifications API</a> lets a web page or app send notifications that are displayed outside the page at the system level; this lets web apps send information to a user even if the application is idle or in the background. This article looks at the basics of using this API in your own apps.</p>
 
 <p>Typically, system notifications refer to the operating system's standard notification mechanism: think for example of how a typical desktop system or mobile device broadcasts notifications.</p>
 

--- a/files/en-us/web/api/otpcredential/code/index.html
+++ b/files/en-us/web/api/otpcredential/code/index.html
@@ -11,7 +11,7 @@ browser-compat: api.OTPCredential.code
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
 
-<p class="summary">The <strong><code>code</code></strong> property of the {{domxref("OTPCredential")}} interface returns the one-time password.</p>
+<p>The <strong><code>code</code></strong> property of the {{domxref("OTPCredential")}} interface returns the one-time password.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/otpcredential/index.html
+++ b/files/en-us/web/api/otpcredential/index.html
@@ -10,7 +10,7 @@ browser-compat: api.OTPCredential
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
 
-<p class="summary">The <strong><code>OTPCredential</code></strong> interface of the {{domxref('WebOTP API','','',' ')}} contains the attributes that are returned when a new one-time password is retreived.</p>
+<p>The <strong><code>OTPCredential</code></strong> interface of the {{domxref('WebOTP API','','',' ')}} contains the attributes that are returned when a new one-time password is retreived.</p>
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/overconstrainederror/constraint/index.html
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.html
@@ -17,7 +17,7 @@ browser-compat: api.OverconstrainedError.constraint
 <div>{{draft}}{{securecontext_header}}{{APIRef("Media Capture and
   Streams")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>constraint</code></strong> read-only property of the
+<p>The <strong><code>constraint</code></strong> read-only property of the
   {{domxref("OverconstrainedError")}} interface returns the constraint that was supplied
   in the constructor, meaning the contraint that was not satisfied.</p>
 

--- a/files/en-us/web/api/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OverconstrainedError
 ---
 <div>{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>OverconstrainedError</code></strong> interface of the <a href="/en-US/docs/Web/API/Media_Streams_API">Media Capture and Streams API</a> indicates that the set of desired capabilities for the current {{domxref('MediaStreamTrack')}} cannot currently be met. When this event is thrown on a MediaStreamTrack, it is muted until either the current constraints can be established or until satisfiable constraints are applied.</p>
+<p>The <strong><code>OverconstrainedError</code></strong> interface of the <a href="/en-US/docs/Web/API/Media_Streams_API">Media Capture and Streams API</a> indicates that the set of desired capabilities for the current {{domxref('MediaStreamTrack')}} cannot currently be met. When this event is thrown on a MediaStreamTrack, it is muted until either the current constraints can be established or until satisfiable constraints are applied.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
@@ -16,7 +16,7 @@ browser-compat: api.OverconstrainedError.OverconstrainedError
 <div>{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
 </div>
 
-<p class="summary">The <strong><code>OverconstrainedError</code></strong> constructor
+<p>The <strong><code>OverconstrainedError</code></strong> constructor
   creates a new {{domxref("OverconstrainedError")}} object which indicates that the set of
   desired capabilities for the current {{domxref("MediaStreamTrack")}} cannot currently be
   met. When this event is thrown on a <code>MediaStreamTrack</code>, it is muted until

--- a/files/en-us/web/api/paintworklet/index.html
+++ b/files/en-us/web/api/paintworklet/index.html
@@ -15,7 +15,7 @@ browser-compat: api.PaintWorkletGlobalScope
 ---
 <p>{{APIRef("CSS Painting API")}} {{SeeCompatTable}}</p>
 
-<p class="summary">The <strong><code>PaintWorklet</code></strong> interface of the {{domxref('CSS Painting API','','',' ')}} programmatically generates an image where a CSS property expects a file. Access this interface through {{DOMxRef("CSS.paintWorklet")}}.</p>
+<p>The <strong><code>PaintWorklet</code></strong> interface of the {{domxref('CSS Painting API','','',' ')}} programmatically generates an image where a CSS property expects a file. Access this interface through {{DOMxRef("CSS.paintWorklet")}}.</p>
 
 <h2 id="privacy_concerns">Privacy concerns</h2>
 

--- a/files/en-us/web/api/paintworklet/registerpaint/index.html
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.html
@@ -16,7 +16,7 @@ browser-compat: api.PaintWorkletGlobalScope.registerPaint
 ---
 <div>{{draft}}{{APIRef("CSS Painting API")}}</div>
 
-<p class="summary">The
+<p>The
   <strong><code>PaintWorkletGlobalScope.registerPaint()</code></strong> method of the
   {{domxref("PaintWorklet")}} interface registers a class programmatically generate an
   image where a CSS property expects a file.</p>

--- a/files/en-us/web/api/performanceelementtiming/element/index.html
+++ b/files/en-us/web/api/performanceelementtiming/element/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.element
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>element</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns an {{domxref("Element")}} which is a literal representation of the associated element.</p>
+<p>The <strong><code>element</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns an {{domxref("Element")}} which is a literal representation of the associated element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/id/index.html
+++ b/files/en-us/web/api/performanceelementtiming/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.id
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the {{htmlattrxref("id")}} of the associated element.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the {{htmlattrxref("id")}} of the associated element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.html
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.identifier
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>identifier</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the value of the <code><a href="/en-US/docs/Web/HTML/Attributes/elementtiming">elementtiming</a></code> attribute on the element.</p>
+<p>The <strong><code>identifier</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the value of the <code><a href="/en-US/docs/Web/HTML/Attributes/elementtiming">elementtiming</a></code> attribute on the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/index.html
+++ b/files/en-us/web/api/performanceelementtiming/index.html
@@ -10,7 +10,7 @@ browser-compat: api.PerformanceElementTiming
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>PerformanceElementTiming</code></strong> interface of the {{domxref('Element Timing API','','',' ')}} reports timing information on a specific element identified by the page author. For example it could report timing information about the main image in an article.</p>
+<p>The <strong><code>PerformanceElementTiming</code></strong> interface of the {{domxref('Element Timing API','','',' ')}} reports timing information on a specific element identified by the page author. For example it could report timing information about the main image in an article.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.intersectionRect
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>intersectionRect</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the rectangle of the element within the viewport.</p>
+<p>The <strong><code>intersectionRect</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the rectangle of the element within the viewport.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.loadTime
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>loadTime</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface always returns 0 for text. For images it returns the time which is the latest between the time the image resource is loaded and the time it is attached to the element.</p>
+<p>The <strong><code>loadTime</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface always returns 0 for text. For images it returns the time which is the latest between the time the image resource is loaded and the time it is attached to the element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.naturalHeight
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>naturalHeight</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic height of the image element.</p>
+<p>The <strong><code>naturalHeight</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic height of the image element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.naturalWidth
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>naturalWidth</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic width of the image element.</p>
+<p>The <strong><code>naturalWidth</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic width of the image element.</p>
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>width</var> = <var>PerformanceElementTiming</var>.naturalWidth;</pre>

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.renderTime
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>renderTime</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the render time of the associated element.</p>
+<p>The <strong><code>renderTime</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the render time of the associated element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.html
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.toJSON
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("PerformanceElementTiming")}} interface is a standard serializer. It returns a JSON representation of the object's properties.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("PerformanceElementTiming")}} interface is a standard serializer. It returns a JSON representation of the object's properties.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceelementtiming/url/index.html
+++ b/files/en-us/web/api/performanceelementtiming/url/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceElementTiming.url
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
-<p class="summary">The <strong><code>url</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the initial URL of the resource request when the element is an image.</p>
+<p>The <strong><code>url</code></strong> read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the initial URL of the resource request when the element is an image.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceObserver.supportedEntryTypes
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p class="summary">The <strong><code>supportedEntryTypes</code></strong> read-only property of the
+<p>The <strong><code>supportedEntryTypes</code></strong> read-only property of the
     {{domxref("PerformanceObserver")}} interface returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.</p>
 
 <p>As the list of supported entries varies per browser and is evolving, this property allows web developers to check which are available.</p>

--- a/files/en-us/web/api/performanceservertiming/tojson/index.html
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.html
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceServerTiming.toJSON
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the
+<p>The <strong><code>toJSON()</code></strong> method of the
   {{domxref("PerformanceServerTiming")}} interface returns a {{domxref("DOMString")}} that
   is the JSON representation of the {{domxref('PerformanceServerTiming')}} object.</p>
 

--- a/files/en-us/web/api/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.PeriodicSyncEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>PeriodicSyncEvent</code></strong> interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to run tasks in the service worker with network connectivity.</p>
+<p>The <strong><code>PeriodicSyncEvent</code></strong> interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to run tasks in the service worker with network connectivity.</p>
 
 <p>An instance of this event is passed to the {{domxref('ServiceWorkerGlobalScope.onperiodicsync')}} handler. This happens periodically, at an interval greater than or equal to that set in the {{domxref('PeriodicSyncManager.register()')}} method. Other implementation-specific factors such as the user's engagement with the site decide the actual interval.</p>
 

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PeriodicSyncEvent.PeriodicSyncEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>PeriodicSyncEvent()</code></strong> constructor
+<p>The <strong><code>PeriodicSyncEvent()</code></strong> constructor
   creates a new {{domxref("PeriodicSyncEvent")}} object. This constructor is not typically
   used. The browser creates these objects itself and provides them to
   {{domxref('ServiceWorkerGlobalScope.onperiodicsync')}} callback.</p>

--- a/files/en-us/web/api/periodicsyncevent/tag/index.html
+++ b/files/en-us/web/api/periodicsyncevent/tag/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PeriodicSyncEvent.tag
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>tag</code></strong> read-only property of the
+<p>The <strong><code>tag</code></strong> read-only property of the
   {{domxref("PeriodicSyncEvent")}} interface returns the developer-defined identifier for
   the {{domxref('PeriodicSyncEvent')}}. This is specified when calling the
   {{domxref('PeriodicSyncManager.register()')}} method of the

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.html
@@ -14,7 +14,7 @@ browser-compat: api.PeriodicSyncManager.getTags
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>getTags()</code></strong> method of the
+<p>The <strong><code>getTags()</code></strong> method of the
   {{domxref("PeriodicSyncManager")}} interface returns a {{jsxref('Promise')}} that
   resolves with a list of {{jsxref('String')}} objects representing the tags that are
   currently registered for periodic syncing.</p>

--- a/files/en-us/web/api/periodicsyncmanager/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/index.html
@@ -14,7 +14,7 @@ browser-compat: api.PeriodicSyncManager
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>PeriodicSyncManager</code></strong> interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to register tasks to be run in a service worker at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests. Access <code>PeriodicSyncManager</code> through the {{domxref('ServiceWorkerRegistration.periodicSync')}}.</p>
+<p>The <strong><code>PeriodicSyncManager</code></strong> interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to register tasks to be run in a service worker at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests. Access <code>PeriodicSyncManager</code> through the {{domxref('ServiceWorkerRegistration.periodicSync')}}.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/register/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PeriodicSyncManager.register
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>register()</code></strong> method of the
+<p>The <strong><code>register()</code></strong> method of the
   {{domxref("PeriodicSyncManager")}} interface registers a periodic sync request with the
   browser with the specified tag and options. It returns a {{jsxref('Promise')}} that
   resolves when the registration completes.</p>

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PeriodicSyncManager.unregister
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>unregister()</code></strong> method of the
+<p>The <strong><code>unregister()</code></strong> method of the
   {{domxref("PeriodicSyncManager")}} interface unregisters the periodic sync request
   corresponding to the specified tag and returns a {{jsxref('Promise')}} that resolves
   when unregistration completes.</p>

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.html
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Permissions API")}}{{SeeCompatTable}}</p>
 
-<p class="summary">This article provides a basic guide to using the W3C Permissions API, which provides a programmatic way to query the status of API permissions attributed to the current context.</p>
+<p>This article provides a basic guide to using the W3C Permissions API, which provides a programmatic way to query the status of API permissions attributed to the current context.</p>
 
 <h2 id="The_trouble_with_asking_for_permission...">The trouble with asking for permission...</h2>
 

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.html
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PresentationConnectionCloseEvent
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}</p>
 
-<p class="summary">The <strong><code>PresentationConnectionCloseEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/Presentation_API">Presentation API</a> is fired on a {{domxref("PresentationConnection")}} when it is closed.</p>
+<p>The <strong><code>PresentationConnectionCloseEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/Presentation_API">Presentation API</a> is fired on a {{domxref("PresentationConnection")}} when it is closed.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/push_api/index.html
+++ b/files/en-us/web/api/push_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{ApiRef("Push API")}}</div>
 
-<p class="summary">The <strong>Push API</strong> gives web applications the ability to receive messages pushed to them from a server, whether or not the web app is in the foreground, or even currently loaded, on a user agent. This lets developers deliver asynchronous notifications and updates to users that opt in, resulting in better engagement with timely new content.</p>
+<p>The <strong>Push API</strong> gives web applications the ability to receive messages pushed to them from a server, whether or not the web app is in the foreground, or even currently loaded, on a user agent. This lets developers deliver asynchronous notifications and updates to users that opt in, resulting in better engagement with timely new content.</p>
 
 <h2 id="Push_concepts_and_usage">Push concepts and usage</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PushSubscriptionOptions.applicationServerKey
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
-<p class="summary">The <strong><code>applicationServerKey</code></strong> read-only property of the {{domxref("PushSubscriptionOptions")}} interface contains the public key used by the push server.</p>
+<p>The <strong><code>applicationServerKey</code></strong> read-only property of the {{domxref("PushSubscriptionOptions")}} interface contains the public key used by the push server.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.html
@@ -10,7 +10,7 @@ browser-compat: api.PushSubscriptionOptions
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
-<p class="summary">The <strong><code>PushSubscriptionOptions</code></strong> interface of the {{domxref('Push API','','',' ')}} represents the options associated with a push subscription.</p>
+<p>The <strong><code>PushSubscriptionOptions</code></strong> interface of the {{domxref('Push API','','',' ')}} represents the options associated with a push subscription.</p>
 
 <p>The read-only <code>PushSubscriptionOptions</code> object is returned by calling {{domxref("PushSubscription.options")}} on a {{domxref("PushSubscription")}}. This interface has no constructor of its own.</p>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
@@ -11,7 +11,7 @@ browser-compat: api.PushSubscriptionOptions.userVisibleOnly
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
-<p class="summary">The <strong><code>userVisibleOnly</code></strong> read-only property of the {{domxref("PushSubscriptionOptions")}} interface indicates if the returned push subscription will only be used for messages whose effect is made visible to the user.</p>
+<p>The <strong><code>userVisibleOnly</code></strong> read-only property of the {{domxref("PushSubscriptionOptions")}} interface indicates if the returned push subscription will only be used for messages whose effect is made visible to the user.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableByteStreamController.byobRequest
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>byobRequest</code></strong> read-only property of the
+<p>The <strong><code>byobRequest</code></strong> read-only property of the
   {{domxref("ReadableByteStreamController")}} interface returns the current BYOB pull
   request, or <code>undefined</code> if there are no pending requests.</p>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableByteStreamController.close
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>close()</code></strong> method of the
+<p>The <strong><code>close()</code></strong> method of the
   {{domxref("ReadableByteStreamController")}} interface closes the associated stream.</p>
 
 <div class="note">

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableByteStreamController.desiredSize
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>desiredSize</code></strong> read-only property of the
+<p>The <strong><code>desiredSize</code></strong> read-only property of the
   {{domxref("ReadableByteStreamController")}} interface returns the desired size required
   to fill the stream's internal queue.</p>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableByteStreamController.enqueue
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>enqueue()</code></strong> method of the
+<p>The <strong><code>enqueue()</code></strong> method of the
   {{domxref("ReadableByteStreamController")}} interface enqueues a given chunk in the
   associated stream.</p>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableByteStreamController.error
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>error()</code></strong> method of the
+<p>The <strong><code>error()</code></strong> method of the
   {{domxref("ReadableByteStreamController")}} interface causes any future interactions
   with the associated stream to error.</p>
 

--- a/files/en-us/web/api/readablestream/cancel/index.html
+++ b/files/en-us/web/api/readablestream/cancel/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStream.cancel
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>cancel()</code></strong> method of the
+<p>The <strong><code>cancel()</code></strong> method of the
   {{domxref("ReadableStream")}} interface returns a {{jsxref("Promise")}} that
   resolves when the stream is canceled.</p>
 

--- a/files/en-us/web/api/readablestream/getreader/index.html
+++ b/files/en-us/web/api/readablestream/getreader/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStream.getReader
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>getReader()</code></strong> method of the
+<p>The <strong><code>getReader()</code></strong> method of the
   {{domxref("ReadableStream")}} interface creates a reader and locks the stream to it.
   While the stream is locked, no other reader can be acquired until this one is released.
 </p>

--- a/files/en-us/web/api/readablestream/locked/index.html
+++ b/files/en-us/web/api/readablestream/locked/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStream.locked
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>locked</code></strong> read-only property of the
+<p>The <strong><code>locked</code></strong> read-only property of the
   {{domxref("ReadableStream")}} interface returns whether or not the readable stream is <a
     href="https://streams.spec.whatwg.org/#lock" id="ref-for-locked-to-a-reader②">locked
     to a reader</a>.</p>

--- a/files/en-us/web/api/readablestream/pipethrough/index.html
+++ b/files/en-us/web/api/readablestream/pipethrough/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStream.pipeThrough
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>pipeThrough()</code></strong> method of the
+<p>The <strong><code>pipeThrough()</code></strong> method of the
   {{domxref("ReadableStream")}} interface provides a chainable way of piping the current
   stream through a transform stream or any other writable/readable pair.</p>
 

--- a/files/en-us/web/api/readablestream/pipeto/index.html
+++ b/files/en-us/web/api/readablestream/pipeto/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStream.pipeTo
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>pipeTo()</code></strong> method of the
+<p>The <strong><code>pipeTo()</code></strong> method of the
   {{domxref("ReadableStream")}} interface pipes the current <code>ReadableStream</code> to
   a given {{domxref("WritableStream")}} and returns a {{jsxref("Promise")}} that fulfills when the
   piping process completes successfully, or rejects if any errors were encountered.</p>

--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ReadableStream.ReadableStream
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>ReadableStream()</code></strong> constructor creates
+<p>The <strong><code>ReadableStream()</code></strong> constructor creates
   and returns a readable stream object from the given handlers.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/readablestream/tee/index.html
+++ b/files/en-us/web/api/readablestream/tee/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStream.tee
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>tee()</code></strong> method of the
+<p>The <strong><code>tee()</code></strong> method of the
   {{domxref("ReadableStream")}} interface <a
     href="https://streams.spec.whatwg.org/#tee-a-readable-stream"
     id="ref-for-tee-a-readable-stream②">tees</a> the current readable stream, returning a

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBReader.cancel
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>cancel()</code></strong> method of the
+<p>The <strong><code>cancel()</code></strong> method of the
   {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
 
 <div class="note">

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBReader.closed
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>closed</code></strong> read-only property
+<p>The <strong><code>closed</code></strong> read-only property
   of the {{domxref("ReadableStreamBYOBReader")}} interface returns a
   {{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock
   is released, or rejects if the stream throws an error. This property enables you

--- a/files/en-us/web/api/readablestreambyobreader/read/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBReader.read
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>read()</code></strong> method of the
+<p>The <strong><code>read()</code></strong> method of the
   {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsxref("Promise")}} that resolves with an obect representing the next chunk in the stream's queue.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamBYOBReader.ReadableStreamBYOBReader
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>ReadableStreamBYOBReader()</code></strong>
+<p>The <strong><code>ReadableStreamBYOBReader()</code></strong>
   constructor creates and returns a <code>ReadableStreamBYOBReader</code> object instance.
 </p>
 

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBReader.releaseLock
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>releaseLock()</code></strong> method of the
+<p>The <strong><code>releaseLock()</code></strong> method of the
   {{domxref("ReadableStreamBYOBReader")}} interface releases the reader's lock on the
   stream. After the lock is released, the reader is no longer active.</p>
 

--- a/files/en-us/web/api/readablestreambyobrequest/respond/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respond/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBRequest.respond
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>error()</code></strong> method of the
+<p>The <strong><code>error()</code></strong> method of the
   {{domxref("ReadableStreamBYOBRequest")}} interface xxx</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBRequest.respondWithNewView
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>respondWithNewView()</code></strong> method of the
+<p>The <strong><code>respondWithNewView()</code></strong> method of the
   {{domxref("ReadableStreamBYOBRequest")}} interface xxx</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/readablestreambyobrequest/view/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStreamBYOBRequest.view
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>view</code></strong> getter property of the
+<p>The <strong><code>view</code></strong> getter property of the
   {{domxref("ReadableStreamBYOBRequest")}} interface returns the current view.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultController.close
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>close()</code></strong> method of the
+<p>The <strong><code>close()</code></strong> method of the
   {{domxref("ReadableStreamDefaultController")}} interface closes the associated stream.
 </p>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultController.desiredSize
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>desiredSize</code></strong> read-only property of the
+<p>The <strong><code>desiredSize</code></strong> read-only property of the
   {{domxref("ReadableStreamDefaultController")}} interface returns the desired size
   required to fill the stream's internal queue.</p>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultController.enqueue
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>enqueue()</code></strong> method of the
+<p>The <strong><code>enqueue()</code></strong> method of the
   {{domxref("ReadableStreamDefaultController")}} interface enqueues a given chunk in the
   associated stream.</p>
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
@@ -12,12 +12,12 @@ browser-compat: api.ReadableStreamDefaultController.error
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>error()</code></strong> method of the
+<p>The <strong><code>error()</code></strong> method of the
   {{domxref("ReadableStreamDefaultController")}} interface causes any future interactions
   with the associated stream to error.</p>
 
 <div class="notecard note">
-  <p class="summary"><strong>Note</strong>: The <code>error()</code> method can be called
+  <p><strong>Note</strong>: The <code>error()</code> method can be called
     more than once, and can be called when the stream is not readable.</p>
 </div>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultReader.cancel
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>cancel()</code></strong> method of the
+<p>The <strong><code>cancel()</code></strong> method of the
   {{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
 
 <p>Cancel is used when you've completely finished with the stream and don't need any more

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultReader.closed
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>closed</code></strong> read-only property of the
+<p>The <strong><code>closed</code></strong> read-only property of the
   {{domxref("ReadableStreamDefaultReader")}} interface returns a
   {{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock
   is released, or rejects if the stream throws an error. This property enables you

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultReader.read
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>read()</code></strong> method of the
+<p>The <strong><code>read()</code></strong> method of the
   {{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsxref("Promise")}} providing access
   to the next chunk in the stream's internal queue.</p>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ReadableStreamDefaultReader.ReadableStreamDefaultReader
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>ReadableStreamDefaultReader()</code></strong>
+<p>The <strong><code>ReadableStreamDefaultReader()</code></strong>
   constructor creates and returns a <code>ReadableStreamDefaultReader</code> object
   instance.</p>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStreamDefaultReader.releaseLock
 ---
 <div>{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>releaseLock()</code></strong> method of the
+<p>The <strong><code>releaseLock()</code></strong> method of the
   {{domxref("ReadableStreamDefaultReader")}} interface releases the reader's lock on the
   stream.</p>
 

--- a/files/en-us/web/api/remote_playback_api/index.html
+++ b/files/en-us/web/api/remote_playback_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The Remote Playback API extends the {{domxref("HTMLMediaElement")}} to enable the control of remote playback of media from a webpage.</p>
+<p>The Remote Playback API extends the {{domxref("HTMLMediaElement")}} to enable the control of remote playback of media from a webpage.</p>
 
 <h2> Concepts and Usage</h2>
 

--- a/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.html
+++ b/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.cancelWatchAvailability
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>cancelWatchAvailability()</code></strong> method of the {{domxref("RemotePlayback")}} interface cancels the request to watch for one or all available devices.</p>
+<p>The <strong><code>cancelWatchAvailability()</code></strong> method of the {{domxref("RemotePlayback")}} interface cancels the request to watch for one or all available devices.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/index.html
+++ b/files/en-us/web/api/remoteplayback/index.html
@@ -10,7 +10,7 @@ browser-compat: api.RemotePlayback
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>RemotePlayback</code></strong> interface of the {{domxref('Remote Playback API','','',' ')}} allows the page to detect availability of remote playback devices, then connect to and control playing on these devices.</p>
+<p>The <strong><code>RemotePlayback</code></strong> interface of the {{domxref('Remote Playback API','','',' ')}} allows the page to detect availability of remote playback devices, then connect to and control playing on these devices.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/remoteplayback/onconnect/index.html
+++ b/files/en-us/web/api/remoteplayback/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.onconnect
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent connects to the remote device.</p>
+<p>The <strong><code>onconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent connects to the remote device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/onconnecting/index.html
+++ b/files/en-us/web/api/remoteplayback/onconnecting/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.onconnecting
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>onconnecting</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent initiates remote playback.</p>
+<p>The <strong><code>onconnecting</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent initiates remote playback.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/ondisconnect/index.html
+++ b/files/en-us/web/api/remoteplayback/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.ondisconnect
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent disconnects from the remote device.</p>
+<p>The <strong><code>ondisconnect</code></strong> event handler of the {{domxref("RemotePlayback")}} interface processes the events fired when the user agent disconnects from the remote device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/prompt/index.html
+++ b/files/en-us/web/api/remoteplayback/prompt/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.prompt
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>prompt()</code></strong> method of the {{domxref("RemotePlayback")}} interface prompts the user to select an available remote playback device and give permission for the current media to be played using that device.</p>
+<p>The <strong><code>prompt()</code></strong> method of the {{domxref("RemotePlayback")}} interface prompts the user to select an available remote playback device and give permission for the current media to be played using that device.</p>
 
 <p>If the user gives permission, the {{domxref("RemotePlayback.state","state")}} will be set to <code>connecting</code> and the user agent will connect to the device to initiate playback.</p>
 

--- a/files/en-us/web/api/remoteplayback/state/index.html
+++ b/files/en-us/web/api/remoteplayback/state/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.state
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>state</code></strong> read-only property of the {{domxref("RemotePlayback")}} interface returns the current state of the <code>RemotePlayback</code> connection.</p>
+<p>The <strong><code>state</code></strong> read-only property of the {{domxref("RemotePlayback")}} interface returns the current state of the <code>RemotePlayback</code> connection.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/remoteplayback/watchavailability/index.html
+++ b/files/en-us/web/api/remoteplayback/watchavailability/index.html
@@ -11,7 +11,7 @@ browser-compat: api.RemotePlayback.watchAvailability
 ---
 <div>{{DefaultAPISidebar("Remote Playback API")}}</div>
 
-<p class="summary">The <strong><code>watchAvailability()</code></strong> method of the {{domxref("RemotePlayback")}} interface watches the list of available remote playment devices and returns a {{jsxref("Promise")}} that resolves with the <code>callbackId</code> of a remote playback device.</p>
+<p>The <strong><code>watchAvailability()</code></strong> method of the {{domxref("RemotePlayback")}} interface watches the list of available remote playment devices and returns a {{jsxref("Promise")}} that resolves with the <code>callbackId</code> of a remote playback device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/report/index.html
+++ b/files/en-us/web/api/report/index.html
@@ -12,9 +12,9 @@ browser-compat: api.Report
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>Report</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents a single report.</p>
+<p>The <code>Report</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> represents a single report.</p>
 
-<p class="summary">Reports can be accessed in a number of ways:</p>
+<p>Reports can be accessed in a number of ways:</p>
 
 <ul>
  <li class="summary">Via the {{domxref("ReportingObserver.takeRecords()")}} method — this returns all reports in an observer's report queue, and then empties the queue.</li>

--- a/files/en-us/web/api/reportbody/index.html
+++ b/files/en-us/web/api/reportbody/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ReportBody
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>ReportBody</code></strong> interface of the {{domxref('Reporting API','','',' ')}} represents the body of a report. Individual report types inherit from this interface, adding specific attributes relevant to the particular report.</p>
+<p>The <strong><code>ReportBody</code></strong> interface of the {{domxref('Reporting API','','',' ')}} represents the body of a report. Individual report types inherit from this interface, adding specific attributes relevant to the particular report.</p>
 
 <h3>Reports that inherit from <code>ReportBody</code></h3>
 

--- a/files/en-us/web/api/reportbody/tojson/index.html
+++ b/files/en-us/web/api/reportbody/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ReportBody.toJSON
 ---
 <div>{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("ReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>ReportBody</code> object.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("ReportBody")}} interface is a <em>serializer</em>, and returns a JSON representation of the <code>ReportBody</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/reporting_api/index.html
+++ b/files/en-us/web/api/reporting_api/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The Reporting API provides a generic reporting mechanism for web applications to use to make reports available based on various platform features (for example <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a>, <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy">Feature-Policy</a>, or feature deprecation reports) in a consistent manner.</p>
+<p>The Reporting API provides a generic reporting mechanism for web applications to use to make reports available based on various platform features (for example <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a>, <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy">Feature-Policy</a>, or feature deprecation reports) in a consistent manner.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 

--- a/files/en-us/web/api/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReportingObserver
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>ReportingObserver</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> allows you to collect and access reports.</p>
+<p>The <code>ReportingObserver</code> interface of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> allows you to collect and access reports.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/reportingobserveroptions/index.html
+++ b/files/en-us/web/api/reportingobserveroptions/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ReportingObserverOptions
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
-<p class="summary">The <code>ReportingObserverOptions</code> dictionary of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> allows options to be set in the constructor when creating a {{domxref("ReportingObserver")}}.</p>
+<p>The <code>ReportingObserverOptions</code> dictionary of the <a href="/en-US/docs/Web/API/Reporting_API">Reporting API</a> allows options to be set in the constructor when creating a {{domxref("ReportingObserver")}}.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/resizeobserver/disconnect/index.html
+++ b/files/en-us/web/api/resizeobserver/disconnect/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ResizeObserver.disconnect
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>disconnect()</code></strong> method of the
+<p>The <strong><code>disconnect()</code></strong> method of the
   {{domxref("ResizeObserver")}} interface unobserves all observed {{domxref('Element')}}
   or {{domxref('SVGElement')}} targets.</p>
 

--- a/files/en-us/web/api/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/index.html
@@ -15,10 +15,10 @@ browser-compat: api.ResizeObserver
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>ResizeObserver</code></strong> interface reports changes to the dimensions of an {{domxref('Element')}}'s content or border box, or the bounding box of an {{domxref('SVGElement')}}.</p>
+<p>The <strong><code>ResizeObserver</code></strong> interface reports changes to the dimensions of an {{domxref('Element')}}'s content or border box, or the bounding box of an {{domxref('SVGElement')}}.</p>
 
 <div class="notecard note">
-<p class="summary"><strong>Note</strong>: The content box is the box in which content can be placed, meaning the border box minus the padding and border width. The border box encompasses the content, padding, and border. See <a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">The box model</a> for further explanation.</p>
+<p><strong>Note</strong>: The content box is the box in which content can be placed, meaning the border box minus the padding and border width. The border box encompasses the content, padding, and border. See <a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">The box model</a> for further explanation.</p>
 </div>
 
 <p><code>ResizeObserver</code> avoids infinite callback loops and cyclic dependencies that are often created when resizing via a callback function. It does this by only processing elements deeper in the DOM in subsequent frames. Implementations should, if they follow the specification, invoke resize events before paint and after layout.</p>

--- a/files/en-us/web/api/resizeobserver/observe/index.html
+++ b/files/en-us/web/api/resizeobserver/observe/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ResizeObserver.observe
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>observe()</code></strong> method of the
+<p>The <strong><code>observe()</code></strong> method of the
   {{domxref("ResizeObserver")}} interface starts observing the specified
   {{domxref('Element')}} or {{domxref('SVGElement')}}.</p>
 

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ResizeObserver.ResizeObserver
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>ResizeObserver</code></strong> constructor creates a
+<p>The <strong><code>ResizeObserver</code></strong> constructor creates a
   new {{domxref("ResizeObserver")}} object, which can be used to report changes to the
   content or border box of an {{domxref('Element')}} or the bounding box of an
   {{domxref('SVGElement')}}.</p>

--- a/files/en-us/web/api/resizeobserver/unobserve/index.html
+++ b/files/en-us/web/api/resizeobserver/unobserve/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ResizeObserver.unobserve
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>unobserve()</code></strong> method of the
+<p>The <strong><code>unobserve()</code></strong> method of the
   {{domxref("ResizeObserver")}} interface ends the observing of a specified
   {{domxref('Element')}} or {{domxref('SVGElement')}}.</p>
 

--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ResizeObserverEntry.borderBoxSize
 ---
 <div>{{APIRef("Resize Observer API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>borderBoxSize</code></strong> read-only property of
+<p>The <strong><code>borderBoxSize</code></strong> read-only property of
   the {{domxref("ResizeObserverEntry")}} interface returns an array containing the new
   border box size of the observed element when the callback is run.</p>
 

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ResizeObserverEntry.contentBoxSize
 ---
 <div>{{APIRef("Resize Observer API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The <strong><code>contentBoxSize</code></strong> read-only property of
+<p>The <strong><code>contentBoxSize</code></strong> read-only property of
   the {{domxref("ResizeObserverEntry")}} interface returns an array containing the new
   content box size of the observed element when the callback is run.</p>
 

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ResizeObserverEntry.contentRect
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <code>contentRect</code> read-only property of the
+<p>The <code>contentRect</code> read-only property of the
   {{domxref("ResizeObserverEntry")}} interface returns a {{domxref('DOMRectReadOnly')}}
   object containing the new size of the observed element when the callback is run. Note
   that this is better supported than {{domxref("ResizeObserverEntry.borderBoxSize")}} or

--- a/files/en-us/web/api/resizeobserverentry/index.html
+++ b/files/en-us/web/api/resizeobserverentry/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ResizeObserverEntry
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>ResizeObserverEntry</code></strong> interface represents the object passed to the {{domxref('ResizeObserver.ResizeObserver','ResizeObserver()')}} constructor's callback function, which allows you to access the new dimensions of the {{domxref("Element")}} or {{domxref("SVGElement")}} being observed.</p>
+<p>The <strong><code>ResizeObserverEntry</code></strong> interface represents the object passed to the {{domxref('ResizeObserver.ResizeObserver','ResizeObserver()')}} constructor's callback function, which allows you to access the new dimensions of the {{domxref("Element")}} or {{domxref("SVGElement")}} being observed.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/resizeobserverentry/target/index.html
+++ b/files/en-us/web/api/resizeobserverentry/target/index.html
@@ -16,7 +16,7 @@ browser-compat: api.ResizeObserverEntry.target
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>target</code></strong> read-only property of the
+<p>The <strong><code>target</code></strong> read-only property of the
   {{domxref("ResizeObserverEntry")}} interface returns a reference to the
   {{domxref('Element')}} or {{domxref('SVGElement')}} that is being observed.</p>
 

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.html
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ResizeObserverSize.blockSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>blockSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the block dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or width.</p>
+<p>The <strong><code>blockSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the block dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or width.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/resizeobserversize/index.html
+++ b/files/en-us/web/api/resizeobserversize/index.html
@@ -10,7 +10,7 @@ browser-compat: api.ResizeObserverSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>ResizeObserverSize</code></strong> interface of the {{domxref('Resize Observer API')}} is used by the {{domxref("ResizeObserverEntry")}} interface to access the box sizing properties of the element being observed.</p>
+<p>The <strong><code>ResizeObserverSize</code></strong> interface of the {{domxref('Resize Observer API')}} is used by the {{domxref("ResizeObserverEntry")}} interface to access the box sizing properties of the element being observed.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.html
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ResizeObserverSize.inlineSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
-<p class="summary">The <strong><code>inlineSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the inline dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or height.</p>
+<p>The <strong><code>inlineSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the inline dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or height.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/sanitizer/index.html
+++ b/files/en-us/web/api/sanitizer/index.html
@@ -9,7 +9,7 @@ browser-compat: api.Sanitizer
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}</div>
 
-<p class="summary">The <strong><code>Sanitizer</code></strong> interface of the {{domxref('HTML Sanitizer API')}} allows developers to take untrusted strings of HTML, and sanitize them for safe insertion into a document’s DOM.</p>
+<p>The <strong><code>Sanitizer</code></strong> interface of the {{domxref('HTML Sanitizer API')}} allows developers to take untrusted strings of HTML, and sanitize them for safe insertion into a document’s DOM.</p>
 
 <h2 id="Constructors">Constructors</h2>
 

--- a/files/en-us/web/api/sanitizer/sanitize/index.html
+++ b/files/en-us/web/api/sanitizer/sanitize/index.html
@@ -9,7 +9,7 @@ browser-compat: api.Sanitizer.sanitize
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}</div>
 
-<p class="summary">The <strong><code>sanitize()</code></strong> method of the
+<p>The <strong><code>sanitize()</code></strong> method of the
   {{domxref("sanitizer")}} interface returns a sanitized {{domxref('DocumentFragment')}}
   from an input, removing any offending elements or attributes.</p>
 

--- a/files/en-us/web/api/sanitizer/sanitizer/index.html
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.html
@@ -9,7 +9,7 @@ browser-compat: api.Sanitizer.Sanitizer
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}</div>
 
-<p class="summary">The <strong><code>Sanitizer()</code></strong> constructor creates a new
+<p>The <strong><code>Sanitizer()</code></strong> constructor creates a new
   {{domxref("sanitizer")}} object which allows developers to take untrusted strings of
   HTML, and sanitize them for safe insertion into a document’s DOM.</p>
 

--- a/files/en-us/web/api/sanitizer/sanitizetostring/index.html
+++ b/files/en-us/web/api/sanitizer/sanitizetostring/index.html
@@ -9,7 +9,7 @@ browser-compat: api.Sanitizer.sanitizeToString
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}</div>
 
-<p class="summary">The <strong><code>sanitizeToString()</code></strong> method of the
+<p>The <strong><code>sanitizeToString()</code></strong> method of the
   {{domxref("Sanitizer")}} interface returns a sanitized {{jsxref('String')}} from an
   input, removing any offending elements or attributes.</p>
 

--- a/files/en-us/web/api/screen_wake_lock_api/index.html
+++ b/files/en-us/web/api/screen_wake_lock_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Screen Wake Lock API")}}</p>
 
-<p class="summary">The Screen Wake Lock API provides a way to prevent devices from dimming or locking the screen when an application needs to keep running.</p>
+<p>The Screen Wake Lock API provides a way to prevent devices from dimming or locking the screen when an application needs to keep running.</p>
 
 <h2 id="Concepts_and_Usage">Concepts and Usage</h2>
 

--- a/files/en-us/web/api/scrolltooptions/index.html
+++ b/files/en-us/web/api/scrolltooptions/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ScrollToOptions
 ---
 <div>{{ APIRef("CSSOM View") }}</div>
 
-<p class="summary">The <strong><code>ScrollToOptions</code></strong> dictionary of the CSSOM View spec contains properties specifying where an element should be scrolled to, and whether the scrolling should be smooth.</p>
+<p>The <strong><code>ScrollToOptions</code></strong> dictionary of the CSSOM View spec contains properties specifying where an element should be scrolled to, and whether the scrolling should be smooth.</p>
 
 <p>A <code>ScrollToOptions</code> dictionary can be provided as a parameter for the following methods:</p>
 

--- a/files/en-us/web/api/serial/getports/index.html
+++ b/files/en-us/web/api/serial/getports/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Serial.getPorts
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>getPorts()</code></strong> method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access. </p>
+<p>The <strong><code>getPorts()</code></strong> method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serial/onconnect/index.html
+++ b/files/en-us/web/api/serial/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Serial.onconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("Serial")}} interface is called when a port has been connected from a device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.
+<p>The <strong><code>onconnect</code></strong> <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> of the {{domxref("Serial")}} interface is called when a port has been connected from a device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.
 
 <p>This event is only fired for ports associated with removable devices such as those connected via USB. The user must grant the origin permission to access this device during a call to {{domxref("Serial.requestPort()","requestPort()")}} before this event will be fired.</p>
 

--- a/files/en-us/web/api/serial/ondisconnect/index.html
+++ b/files/en-us/web/api/serial/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Serial.ondisconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> EventHandler of the {{domxref("Serial")}} interface is called when the port has been disconnected from the device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.</p>
+<p>The <strong><code>ondisconnect</code></strong> EventHandler of the {{domxref("Serial")}} interface is called when the port has been disconnected from the device. This method receives an {{domxref("Event")}} object. The target of this event is the {{domxref("SerialPort")}} interface that has been disconnected.</p>
 
 <p>This event is only fired for ports associated with removable devices such as those connected via USB. The user must grant the origin permission to access this device during a call to {{domxref("Serial.requestPort()", "requestPort()")}} before this event will be fired.</p>
 

--- a/files/en-us/web/api/serial/requestport/index.html
+++ b/files/en-us/web/api/serial/requestport/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Serial.requestPort
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>Serial.requestPort()</code></strong> method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user or rejects if no device was selected.</p>
+<p>The <strong><code>Serial.requestPort()</code></strong> method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user or rejects if no device was selected.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/close/index.html
+++ b/files/en-us/web/api/serialport/close/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.close
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>SerialPort.close()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port closes.</p>
+<p>The <strong><code>SerialPort.close()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port closes.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/getinfo/index.html
+++ b/files/en-us/web/api/serialport/getinfo/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.getInfo
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>SerialPort.getInfo()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing properties of the port.</p>
+<p>The <strong><code>SerialPort.getInfo()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing properties of the port.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/getsignals/index.html
+++ b/files/en-us/web/api/serialport/getsignals/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.getSignals
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>SerialPort.getSignals()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing the current state of the port's control signals.</p>
+<p>The <strong><code>SerialPort.getSignals()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing the current state of the port's control signals.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/onconnect/index.html
+++ b/files/en-us/web/api/serialport/onconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.onconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>onconnect</code></strong> event handler of the {{domxref("SerialPort")}} interface is called when the port has disconnected from the device. This method receives an {{domxref("Event")}} object. This event is only fired for ports associated with removable devices such as those connected via USB. This event bubbles to the instance of {{domxref("Serial")}} that returned this interface..</p>
+<p>The <strong><code>onconnect</code></strong> event handler of the {{domxref("SerialPort")}} interface is called when the port has disconnected from the device. This method receives an {{domxref("Event")}} object. This event is only fired for ports associated with removable devices such as those connected via USB. This event bubbles to the instance of {{domxref("Serial")}} that returned this interface..</p>
 
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/serialport/ondisconnect/index.html
+++ b/files/en-us/web/api/serialport/ondisconnect/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.ondisconnect
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>ondisconnect</code></strong> event handler of the {{domxref("SerialPort")}} interface is called when the port has disconnected from the device. This method receives an {{domxref("Event")}} object. This event is only fired for ports associated with removable devices such as those connected via USB. This event bubbles to the instance of {{domxref("Serial")}} that returned this interface.
+<p>The <strong><code>ondisconnect</code></strong> event handler of the {{domxref("SerialPort")}} interface is called when the port has disconnected from the device. This method receives an {{domxref("Event")}} object. This event is only fired for ports associated with removable devices such as those connected via USB. This event bubbles to the instance of {{domxref("Serial")}} that returned this interface.
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/open/index.html
+++ b/files/en-us/web/api/serialport/open/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.open
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>open()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port is opened. By default the port is opened with 8 data bits, 1 stop bit and no parity checking. The <code>baudRate</code> parameter is required.</p>
+<p>The <strong><code>open()</code></strong> method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port is opened. By default the port is opened with 8 data bits, 1 stop bit and no parity checking. The <code>baudRate</code> parameter is required.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/readable/index.html
+++ b/files/en-us/web/api/serialport/readable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.readable
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port. Chunks read from this stream are instances of {{jsxref("Uint8Array")}}. This property is non-null as long as the port is open and has not encountered a fatal error.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port. Chunks read from this stream are instances of {{jsxref("Uint8Array")}}. This property is non-null as long as the port is open and has not encountered a fatal error.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/setsignals/index.html
+++ b/files/en-us/web/api/serialport/setsignals/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.setSignals
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>setSignals()</code></strong> method of the {{domxref("SerialPort")}} interface sets control signals on the port and returns a {{jsxref("Promise")}} that resolves when they are set.</p>
+<p>The <strong><code>setSignals()</code></strong> method of the {{domxref("SerialPort")}} interface sets control signals on the port and returns a {{jsxref("Promise")}} that resolves when they are set.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serialport/writable/index.html
+++ b/files/en-us/web/api/serialport/writable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SerialPort.writable
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port. Chunks written to this stream must be instances of {{domxref("BufferSource")}} (for example, an {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} such as {{jsxref("Uint8Array")}}). This property is non-null as long as the port is open and has not encountered a fatal error.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port. Chunks written to this stream must be instances of {{domxref("BufferSource")}} (for example, an {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} such as {{jsxref("Uint8Array")}}). This property is non-null as long as the port is open and has not encountered a fatal error.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{ServiceWorkerSidebar}}</div>
 
-<p class="summary">Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.</p>
+<p>Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.</p>
 
 <h2 id="Service_worker_concepts_and_usage">Service worker concepts and usage</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
 ---
 <div>{{draft}}{{APIRef("Service Workers API")}}</div>
 
-<p class="summary">The <strong><code>contentdelete</code></strong> event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when an item is removed from the indexed content via the user agent.</p>
+<p>The <strong><code>contentdelete</code></strong> event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when an item is removed from the indexed content via the user agent.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ServiceWorkerGlobalScope.oncontentdelete
 ---
 <div>{{draft}}{{APIRef("Service Workers API")}}</div>
 
-<p class="summary">The <strong><code>oncontentdelete</code></strong> property of the {{domxref("ServiceWorkerGlobalScope")}} interface is an event handler fired when an item is removed from the indexed content via the user agent. </p>
+<p>The <strong><code>oncontentdelete</code></strong> property of the {{domxref("ServiceWorkerGlobalScope")}} interface is an event handler fired when an item is removed from the indexed content via the user agent. </p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ServiceWorkerGlobalScope.onperiodicsync
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>onperiodicsync</code></strong> property of the {{domxref("ServiceWorkerGlobalScope")}} interface is an event handler fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.</p>
+<p>The <strong><code>onperiodicsync</code></strong> property of the {{domxref("ServiceWorkerGlobalScope")}} interface is an event handler fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.html
@@ -11,7 +11,7 @@ browser-compat: api.ServiceWorkerGlobalScope.periodicsync_event
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The <strong><code>periodicsync</code></strong> event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.</p>
+<p>The <strong><code>periodicsync</code></strong> event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/serviceworkerregistration/index/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ServiceWorkerRegistration.index
 ---
 <div>{{draft}}{{DefaultAPISidebar("Service Worker API")}}</div>
 
-<p class="summary">The <strong><code>index</code></strong> read-only property of the
+<p>The <strong><code>index</code></strong> read-only property of the
   {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the
   {{domxref('ContentIndex')}} interface, which allows for indexing of offline content.</p>
 

--- a/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
@@ -14,7 +14,7 @@ browser-compat: api.ServiceWorkerRegistration.periodicSync
 ---
 <div>{{draft}}{{DefaultAPISidebar("Service Worker API")}}</div>
 
-<p class="summary">The <strong><code>periodicSync</code></strong> read-only property of
+<p>The <strong><code>periodicSync</code></strong> read-only property of
   the {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the
   {{domxref('PeriodicSyncManager')}} interface, which allows for registering of tasks to
   run at specific intervals.</p>

--- a/files/en-us/web/api/storage_access_api/using/index.html
+++ b/files/en-us/web/api/storage_access_api/using/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{SeeCompatTable}}{{DefaultAPISidebar("Storage Access API")}}</div>
 
-<p class="summary">The <a href="/en-US/docs/Web/API/Storage_Access_API">Storage Access API</a> should be used by embedded cross-origin documents to verify whether they have access to their first-party storage and, if not, to request access. We’ll briefly look at a common storage access scenario.</p>
+<p>The <a href="/en-US/docs/Web/API/Storage_Access_API">Storage Access API</a> should be used by embedded cross-origin documents to verify whether they have access to their first-party storage and, if not, to request access. We’ll briefly look at a common storage access scenario.</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/api/streams_api/concepts/index.html
+++ b/files/en-us/web/api/streams_api/concepts/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{apiref("Streams")}}</div>
 
-<p class="summary">The <a href="/en-US/docs/Web/API/Streams_API">Streams API</a> adds a very useful set of tools to the web platform, providing objects allowing JavaScript to programmatically access streams of data received over the network and process them as desired by the developer. Some of the concepts and terminology associated with streams might be new to you — this article explains all you need to know.</p>
+<p>The <a href="/en-US/docs/Web/API/Streams_API">Streams API</a> adds a very useful set of tools to the web platform, providing objects allowing JavaScript to programmatically access streams of data received over the network and process them as desired by the developer. Some of the concepts and terminology associated with streams might be new to you — this article explains all you need to know.</p>
 
 <h2 id="Readable_streams">Readable streams</h2>
 

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.html
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{apiref("Streams")}}</div>
 
-<p class="summary">As a JavaScript developer, programmatically reading and manipulating streams of data received over the network, chunk by chunk, is very useful! But how do you use the Streams API’s readable stream functionality? This article explains the basics.</p>
+<p>As a JavaScript developer, programmatically reading and manipulating streams of data received over the network, chunk by chunk, is very useful! But how do you use the Streams API’s readable stream functionality? This article explains the basics.</p>
 
 <div class="note">
 <p><strong>Note</strong>: This article assumes that you understand the use cases of readable streams, and are aware of the high-level concepts. If not, we suggest that you first read the <a href="/en-US/docs/Web/API/Streams_API#concepts_and_usage">Streams concepts and usage overview</a> and dedicated <a href="/en-US/docs/Web/API/Streams_API/Concepts">Streams API concepts</a> article, then come back.</p>

--- a/files/en-us/web/api/stylesheet/disabled/index.html
+++ b/files/en-us/web/api/stylesheet/disabled/index.html
@@ -12,7 +12,7 @@ browser-compat: api.StyleSheet.disabled
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <code><strong>disabled</strong></code> property of the
+<p>The <code><strong>disabled</strong></code> property of the
   {{domxref("StyleSheet")}} interface determines whether the style sheet is prevented from
   applying to the document.</p>
 

--- a/files/en-us/web/api/stylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/index.html
@@ -13,7 +13,7 @@ browser-compat: api.StyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">An object implementing the <code>StyleSheet</code> interface represents a single style sheet. CSS style sheets will further implement the more specialized {{domxref("CSSStyleSheet")}} interface.</p>
+<p>An object implementing the <code>StyleSheet</code> interface represents a single style sheet. CSS style sheets will further implement the more specialized {{domxref("CSSStyleSheet")}} interface.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/stylesheet/parentstylesheet/index.html
+++ b/files/en-us/web/api/stylesheet/parentstylesheet/index.html
@@ -11,7 +11,7 @@ browser-compat: api.StyleSheet.parentStyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <code><strong>parentStyleSheet</strong></code> property of the
+<p>The <code><strong>parentStyleSheet</strong></code> property of the
   {{domxref("StyleSheet")}} interface returns the style sheet, if any, that is including
   the given style sheet.</p>
 

--- a/files/en-us/web/api/stylesheetlist/item/index.html
+++ b/files/en-us/web/api/stylesheetlist/item/index.html
@@ -11,7 +11,7 @@ browser-compat: api.StyleSheetList.item
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>item()</code></strong> method of the {{domxref("StyleSheetList")}} interface returns a single {{domxref("CSSStyleSheet")}} object.</p>
+<p>The <strong><code>item()</code></strong> method of the {{domxref("StyleSheetList")}} interface returns a single {{domxref("CSSStyleSheet")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/stylesheetlist/length/index.html
+++ b/files/en-us/web/api/stylesheetlist/length/index.html
@@ -11,7 +11,7 @@ browser-compat: api.StyleSheetList.length
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p class="summary">The <strong><code>length</code></strong> read-only property of the {{domxref("StyleSheetList")}} interface returns the number of {{domxref("CSSStyleSheet")}} objects in the collection.</p>
+<p>The <strong><code>length</code></strong> read-only property of the {{domxref("StyleSheetList")}} interface returns the number of {{domxref("CSSStyleSheet")}} objects in the collection.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgimageelement/decoding/index.html
+++ b/files/en-us/web/api/svgimageelement/decoding/index.html
@@ -14,7 +14,7 @@ browser-compat: api.SVGImageElement.decoding
 ---
 <div>{{APIRef}}</div>
 
-<p class="summary">The <strong><code>decoding</code></strong> property of the
+<p>The <strong><code>decoding</code></strong> property of the
   {{domxref("SVGImageElement")}} interface represents a hint given to the browser on how
   it should decode the image.</p>
 

--- a/files/en-us/web/api/svgimageelement/height/index.html
+++ b/files/en-us/web/api/svgimageelement/height/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGImageElement.height
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>height</code></strong> read-only property of the
+<p>The <strong><code>height</code></strong> read-only property of the
   {{domxref("SVGImageElement")}} interface returns an {{domxref("SVGAnimatedLength")}}
   corresponding to the {{SVGAttr("height")}} attribute of the given
   {{SVGElement("image")}} element.</p>

--- a/files/en-us/web/api/svgimageelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgimageelement/preserveaspectratio/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGImageElement.preserveAspectRatio
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>preserveAspectRatio</code></strong> read-only
+<p>The <strong><code>preserveAspectRatio</code></strong> read-only
   property of the {{domxref("SVGImageElement")}} interface returns an
   {{domxref("SVGAnimatedPreserveAspectRatio")}} corresponding to the
   {{SVGAttr("preserveAspectRatio")}} attribute of the given {{SVGElement("image")}}

--- a/files/en-us/web/api/svgimageelement/width/index.html
+++ b/files/en-us/web/api/svgimageelement/width/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGImageElement.width
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>width</code></strong> read-only property of the
+<p>The <strong><code>width</code></strong> read-only property of the
   {{domxref("SVGImageElement")}} interface returns an {{domxref("SVGAnimatedLength")}}
   corresponding to the {{SVGAttr("width")}} attribute of the given {{SVGElement("image")}}
   element.</p>

--- a/files/en-us/web/api/svgimageelement/x/index.html
+++ b/files/en-us/web/api/svgimageelement/x/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGImageElement.x
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>x</code></strong> read-only property of the
+<p>The <strong><code>x</code></strong> read-only property of the
   {{domxref("SVGImageElement")}} interface returns an {{domxref("SVGAnimatedLength")}}
   corresponding to the {{SVGAttr("x")}} attribute of the given {{SVGElement("image")}}
   element.</p>

--- a/files/en-us/web/api/svgimageelement/y/index.html
+++ b/files/en-us/web/api/svgimageelement/y/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGImageElement.y
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>y</code></strong> read-only property of the
+<p>The <strong><code>y</code></strong> read-only property of the
   {{domxref("SVGImageElement")}} interface returns an {{domxref("SVGAnimatedLength")}}
   corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("image")}}
   element.</p>

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -10,7 +10,7 @@ browser-compat: api.SVGMarkerElement
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>SVGMarkerElement</code></strong> interface provides access to the properties of {{SVGElement("marker")}} elements, as well as methods to manipulate them. The {{SVGElement("marker")}} element defines the graphics used for drawing marks on a shape.</p>
+<p>The <strong><code>SVGMarkerElement</code></strong> interface provides access to the properties of {{SVGElement("marker")}} elements, as well as methods to manipulate them. The {{SVGElement("marker")}} element defines the graphics used for drawing marks on a shape.</p>
 
 <p>{{InheritanceDiagram(600, 140)}}</p>
 

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.markerHeight
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>markerHeight</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the height of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerHeight")}} attribute.</p>
+<p>The <strong><code>markerHeight</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the height of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerHeight")}} attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.markerUnits
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>markerUnits</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object. This object returns an integer which represents the keyword values that the {{SVGattr("markerUnits")}} attribute accepts.</p>
+<p>The <strong><code>markerUnits</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object. This object returns an integer which represents the keyword values that the {{SVGattr("markerUnits")}} attribute accepts.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.markerWidth
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>markerWidth</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the width of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerWidth")}} attribute.</p>
+<p>The <strong><code>markerWidth</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the width of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerWidth")}} attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.orientAngle
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>orientAngle</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedAngle")}} object containing the angle of the {{SVGattr("orient")}} attribute.</p>
+<p>The <strong><code>orientAngle</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedAngle")}} object containing the angle of the {{SVGattr("orient")}} attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.orientType
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>orientType</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object indicating whether the {{SVGattr("orient")}} attribute is <code>auto</code>, an angle value, or something else.</p>
+<p>The <strong><code>orientType</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object indicating whether the {{SVGattr("orient")}} attribute is <code>auto</code>, an angle value, or something else.</p>
 
 <p>This <em>something else</em> is most likely to be the keyword <code>auto-start-reverse</code> however the spec leaves it open for this to be other values. Unsupported values will generally be thrown away by the parser, leaving the value the default of <code>auto</code>.</p>
 

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.preserveAspectRatio
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>preserveAspectRatio</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedPreserveAspectRatio")}} object containing the value of the {{SVGattr("preserveAspectRatio")}} attribute of the {{SVGElement("marker")}}.</p>
+<p>The <strong><code>preserveAspectRatio</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedPreserveAspectRatio")}} object containing the value of the {{SVGattr("preserveAspectRatio")}} attribute of the {{SVGElement("marker")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/refx/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refx/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.refX
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>refX</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</p>
+<p>The <strong><code>refX</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/refy/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.refY
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>refY</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</p>
+<p>The <strong><code>refY</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.setOrientToAngle
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>setOrientToAngle()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface sets the value of the <code>orient</code> attribute to the value in the {{domxref("SVGAngle")}} passed in.</p>
+<p>The <strong><code>setOrientToAngle()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface sets the value of the <code>orient</code> attribute to the value in the {{domxref("SVGAngle")}} passed in.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.setOrientToAuto
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>setOrientToAuto()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface  sets the value of the <code>orient</code> attribute to <code>auto</code>.</p>
+<p>The <strong><code>setOrientToAuto()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface  sets the value of the <code>orient</code> attribute to <code>auto</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.html
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGMarkerElement.viewBox
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>viewBox</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedRect")}} object which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</p>
+<p>The <strong><code>viewBox</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedRect")}} object which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.appendItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>appendItem()</code></strong> method of the {{domxref("SVGPointList")}} interface adds a {{domxref("SVGPoint","point")}} to the end of the list.</p>
+<p>The <strong><code>appendItem()</code></strong> method of the {{domxref("SVGPointList")}} interface adds a {{domxref("SVGPoint","point")}} to the end of the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.clear
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>clear()</code></strong> method of the {{domxref("SVGPointList")}} interface removes all items from the list.</p>
+<p>The <strong><code>clear()</code></strong> method of the {{domxref("SVGPointList")}} interface removes all items from the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.getItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>getItem()</code></strong> method of the {{domxref("SVGPointList")}} interface gets one item from the list at the specified index.</p>
+<p>The <strong><code>getItem()</code></strong> method of the {{domxref("SVGPointList")}} interface gets one item from the list at the specified index.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -10,7 +10,7 @@ browser-compat: api.SVGPointList
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>SVGPointList</code></strong> interface represents a list of {{domxref("SVGPoint")}} objects.</p>
+<p>The <strong><code>SVGPointList</code></strong> interface represents a list of {{domxref("SVGPoint")}} objects.</p>
 
 <p>An <code>SVGPointList</code> can be designated as read-only, which means that attempts to modify the object will result in an exception being thrown.</p>
 

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.initialize
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>initialize()</code></strong> method of the {{domxref("SVGPointList")}} interface clears the list then adds a single new {{domxref("SVGPoint")}} object to the list.</p>
+<p>The <strong><code>initialize()</code></strong> method of the {{domxref("SVGPointList")}} interface clears the list then adds a single new {{domxref("SVGPoint")}} object to the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.insertItemBefore
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>insertItemBefore()</code></strong> method of the {{domxref("SVGPointList")}} interface inserts a {{domxref("SVGPoint", "point")}} before another item in the list.</p>
+<p>The <strong><code>insertItemBefore()</code></strong> method of the {{domxref("SVGPointList")}} interface inserts a {{domxref("SVGPoint", "point")}} before another item in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/length/index.html
+++ b/files/en-us/web/api/svgpointlist/length/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.length
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>length</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
+<p>The <strong><code>length</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.html
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.numberOfItems
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>numberOfItems</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
+<p>The <strong><code>numberOfItems</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/removeitem/index.html
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.removeItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>removeItem()</code></strong> method of the {{domxref("SVGPointList")}} interface removes a {{domxref("SVGPoint","point")}} from the list.</p>
+<p>The <strong><code>removeItem()</code></strong> method of the {{domxref("SVGPointList")}} interface removes a {{domxref("SVGPoint","point")}} from the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -11,7 +11,7 @@ browser-compat: api.SVGPointList.replaceItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>replaceItem()</code></strong> method of the {{domxref("SVGPointList")}} interface replaces an {{domxref("SVGPoint","point")}} in the list.</p>
+<p>The <strong><code>replaceItem()</code></strong> method of the {{domxref("SVGPointList")}} interface replaces an {{domxref("SVGPoint","point")}} in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextDecoderStream.encoding
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the specific encoder.</p>
+<p>The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the specific encoder.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextDecoderStream.fatal
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>fatal</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("boolean")}} indicating if the error mode of the <code>TextDecoderStream</code> object is set to <code>fatal</code>.</p>
+<p>The <strong><code>fatal</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("boolean")}} indicating if the error mode of the <code>TextDecoderStream</code> object is set to <code>fatal</code>.</p>
 
 <p>The two possible values of error mode are <code>fatal</code> or <code>replacement</code>, the default being <code>replacement</code> which pushes a replacement character <code>U+FFFD</code> (�) to the output.</p>
 

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TextDecoderStream.ignoreBOM
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>ignoreBOM</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{jsxref("boolean")}} indicating if the byte order mark (BOM) is to be ignored.</p>
+<p>The <strong><code>ignoreBOM</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{jsxref("boolean")}} indicating if the byte order mark (BOM) is to be ignored.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TextDecoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>TextDecoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} converts a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextDecoder")}}.</p>
+<p>The <strong><code>TextDecoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} converts a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextDecoder")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextDecoderStream.readable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TextDecoderStream.TextDecoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>TextDecoderStream()</code></strong> constructor creates a new {{domxref("TextDecoderStream")}} object which is used to convert a stream of text in a binary encoding into strings.</p>
+<p>The <strong><code>TextDecoderStream()</code></strong> constructor creates a new {{domxref("TextDecoderStream")}} object which is used to convert a stream of text in a binary encoding into strings.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/writable/index.html
+++ b/files/en-us/web/api/textdecoderstream/writable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextDecoderStream.writable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("WritableStream")}}.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("WritableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textencoderstream/encoding/index.html
+++ b/files/en-us/web/api/textencoderstream/encoding/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TextEncoderStream.encoding
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a
+<p>The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a
   {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the current <code>TextEncoderStream</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextEncoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>TextEncoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} converts a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextEncoder")}}.</p>
+<p>The <strong><code>TextEncoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} converts a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextEncoder")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/textencoderstream/readable/index.html
+++ b/files/en-us/web/api/textencoderstream/readable/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TextEncoderStream.readable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TextEncoderStream.TextEncoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>TextEncoderStream()</code></strong> constructor creates a new {{domxref("TextEncoderStream")}} object which is used to convert a stream of strings into bytes using UTF-8 encoding.</p>
+<p>The <strong><code>TextEncoderStream()</code></strong> constructor creates a new {{domxref("TextEncoderStream")}} object which is used to convert a stream of strings into bytes using UTF-8 encoding.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textencoderstream/writable/index.html
+++ b/files/en-us/web/api/textencoderstream/writable/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TextEncoderStream.writable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("WritableStream")}}.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("WritableStream")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/activecues/index.html
+++ b/files/en-us/web/api/texttrack/activecues/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.activeCues
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>activeCues</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object listing the currently active cues.</p>
+<p>The <strong><code>activeCues</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object listing the currently active cues.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/addcue/index.html
+++ b/files/en-us/web/api/texttrack/addcue/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.addCue
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>addCue()</code></strong> method of the {{domxref("TextTrack")}} interface adds a new cue to the list of cues.</p>
+<p>The <strong><code>addCue()</code></strong> method of the {{domxref("TextTrack")}} interface adds a new cue to the list of cues.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/cues/index.html
+++ b/files/en-us/web/api/texttrack/cues/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.cues
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>cues</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object containing all of the track's cues.</p>
+<p>The <strong><code>cues</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object containing all of the track's cues.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/id/index.html
+++ b/files/en-us/web/api/texttrack/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.id
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the ID of the track if it has one.</p>
+<p>The <strong><code>id</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the ID of the track if it has one.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.html
+++ b/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.label
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>inBandMetadataTrackDispatchType</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the text track's in-band metadata dispatch type of the text track represented by the {{domxref("TextTrack")}} object.</p>
+<p>The <strong><code>inBandMetadataTrackDispatchType</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the text track's in-band metadata dispatch type of the text track represented by the {{domxref("TextTrack")}} object.</p>
 
 <p>An in-band metadata dispatch type is a string extracted from a media resource specifically for in-band metadata tracks. An example of a media resource that might have such tracks is a TV station streaming a broadcast on the web. Text Tracks may be used to include metadata for ad targeting, additional information such as recipe data during a cooking show, or trivia game data during a game show.</p>
 

--- a/files/en-us/web/api/texttrack/kind/index.html
+++ b/files/en-us/web/api/texttrack/kind/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.kind
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>kind</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the kind of text track this object represents. This decides how the track will be handled by a user agent.</p>
+<p>The <strong><code>kind</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the kind of text track this object represents. This decides how the track will be handled by a user agent.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/label/index.html
+++ b/files/en-us/web/api/texttrack/label/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.label
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>label</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a human-readable label for the text track, if it is available.</p>
+<p>The <strong><code>label</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns a human-readable label for the text track, if it is available.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrack/language/index.html
+++ b/files/en-us/web/api/texttrack/language/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.language
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>language</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the language of the text track.</p>
+<p>The <strong><code>language</code></strong> read-only property of the {{domxref("TextTrack")}} interface returns the language of the text track.</p>
 
 <p>This uses the same values as the HTML {{htmlattrxref("lang")}} attribute. These values are documented in the <a href="https://datatracker.ietf.org/doc/html/bcp47">Tags for Identifying Languages</a> (BCP 47) document from the IETF.</p>
 

--- a/files/en-us/web/api/texttrack/removecue/index.html
+++ b/files/en-us/web/api/texttrack/removecue/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrack.removeCue
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>removeCue()</code></strong> method of the {{domxref("TextTrack")}} interface removes a cue from the list of cues.</p>
+<p>The <strong><code>removeCue()</code></strong> method of the {{domxref("TextTrack")}} interface removes a cue from the list of cues.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcue/endtime/index.html
+++ b/files/en-us/web/api/texttrackcue/endtime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.endTime
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>endTime</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the end time of the cue.</p>
+<p>The <strong><code>endTime</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the end time of the cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcue/id/index.html
+++ b/files/en-us/web/api/texttrackcue/id/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.id
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>id</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the identifier for this cue.</p>
+<p>The <strong><code>id</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the identifier for this cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcue/onenter/index.html
+++ b/files/en-us/web/api/texttrackcue/onenter/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.onenter
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>onenter</code></strong> EventHandler of the {{domxref("TextTrackCue")}} interface processes the <code>enter</code> event.</p>
+<p>The <strong><code>onenter</code></strong> EventHandler of the {{domxref("TextTrackCue")}} interface processes the <code>enter</code> event.</p>
 
 <p> The <code>enter</code> event fires when a cue becomes active. In the case of subtitles or a caption this is when it displays over the media.</p>
 

--- a/files/en-us/web/api/texttrackcue/onexit/index.html
+++ b/files/en-us/web/api/texttrackcue/onexit/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.onexit
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>onexit</code></strong> EventHandler of the {{domxref("TextTrackCue")}} interface processes <code>exit</code> events.</p>
+<p>The <strong><code>onexit</code></strong> EventHandler of the {{domxref("TextTrackCue")}} interface processes <code>exit</code> events.</p>
 
 <p> The <code>exit</code> event fires when a cue stops being active.</p>
 

--- a/files/en-us/web/api/texttrackcue/pauseonexit/index.html
+++ b/files/en-us/web/api/texttrackcue/pauseonexit/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.pauseOnExit
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>pauseOnExit</code></strong> property of the {{domxref("TextTrackCue")}} interface returns or sets the flag indicating whether playback of the media should pause when the end of the range to which this cue applies is reached.</p>
+<p>The <strong><code>pauseOnExit</code></strong> property of the {{domxref("TextTrackCue")}} interface returns or sets the flag indicating whether playback of the media should pause when the end of the range to which this cue applies is reached.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcue/starttime/index.html
+++ b/files/en-us/web/api/texttrackcue/starttime/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.startTime
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>startTime</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the start time of the cue.</p>
+<p>The <strong><code>startTime</code></strong> property of the {{domxref("TextTrackCue")}} interface returns and sets the start time of the cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcue/track/index.html
+++ b/files/en-us/web/api/texttrackcue/track/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TextTrackCue.track
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>track</code></strong> read-only property of the {{domxref("TextTrackCue")}} interface returns the {{domxref("TextTrack")}} object that this cue belongs to.</p>
+<p>The <strong><code>track</code></strong> read-only property of the {{domxref("TextTrackCue")}} interface returns the {{domxref("TextTrack")}} object that this cue belongs to.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
@@ -13,7 +13,7 @@ browser-compat: api.TextTrackCueList.getCueById
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>getCueById()</code></strong> method of the {{domxref("TextTrackCueList")}} interface returns the first {{domxref("VTTCue")}} in the list represented by the <code>TextTrackCueList</code> object whose identifier matches the value of <code>id</code>.</p>
+<p>The <strong><code>getCueById()</code></strong> method of the {{domxref("TextTrackCueList")}} interface returns the first {{domxref("VTTCue")}} in the list represented by the <code>TextTrackCueList</code> object whose identifier matches the value of <code>id</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/texttrackcuelist/index.html
+++ b/files/en-us/web/api/texttrackcuelist/index.html
@@ -12,7 +12,7 @@ browser-compat: api.TextTrackCueList
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>TextTrackCueList</code></strong> array-like object represents a dynamically updating list of {{domxref("TextTrackCue")}} objects.</p>
+<p>The <strong><code>TextTrackCueList</code></strong> array-like object represents a dynamically updating list of {{domxref("TextTrackCue")}} objects.</p>
 
 <p>This interface has no constructor. Retrieve an instance of this object with {{domxref('TextTrack.cues')}} which returns all of the cues in a {{domxref("TextTrack")}} object.</p>
 

--- a/files/en-us/web/api/texttrackcuelist/length/index.html
+++ b/files/en-us/web/api/texttrackcuelist/length/index.html
@@ -13,7 +13,7 @@ browser-compat: api.TextTrackCueList.length
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>length</code></strong> read-only property of the {{domxref("TextTrackCueList")}} interface returns the number of cues in the list.</p>
+<p>The <strong><code>length</code></strong> read-only property of the {{domxref("TextTrackCueList")}} interface returns the number of cues in the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transformstream/readable/index.html
+++ b/files/en-us/web/api/transformstream/readable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStream.readable
 ---
 <p>{{APIRef("Streams")}}</p>
 
-<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("ReadableStream")}} instance controlled by this <code>TransformStream</code>.</p>
+<p>The <strong><code>readable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("ReadableStream")}} instance controlled by this <code>TransformStream</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TransformStream.TransformStream
 ---
 <p>{{APIRef("Streams")}}</p>
 
-<p class="summary">The <strong><code>TransformStream()</code></strong> constructor creates a new {{domxref("TransformStream")}} object which represents a pair of streams: a {{domxref("WritableStream")}} representing the writable side, and a {{domxref("ReadableStream")}} representing the readable side.</p>
+<p>The <strong><code>TransformStream()</code></strong> constructor creates a new {{domxref("TransformStream")}} object which represents a pair of streams: a {{domxref("WritableStream")}} representing the writable side, and a {{domxref("ReadableStream")}} representing the readable side.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transformstream/writable/index.html
+++ b/files/en-us/web/api/transformstream/writable/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStream.writable
 ---
 <p>{{APIRef("Streams")}}</p>
 
-<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("WritableStream")}} instance controlled by this <code>TransformStream</code>.</p>
+<p>The <strong><code>writable</code></strong> read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("WritableStream")}} instance controlled by this <code>TransformStream</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStreamDefaultController.desiredSize
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
-<p class="summary">The <strong><code>desiredSize</code></strong> read-only property of the {{domxref("TransformStreamDefaultController")}} interface returns the desired size to fill the queue of the associated {{domxref("ReadableStream")}}.</p>
+<p>The <strong><code>desiredSize</code></strong> read-only property of the {{domxref("TransformStreamDefaultController")}} interface returns the desired size to fill the queue of the associated {{domxref("ReadableStream")}}.</p>
 
 <p>The internal queue of a <code>ReadableStream</code> contains chunks that have been enqueued, but not yet read. The browser determines the <strong>desired size</strong> to fill the stream, and it is this value returned by the <code>desiredSize</code> property.</p>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStreamDefaultController.enqueue
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
-<p class="summary">The <strong><code>enqueue()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface enqueues the given chunk in the readable side of the stream.</p>
+<p>The <strong><code>enqueue()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface enqueues the given chunk in the readable side of the stream.</p>
 
 <p>For more information on readable streams and chunks see <a href="/en-US/docs/Web/API/Streams_API/Using_readable_streams">Using Readable Streams</a>.</p>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStreamDefaultController.error
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
-<p class="summary">The <strong><code>error()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface errors both sides of the stream. Any further interactions with it will fail with the given error message, and any chunks in the queue will be discarded.</p>
+<p>The <strong><code>error()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface errors both sides of the stream. Any further interactions with it will fail with the given error message, and any chunks in the queue will be discarded.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TransformStreamDefaultController
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
-<p class="summary">The <strong><code>TransformStreamDefaultController</code></strong> interface of the {{domxref('Streams API','','',' ')}} provides methods to manipulate the associated {{domxref("ReadableStream")}} and {{domxref("WritableStream")}}.</p>
+<p>The <strong><code>TransformStreamDefaultController</code></strong> interface of the {{domxref('Streams API','','',' ')}} provides methods to manipulate the associated {{domxref("ReadableStream")}} and {{domxref("WritableStream")}}.</p>
 
 <p>When constructing a {{domxref("TransformStream")}}, the <code>TransformStreamDefaultController</code> is created. It therefore has no constructor. The way to get an instance of <code>TransformStreamDefaultController</code> is via the callback methods of {{domxref("TransformStream.TransformStream()")}}.</p>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TransformStreamDefaultController.terminate
 ---
 <div>{{DefaultAPISidebar("Streams API")}}</div>
 
-<p class="summary">The <strong><code>terminate()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface Closes the readable side and errors the writable side of the stream.</p>
+<p>The <strong><code>terminate()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface Closes the readable side and errors the writable side of the stream.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trusted_types_api/index.html
+++ b/files/en-us/web/api/trusted_types_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong>Trusted Types API</strong> gives web developers a way to lock down the insecure parts of the {{domxref("Document Object Model","DOM API")}} to prevent client-side {{Glossary("Cross-site scripting")}} (XSS) attacks.</p>
+<p>The <strong>Trusted Types API</strong> gives web developers a way to lock down the insecure parts of the {{domxref("Document Object Model","DOM API")}} to prevent client-side {{Glossary("Cross-site scripting")}} (XSS) attacks.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/trustedhtml/index.html
+++ b/files/en-us/web/api/trustedhtml/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TrustedHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedHTML</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that will render it as HTML. These objects are created via {{domxref("TrustedTypePolicy.createHTML", "TrustedTypePolicy.createHTML()")}} and therefore have no constructor.</p>
+<p>The <strong><code>TrustedHTML</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that will render it as HTML. These objects are created via {{domxref("TrustedTypePolicy.createHTML", "TrustedTypePolicy.createHTML()")}} and therefore have no constructor.</p>
 
 <p>The value of a <strong>TrustedHTML</strong> object is set when the object is created and cannot be changed by JavaScript as there is no setter exposed.</p>
 

--- a/files/en-us/web/api/trustedhtml/tojson/index.html
+++ b/files/en-us/web/api/trustedhtml/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedHTML.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedHTML")}} interface returns a JSON representation of the stored data.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedHTML")}} interface returns a JSON representation of the stored data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedhtml/tostring/index.html
+++ b/files/en-us/web/api/trustedhtml/tostring/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedHTML.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("TrustedHTML")}} interface returns a string which may safely inserted into an injection sink.</p>
+<p>The <strong><code>toString()</code></strong> method of the {{domxref("TrustedHTML")}} interface returns a string which may safely inserted into an injection sink.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedscript/index.html
+++ b/files/en-us/web/api/trustedscript/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TrustedScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedScript</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string with an uncompiled script body that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that might execute the script. These objects are created via {{domxref("TrustedTypePolicy.createScript","TrustedTypePolicy.createScript()")}} and therefore have no constructor.</p>
+<p>The <strong><code>TrustedScript</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string with an uncompiled script body that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that might execute the script. These objects are created via {{domxref("TrustedTypePolicy.createScript","TrustedTypePolicy.createScript()")}} and therefore have no constructor.</p>
 
 <p>The value of a <strong>TrustedScript</strong> object is set when the object is created and cannot be changed by JavaScript as there is no setter exposed.</p>
 

--- a/files/en-us/web/api/trustedscript/tojson/index.html
+++ b/files/en-us/web/api/trustedscript/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedScript.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedScript")}} interface returns a JSON representation of the stored data.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedScript")}} interface returns a JSON representation of the stored data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedscript/tostring/index.html
+++ b/files/en-us/web/api/trustedscript/tostring/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedScript.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("TrustedScript")}} interface returns a string which may safely inserted into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a>.</p>
+<p>The <strong><code>toString()</code></strong> method of the {{domxref("TrustedScript")}} interface returns a string which may safely inserted into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedscripturl/index.html
+++ b/files/en-us/web/api/trustedscripturl/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TrustedScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedScriptURL</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that will parse it as a URL of an external script. These objects are created via {{domxref("TrustedTypePolicy.createScriptURL","TrustedTypePolicy.createScriptURL()")}} and therefore have no constructor.</p>
+<p>The <strong><code>TrustedScriptURL</code></strong> interface of the {{domxref('Trusted Types API')}} represents a string that a developer can insert into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a> that will parse it as a URL of an external script. These objects are created via {{domxref("TrustedTypePolicy.createScriptURL","TrustedTypePolicy.createScriptURL()")}} and therefore have no constructor.</p>
 
 <p>The value of a <strong>TrustedScriptURL</strong> object is set when the object is created and cannot be changed by JavaScript as there is no setter exposed.</p>
 

--- a/files/en-us/web/api/trustedscripturl/tojson/index.html
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedScriptURL.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedScriptURL")}} interface returns a JSON representation of the stored data.</p>
+<p>The <strong><code>toJSON()</code></strong> method of the {{domxref("TrustedScriptURL")}} interface returns a JSON representation of the stored data.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedscripturl/tostring/index.html
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedScriptURL.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("TrustedScriptURL")}} interface returns a string which may safely inserted into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a>.</p>
+<p>The <strong><code>toString()</code></strong> method of the {{domxref("TrustedScriptURL")}} interface returns a string which may safely inserted into an <a href="/en-US/docs/Web/API/Trusted_Types_API#injection_sinks">injection sink</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicy.createHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>createHTML()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedHTML")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+<p>The <strong><code>createHTML()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedHTML")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicy.createScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>createScript()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScript")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+<p>The <strong><code>createScript()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScript")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicy.createScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>createScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScriptURL")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+<p>The <strong><code>createScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScriptURL")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TrustedTypePolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedTypePolicy</code></strong> interface of the {{domxref('Trusted Types API')}} defines a group of functions which create {{domxref('TrustedType')}} objects.</p>
+<p>The <strong><code>TrustedTypePolicy</code></strong> interface of the {{domxref('Trusted Types API')}} defines a group of functions which create {{domxref('TrustedType')}} objects.</p>
 
 <p>A <code>TrustedTypePolicy</code> object is created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}} to define a policy for enforcing security rules on input. Therefore, <code>TrustedTypePolicy</code> has no constructor.</p>
 

--- a/files/en-us/web/api/trustedtypepolicy/name/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicy.name
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>name</code></strong> read-only property of the {{domxref("TrustedTypePolicy")}} interface returns the name of the policy.</p>
+<p>The <strong><code>name</code></strong> read-only property of the {{domxref("TrustedTypePolicy")}} interface returns the name of the policy.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.createPolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>createPolicy()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface creates a {{domxref("TrustedTypePolicy")}} object that implements the rules passed as <code>policyOptions</code>.</p>
+<p>The <strong><code>createPolicy()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface creates a {{domxref("TrustedTypePolicy")}} object that implements the rules passed as <code>policyOptions</code>.</p>
 
 <h3 id="Default_policy">The default policy</h3>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.defaultPolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>defaultPolicy</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</p>
+<p>The <strong><code>defaultPolicy</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.emptyHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>emptyHTML</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedHTML")}} object containing an empty string.</p>
+<p>The <strong><code>emptyHTML</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedHTML")}} object containing an empty string.</p>
 
 <p>This object can be used when the application requires an empty string to be inserted into an injection sink.</p>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.emptyScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>emptyScript</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedScript")}} object containing an empty string.</p>
+<p>The <strong><code>emptyScript</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedScript")}} object containing an empty string.</p>
 
 <p>This object can be used when the application requires an empty string to be inserted into an injection sink which is expecting a <code>TrustedScript</code> object.</p>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.getAttributeType
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>getAttributeType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element, and if so which Trusted Type is used.</p>
+<p>The <strong><code>getAttributeType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element, and if so which Trusted Type is used.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.getPropertyType
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>getPropertyType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element's property.</p>
+<p>The <strong><code>getPropertyType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element's property.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -10,7 +10,7 @@ browser-compat: api.TrustedTypePolicyFactory
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedTypePolicyFactory</code></strong> interface of the {{domxref('Trusted Types API')}} creates policies and allows the verification of Trusted Type objects against created policies.</p>
+<p>The <strong><code>TrustedTypePolicyFactory</code></strong> interface of the {{domxref('Trusted Types API')}} creates policies and allows the verification of Trusted Type objects against created policies.</p>
 
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.isHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>isHTML()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedHTML")}} object.</p>
+<p>The <strong><code>isHTML()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedHTML")}} object.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.isScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>isScript()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScript")}} object.</p>
+<p>The <strong><code>isScript()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScript")}} object.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -11,7 +11,7 @@ browser-compat: api.TrustedTypePolicyFactory.isScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>isScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScriptURL")}} object.</p>
+<p>The <strong><code>isScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScriptURL")}} object.</p>
 
 <div class="notecard note">
   <h4>Note:</h4>

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.html
@@ -14,7 +14,7 @@ browser-compat: api.USBConfiguration.configurationName
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("")}}</div>
 
-<p class="summary">The <strong><code>configurationName</code></strong> read-only property
+<p>The <strong><code>configurationName</code></strong> read-only property
   of the {{domxref("USBConfiguration")}} interface returns the name provided by the device
   to describe this configuration. This is equal to the value of the string descriptor with
   the index provided in the <a

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.USBConfiguration.configurationValue
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
-<p class="summary">The <strong><code>configurationValue</code></strong> read-only property
+<p>The <strong><code>configurationValue</code></strong> read-only property
   of the {{domxref("USBConfiguration")}} interface null</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.html
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.html
@@ -14,7 +14,7 @@ browser-compat: api.USBConfiguration.interfaces
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>interfaces</code></strong> read-only property of the
+<p>The <strong><code>interfaces</code></strong> read-only property of the
   {{domxref("USBConfiguration")}} interface returns an array containing instances of the
   {{domxref('USBInterface')}} describing each interface supported by this configuration.
 </p>

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
@@ -15,7 +15,7 @@ browser-compat: api.USBConfiguration.USBConfiguration
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
-<p class="summary">The <strong><code>USBConfiguration()</code></strong> constructor
+<p>The <strong><code>USBConfiguration()</code></strong> constructor
   creates a new {{domxref("USBConfiguration")}} object which contains information about
   the configuration on the provided USBDevice with the given configuration value.</p>
 

--- a/files/en-us/web/api/usbconnectionevent/device/index.html
+++ b/files/en-us/web/api/usbconnectionevent/device/index.html
@@ -11,7 +11,7 @@ browser-compat: api.USBConnectionEvent.device
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
-<p class="summary">The <strong><code>device</code></strong> read-only property of the {{domxref("USBConnectionEvent")}} interface returns a {{domxref("USBDevice")}} object representing the device being connected or disconnected.</p>
+<p>The <strong><code>device</code></strong> read-only property of the {{domxref("USBConnectionEvent")}} interface returns a {{domxref("USBDevice")}} object representing the device being connected or disconnected.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.USBConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
-<p class="summary">The <strong><code>USBConnectionEvent</code></strong> interface of the {{domxref('WebUSB API','','',' ')}} is the event type passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}} when the user agent detects that a new USB device has been connected or disconnected.</p>
+<p>The <strong><code>USBConnectionEvent</code></strong> interface of the {{domxref('WebUSB API','','',' ')}} is the event type passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}} when the user agent detects that a new USB device has been connected or disconnected.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
@@ -10,7 +10,7 @@ browser-compat: api.USBConnectionEvent.USBConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
-<p class="summary">The <strong><code>USBConnectionEvent()</code></strong> constructor creates a new {{domxref("USBConnectionEvent")}} object which is passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}}. This constructor is not typically used, it is created by the browser in response to the connection and disconnection of a USB device.</p>
+<p>The <strong><code>USBConnectionEvent()</code></strong> constructor creates a new {{domxref("USBConnectionEvent")}} object which is passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}}. This constructor is not typically used, it is created by the browser in response to the connection and disconnection of a USB device.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/user-agent_client_hints_api/index.html
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.html
@@ -10,7 +10,7 @@ browser-compat: api.NavigatorUAData
 ---
 <div>{{DefaultAPISidebar("User-Agent Client Hints API")}}</div>
 
-<p class="summary">The User-Agent Client Hints API extends <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.</p>
+<p>The User-Agent Client Hints API extends <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.</p>
 
 <h2> Concepts and Usage</h2>
 

--- a/files/en-us/web/api/vibration_api/index.html
+++ b/files/en-us/web/api/vibration_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Vibration API")}}</div>
 
-<p class="summary">Most modern mobile devices include vibration hardware, which lets software code provide physical feedback to the user by causing the device to shake. The <strong>Vibration API</strong> offers Web apps the ability to access this hardware, if it exists, and does nothing if the device doesn't support it.</p>
+<p>Most modern mobile devices include vibration hardware, which lets software code provide physical feedback to the user by causing the device to shake. The <strong>Vibration API</strong> offers Web apps the ability to access this hardware, if it exists, and does nothing if the device doesn't support it.</p>
 
 <h2 id="Describing_vibrations">Describing vibrations</h2>
 

--- a/files/en-us/web/api/vttcue/align/index.html
+++ b/files/en-us/web/api/vttcue/align/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.align
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>align</code></strong> property of the {{domxref("VTTCue")}} interface represents the alignment of all of the lines of text in the text box.</p>
+<p>The <strong><code>align</code></strong> property of the {{domxref("VTTCue")}} interface represents the alignment of all of the lines of text in the text box.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/getcueashtml/index.html
+++ b/files/en-us/web/api/vttcue/getcueashtml/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.getCueAsHTML
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>getCueAsHTML()</code></strong> method of the {{domxref("VTTCue")}} interface returns a {{domxref("DocumentFragment")}} containing the cue content.</p>
+<p>The <strong><code>getCueAsHTML()</code></strong> method of the {{domxref("VTTCue")}} interface returns a {{domxref("DocumentFragment")}} containing the cue content.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/line/index.html
+++ b/files/en-us/web/api/vttcue/line/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.line
 ---
 <div>{{DefaultAPISidebar("")}}</div>
 
-<p class="summary">The <strong><code>line</code></strong> property of the {{domxref("VTTCue")}} interface represents the cue line of this WebVTT cue.</p>
+<p>The <strong><code>line</code></strong> property of the {{domxref("VTTCue")}} interface represents the cue line of this WebVTT cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/linealign/index.html
+++ b/files/en-us/web/api/vttcue/linealign/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.lineAlign
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>lineAlign</code></strong> property of the {{domxref("VTTCue")}} interface represents the alignment of this VTT cue.</p>
+<p>The <strong><code>lineAlign</code></strong> property of the {{domxref("VTTCue")}} interface represents the alignment of this VTT cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/position/index.html
+++ b/files/en-us/web/api/vttcue/position/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.position
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>position</code></strong> property of the {{domxref("VTTCue")}} interface represents the indentation of the cue within the line.</p>
+<p>The <strong><code>position</code></strong> property of the {{domxref("VTTCue")}} interface represents the indentation of the cue within the line.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/positionalign/index.html
+++ b/files/en-us/web/api/vttcue/positionalign/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.positionAlign
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>positionAlign</code></strong> property of the {{domxref("VTTCue")}} interface is used to determine what {{domxref("VTTCue.position")}} is anchored to.</p>
+<p>The <strong><code>positionAlign</code></strong> property of the {{domxref("VTTCue")}} interface is used to determine what {{domxref("VTTCue.position")}} is anchored to.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/region/index.html
+++ b/files/en-us/web/api/vttcue/region/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.region
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>region</code></strong> property of the {{domxref("VTTCue")}} interface returns and sets the {{domxref("VTTRegion")}} that this cue belongs to.</p>
+<p>The <strong><code>region</code></strong> property of the {{domxref("VTTCue")}} interface returns and sets the {{domxref("VTTRegion")}} that this cue belongs to.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/size/index.html
+++ b/files/en-us/web/api/vttcue/size/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.size
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>size</code></strong> property of the {{domxref("VTTCue")}} interface represents the size of the cue as a percentage of the video size.</p>
+<p>The <strong><code>size</code></strong> property of the {{domxref("VTTCue")}} interface represents the size of the cue as a percentage of the video size.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/snaptolines/index.html
+++ b/files/en-us/web/api/vttcue/snaptolines/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.snapToLines
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>snapToLines</code></strong> property of the {{domxref("VTTCue")}} interface is a {{jsxref("Boolean")}} indicating if the {{domxref("VTTCue.line")}} property is an integer number of lines, or a percentage of the video size.</p>
+<p>The <strong><code>snapToLines</code></strong> property of the {{domxref("VTTCue")}} interface is a {{jsxref("Boolean")}} indicating if the {{domxref("VTTCue.line")}} property is an integer number of lines, or a percentage of the video size.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/text/index.html
+++ b/files/en-us/web/api/vttcue/text/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.text
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>text</code></strong> property of the {{domxref("VTTCue")}} interface represents the text contents of the cue.</p>
+<p>The <strong><code>text</code></strong> property of the {{domxref("VTTCue")}} interface represents the text contents of the cue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/vttcue/vertical/index.html
+++ b/files/en-us/web/api/vttcue/vertical/index.html
@@ -11,7 +11,7 @@ browser-compat: api.VTTCue.vertical
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>vertical</code></strong> property of the {{domxref("VTTCue")}} interface is a {{domxref("DOMString","string")}} representing the cue's writing direction.</p>
+<p>The <strong><code>vertical</code></strong> property of the {{domxref("VTTCue")}} interface is a {{domxref("DOMString","string")}} representing the cue's writing direction.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/wakelock/index.html
+++ b/files/en-us/web/api/wakelock/index.html
@@ -11,7 +11,7 @@ browser-compat: api.WakeLock
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The <strong><code>WakeLock</code></strong> interface of the {{domxref('Screen Wake Lock API')}} prevents device screens from dimming or locking when an application needs to keep running.</p>
+<p>The <strong><code>WakeLock</code></strong> interface of the {{domxref('Screen Wake Lock API')}} prevents device screens from dimming or locking when an application needs to keep running.</p>
 
 <p>The system wake lock is exposed through the global {{domxref('Navigator.wakelock')}} property.</p>
 

--- a/files/en-us/web/api/wakelock/request/index.html
+++ b/files/en-us/web/api/wakelock/request/index.html
@@ -11,7 +11,7 @@ browser-compat: api.WakeLock.request
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The <strong><code>request()</code></strong> method of the
+<p>The <strong><code>request()</code></strong> method of the
 	{{domxref("WakeLock")}} interface returns a {{jsxref("Promise")}} that resolves with a
 	{{domxref("WakeLockSentinel")}} object, which allows control over screen dimming and
 	locking.</p>

--- a/files/en-us/web/api/wakelocksentinel/index.html
+++ b/files/en-us/web/api/wakelocksentinel/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WakeLockSentinel
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The <strong><code>WakeLockSentinel</code></strong> interface of the {{domxref('Screen Wake Lock API')}} provides a handle to the underlying platform wake lock and can be manually released and reacquired. An {{jsxref('Object')}} representing the wake lock is returned via the {{domxref('WakeLock.request()','navigator.wakelock.request()')}} method.</p>
+<p>The <strong><code>WakeLockSentinel</code></strong> interface of the {{domxref('Screen Wake Lock API')}} provides a handle to the underlying platform wake lock and can be manually released and reacquired. An {{jsxref('Object')}} representing the wake lock is returned via the {{domxref('WakeLock.request()','navigator.wakelock.request()')}} method.</p>
 
 <p>An acquired <code>WakeLockSentinel</code> can be released manually via the {{domxref('WakeLockSentinel.release','release()')}} method, or automatically via the platform wake lock. This can happen if the document becomes inactive or looses visibility, if the device is low on power or the user turns on a power save mode. Releasing all <code>WakeLockSentinel</code> instances of a given wake lock type will cause the underlying platform wake lock to be released.</p>
 

--- a/files/en-us/web/api/wakelocksentinel/onrelease/index.html
+++ b/files/en-us/web/api/wakelocksentinel/onrelease/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WakeLockSentinel.onrelease
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The <strong><code>onrelease</code></strong> property of the
+<p>The <strong><code>onrelease</code></strong> property of the
 	{{domxref("WakeLockSentinel")}} is fired when the sentinel object's handle has been
 	released.</p>
 

--- a/files/en-us/web/api/wakelocksentinel/release/index.html
+++ b/files/en-us/web/api/wakelocksentinel/release/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WakeLockSentinel.release
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The <strong><code>release()</code></strong> method of the
+<p>The <strong><code>release()</code></strong> method of the
 	{{domxref("WakeLockSentinel")}} interface releases the
 	{{domxref("WakeLockSentinel")}}, returning a {{jsxref("Promise")}} that is resolved
 	once the sentinel has been successfully released.</p>

--- a/files/en-us/web/api/wakelocksentinel/released/index.html
+++ b/files/en-us/web/api/wakelocksentinel/released/index.html
@@ -10,7 +10,7 @@ browser-compat: api.WakeLockSentinel.released
 ---
 <div>{{draft}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The read-only <strong><code>released</code></strong> property of the
+<p>The read-only <strong><code>released</code></strong> property of the
 	{{domxref("WakeLockSentinel")}} interface returns a boolean that indicates whether
 	a {{domxref("WakeLockSentinel")}} has been released yet.</p>
 

--- a/files/en-us/web/api/wakelocksentinel/type/index.html
+++ b/files/en-us/web/api/wakelocksentinel/type/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WakeLockSentinel.type
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}</div>
 
-<p class="summary">The read-only <strong><code>type</code></strong> property of the
+<p>The read-only <strong><code>type</code></strong> property of the
 	{{domxref("WakeLockSentinel")}} interface returns a {{jsxref("String")}}
 	representation of the currently acquired {{domxref("WakeLockSentinel")}} type.</p>
 

--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.html
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.html
@@ -20,7 +20,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Web Animations")}}</p>
 
-<p class="summary">The Web Animations API lets us construct animations and control their playback with JavaScript. This article will start you off in the right direction with fun demos and tutorials featuring Alice in Wonderland.</p>
+<p>The Web Animations API lets us construct animations and control their playback with JavaScript. This article will start you off in the right direction with fun demos and tutorials featuring Alice in Wonderland.</p>
 
 <h2 id="Meet_the_Web_Animations_API">Meet the Web Animations API</h2>
 

--- a/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.html
+++ b/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Web Animations")}}</p>
 
-<p class="summary">The Web Animations API (WAAPI) provides JavaScript developers access to the browser’s animation engine and describes how animations should be implemented across browsers. This article will introduce you to the important concepts behind the WAAPI, providing you with a theoretical understanding of how it works so you can use it effectively. To learn how to put the API to use, check out its sister article, <a href="/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API">Using the Web Animations API</a>.</p>
+<p>The Web Animations API (WAAPI) provides JavaScript developers access to the browser’s animation engine and describes how animations should be implemented across browsers. This article will introduce you to the important concepts behind the WAAPI, providing you with a theoretical understanding of how it works so you can use it effectively. To learn how to put the API to use, check out its sister article, <a href="/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API">Using the Web Animations API</a>.</p>
 
 <p>The Web Animations API fills the gap between declarative CSS animations and transitions, and dynamic JavaScript animations. This means we can use it to create and manipulate CSS-like animations that go from one pre-defined state to another, or we can use variables, loops, and callbacks to create interactive animations that adapt and react to changing inputs.</p>
 

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Audio API")}}</div>
 
-<p class="summary">In this tutorial, we're going to cover sound creation and modification, as well as timing and scheduling. We're going to introduce sample loading, envelopes, filters, wavetables, and frequency modulation. If you're familiar with these terms and you're looking for an introduction to their application within with the Web Audio API, you've come to the right place.</p>
+<p>In this tutorial, we're going to cover sound creation and modification, as well as timing and scheduling. We're going to introduce sample loading, envelopes, filters, wavetables, and frequency modulation. If you're familiar with these terms and you're looking for an introduction to their application within with the Web Audio API, you've come to the right place.</p>
 
 <h2 id="Demo">Demo</h2>
 

--- a/files/en-us/web/api/web_audio_api/best_practices/index.html
+++ b/files/en-us/web/api/web_audio_api/best_practices/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{apiref("Web Audio API")}}</div>
 
-<p class="summary">There's no strict right or wrong way when writing creative code. As long as you consider security, performance, and accessibility, you can adapt to your own style. In this article, we'll share a number of <em>best practices</em> — guidelines, tips, and tricks for working with the Web Audio API.</p>
+<p>There's no strict right or wrong way when writing creative code. As long as you consider security, performance, and accessibility, you can adapt to your own style. In this article, we'll share a number of <em>best practices</em> — guidelines, tips, and tricks for working with the Web Audio API.</p>
 
 <h2 id="Loading_soundsfiles">Loading sounds/files</h2>
 

--- a/files/en-us/web/api/web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Audio API")}}</div>
 
-<p class="summary">The Web Audio API provides a powerful and versatile system for controlling audio on the Web, allowing developers to choose audio sources, add effects to audio, create audio visualizations, apply spatial effects (such as panning) and much more.</p>
+<p>The Web Audio API provides a powerful and versatile system for controlling audio on the Web, allowing developers to choose audio sources, add effects to audio, create audio visualizations, apply spatial effects (such as panning) and much more.</p>
 
 <h2 id="Web_audio_concepts_and_usage">Web audio concepts and usage</h2>
 

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>IIRFilterNode</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> is an {{domxref("AudioNode")}} processor that implements a general <a href="https://en.wikipedia.org/wiki/infinite%20impulse%20response">infinite impulse response</a> (IIR) filter; this type of filter can be used to implement tone control devices and graphic equalizers, and the filter response parameters can be specified, so that it can be tuned as needed. This article looks at how to implement one, and use it in a simple example.</p>
+<p>The <strong><code>IIRFilterNode</code></strong> interface of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> is an {{domxref("AudioNode")}} processor that implements a general <a href="https://en.wikipedia.org/wiki/infinite%20impulse%20response">infinite impulse response</a> (IIR) filter; this type of filter can be used to implement tone control devices and graphic equalizers, and the filter response parameters can be specified, so that it can be tuned as needed. This article looks at how to implement one, and use it in a simple example.</p>
 
 <h2 id="Demo">Demo</h2>
 

--- a/files/en-us/web/api/web_authentication_api/index.html
+++ b/files/en-us/web/api/web_authentication_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web Authentication API")}}</div>
 
-<p class="summary">The Web Authentication API is an extension of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> that enables strong authentication with public key cryptography, enabling passwordless authentication and/or secure second-factor authentication without SMS texts.</p>
+<p>The Web Authentication API is an extension of the <a href="/en-US/docs/Web/API/Credential_Management_API">Credential Management API</a> that enables strong authentication with public key cryptography, enabling passwordless authentication and/or secure second-factor authentication without SMS texts.</p>
 
 <h2 id="Web_authentication_concepts_and_usage">Web authentication concepts and usage</h2>
 

--- a/files/en-us/web/api/web_locks_api/index.html
+++ b/files/en-us/web/api/web_locks_api/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{SeeCompatTable}}{{APIRef("Web Locks")}}{{DefaultAPISidebar}}</div>
 
-<p class="summary">The Web Locks API allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.</p>
+<p>The Web Locks API allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.</p>
 
 <h2 id="Web_Locks_Concepts_and_Usage">Web Locks Concepts and Usage</h2>
 

--- a/files/en-us/web/api/web_midi_api/index.html
+++ b/files/en-us/web/api/web_midi_api/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Web MIDI API")}}</p>
 
-<p class="summary">The Web MIDI API connects to and interacts with with Musical Instrument Digital Interface (MIDI) Devices.</p>
+<p>The Web MIDI API connects to and interacts with with Musical Instrument Digital Interface (MIDI) Devices.</p>
 
 <p>The interfaces deal with the practical aspects of sending and receiving MIDI messages. Therefore, the API can be used for musical and non-musical uses, with any MIDI device connected to your computer.</p>
 

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.html
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
-<p class="summary">The Web Periodic Background Synchronization API provides a way to register tasks to be run in a {{domxref('Service Worker API','service worker')}} at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests.</p>
+<p>The Web Periodic Background Synchronization API provides a way to register tasks to be run in a {{domxref('Service Worker API','service worker')}} at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests.</p>
 
 <h2 id="Web_Periodic_Background_Synchronization_Concepts_and_Usage">Web Periodic Background Synchronization Concepts and Usage</h2>
 

--- a/files/en-us/web/api/web_serial_api/index.html
+++ b/files/en-us/web/api/web_serial_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web Serial API")}}</div>
 
-<p class="summary">The <strong>Web Serial API</strong> provides a way for websites to read from and write to serial devices. These devices may be connected via a serial port, or be USB or Bluetooth devices that emulate a serial port.</p>
+<p>The <strong>Web Serial API</strong> provides a way for websites to read from and write to serial devices. These devices may be connected via a serial port, or be USB or Bluetooth devices that emulate a serial port.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.html
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.html
@@ -11,7 +11,7 @@ tags:
   - speech
   - synthesis
 ---
-<p class="summary">The Web Speech API provides two distinct areas of functionality — speech recognition, and speech synthesis (also known as text to speech, or tts) — which open up interesting new possibilities for accessibility, and control mechanisms. This article provides a simple introduction to both areas, along with demos.</p>
+<p>The Web Speech API provides two distinct areas of functionality — speech recognition, and speech synthesis (also known as text to speech, or tts) — which open up interesting new possibilities for accessibility, and control mechanisms. This article provides a simple introduction to both areas, along with demos.</p>
 
 <h2 id="Speech_recognition">Speech recognition</h2>
 

--- a/files/en-us/web/api/web_workers_api/index.html
+++ b/files/en-us/web/api/web_workers_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Workers API")}}</div>
 
-<p class="summary"><strong>Web Workers</strong> makes it possible to run a script operation in a background thread separate from the main execution thread of a web application. The advantage of this is that laborious processing can be performed in a separate thread, allowing the main (usually the UI) thread to run without being blocked/slowed down.</p>
+<p><strong>Web Workers</strong> makes it possible to run a script operation in a background thread separate from the main execution thread of a web application. The advantage of this is that laborious processing can be performed in a separate thread, allowing the main (usually the UI) thread to run without being blocked/slowed down.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Web Workers can also use the Web Worker API (i.e. workers can spawn workers, provided they are hosted within the same <a href="/en-US/docs/Glossary/Origin">origin</a> as the parent page).</p>

--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
@@ -18,7 +18,7 @@ tags:
 ---
 <p>{{WebGLSidebar}}</p>
 
-<p class="summary">Matrices can be used to represent transformations of objects in space, and are used for performing many key types of computation when constructing images and visualizing data on the Web. This article explores how to create matrices and how to use them with <a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">CSS transforms</a> and the <code>matrix3d</code> transform type.</p>
+<p>Matrices can be used to represent transformations of objects in space, and are used for performing many key types of computation when constructing images and visualizing data on the Web. This article explores how to create matrices and how to use them with <a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">CSS transforms</a> and the <code>matrix3d</code> transform type.</p>
 
 <p>While this article uses <a href="/en-US/docs/Web/CSS">CSS</a> to simplify explanations, matrices are a core concept used by many different technologies including <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>, the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a> (VR and AR) API, and <a href="/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders">GLSL shaders</a>. This article is also available as an <a href="https://github.com/TatumCreative/mdn-matrix-math">MDN content kit</a>. The live examples use a collection of <a href="https://github.com/TatumCreative/mdn-webgl">utility functions</a> available under a global object named <code>MDN</code>.</p>
 

--- a/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.html
+++ b/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.html
@@ -17,7 +17,7 @@ tags:
 ---
 <p>{{WebGLSidebar}}</p>
 
-<p class="summary">This article explores how to take data within a <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> project, and project it into the proper spaces to display it on the screen. It assumes a knowledge of basic matrix math using translation, scale, and rotation matrices. It explains the three core matrices that are typically used when composing a 3D scene: the model, view and projection matrices.</p>
+<p>This article explores how to take data within a <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> project, and project it into the proper spaces to display it on the screen. It assumes a knowledge of basic matrix math using translation, scale, and rotation matrices. It explains the three core matrices that are typically used when composing a 3D scene: the model, view and projection matrices.</p>
 
 <div class="note">
 <p><strong>Note</strong>: This article is also available as an <a href="https://github.com/TatumCreative/mdn-model-view-projection">MDN content kit</a>. It also uses a collection of <a href="https://github.com/TatumCreative/mdn-webgl">utility functions</a> available under the <code>MDN</code> global object.</p>

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.html
@@ -11,7 +11,7 @@ browser-compat: api.WebGLRenderingContext.getShaderPrecisionFormat
 ---
 <div>{{APIRef("WebGL")}}</div>
 
-<p class="summary">The
+<p>The
   <strong><code>WebGLRenderingContext.getShaderPrecisionFormat()</code></strong> method of
   the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> returns a new
   {{domxref("WebGLShaderPrecisionFormat")}} object describing the range and precision for

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
@@ -11,7 +11,7 @@ browser-compat: api.WebGLRenderingContext.vertexAttribPointer
 ---
 <div>{{APIRef("WebGL")}}</div>
 
-<p class="summary">The
+<p>The
   <strong><code>WebGLRenderingContext.vertexAttribPointer()</code></strong> method of the
   <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> binds the buffer currently bound
   to <code>gl.ARRAY_BUFFER</code> to a generic vertex attribute of the current vertex

--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
 
-<p class="summary">The <strong>WebOTP API</strong> provides a method for verifying that a phone number belongs to the user, by generating a one-time password on receipt of a specially formatted SMS message.</p>
+<p>The <strong>WebOTP API</strong> provides a method for verifying that a phone number belongs to the user, by generating a one-time password on receipt of a specially formatted SMS message.</p>
 
 <h2> Concepts and Usage</h2>
 

--- a/files/en-us/web/api/webusb_api/index.html
+++ b/files/en-us/web/api/webusb_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Web USB API")}}</div>
 
-<p class="summary">The <strong>WebUSB API</strong> provides a way to expose non-standard Universal Serial Bus (USB) compatible devices services to the web, to make USB safer and easier to use.</p>
+<p>The <strong>WebUSB API</strong> provides a way to expose non-standard Universal Serial Bus (USB) compatible devices services to the web, to make USB safer and easier to use.</p>
 
 <h2>Concepts and Usage</h2>
 

--- a/files/en-us/web/api/webvr_api/concepts/index.html
+++ b/files/en-us/web/api/webvr_api/concepts/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 
-<p class="summary">This article discusses some of the concepts and theory behind virtual reality (VR). If you are a newcomer to the area, it is worthwhile getting an understanding of these topics before you start diving into code.</p>
+<p>This article discusses some of the concepts and theory behind virtual reality (VR). If you are a newcomer to the area, it is worthwhile getting an understanding of these topics before you start diving into code.</p>
 
 <h2 id="The_history_of_VR">The history of VR</h2>
 

--- a/files/en-us/web/api/webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 
-<p class="summary">WebVR provides support for exposing virtual reality devices — for example, head-mounted displays like the Oculus Rift or HTC Vive — to web apps, enabling developers to translate position and movement information from the display into movement around a 3D scene. This has numerous, interesting applications, from virtual product tours and interactive training apps to immersive first-person games.</p>
+<p>WebVR provides support for exposing virtual reality devices — for example, head-mounted displays like the Oculus Rift or HTC Vive — to web apps, enabling developers to translate position and movement information from the display into movement around a 3D scene. This has numerous, interesting applications, from virtual product tours and interactive training apps to immersive first-person games.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 
-<p class="summary">The WebVR API is a fantastic addition to the web developer's toolkit, allowing WebGL scenes to be presented in virtual reality displays such as the Oculus Rift and HTC Vive. But how do you get started with developing VR apps for the Web? This article will guide you through the basics.</p>
+<p>The WebVR API is a fantastic addition to the web developer's toolkit, allowing WebGL scenes to be presented in virtual reality displays such as the Oculus Rift and HTC Vive. But how do you get started with developing VR apps for the Web? This article will guide you through the basics.</p>
 
 <h2 id="Getting_started">Getting started</h2>
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
-<p class="summary">Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a>, and specifically the <a href="/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions">Gamepad Extensions API</a> that adds API features for accessing <a href="/en-US/docs/Web/API/GamepadPose">controller pose</a>, <a href="/en-US/docs/Web/API/GamepadHapticActuator">haptic actuators</a>, and more. This article explains the basics.</p>
+<p>Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a>, and specifically the <a href="/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions">Gamepad Extensions API</a> that adds API features for accessing <a href="/en-US/docs/Web/API/GamepadPose">controller pose</a>, <a href="/en-US/docs/Web/API/GamepadHapticActuator">haptic actuators</a>, and more. This article explains the basics.</p>
 
 <div class="notecard note"><strong>Note:</strong> WebVR API is replaced by <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>. WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.</div>
 

--- a/files/en-us/web/api/window/name/index.html
+++ b/files/en-us/web/api/window/name/index.html
@@ -10,7 +10,7 @@ browser-compat: api.Window.name
 ---
 <div>{{APIRef}}</div>
 
-<p class="summary">The <code>Window.name</code> property
+<p>The <code>Window.name</code> property
     gets/sets the name of the window's browsing context.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/window/showdirectorypicker/index.html
+++ b/files/en-us/web/api/window/showdirectorypicker/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Window.showDirectoryPicker
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>showDirectoryPicker()</code></strong> method of the
+<p>The <strong><code>showDirectoryPicker()</code></strong> method of the
   {{domxref("Window")}} interface displays a directory picker which allows the user to
   select a directory.</p>
 

--- a/files/en-us/web/api/window/showopenfilepicker/index.html
+++ b/files/en-us/web/api/window/showopenfilepicker/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Window.showOpenFilePicker
 <div>{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>showOpenFilePicker()</code></strong> method of the
+<p>The <strong><code>showOpenFilePicker()</code></strong> method of the
   {{domxref("Window")}} interface shows a file picker that allows a user to select a file
   or multiple files and returns a handle for the file(s).</p>
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.html
+++ b/files/en-us/web/api/window/showsavefilepicker/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Window.showSaveFilePicker
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
 
-<p class="summary">The <strong><code>showSaveFilePicker()</code></strong> method of the
+<p>The <strong><code>showSaveFilePicker()</code></strong> method of the
   {{domxref("Window")}} interface shows a file picker that allows a user to save a file.
   Either by selecting an existing file, or entering a name for a new file.</p>
 

--- a/files/en-us/web/api/window/transitionend_event/index.html
+++ b/files/en-us/web/api/window/transitionend_event/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Window.transitionend_event
 ---
 <div>{{APIRef}}</div>
 
-<p class="summary">The <strong><code>transitionend</code></strong> event is fired when a <a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transition</a> has completed. In the case where a transition is removed before completion, such as if the {{cssxref("transition-property")}} is removed or {{cssxref("display")}} is set to <code>none</code>, then the event will not be generated.</p>
+<p>The <strong><code>transitionend</code></strong> event is fired when a <a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transition</a> has completed. In the case where a transition is removed before completion, such as if the {{cssxref("transition-property")}} is removed or {{cssxref("display")}} is set to <code>none</code>, then the event will not be generated.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/workernavigator/serial/index.html
+++ b/files/en-us/web/api/workernavigator/serial/index.html
@@ -11,7 +11,7 @@ browser-compat: api.WorkerNavigator.serial
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p class="summary">The <strong><code>serial</code></strong> read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
+<p>The <strong><code>serial</code></strong> read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
 
 <p>When getting, the same instance of the {{domxref("Serial")}} object will always be returned.</p>
 

--- a/files/en-us/web/api/writablestream/abort/index.html
+++ b/files/en-us/web/api/writablestream/abort/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStream.abort
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>abort()</code></strong> method of the
+<p>The <strong><code>abort()</code></strong> method of the
   {{domxref("WritableStream")}} interface aborts the stream, signaling that the producer
   can no longer successfully write to the stream and it is to be immediately moved to an
   error state, with any queued writes discarded.</p>

--- a/files/en-us/web/api/writablestream/getwriter/index.html
+++ b/files/en-us/web/api/writablestream/getwriter/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStream.getWriter
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>getWriter()</code></strong> method of the
+<p>The <strong><code>getWriter()</code></strong> method of the
   {{domxref("WritableStream")}} interface returns a new instance of
   {{domxref("WritableStreamDefaultWriter")}} and locks the stream to that instance. While
   the stream is locked, no other writer can be acquired until this one is released. </p>

--- a/files/en-us/web/api/writablestream/locked/index.html
+++ b/files/en-us/web/api/writablestream/locked/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStream.locked
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>locked</code></strong> read-only property of the
+<p>The <strong><code>locked</code></strong> read-only property of the
   {{domxref("WritableStream")}} interface returns a boolean indicating whether the
   <code>WritableStream</code> is locked to a writer. </p>
 

--- a/files/en-us/web/api/writablestream/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/writablestream/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WritableStream.WritableStream
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>WritableStream()</code></strong> constructor creates
+<p>The <strong><code>WritableStream()</code></strong> constructor creates
   a new {{domxref("WritableStream")}} object instance.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStreamDefaultController.error
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>error()</code></strong> method of the
+<p>The <strong><code>error()</code></strong> method of the
   {{domxref("WritableStreamDefaultController")}} interface causes any future interactions
   with the associated stream to error.</p>
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStreamDefaultWriter.abort
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>abort()</code></strong> method of the
+<p>The <strong><code>abort()</code></strong> method of the
   {{domxref("WritableStreamDefaultWriter")}} interface aborts the stream, signaling that
   the producer can no longer successfully write to the stream and it is to be immediately
   moved to an error state, with any queued writes discarded. </p>

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStreamDefaultWriter.close
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>close()</code></strong> method of the
+<p>The <strong><code>close()</code></strong> method of the
   {{domxref("WritableStreamDefaultWriter")}} interface closes the associated writable
   stream. </p>
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStreamDefaultWriter.closed
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>closed</code></strong> read-only property of the
+<p>The <strong><code>closed</code></strong> read-only property of the
   {{domxref("WritableStreamDefaultWriter")}} interface returns a promise that fulfills if
   the stream becomes closed or the writer's lock is released, or rejects if the stream
   errors.</p>

--- a/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WritableStreamDefaultWriter.desiredSize
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>desiredSize</code></strong> read-only property of the
+<p>The <strong><code>desiredSize</code></strong> read-only property of the
   {{domxref("WritableStreamDefaultWriter")}} interface returns the desired size required
   to fill the stream's internal queue.</p>
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.html
@@ -12,7 +12,7 @@ browser-compat: api.WritableStreamDefaultWriter.WritableStreamDefaultWriter
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
-<p class="summary">The <strong><code>WritableStreamDefaultWriter()</code></strong>
+<p>The <strong><code>WritableStreamDefaultWriter()</code></strong>
   constructor creates a new {{domxref("WritableStreamDefaultWriter")}} object instance.
 </p>
 


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8110.

It removes `class="summary"` from Web/API pages, in the cases where it was attached to a `<p>`. Because there are a lot of these, I'm doing it in 2 PRs. This is part 2. Part 1 is here: https://github.com/mdn/content/pull/8172.

In all these cases the marked-up paragraph was the first one anyway, so it's a no-op. Except for a few cases where a page contained more than one `<p class="summary">`, but that just seems to be an error in the page.

I will go back and check after this is merged in case I have missed any stragglers, but this ought to finish off https://github.com/mdn/content/issues/8110.