### PR TITLE
Fix heading notes

### DIFF
--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -22,8 +22,7 @@ return controller.signal;</pre>
 <p>This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that the abort logic should be run even if the intended fetch operation has not been started).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The method is similar in purpose to {{JSxRef("Promise.reject")}}</p>
+  <p><strong>Note:</strong> The method is similar in purpose to {{JSxRef("Promise.reject")}}</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/abortsignal/index.html
+++ b/files/en-us/web/api/abortsignal/index.html
@@ -77,8 +77,7 @@ function fetchVideo() {
 }</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an "<code>AbortError</code>" <code>DOMException</code>.</p>
+  <p><strong>Note:</strong> When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an "<code>AbortError</code>" <code>DOMException</code>.</p>
 </div>
 
 <p>You can find a <a href="https://github.com/mdn/dom-examples/tree/master/abort-api">full working example on GitHub</a>; you can also see it  <a href="https://mdn.github.io/dom-examples/abort-api/">running live</a>.</p>

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
@@ -35,8 +35,7 @@ browser-compat: api.AudioBufferSourceNode.buffer
 <h2 id="Example">Example</h2>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>For a full working example, see <a href="https://mdn.github.io/webaudio-examples/audio-buffer/"> this code running
+  <p><strong>Note:</strong> For a full working example, see <a href="https://mdn.github.io/webaudio-examples/audio-buffer/"> this code running
       live</a>, or <a href="https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html">view the source</a>.</p>
 </div>
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.html
+++ b/files/en-us/web/api/audiolistener/forwardx/index.html
@@ -16,8 +16,7 @@ browser-compat: api.AudioListener.forwardX
 <p>The <code>forwardX</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x value of the direction vector defining the forward direction the listener is pointing in.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+  <p><strong>Note:</strong> The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/audiolistener/forwardy/index.html
+++ b/files/en-us/web/api/audiolistener/forwardy/index.html
@@ -16,8 +16,7 @@ browser-compat: api.AudioListener.forwardY
 <p>The <code>forwardY</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y value of the direction vector defining the forward direction the listener is pointing in.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+  <p><strong>Note:</strong> The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/audiolistener/forwardz/index.html
+++ b/files/en-us/web/api/audiolistener/forwardz/index.html
@@ -16,8 +16,7 @@ browser-compat: api.AudioListener.forwardZ
 <p>The <code>forwardZ</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z value of the direction vector defining the forward direction the listener is pointing in.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+  <p><strong>Note:</strong> The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -146,8 +146,7 @@ function positionPanner() {
 }</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>In terms of working out what position values to apply to the
+  <p><strong>Note:</strong> In terms of working out what position values to apply to the
     listener and panner, to make the sound appropriate to what the visuals are doing on
     screen, there is quite a bit of math involved, but you will soon get used to it with a
     bit of experimentation.</p>

--- a/files/en-us/web/api/blobbuilder/index.html
+++ b/files/en-us/web/api/blobbuilder/index.html
@@ -13,8 +13,7 @@ browser-compat: api.BlobBuilder
 <p>{{APIRef("File API")}}{{ deprecated_header}}</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The <code>BlobBuilder</code> interface has been
+  <p><strong>Note:</strong> The <code>BlobBuilder</code> interface has been
   deprecated in favor of the newly introduced {{domxref('Blob')}} constructor.</p>
 </div>
 

--- a/files/en-us/web/api/cache/index.html
+++ b/files/en-us/web/api/cache/index.html
@@ -23,13 +23,11 @@ browser-compat: api.Cache
 <p>You are also responsible for periodically purging cache entries. Each browser has a hard limit on the amount of cache storage that a given origin can use. Cache quota usage estimates are available via the {{domxref("StorageEstimate")}} API. The browser does its best to manage disk space, but it may delete the Cache storage for an origin. The browser will generally delete all of the data for an origin or none of the data for an origin. Make sure to version caches by name and use the caches only from the version of the script that they can safely operate on. See <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#deleting_old_caches">Deleting old caches</a> for more information.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The key matching algorithm depends on the <a href="https://www.fastly.com/blog/best-practices-for-using-the-vary-header">VARY header</a> in the value. So matching a new key requires looking at both key and value for entries in the Cache.</p>
+  <p><strong>Note:</strong> The key matching algorithm depends on the <a href="https://www.fastly.com/blog/best-practices-for-using-the-vary-header">VARY header</a> in the value. So matching a new key requires looking at both key and value for entries in the Cache.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The caching API doesn't honor HTTP caching headers.</p>
+  <p><strong>Note:</strong> The caching API doesn't honor HTTP caching headers.</p>
 </div>
 
 <p>{{AvailableInWorkers}}</p>
@@ -67,8 +65,7 @@ browser-compat: api.Cache
 <p>In the code example, <code>caches</code> is a property of the {{domxref("ServiceWorkerGlobalScope")}}. It holds the <code>CacheStorage</code> object, by which it can access the {{domxref("CacheStorage")}} interface. This is an implementation of the {{domxref("WindowOrWorkerGlobalScope")}} mixin.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>In Chrome, visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below the registered service worker to view logging statements for the various actions the <code><a href="https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js">service-worker.js</a></code> script is performing.</p>
+  <p><strong>Note:</strong> In Chrome, visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below the registered service worker to view logging statements for the various actions the <code><a href="https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js">service-worker.js</a></code> script is performing.</p>
 </div>
 
 <pre class="brush: js">var CACHE_VERSION = 1;

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -20,8 +20,7 @@ browser-compat: api.CacheStorage
 <ul>
  <li>Provides a master directory of all the named caches that can be accessed by a {{domxref("ServiceWorker")}} or other type of worker or {{domxref("window")}} scope (you’re not limited to only using it with service workers).
   <div class="notecard note">
-    <h4>Note</h4>
-    <p><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">Chrome and Safari only expose `CacheStorage` to the windowed context over HTTPS</a>. {{domxref("WindowOrWorkerGlobalScope/caches", "WorkerGlobalScope.caches")}} will be undefined unless an SSL certificate is configured.</p>
+    <p><strong>Note:</strong> <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">Chrome and Safari only expose `CacheStorage` to the windowed context over HTTPS</a>. {{domxref("WindowOrWorkerGlobalScope/caches", "WorkerGlobalScope.caches")}} will be undefined unless an SSL certificate is configured.</p>
   </div>
  </li>
  <li>Maintains a mapping of string names to corresponding {{domxref("Cache")}} objects.</li>
@@ -34,13 +33,11 @@ browser-compat: api.CacheStorage
 <p>You can access <code>CacheStorage</code> through the global {{domxref("WindowOrWorkerGlobalScope.caches", "caches")}} property.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
+  <p><strong>Note:</strong> CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>{{domxref("CacheStorage.match()")}} is a convenience method. Equivalent functionality to match a cache entry can be implemented by returning an array of cache names from {{domxref("CacheStorage.keys()")}}, opening each cache with {{domxref("CacheStorage.open()")}}, and matching the one you want with {{domxref("Cache.match()")}}.</p>
+  <p><strong>Note:</strong> {{domxref("CacheStorage.match()")}} is a convenience method. Equivalent functionality to match a cache entry can be implemented by returning an array of cache names from {{domxref("CacheStorage.keys()")}}, opening each cache with {{domxref("CacheStorage.open()")}}, and matching the one you want with {{domxref("Cache.match()")}}.</p>
 </div>
 
 <p>{{AvailableInWorkers}}</p>

--- a/files/en-us/web/api/console/warn/index.html
+++ b/files/en-us/web/api/console/warn/index.html
@@ -17,8 +17,7 @@ browser-compat: api.console.warn
 
 <p>{{AvailableInWorkers}}</p>
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>In Chrome and Firefox, warnings have a small exclamation point icon next to them in the Web
+  <p><strong>Note:</strong> In Chrome and Firefox, warnings have a small exclamation point icon next to them in the Web
     console log.</p>
 </div>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -46,8 +46,7 @@ browser-compat: api.CookieChangeEvent.changed
     </dl>
 
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+      <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
     </div>
   </dd>
 </dl>

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -13,8 +13,7 @@ browser-compat: api.CookieChangeEvent.CookieChangeEvent
 <p>The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-    <p>This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
+    <p><strong>Note:</strong> This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -46,8 +46,7 @@ browser-compat: api.CookieChangeEvent.deleted
     </dl>
 
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+      <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
     </div>
   </dd>
 </dl>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -21,8 +21,7 @@ browser-compat: api.CookieChangeEvent
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
+  <p><strong>Note:</strong> A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
 </div>
 
 <h2 id="Constructor">Constructor</h2>

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -69,8 +69,7 @@ var <var>cookie</var> = CookieStore.get(<var>options</var>);</pre>
     </dl>
 
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+      <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
     </div>
   </dd>
 </dl>

--- a/files/en-us/web/api/cookiestore/set/index.html
+++ b/files/en-us/web/api/cookiestore/set/index.html
@@ -52,8 +52,7 @@ var <var>promise</var> = cookieStore.set(<var>options</var>);</pre>
         </dl>
 
         <div class="notecard note">
-          <h4>Note</h4>
-          <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+          <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
         </div>
       </dd>
     </dl>

--- a/files/en-us/web/api/customevent/initcustomevent/index.html
+++ b/files/en-us/web/api/customevent/initcustomevent/index.html
@@ -22,8 +22,7 @@ browser-compat: api.CustomEvent.initCustomEvent
   dispatched, it doesn't do anything anymore.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p><strong>Do not use this method anymore, as it is deprecated.</strong></p>
+  <p><strong>Note:</strong> <strong>Do not use this method anymore, as it is deprecated.</strong></p>
 
   <p>Rather than using the feature, instead use specific event constructors, like {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}.
 	The page on <a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a> gives more information about the way to use those.</p>

--- a/files/en-us/web/api/datatransfer/addelement/index.html
+++ b/files/en-us/web/api/datatransfer/addelement/index.html
@@ -19,8 +19,7 @@ browser-compat: api.DataTransfer.addElement
   dragged).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This method is Firefox-specific.</p>
+  <p><strong>Note:</strong> This method is Firefox-specific.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.html
@@ -33,8 +33,7 @@ browser-compat: api.DataTransfer.mozSetDataAt
   or number type (which will be converted into a string) or an {{ interface("nsISupports") }}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This method is Firefox-specific.</p>
+  <p><strong>Note:</strong> This method is Firefox-specific.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.html
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.html
@@ -20,8 +20,7 @@ browser-compat: api.DataTransfer.mozSourceNode
   returned.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>>
-  <p>This property is Firefox-specific.</p>
+  <p><strong>Note:</strong> This property is Firefox-specific.</p>
 </div>
 
 <p>This property is {{readonlyInline}}.</p>

--- a/files/en-us/web/api/datatransfer/moztypesat/index.html
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.html
@@ -20,8 +20,7 @@ browser-compat: api.DataTransfer.mozTypesAt
 </p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This method is Firefox-specific.</p>
+  <p><strong>Note:</strong> This method is Firefox-specific.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.html
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.html
@@ -20,8 +20,7 @@ browser-compat: api.DataTransfer.mozUserCancelled
   event.</p>
 
   <div class="notecard note">
-    <h4>Note</h4>>
-    <p>This property is Firefox-specific.</p>
+    <p><strong>Note:</strong> This property is Firefox-specific.</p>
   </div>
 
 <p>This property is {{readonlyInline}}.</p>

--- a/files/en-us/web/api/deprecationreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/deprecationreportbody/columnnumber/index.html
@@ -14,8 +14,7 @@ browser-compat: api.DeprecationReportBody.columnNumber
 <p>The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} and {{domxref("DeprecationReportBody.lineNumber")}} as it enables the location of the column in that file and line where the error occurred.</p>
+  <p><strong>Note:</strong> This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} and {{domxref("DeprecationReportBody.lineNumber")}} as it enables the location of the column in that file and line where the error occurred.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/deprecationreportbody/linenumber/index.html
+++ b/files/en-us/web/api/deprecationreportbody/linenumber/index.html
@@ -14,8 +14,7 @@ browser-compat: api.DeprecationReportBody.lineNumber
 <p>The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} as it enables the location of the line in that file where the error occurred.</p>
+  <p><strong>Note:</strong> This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} as it enables the location of the line in that file where the error occurred.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.html
@@ -14,8 +14,7 @@ browser-compat: api.DeprecationReportBody.sourceFile
 <p>The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("DeprecationReportBody")}} interface returns the path to the source file where the deprecated feature was used.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property can be used with {{domxref("DeprecationReportBody.lineNumber")}} and {{domxref("DeprecationReportBody.columnNumber")}} to locate the column and line in the file where the error occurred.</p>
+  <p><strong>Note:</strong> This property can be used with {{domxref("DeprecationReportBody.lineNumber")}} and {{domxref("DeprecationReportBody.columnNumber")}} to locate the column and line in the file where the error occurred.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/documenttype/before/index.html
+++ b/files/en-us/web/api/documenttype/before/index.html
@@ -18,8 +18,7 @@ browser-compat: api.DocumentType.before
 </p>
 
 <div class="note">
-  <h4>Note</h4>
-  <p>Putting nodes before the document's doctype will set the rendering mode to
+  <p><strong>Note:</strong> Putting nodes before the document's doctype will set the rendering mode to
     <a href="/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode">quirks mode</a>
     in some browsers (Internet Explorer). It is not advisable to do this.</p>
 </div>

--- a/files/en-us/web/api/documenttype/remove/index.html
+++ b/files/en-us/web/api/documenttype/remove/index.html
@@ -13,8 +13,7 @@ browser-compat: api.DocumentType.remove
 <p>The <code><strong>DocumentType.remove()</strong></code> method removes a document's <code>doctype</code>.</p>
 
 <div class="note">
-  <h4>Note</h4>
-  <p>Removing the document's doctype will set the rendering mode to
+  <p><strong>Note:</strong> Removing the document's doctype will set the rendering mode to
     <a href="/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode">quirks mode</a>!
     Please don’t do this. Willfully designing for quirks mode is not going to help you.
     If you need to work around issues with old Internet Explorer browsers, you might want to look into using

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.html
@@ -30,8 +30,7 @@ compressor.attack.value = 0;
 <p>An {{domxref("AudioParam")}}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+  <p><strong>Note:</strong> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.html
@@ -31,8 +31,7 @@ compressor.knee.value = 40;</pre>
 <p>An {{domxref("AudioParam")}}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+  <p><strong>Note:</strong> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.html
@@ -32,8 +32,7 @@ compressor.ratio.value = 12;
 <p>An {{domxref("AudioParam")}}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+  <p><strong>Note:</strong> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/dynamicscompressornode/release/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.html
@@ -30,8 +30,7 @@ compressor.release.value = 0.25;
 <p>An {{domxref("AudioParam")}}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+  <p><strong>Note:</strong> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.html
@@ -32,8 +32,7 @@ compressor.threshold.value = -50;
 <p>An {{domxref("AudioParam")}}.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+  <p><strong>Note:</strong> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/element/ariachecked/index.html
+++ b/files/en-us/web/api/element/ariachecked/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaChecked
 <p>The <strong><code>ariaChecked</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="checkbox"</code> as this element has built in semantics and does not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="checkbox"</code> as this element has built in semantics and does not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/arialevel/index.html
+++ b/files/en-us/web/api/element/arialevel/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaLevel
 <p>The <strong><code>ariaLevel</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("h1")}} or other correct heading level as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("h1")}} or other correct heading level as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariamultiline/index.html
+++ b/files/en-us/web/api/element/ariamultiline/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaMultiline
 <p>The <strong><code>ariaMultiline</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariamultiselectable/index.html
+++ b/files/en-us/web/api/element/ariamultiselectable/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaMultiSelectable
 <p>The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariaplaceholder/index.html
+++ b/files/en-us/web/api/element/ariaplaceholder/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaPlaceholder
 <p>The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariapressed/index.html
+++ b/files/en-us/web/api/element/ariapressed/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaPressed
 <p>The <strong><code>ariaPressed</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariareadonly/index.html
+++ b/files/en-us/web/api/element/ariareadonly/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaReadOnly
 <p>The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariarequired/index.html
+++ b/files/en-us/web/api/element/ariarequired/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Element.ariaRequired
 <p>The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="text"</code> or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.html
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaAtomic
 <p>The <strong><code>ariaAtomic</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-atomic</code> attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the <code>aria-relevant</code> attribute.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.html
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaAutoComplete
 <p>The <strong><code>ariaAutoComplete</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-autocomplete</code> attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariabusy/index.html
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaBusy
 <p>The <strong><code>ariaBusy</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-busy</code> attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariachecked/index.html
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaChecked
 <p>The <strong><code>ariaChecked</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-checked</code> attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaColCount
 <p>The <strong><code>ariaColCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colcount</code> attribute, which defines the number of columns in a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaColIndex
 <p>The <strong><code>ariaColIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindex</code> attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaColIndexText
 <p>The <strong><code>ariaColIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colindextext</code> attribute, which defines a human readable text alternative of aria-colindex.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.html
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaColSpan
 <p>The <strong><code>ariaColSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-colspan</code> attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.html
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaCurrent
 <p>The <strong><code>ariaCurrent</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-current</code> attribute, which indicates the element that represents the current item within a container or set of related elements.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariadescription/index.html
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaDescription
 <p>The <strong><code>ariaDescription</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-description</code> attribute, which defines a string value that describes or annotates the current element.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.html
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaDisabled
 <p>The <strong><code>ariaDisabled</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.html
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaExpanded
 <p>The <strong><code>ariaExpanded</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-expanded</code> attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.html
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaHasPopup
 <p>The <strong><code>ariaHasPopup</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-haspopup</code> attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariahidden/index.html
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaHidden
 <p>The <strong><code>ariaHidden</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute"><code>aria-hidden</code></a> attribute, which indicates whether the element is exposed to an accessibility API.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.html
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaKeyShortcuts
 <p>The <strong><code>ariaKeyShortcuts</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-keyshortcuts</code> attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/arialabel/index.html
+++ b/files/en-us/web/api/elementinternals/arialabel/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaLabel
 <p>The <strong><code>ariaLabel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute"><code>aria-label</code></a> attribute, which defines a string value that labels the current Element.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/arialevel/index.html
+++ b/files/en-us/web/api/elementinternals/arialevel/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaLevel
 <p>The <strong><code>ariaLevel</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-level</code> attribute, which defines the hierarchical level of an element within a structure.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/arialive/index.html
+++ b/files/en-us/web/api/elementinternals/arialive/index.html
@@ -15,8 +15,7 @@ browser-compat: api.ElementInternals.ariaLive
 <p>The <strong><code>ariaLive</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">aria-live</a></code> attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariamodal/index.html
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaModal
 <p>The <strong><code>ariaModal</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-modal</code> attribute, which indicates whether an element is modal when displayed.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.html
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaMultiline
 <p>The <strong><code>ariaMultiline</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiline</code> attribute, which indicates whether a text box accepts multiple lines of input or only a single line.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.html
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaMultiSelectable
 <p>The <strong><code>ariaMultiSelectable</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-multiselectable</code> attribute, which indicates that the user may select more than one item from the current selectable descendants.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.html
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaOrientation
 <p>The <strong><code>ariaOrientation</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute"><code>aria-orientation</code></a> attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.html
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaPlaceholder
 <p>The <strong><code>ariaPlaceholder</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-placeholder</code> attribute, which defines a short hint intended to aid the user with data entry when the control has no value.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.html
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaPosInSet
 <p>The <strong><code>ariaPosInSet</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-posinset</code> attribute, which defines an element's number or position in the current set of listitems or treeitems.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariapressed/index.html
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaPressed
 <p>The <strong><code>ariaPressed</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-pressed</code> attribute, which indicates the current "pressed" state of toggle buttons.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.html
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaReadOnly
 <p>The <strong><code>ariaReadOnly</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-readonly</code> attribute, which indicates that the element is not editable, but is otherwise operable.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.html
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRelevant
 <p>The <strong><code>ariaRelevant</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarequired/index.html
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRequired
 <p>The <strong><code>ariaRequired</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-required</code> attribute, which indicates that user input is required on the element before a form may be submitted.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.html
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRoleDescription
 <p>The <strong><code>ariaRoleDescription</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-roledescription</code> attribute, which defines a human-readable, author-localized description for the role of an element.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRowCount
 <p>The <strong><code>ariaRowCount</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowcount</code> attribute, which defines the total number of rows in a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRowIndex
 <p>The <strong><code>ariaRowIndex</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindex</code> attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRowIndexText
 <p>The <strong><code>ariaRowIndexText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowindextext</code> attribute, which defines a human readable text alternative of aria-rowindex.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.html
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaRowSpan
 <p>The <strong><code>ariaRowSpan</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-rowspan</code> attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariaselected/index.html
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaSelected
 <p>The <strong><code>ariaSelected</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-selected</code> attribute, which indicates the current "selected" state of elements that have a selected state.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.html
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaSetSize
 <p>The <strong><code>ariaSetSize</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-setsize</code> attribute, which defines the number of items in the current set of listitems or treeitems.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariasort/index.html
+++ b/files/en-us/web/api/elementinternals/ariasort/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaSort
 <p>The <strong><code>ariaSort</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <code>aria-sort</code> attribute, which indicates if items in a table or grid are sorted in ascending or descending order.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaValueMax
 <p>The <strong><code>ariaValueMax</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attribute, which defines the maximum allowed value for a range widget.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaValueMin
 <p>The <strong><code>ariaValueMin</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> attribute, which defines the minimum allowed value for a range widget.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaValueNow
 <p>The <strong><code>ariaValueNow</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> attribute, which defines the current value for a range widget.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.html
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.html
@@ -16,8 +16,7 @@ browser-compat: api.ElementInternals.ariaValueText
 <p>The <strong><code>ariaValueText</code></strong> property of the {{domxref("ElementInternals")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute, which defines the human readable text alternative of aria-valuenow for a range widget.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> Setting aria attributes on <code>ElementInternals</code> allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/elementinternals/index.html
+++ b/files/en-us/web/api/elementinternals/index.html
@@ -39,8 +39,7 @@ browser-compat: api.ElementInternals
 <p>The <code>ElementInternals</code> interface includes the following properties, defined on the <code>ARIAMixin</code> mixin.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
+  <p><strong>Note:</strong> These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">Accessibility Object Model explainer</a>.</p>
 </div>
 
 <dl>

--- a/files/en-us/web/api/elementinternals/setformvalue/index.html
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.html
@@ -28,8 +28,7 @@ ElementInternals.setFormValue(value, state);</pre>
 </dl>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>In general, <code>state</code> is used to pass information specified by a user, the <code>value</code> is suitable for submission to a server, post sanitization. For example, if a custom element asked a user to submit a date, the user might enter "3/15/2019". This would be the <code>state</code>. The server expects a date format of <code>2019-03-15</code>, the date in this format would be passed as the <code>value</code>.</p>
+  <p><strong>Note:</strong> In general, <code>state</code> is used to pass information specified by a user, the <code>value</code> is suitable for submission to a server, post sanitization. For example, if a custom element asked a user to submit a date, the user might enter "3/15/2019". This would be the <code>state</code>. The server expects a date format of <code>2019-03-15</code>, the date in this format would be passed as the <code>value</code>.</p>
 </div>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/elementinternals/setvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.html
@@ -48,8 +48,7 @@ ElementInternals.setValidity(flags, message, anchor);</pre>
     </ul>
 
     <div class="notecard note">
-      <h4>Note:</h4>
-      <p>To set all flags to <code>false</code>, indicating that this element passes all constraints validation, pass in an empty object <code>{}</code>. In this case, you do not need to also pass a <code>message</code>.</p>
+      <p><strong>Note:</strong> To set all flags to <code>false</code>, indicating that this element passes all constraints validation, pass in an empty object <code>{}</code>. In this case, you do not need to also pass a <code>message</code>.</p>
     </div>
   </dd>
   <dt><code>message</code>{{Optional_Inline}}</dt>

--- a/files/en-us/web/api/event/returnvalue/index.html
+++ b/files/en-us/web/api/event/returnvalue/index.html
@@ -24,8 +24,7 @@ browser-compat: api.Event.returnValue
   <code>false</code> prevents the default action.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>While <code>returnValue</code> has been adopted into the DOM
+  <p><strong>Note:</strong> While <code>returnValue</code> has been adopted into the DOM
     standard, it is present primarily to support existing code. You should use
     {{DOMxRef("Event.preventDefault", "preventDefault()")}}, and
     {{domxref("Event.defaultPrevented", "defaultPrevented")}} instead of this historical

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -97,8 +97,7 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
     <code><var>useCapture</var></code> defaults to <code>false</code>.</dd>
   <dd>
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For event listeners attached to the event target, the event is in the target phase,
+      <p><strong>Note:</strong> For event listeners attached to the event target, the event is in the target phase,
         rather than the capturing and bubbling phases.
         Event listeners in the “capturing” phase are called before event listeners in any non-capturing phases.</p>
     </div>
@@ -718,8 +717,7 @@ console.log(someString);  // Expected Value: 'Data' (will never output 'Data Aga
 </pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Although inner scopes have access to <code>const</code>,
+  <p><strong>Note:</strong> Although inner scopes have access to <code>const</code>,
     <code>let</code> variables from outer scopes, you cannot expect any changes to these
     variables to be accessible after the event listener definition, within the same outer
     scope. Why? Because by the time the event listener would execute, the scope in which
@@ -735,8 +733,7 @@ console.log(someString);  // Expected Value: 'Data' (will never output 'Data Aga
   candidates for sharing data among scopes. Let's explore this.</p>
 
   <div class="notecard note">
-    <h4>Note</h4>
-  <p>Functions in JavaScript are actually objects. (Hence they too
+  <p><strong>Note:</strong> Functions in JavaScript are actually objects. (Hence they too
     can have properties, and will be retained in memory even after they finish executing
     if assigned to a variable that persists in memory.)</p>
 </div>
@@ -771,8 +768,7 @@ window.setInterval(function() {
   can respond to the change).</p>
 
   <div class="notecard note">
-    <h4>Note</h4>
-    <p>Objects are stored in variables by reference, meaning only the
+    <p><strong>Note:</strong> Objects are stored in variables by reference, meaning only the
     memory location of the actual data is stored in the variable. Among other things, this
     means variables that "store" objects can actually affect other variables that get
     assigned ("store") the same object reference. When two variables reference the same
@@ -781,8 +777,7 @@ window.setInterval(function() {
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Because objects are stored in variables by reference, you can
+  <p><strong>Note:</strong> Because objects are stored in variables by reference, you can
     return an object from a function to keep it alive (preserve it in memory so you don't
     lose the data) after that function stops executing.</p>
 </div>
@@ -820,8 +815,7 @@ window.setInterval(function() {
   <code>handleEvent()</code> and also the {{event("DOMContentLoaded")}} event.</p>
 
   <div class="notecard note">
-    <h4>Note</h4>
-    <p><code>useCapture</code> is not supported, as IE 8 does not
+    <p><strong>Note:</strong> <code>useCapture</code> is not supported, as IE 8 does not
     have any alternative method. The following code only adds IE 8 support. This IE 8
     polyfill only works in standards mode: a doctype declaration is required.</p>
 </div>
@@ -1002,8 +996,7 @@ for(let i=0, j=0 ; i&lt;els.length ; i++){
   the user is scrolling.</p>
 
   <div class="notecard note">
-    <h4>Note</h4>
-    <p>See the compatibility table below if you need to know which
+    <p><strong>Note:</strong> See the compatibility table below if you need to know which
     browsers (and/or which versions of those browsers) implement this altered behavior.</p>
   </div>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -46,8 +46,7 @@ browser-compat: api.ExtendableCookieChangeEvent.changed
     </dl>
 
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+      <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
     </div>
   </dd>
 </dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -46,8 +46,7 @@ browser-compat: api.ExtendableCookieChangeEvent.deleted
     </dl>
 
     <div class="notecard note">
-      <h4>Note</h4>
-      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+      <p><strong>Note:</strong> For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
     </div>
   </dd>
 </dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -13,8 +13,7 @@ browser-compat: api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
 <p>The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-    <p>This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
+    <p><strong>Note:</strong> This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -21,8 +21,7 @@ browser-compat: api.ExtendableCookieChangeEvent
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
+  <p><strong>Note:</strong> A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
 </div>
 
 <h2 id="Constructor">Constructor</h2>

--- a/files/en-us/web/api/fetch_api/index.html
+++ b/files/en-us/web/api/fetch_api/index.html
@@ -45,8 +45,7 @@ tags:
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Find out more about using the Fetch API features in <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch">Using Fetch</a>, and study concepts in <a href="/en-US/docs/Web/API/Fetch_API/Basic_concepts">Fetch basic concepts</a>.</p>
+  <p><strong>Note:</strong> Find out more about using the Fetch API features in <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch">Using Fetch</a>, and study concepts in <a href="/en-US/docs/Web/API/Fetch_API/Basic_concepts">Fetch basic concepts</a>.</p>
 </div>
 
 <h3 id="Aborting_a_fetch">Aborting a fetch</h3>

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -38,8 +38,7 @@ tags:
 <p>The {{domxref("Response")}} object, in turn, does not directly contain the actual JSON response body but is instead a representation of the entire HTTP response. So, to extract the JSON body content from the {{domxref("Response")}} object, we use the {{domxref("Response.json()", "json()")}} method, which returns a second promise that resolves with the result of parsing the response body text as JSON.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>See the {{anch("Body")}} section for similar methods to extract other types of body content.</p>
+  <p><strong>Note:</strong> See the {{anch("Body")}} section for similar methods to extract other types of body content.</p>
 </div>
 
 <p>Fetch requests are controlled by the <code>connect-src</code> directive of <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">Content Security Policy</a> rather than the directive of the resources it's retrieving.</p>
@@ -94,13 +93,11 @@ postData('https://example.com/answer', { answer: 42 })
 </pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p><code>Access-Control-Allow-Origin</code> is prohibited from using a wildcard for requests with <code>credentials: 'include'</code>. In such cases, the exact origin must be provided; even if you are using a CORS unblocker extension, the requests will still fail.</p>
+  <p><strong>Note:</strong> <code>Access-Control-Allow-Origin</code> is prohibited from using a wildcard for requests with <code>credentials: 'include'</code>. In such cases, the exact origin must be provided; even if you are using a CORS unblocker extension, the requests will still fail.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Browsers should not send credentials in <em>preflight requests</em> irrespective of this setting. For more information see: <a href="/en-US/docs/Web/HTTP/CORS#requests_with_credentials">CORS > Requests with credentials</a>.</p>
+  <p><strong>Note:</strong> Browsers should not send credentials in <em>preflight requests</em> irrespective of this setting. For more information see: <a href="/en-US/docs/Web/HTTP/CORS#requests_with_credentials">CORS > Requests with credentials</a>.</p>
 </div>
 
 
@@ -283,8 +280,7 @@ fetch(myRequest)
 <p>This is pretty useful, as request and response bodies are one use only. Making a copy like this allows you to make use of the request/response again while varying the <code>init</code> options if desired. The copy must be made before the body is read, and reading the body in the copy will also mark it as read in the original request.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>There is also a {{domxref("Request.clone","clone()")}} method that creates a copy. Both methods of creating a copy will fail if the body of the original request or response has already been read, but reading the body of a cloned response or request will not cause it to be marked as read in the original.</p>
+  <p><strong>Note:</strong> There is also a {{domxref("Request.clone","clone()")}} method that creates a copy. Both methods of creating a copy will fail if the body of the original request or response has already been read, but reading the body of a cloned response or request will not cause it to be marked as read in the original.</p>
 </div>
 
 <h2 id="Headers">Headers</h2>
@@ -364,8 +360,7 @@ try {
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>You may not append or set the <code>Content-Length</code> header on a guarded headers object for a <code>response</code>. Similarly, inserting <code>Set-Cookie</code> into a response header is not allowed: ServiceWorkers are not allowed to set cookies via synthesized responses.</p>
+  <p><strong>Note:</strong> You may not append or set the <code>Content-Length</code> header on a guarded headers object for a <code>response</code>. Similarly, inserting <code>Set-Cookie</code> into a response header is not allowed: ServiceWorkers are not allowed to set cookies via synthesized responses.</p>
 </div>
 
 <h2 id="Response_objects">Response objects</h2>
@@ -397,8 +392,7 @@ addEventListener('fetch', function(event) {
 <p>The {{domxref("Response.Response","Response()")}} constructor takes two optional arguments — a body for the response, and an init object (similar to the one that {{domxref("Request.Request","Request()")}} accepts.)</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The static method {{domxref("Response.error","error()")}} returns an error response. Similarly, {{domxref("Response.redirect","redirect()")}} returns a response resulting in a redirect to a specified URL. These are also only relevant to Service Workers.</p>
+  <p><strong>Note:</strong> The static method {{domxref("Response.error","error()")}} returns an error response. Similarly, {{domxref("Response.redirect","redirect()")}} returns a response resulting in a redirect to a specified URL. These are also only relevant to Service Workers.</p>
 </div>
 
 <h2 id="Body">Body</h2>

--- a/files/en-us/web/api/fileexception/index.html
+++ b/files/en-us/web/api/fileexception/index.html
@@ -55,8 +55,7 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
 <h2 id="Constants">Constants</h2>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
+  <p><strong>Note:</strong> Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
 </div>
 
 <table class="standard-table">

--- a/files/en-us/web/api/hid/requestdevice/index.html
+++ b/files/en-us/web/api/hid/requestdevice/index.html
@@ -40,8 +40,7 @@ browser-compat: api.HID.requestDevice
 </dl>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>The device filters are used to narrow the list of devices presented to the user. If no filters are present, all connected devices are shown. When one or more filters are included, a device is included if any filter matches. To match a filter, all of the rules included in that filter must match.</p>
+  <p><strong>Note:</strong> The device filters are used to narrow the list of devices presented to the user. If no filters are present, all connected devices are shown. When one or more filters are included, a device is included if any filter matches. To match a filter, all of the rules included in that filter must match.</p>
 </div>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/hiddevice/open/index.html
+++ b/files/en-us/web/api/hiddevice/open/index.html
@@ -14,8 +14,7 @@ browser-compat: api.HIDDevice.open
 <p>The <strong><code>open()</code></strong> method of the {{domxref("HIDDevice")}} interface requests that the operating sytem opens the HID device.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>HID devices are not opened automatically. Therefore, a {{domxref("HIDDevice")}} returned by {{domxref("HID.getRequestDevice()")}} must be opened with this method before it is available to transfer data.</p>
+  <p><strong>Note:</strong> HID devices are not opened automatically. Therefore, a {{domxref("HIDDevice")}} returned by {{domxref("HID.getRequestDevice()")}} must be opened with this method before it is available to transfer data.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/htmlcanvaselement/mozopaque/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/mozopaque/index.html
@@ -20,8 +20,7 @@ browser-compat: api.HTMLCanvasElement.mozOpaque
   performance can be optimized.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This has been standardized as setting the <code>alpha</code> option to
+  <p><strong>Note:</strong> This has been standardized as setting the <code>alpha</code> option to
   <code>false</code> when creating a drawing context with
   {{domxref("HTMLCanvasElement.getContext()")}}. Use of <code>mozOpaque</code> should be
   avoided. Firefox will stop supporting it in the future.</p>

--- a/files/en-us/web/api/htmlhtmlelement/version/index.html
+++ b/files/en-us/web/api/htmlhtmlelement/version/index.html
@@ -14,8 +14,7 @@ browser-compat: api.HTMLHtmlElement.version
 <div>{{ APIRef("HTML DOM") }} {{deprecated_header}}</div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This property has been declared as deprecated by the W3C technical recommendation for HTML 4.01 in favor of use of the DTD for obtaining version information for a document.</p>
+  <p><strong>Note:</strong> This property has been declared as deprecated by the W3C technical recommendation for HTML 4.01 in favor of use of the DTD for obtaining version information for a document.</p>
 </div>
 
 <p>Returns version information about the document type definition (DTD) of a document. While this property is recognized by Mozilla, the return value for this property is always an empty string.</p>

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -44,8 +44,7 @@ browser-compat: api.IDBDatabaseException
 <h2 id="Constants">Constants</h2>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
+  <p><strong>Note:</strong> Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
 </div>
 
 <table class="standard-table">

--- a/files/en-us/web/api/idbenvironmentsync/index.html
+++ b/files/en-us/web/api/idbenvironmentsync/index.html
@@ -34,8 +34,7 @@ tags:
    <td><code>readonly <a href="/en-US/docs/Web/API/IDBFactorySync">IDBFactorySync</a></code></td>
    <td>Provides a synchronous means of accessing the capabilities of indexed databases. 
      <div class="notecard note">
-       <h4>Note</h4>
-       <p>Until the Indexed Database API specification is finalized, this attribute should be accessed as <code>moz_indexedDBSync</code>.</p>
+       <p><strong>Note:</strong> Until the Indexed Database API specification is finalized, this attribute should be accessed as <code>moz_indexedDBSync</code>.</p>
      </div>  
     </td>
   </tr>

--- a/files/en-us/web/api/idbfactory/databases/index.html
+++ b/files/en-us/web/api/idbfactory/databases/index.html
@@ -18,8 +18,7 @@ browser-compat: api.IDBFactory.databases
 <p>{{AvailableInWorkers}}</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This method is introduced in a draft of a specifications and browser compatibility is limited.</p>
+  <p><strong>Note:</strong> This method is introduced in a draft of a specifications and browser compatibility is limited.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/idbobjectstore/get/index.html
+++ b/files/en-us/web/api/idbobjectstore/get/index.html
@@ -25,8 +25,7 @@ browser-compat: api.IDBObjectStore.get
   request object.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This method produces the same result for: a) a record that doesn't exist in the database and b) a record that has an undefined value.
+  <p><strong>Note:</strong> This method produces the same result for: a) a record that doesn't exist in the database and b) a record that has an undefined value.
     To tell these situations apart, call the <code>openCursor()</code> method with the same key. That method provides a cursor if the record exists, and no cursor if it does not.</p>
 </div>
 

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
@@ -62,8 +62,7 @@ browser-compat: api.InputDeviceInfo.getCapabilities
 </dl>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>If the user has not granted permission to access the input device an empty object will be returned.</p>
+  <p><strong>Note:</strong> If the user has not granted permission to access the input device an empty object will be returned.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.html
@@ -14,8 +14,7 @@ browser-compat: api.InterventionReportBody.columnNumber
 <p>The <strong><code>columnNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} and {{domxref("InterventionReportBody.lineNumber")}} as it enables the location of the column in that file and line where the feature is used.</p>
+  <p><strong>Note:</strong> This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} and {{domxref("InterventionReportBody.lineNumber")}} as it enables the location of the column in that file and line where the feature is used.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.html
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.html
@@ -14,8 +14,7 @@ browser-compat: api.InterventionReportBody.lineNumber
 <p>The <strong><code>lineNumber</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} as it enables the location of the line in that file where the feature is used.</p>
+  <p><strong>Note:</strong> This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} as it enables the location of the line in that file where the feature is used.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.html
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.html
@@ -14,8 +14,7 @@ browser-compat: api.InterventionReportBody.sourceFile
 <p>The <strong><code>sourceFile</code></strong> read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>This property can be used with {{domxref("InterventionReportBody.lineNumber")}} and {{domxref("InterventionReportBody.columnNumber")}} to locate the column and line in the file where the feature is used.</p>
+  <p><strong>Note:</strong> This property can be used with {{domxref("InterventionReportBody.lineNumber")}} and {{domxref("InterventionReportBody.columnNumber")}} to locate the column and line in the file where the feature is used.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/mutationevent/index.html
+++ b/files/en-us/web/api/mutationevent/index.html
@@ -13,8 +13,7 @@ browser-compat: api.MutationEvent
 <div>{{APIRef("DOM Events")}}{{Deprecated_Header}}</div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p><a href="https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents">Mutation Events</a> (W3C DOM Level 3 Events) have been deprecated in favor of <a href="/en-US/docs/Web/API/MutationObserver">Mutation Observers</a> (W3C DOM4).</p>
+  <p><strong>Note:</strong> <a href="https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents">Mutation Events</a> (W3C DOM Level 3 Events) have been deprecated in favor of <a href="/en-US/docs/Web/API/MutationObserver">Mutation Observers</a> (W3C DOM4).</p>
 </div>
 
 <p>The <code><strong>MutationEvent</strong></code> interface provides event properties that are specific to modifications to the Document Object Model (DOM) hierarchy and nodes.</p>

--- a/files/en-us/web/api/navigator/appname/index.html
+++ b/files/en-us/web/api/navigator/appname/index.html
@@ -17,8 +17,7 @@ browser-compat: api.Navigator.appName
   purposes.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on this property to return a real browser name. All browsers return "<code>Netscape</code>" as the value of this property.</p>
+  <p><strong>Note:</strong> Do not rely on this property to return a real browser name. All browsers return "<code>Netscape</code>" as the value of this property.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigator/appversion/index.html
+++ b/files/en-us/web/api/navigator/appversion/index.html
@@ -16,8 +16,7 @@ browser-compat: api.Navigator.appVersion
   the browser.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on this property to return the correct browser version.</p>
+  <p><strong>Note:</strong> Do not rely on this property to return the correct browser version.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigator/mozislocallyavailable/index.html
+++ b/files/en-us/web/api/navigator/mozislocallyavailable/index.html
@@ -15,8 +15,7 @@ browser-compat: api.Navigator.mozIsLocallyAvailable
   add-ons to determine whether or not a given resource is available.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Security exceptions can occur if the requested URI is not from the same origin.</p>
+  <p><strong>Note:</strong> Security exceptions can occur if the requested URI is not from the same origin.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.html
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.html
@@ -14,8 +14,7 @@ browser-compat: api.NavigatorUAData.getHighEntropyValues
 <p>The <strong><code>getHighEntropyValues()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the <em>high entropy</em> values the user-agent returns.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.</p>
+  <p><strong>Note:</strong> The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigatoruadata/index.html
+++ b/files/en-us/web/api/navigatoruadata/index.html
@@ -15,8 +15,7 @@ browser-compat: api.NavigatorUAData
 <p>An instance of this object is returned by calling {{domxref("Navigator.userAgentData")}}. Therefore, this interface has no constructor.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.</p>
+  <p><strong>Note:</strong> The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>

--- a/files/en-us/web/api/navigatoruadata/tojson/index.html
+++ b/files/en-us/web/api/navigatoruadata/tojson/index.html
@@ -14,8 +14,7 @@ browser-compat: api.NavigatorUAData.toJSON
 <p>The <strong><code>toJSON()</code></strong> method of the {{domxref("NavigatorUAData")}} interface is a <em>serializer</em> that returns a JSON representation of the <em>low entropy</em> properties of the <code>NavigatorUAData</code> object.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The low entropy values returned by this method are those which do not reveal information able to identify a user. High entropy values can only be returned by the {{domxref("NavigatorUAData.getHighEntropyValues()")}} method.</p>
+  <p><strong>Note:</strong> The terms <em>high entropy</em> and <em>low entropy</em> refer to the amount of information these values reveal about the browser. The low entropy values returned by this method are those which do not reveal information able to identify a user. High entropy values can only be returned by the {{domxref("NavigatorUAData.getHighEntropyValues()")}} method.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/proximity_events/index.html
+++ b/files/en-us/web/api/proximity_events/index.html
@@ -25,8 +25,7 @@ There are two proximity events (see links for documentation.):
  <p>The difference between them is that {{domxref("UserProximityEvent")}} simply notifies <code>true</code> when the user is considered "close", while {{domxref("DeviceProximityEvent")}} provides an estimate of the actual distance to a nearby object.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Obviously, the API requires the device to have a proximity sensor, which are mostly available only on mobile devices. Devices without such a sensor may support those events but will never fire them.</p>
+  <p><strong>Note:</strong> Obviously, the API requires the device to have a proximity sensor, which are mostly available only on mobile devices. Devices without such a sensor may support those events but will never fire them.</p>
 </div>
 
 

--- a/files/en-us/web/api/remote_playback_api/index.html
+++ b/files/en-us/web/api/remote_playback_api/index.html
@@ -18,8 +18,7 @@ tags:
 <p>The API enables a page, which has an media element such as a video or audio file, to initiate and control playback of that media on a connected remote device. For example, playing a video on a connected TV.</p>
 
 <div class="notecard note">
-  <h4>Proprietary APIs</h4>
-  <p>Safari for iOS has some APIs which enable remote playback on AirPlay. Details of these can be found in <a href="https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_0.html#//apple_ref/doc/uid/TP40014305-CH9-SW16">the Safari 9.0 release notes</a>.</p>
+  <p><strong>Note:</strong>Safari for iOS has some APIs which enable remote playback on AirPlay. Details of these can be found in <a href="https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_0.html#//apple_ref/doc/uid/TP40014305-CH9-SW16">the Safari 9.0 release notes</a>.</p>
 
   <p>Android versions of Firefox and Chrome also contain some remote playback features. These devices will show a Cast button if there is a Cast device available in the local network.</p>
 </div>

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.html
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.html
@@ -14,8 +14,7 @@ browser-compat: api.ResizeObserverSize.blockSize
 <p>The <strong><code>blockSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the block dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or width.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
+  <p><strong>Note:</strong> For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/resizeobserversize/index.html
+++ b/files/en-us/web/api/resizeobserversize/index.html
@@ -13,8 +13,7 @@ browser-compat: api.ResizeObserverSize
 <p>The <strong><code>ResizeObserverSize</code></strong> interface of the {{domxref('Resize Observer API')}} is used by the {{domxref("ResizeObserverEntry")}} interface to access the box sizing properties of the element being observed.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>In <a href="/en-US/docs/Web/CSS/CSS_Columns">multi-column layout</a>, which is a fragmented context, the sizing returned by <code>ResizeObserverSize</code> will be the size of the first column.</p>
+  <p><strong>Note:</strong> In <a href="/en-US/docs/Web/CSS/CSS_Columns">multi-column layout</a>, which is a fragmented context, the sizing returned by <code>ResizeObserverSize</code> will be the size of the first column.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>
@@ -29,8 +28,7 @@ browser-compat: api.ResizeObserverSize
 </dl>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
+  <p><strong>Note:</strong> For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.html
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.html
@@ -14,8 +14,7 @@ browser-compat: api.ResizeObserverSize.inlineSize
 <p>The <strong><code>inlineSize</code></strong> read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the inline dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or height.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
+  <p><strong>Note:</strong> For more explanation of writing modes and block and inline dimensions, read <a href="/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions">Handling different text directions</a>.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -24,8 +24,7 @@ tags:
 
 
 <div class="notecard note">
-  <h4>Tip</h4>
-  <p>On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
+  <p><strong>Note:</strong> On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -29,13 +29,11 @@ tags:
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Unlike previous attempts in this area such as <a href="https://alistapart.com/article/application-cache-is-a-douchebag">AppCache</a>, service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.</p>
+  <p><strong>Note:</strong> Unlike previous attempts in this area such as <a href="https://alistapart.com/article/application-cache-is-a-douchebag">AppCache</a>, service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Service workers make heavy use of <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.</p>
+  <p><strong>Note:</strong> Service workers make heavy use of <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.</p>
 </div>
 
 <h3 id="Registration">Registration</h3>
@@ -74,8 +72,7 @@ tags:
 <p>Your service worker can respond to requests using the {{DOMxRef("FetchEvent")}} event. You can modify the response to these requests in any way you want, using the {{DOMxRef("FetchEvent.respondWith()")}} method.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Because <code>install</code>/<code>activate</code> events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on <code>install</code> or <code>activate</code> events with a promise, functional events such as <code>fetch</code> and <code>push</code> will wait until the promise is successfully resolved.</p>
+  <p><strong>Note:</strong> Because <code>install</code>/<code>activate</code> events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on <code>install</code> or <code>activate</code> events with a promise, functional events such as <code>fetch</code> and <code>push</code> will wait until the promise is successfully resolved.</p>
 </div>
 
 <p>For a complete tutorial to show how to build up your first basic example, read <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers</a>.</p>

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.html
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.html
@@ -19,8 +19,7 @@ tags:
  The previous attempt — <a href="/en-US/docs/Web/HTML/Using_the_application_cache">AppCache</a> — seemed to be a good idea because it allowed you to specify assets to cache really easily. However, it made many assumptions about what you were trying to do and then broke horribly when your app didn’t follow those assumptions exactly. Read Jake Archibald's (unfortunately-titled but well-written) <a href="https://alistapart.com/article/application-cache-is-a-douchebag">Application Cache is a Douchebag</a> for more details.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>From Firefox 84, AppCache has been removed ({{bug("1619673")}}). It is also planned for removal in Chomium 90, and is deprecated in Safari.</p>
+  <p><strong>Note:</strong> From Firefox 84, AppCache has been removed ({{bug("1619673")}}). It is also planned for removal in Chomium 90, and is deprecated in Safari.</p>
 </div>
 
 <p>Service workers should finally fix these issues. Service worker syntax is more complex than that of AppCache, but the trade off is that you can use JavaScript to control your AppCache-implied behaviors with a fine degree of granularity, allowing you to handle this problem and many more. Using a Service worker you can easily set an app up to use cached assets first, thus providing a default experience even when offline, before then getting more data from the network (commonly known as <a href="http://offlinefirst.org/">Offline First</a>). This is already available with native apps, which is one of the main reasons native apps are often chosen over web apps.</p>
@@ -81,8 +80,7 @@ tags:
  Instead, we could build our own promise to handle this kind of case. (See our <a href="https://github.com/mdn/js-examples/tree/master/promises-test">Promises test</a> example for the source code, or <a href="https://mdn.github.io/js-examples/promises-test/">look at it running live</a>.)</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>A real service worker implementation would use caching and onfetch rather than the XMLHttpRequest API. Those features are not used here so that you can focus on understanding Promises.</p>
+  <p><strong>Note:</strong> A real service worker implementation would use caching and onfetch rather than the XMLHttpRequest API. Those features are not used here so that you can focus on understanding Promises.</p>
 </div>
 
 

--- a/files/en-us/web/api/svggraphicselement/getbbox/index.html
+++ b/files/en-us/web/api/svggraphicselement/getbbox/index.html
@@ -18,8 +18,7 @@ browser-compat: api.SVGGraphicsElement.getBBox
   geometry attributes on all the elements contained in the target element).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p><code>getBBox()</code> must return the actual bounding box at
+  <p><strong>Note:</strong> <code>getBBox()</code> must return the actual bounding box at
     the time the method was called—even in case the element has not yet been rendered. It
     also does not account for any transformation applied to the element or its parents.
   </p>

--- a/files/en-us/web/api/transformstream/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/transformstream/index.html
@@ -65,8 +65,7 @@ new TransformStream(transformer, writableStrategy, readableStrategy);</pre>
 </dl>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>You could define your own custom
+  <p><strong>Note:</strong> You could define your own custom
     <code>readableStrategy</code> or <code>writableStrategy</code>, or use an instance of
     {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}}
     for the object values.</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -18,13 +18,11 @@ browser-compat: api.TrustedTypePolicyFactory.createPolicy
 <p>In Chrome a policy with a name of "default" creates a special policy that will be used if a string (rather than a Trusted Type object) is passed to an injection sink. This can be used in a transitional phase while moving from an application that inserted strings into injection sinks.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The above behavior is not yet settled in the specification and may change in future.</p>
+  <p><strong>Note:</strong> The above behavior is not yet settled in the specification and may change in future.</p>
 </div>
 
 <div class="notecard warning">
-  <h4>Note</h4>
-  <p>A lax default policy could defeat the purpose of using Trusted Types, and therefore should be defined with strict rules to ensure it cannot be used to run dangerous code.</p>
+  <p><strong>Note:</strong> A lax default policy could defeat the purpose of using Trusted Types, and therefore should be defined with strict rules to ensure it cannot be used to run dangerous code.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -14,8 +14,7 @@ browser-compat: api.TrustedTypePolicyFactory.defaultPolicy
 <p>The <strong><code>defaultPolicy</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Information about the creation and use of default policies can be found in the <code><a href="/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#default_policy">createPolicy()</a></code> documentation.</p>
+  <p><strong>Note:</strong> Information about the creation and use of default policies can be found in the <code><a href="/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#default_policy">createPolicy()</a></code> documentation.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -14,8 +14,7 @@ browser-compat: api.TrustedTypePolicyFactory.isHTML
 <p>The <strong><code>isHTML()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedHTML")}} object.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>The purpose of the functions <code>isHTML()</code>, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p><strong>Note:</strong> The purpose of the functions <code>isHTML()</code>, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -14,8 +14,7 @@ browser-compat: api.TrustedTypePolicyFactory.isScript
 <p>The <strong><code>isScript()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScript")}} object.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>The purpose of the functions <code>isScript()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p><strong>Note:</strong> The purpose of the functions <code>isScript()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -14,8 +14,7 @@ browser-compat: api.TrustedTypePolicyFactory.isScriptURL
 <p>The <strong><code>isScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScriptURL")}} object.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>The purpose of the functions <code>isScriptURL()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p><strong>Note:</strong> The purpose of the functions <code>isScriptURL()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
@@ -31,9 +31,7 @@ tags:
 </ol>
 
 <div class="notecard note">
-<h4>Channel notation</h4>
-
-<p>The number of audio channels available on a signal is frequently presented in a numeric format, such as 2.0 or 5.1. This is called {{interwiki("wikipedia", "Surround_sound#Channel_notation", "channel notation")}}. The first number is the number of full frequency range audio channels that the signal includes. The number after the period indicates the number of those channels which are reserved for low-frequency effect (LFE) outputs; these are often referred to as <strong>subwoofers</strong>.</p>
+<p><strong>Note:</strong> The number of audio channels available on a signal is frequently presented in a numeric format, such as 2.0 or 5.1. This is called {{interwiki("wikipedia", "Surround_sound#Channel_notation", "channel notation")}}. The first number is the number of full frequency range audio channels that the signal includes. The number after the period indicates the number of those channels which are reserved for low-frequency effect (LFE) outputs; these are often referred to as <strong>subwoofers</strong>.</p>
 </div>
 
 <p><img alt="A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information." src="webaudioapi_en.svg"></p>

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
@@ -96,8 +96,7 @@ gl.vertexAttribPointer(aVertexPosition, vertexNumComponents,
 gl.drawArrays(gl.TRIANGLES, 0, vertexCount);</pre>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>This code snippet is taken from <a
+  <p><strong>Note:</strong> This code snippet is taken from <a
     href="/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#Drawing_and_animating_the_scene">the
     function <code>animateScene()</code></a> in "A basic 2D WebGL animation example." See
   that article for the full sample and to see the resulting animation in action.</p>

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
@@ -136,8 +136,7 @@ gl.uniform2fv(uRotationVector, currentRotation);
 gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);</pre>
 
 <div class="notecard note">
-    <h3>Note</h3>
-    <p>This code snippet is taken from <a
+    <p><strong>Note:</strong> This code snippet is taken from <a
         href="/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#Drawing_and_animating_the_scene">the
         function <code>animateScene()</code></a> in "A basic 2D WebGL animation example."
     See that article for the full sample and to see the resulting animation in action.</p>

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.html
@@ -33,8 +33,7 @@ hangUpBtn.addEventListener('click', function (){
 </ol>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The <code>on('close')</code> event that is called on the <code>conn</code> variable isn’t available in Firefox yet; this just means that in Firefox each caller will have to hang up individually.</p>
+  <p><strong>Note:</strong> The <code>on('close')</code> event that is called on the <code>conn</code> variable isn’t available in Firefox yet; this just means that in Firefox each caller will have to hang up individually.</p>
 </div>
 
 <div class="notecard warning">

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
@@ -24,8 +24,7 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs
 <p>Before you get started, you'll want to make sure you've <a href="https://nodejs.org/en/download/">installed node</a> and <a href="https://classic.yarnpkg.com/en/docs/install" rel="noopener nofollow">Yarn</a> (the instructions in later articles assume Yarn, but you can feel free to use <a href="https://docs.npmjs.com/getting-started/">npm</a> or annother manager if you'd prefer).</p>
 
 <div class="note notecard">
-  <h4>Note</h4>
-  <p>If you learn better by following step-by-step code, we've also provided this <a href="https://github.com/SamsungInternet/WebPhone/tree/master/tutorial">tutorial in code</a>, which you can use instead.</p>
+  <p><strong>Note:</strong> If you learn better by following step-by-step code, we've also provided this <a href="https://github.com/SamsungInternet/WebPhone/tree/master/tutorial">tutorial in code</a>, which you can use instead.</p>
 </div>
 
   <h3>Table of Contents</h3>

--- a/files/en-us/web/api/webrtc_api/intro_to_rtp/index.html
+++ b/files/en-us/web/api/webrtc_api/intro_to_rtp/index.html
@@ -47,11 +47,6 @@ tags:
 
 <p>RTP itself doesn't provide every possible feature, which is why other protocols are also used by WebRTC. Some of the more noteworthy things RTP doesn't include:</p>
 
-<div class="notecard note">
-  <h4>Editor's note</h4>
-  <p> we should add information about where these deficiencies are compensated for, if they are at all.</p>
-</div>
-
 <ul>
  <li>RTP does <em>not</em> guarantee <strong>{{interwiki("wikipedia", "quality-of-service")}}</strong> (<strong>QoS</strong>).</li>
  <li>While RTP is intended for use in latency-critical scenarios, it doesn't inherently offer any features that ensure QoS. Instead, it only offers the information necessary to allow QoS to be implemented elsewhere in the stack.</li>

--- a/files/en-us/web/api/window/showmodaldialog/index.html
+++ b/files/en-us/web/api/window/showmodaldialog/index.html
@@ -81,8 +81,7 @@ browser-compat: api.Window.showModalDialog
 </table>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Firefox does not implement the <code>dialogHide</code>, <code>edge</code>, <code>status</code>, or <code>unadorned</code> arguments.</p>
+  <p><strong>Note:</strong> Firefox does not implement the <code>dialogHide</code>, <code>edge</code>, <code>status</code>, or <code>unadorned</code> arguments.</p>
 </div>
 
 <h2 id="Notes">Notes</h2>

--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -96,8 +96,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.fetch
           <dt><code>include</code></dt>
           <dd>Tells browsers to include credentials in both same- and cross-origin requests, and always use any credentials sent back in responses.
             <div class="notecard note">
-              <h4>Note</h4>
-              <p>Credentials may be included in simple and "final" cross-origin requests, but should not be included in <a href="/en-US/docs/Web/HTTP/CORS#preflight_requests_and_credentials">CORS preflight requests</a>.</p>
+              <p><strong>Note:</strong> Credentials may be included in simple and "final" cross-origin requests, but should not be included in <a href="/en-US/docs/Web/HTTP/CORS#preflight_requests_and_credentials">CORS preflight requests</a>.</p>
             </div>
           </dd>
         </dl>

--- a/files/en-us/web/api/workernavigator/appname/index.html
+++ b/files/en-us/web/api/workernavigator/appname/index.html
@@ -17,8 +17,7 @@ browser-compat: api.WorkerNavigator.appName
   purposes.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on this property to return a real browser name. All browsers return "<code>Netscape</code>" as the value of this property.</p>
+  <p><strong>Note:</strong> Do not rely on this property to return a real browser name. All browsers return "<code>Netscape</code>" as the value of this property.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/workernavigator/appversion/index.html
+++ b/files/en-us/web/api/workernavigator/appversion/index.html
@@ -16,8 +16,7 @@ browser-compat: api.WorkerNavigator.appVersion
   the browser.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Do not rely on this property to return the correct browser version.</p>
+  <p><strong>Note:</strong> Do not rely on this property to return the correct browser version.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -58,8 +58,7 @@ browser-compat: api.XMLHttpRequest
  <dt id="xmlhttprequest-statustext">{{domxref("XMLHttpRequest.statusText")}} {{readonlyinline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the response string returned by the HTTP server. Unlike {{domxref("XMLHttpRequest.status")}}, this includes the entire text of the response message ("<code>200 OK</code>", for example).
  <div class="notecard note">
-   <h4>Note</h4>
-    <p>According to the HTTP/2 specification (<a href="https://http2.github.io/http2-spec/#rfc.section.8.1.2.4">8.1.2.4</a> <a href="https://http2.github.io/http2-spec/#HttpResponse">Response Pseudo-Header Fields</a>), HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.</p>
+    <p><strong>Note:</strong> According to the HTTP/2 specification (<a href="https://http2.github.io/http2-spec/#rfc.section.8.1.2.4">8.1.2.4</a> <a href="https://http2.github.io/http2-spec/#HttpResponse">Response Pseudo-Header Fields</a>), HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.</p>
  </div>
  </dd>
  <dt id="xmlhttprequest-timeout">{{domxref("XMLHttpRequest.timeout")}}</dt>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8180.

A common way in which notes and warnings are not convertible to Markdown is for the note to use a `<h4>` instead of `<strong>`.

This PR converts these cases. There are four commits:

* the first automates `<h4>Note</h4>` conversion
* the second automates `<h4>Note:</h4>` conversion
* the third manually fixes a few stragglers
* the fourth fixes a few instances of `<h3>Note</h3>`

