### PR TITLE
Fix links on CSS reference page

### DIFF
--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -48,7 +48,7 @@ div.menu-bar li:hover > ul {
 }
 ```
 
-For a beginner-level introduction to the syntax of selectors, see our [guide on CSS Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors). Be aware that any [syntax](/en-US/docs/Web/CSS/syntax) error in a rule definition invalidates the entire rule. Invalid rules are ignored by the browser. Note that CSS rule definitions are entirely (ASCII) [text-based](https://www.w3.org/TR/css-syntax-3/#intro), whereas DOM-CSS / CSSOM (the rule management system) is [object-based](https://www.w3.org/TR/cssom/#introduction).
+For a beginner-level introduction to the syntax of selectors, see our [guide on CSS Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors). Be aware that any [syntax](/en-US/docs/Web/CSS/Syntax) error in a rule definition invalidates the entire rule. Invalid rules are ignored by the browser. Note that CSS rule definitions are entirely (ASCII) [text-based](https://www.w3.org/TR/css-syntax-3/#intro), whereas DOM-CSS / CSSOM (the rule management system) is [object-based](https://www.w3.org/TR/cssom/#introduction).
 
 ### At-rule syntax
 
@@ -133,13 +133,13 @@ Combinators are selectors that establish a relationship between two or more simp
 ### Layout
 
 - [Block formatting context](/en-US/docs/Web/Guide/CSS/Block_formatting_context)
-- [Box model](/en-US/docs/Web/CSS/box_model)
-- [Containing block](/en-US/docs/Web/CSS/All_About_The_Containing_Block)
+- [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+- [Containing block](/en-US/docs/Web/CSS/Containing_block)
 - [Layout mode](/en-US/docs/Web/CSS/Layout_mode)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
 - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)
 - [Stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
-- [Visual formatting model](/en-US/docs/Web/Guide/CSS/Visual_formatting_model)
+- [Visual formatting model](/en-US/docs/Web/CSS/Visual_formatting_model)
 
 ## DOM-CSS / CSSOM
 


### PR DESCRIPTION
This fixes the following broken link flaws:

1. /en-US/docs/Web/CSS/syntax 👀 line 51:164 Fixable 👍🏼
**Suggestion:** /en-US/docs/Web/CSS/~~syntax~~*Syntax*
2. /en-US/docs/Web/CSS/box_model 👀 line 136:3 Fixable 👍🏼
**Suggestion:** /en-US/docs/Web/CSS/~~box_model~~*CSS_Box_Model/Introduction_to_the_CSS_box_model*
3. /en-US/docs/Web/CSS/All_About_The_Containing_Block 👀 line 137:3 Fixable 👍🏼
**Suggestion:** /en-US/docs/Web/CSS/~~All_About_The_Containing_Block~~*Containing_block*
4. /en-US/docs/Web/Guide/CSS/Visual_formatting_model 👀 line 142:3 Fixable 👍🏼
**Suggestion:** /en-US/docs/Web/~~Guide/~~ CSS/Visual_formatting_model