### PR TITLE
remove useless className and chars

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/index.html
@@ -7,7 +7,7 @@ tags:
   - Overview
   - Reference
 ---
-<p class="summary">ARIA defines semantics that can be applied to elements, with these divided into <strong>roles</strong> (defining a type of user interface element) and <strong>states</strong> and <strong>properties</strong> that are supported by a role. Authors must assign an ARIA role and the appropriate states and properties to an element during its life-cycle, unless the element already has appropriate ARIA semantics (via use of an appropriate HTML element). Addition of ARIA semantics only exposes extra information to a browser's accessibility API, and does not affect a page's DOM.</p>
+<p>ARIA defines semantics that can be applied to elements, with these divided into <strong>roles</strong> (defining a type of user interface element) and <strong>states</strong> and <strong>properties</strong> that are supported by a role. Authors must assign an ARIA role and the appropriate states and properties to an element during its life-cycle, unless the element already has appropriate ARIA semantics (via use of an appropriate HTML element). Addition of ARIA semantics only exposes extra information to a browser's accessibility API, and does not affect a page's DOM.</p>
 
 <h2 id="Roles">Roles</h2>
 
@@ -20,7 +20,7 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">gridcell</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_link_role">link</a></li>
  <li>menuitem</li>
- <li>menuitemcheckbox </li>
+ <li>menuitemcheckbox</li>
  <li>menuitemradio</li>
  <li>option</li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role">progressbar</a></li>
@@ -40,7 +40,7 @@ tags:
 
 <h3 id="Composite_roles">Composite roles</h3>
 
-<p>The techniques below describe each composite role as well as their required and optional child roles.</p>
+<p>The techniques below describe each composite role as well as their required and optional child roles.</p>
 
 <div class="index">
 <ul>
@@ -206,6 +206,6 @@ tags:
 
 <div class="index">
 <ul>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/x-ms-aria-flowfrom">x-ms-aria-flowfrom</a> {{Non-standard_Inline}}</li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/x-ms-aria-flowfrom">x-ms-aria-flowfrom</a> {{Non-standard_Inline}}</li>
 </ul>
 </div>

--- a/files/en-us/web/accessibility/aria/forms/index.html
+++ b/files/en-us/web/accessibility/aria/forms/index.html
@@ -13,4 +13,4 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/forms/Multipart_labels">Multi-part labels</a>: Enabling complex form labels with a control inside each label</li>
 </ul>
 
-<p>See also the <a href="https://web.archive.org/web/20120801225355/http://yaccessibilityblog.com/library/aria-invalid-form-inputs.html">Yahoo! article on form validation and ARIA</a> (retrieved on archive.org), covering much of the same content.</p>
+<p>See also the <a href="https://web.archive.org/web/20120801225355/http://yaccessibilityblog.com/library/aria-invalid-form-inputs.html">Yahoo! article on form validation and ARIA</a> (retrieved on archive.org), covering much of the same content.</p>

--- a/files/en-us/web/accessibility/aria/index.html
+++ b/files/en-us/web/accessibility/aria/index.html
@@ -6,11 +6,11 @@ tags:
   - Accessibility
   - HTML
 ---
-<p class="summary"><span class="seoSummary">Accessible Rich Internet Applications <strong>(ARIA) </strong> is a set of attributes that define ways to make web content and web applications (especially those developed with JavaScript) more accessible to people with disabilities. </span></p>
+<p>Accessible Rich Internet Applications <strong>(ARIA)</strong> is a set of attributes that define ways to make web content and web applications (especially those developed with JavaScript) more accessible to people with disabilities.</p>
 
-<p><span class="seoSummary">It supplements HTML so that interactions and widgets commonly used in applications can be passed to assistive technologies</span> when there is not otherwise a mechanism. For example, ARIA enables accessible navigation landmarks in HTML4, JavaScript widgets, form hints and error messages, live content updates, and more. </p>
+<p>It supplements HTML so that interactions and widgets commonly used in applications can be passed to assistive technologies when there is not otherwise a mechanism. For example, ARIA enables accessible navigation landmarks in HTML4, JavaScript widgets, form hints and error messages, live content updates, and more. </p>
 
-<div class="warning">
+<div class="notecard warning">
 <p>Many of these widgets were later incorporated into HTML5, and <strong>developers should prefer using the correct semantic HTML element over using ARIA</strong>, if such an element exists. For instance, native elements have built-in <a href="/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets">keyboard accessibility</a>, roles and states. However, if you choose to use ARIA, you are responsible for mimicking (the equivalent) browser behavior in script.</p>
 </div>
 
@@ -21,7 +21,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>This progress bar is built using a <code>&lt;div&gt;</code>, which has no meaning. Unfortunately, there isn't a more semantic tag available to developers in HTML 4, so we need to include ARIA roles and properties. These are specified by adding attributes to the element. In this example, the <code>role="progressbar"</code> attribute informs the browser that this element is actually a JavaScript-powered progress bar widget. The <code>aria-valuemin</code> and <code>aria-valuemax</code> attributes specify the minimum and maximum values for the progress bar, and the <code>aria-valuenow</code> describes the current state of it and therefore must be kept updated with JavaScript.</p>
+<p>This progress bar is built using a {{HTMLElement("div")}}, which has no meaning. Unfortunately, there isn't a more semantic tag available to developers in HTML 4, so we need to include ARIA roles and properties. These are specified by adding attributes to the element. In this example, the <code>role="progressbar"</code> attribute informs the browser that this element is actually a JavaScript-powered progress bar widget. The <code>aria-valuemin</code> and <code>aria-valuemax</code> attributes specify the minimum and maximum values for the progress bar, and the <code>aria-valuenow</code> describes the current state of it and therefore must be kept updated with JavaScript.</p>
 
 <p>Along with placing them directly in the markup, ARIA attributes can be added to the element and updated dynamically using JavaScript code like this:</p>
 
@@ -40,10 +40,10 @@ function updateProgress(percentComplete) {
   progressBar.setAttribute("aria-valuenow", percentComplete);
 }</pre>
 
-<div class="note">
+<div class="notecard note">
 <p>Note that ARIA was invented after HTML4, so does not validate in HTML4 or its XHTML variants. However, the accessibility gains it provides far outweigh any technical invalidity.</p>
 
-<p>In HTML5, all ARIA attributes validate. The new landmark elements (<code>&lt;main&gt;</code>, <code>&lt;header&gt;</code>, <code>&lt;nav&gt;</code> etc) have built-in ARIA roles, so there is no need to duplicate them.</p>
+<p>In HTML5, all ARIA attributes validate. The new landmark elements ({{HTMLElement("main")}}, {{HTMLElement("header")}}, {{HTMLElement("nav")}} etc.) have built-in ARIA roles, so there is no need to duplicate them.</p>
 </div>
 
 <h2 id="Support">Support</h2>
@@ -54,7 +54,7 @@ function updateProgress(percentComplete) {
 
 <p>It is also important to test your authored ARIA with actual assistive technology. Much as how browser emulators and simulators are not an effective solution for testing full support, proxy assistive technology solutions aren't sufficient to fully guarantee functionality.</p>
 
-<h2 class="Documentation" id="Tutorials">Tutorials</h2>
+<h2 id="Tutorials">Tutorials</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets">Introduction to ARIA</a></dt>
@@ -78,29 +78,27 @@ function updateProgress(percentComplete) {
 
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets">Writing keyboard-navigable JavaScript widgets</a></dt>
- <dd>Built-in elements like &lt;input&gt;, &lt;button&gt; etc have built-in keyboard accessibility. If you 'fake' these with &lt;div&gt;s and ARIA, you must ensure your widgets are keyboard accessible.</dd>
+ <dd>Built-in elements like {{HTMLElement("input")}}, {{HTMLElement("button")}} etc have built-in keyboard accessibility. If you 'fake' these with {{HTMLElement("div")}}s and ARIA, you must ensure your widgets are keyboard accessible.</dd>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">Live regions</a></dt>
  <dd>Live regions provide suggestions to screen readers about how to handle changes to the contents of a page.</dd>
  <dt><a href="https://www.freedomscientific.com/Training/Surfs-up/AriaLiveRegions.htm">Using ARIA Live Regions to announce content changes</a></dt>
  <dd>A quick summary of live regions, by the makers of JAWS screen reader software. Live regions are also supported by NVDA with Firefox, and VoiceOver with Safari.</dd>
 </dl>
 
-<h2 class="Tools" id="References">References</h2>
+<h2 id="References">References</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles">ARIA Roles</a></dt>
  <dd>Reference pages covering all the WAI-ARIA roles discussed on MDN.</dd>
 </dl>
 
-<h2 class="Tools" id="Standardization_Efforts">Standardization Efforts</h2>
+<h2 id="Standardization_Efforts">Standardization Efforts</h2>
 
 <dl>
  <dt><a href="https://www.w3.org/TR/wai-aria-1.1/">WAI-ARIA Specification</a></dt>
  <dd>The W3C specification itself.</dd>
  <dt><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices</a></dt>
- <dd>
- <p>The official best practices documents how best to ARIA-ify common widgets and interactions. An excellent resource.</p>
- </dd>
+ <dd><p>The official best practices documents how best to ARIA-ify common widgets and interactions. An excellent resource.</p></dd>
 </dl>
 
 <h2 id="Videos">Videos</h2>

--- a/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
+++ b/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>ARIA is supported in the following browsers:</p>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
    <th>Browser</th>
@@ -70,7 +70,7 @@ tags:
 
 <p>Assistive technologies are increasingly adopting ARIA. Some of them include:</p>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
    <th>Assistive Technology</th>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

- remove useless classes and special chars
- replace element link to `HTMLElement` macros

> Anything else that could help us review it
