### PR TITLE
Replace element reference and strange empty chars

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/list_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.html
@@ -10,7 +10,7 @@ tags:
   - Role
   - list
 ---
-<p><span class="seoSummary">The ARIA <code>list</code> role can be used to identify a list of items. It is normally used in conjunction with the <code>listitem</code> role, which is used to identify a list item contained inside the list.</span></p>
+<p>The ARIA <code>list</code> role can be used to identify a list of items. It is normally used in conjunction with the <code>listitem</code> role, which is used to identify a list item contained inside the list.</p>
 
 <pre class="brush: html">&lt;section role="list"&gt;
   &lt;div role="listitem"&gt;List item 1&lt;/div&gt;
@@ -23,11 +23,11 @@ tags:
 
 <p>Any content that consists of an outer container with a list of elements inside it can be identified to assistive technologies using the <code>list</code> and <code>listitem</code> containers respectively. A <code>list</code> must have one or more <code>listitem</code> children, or, alternatively, have one or more <code>group</code>s as children, with each <code>group</code> having one or more <code>listitem</code>s as children.</p>
 
-<p>There are no hard and fast rules about which elements you should use to markup the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.</p>
+<p>There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.</p>
 
 <div class="notecard warning">
   <h4>Warning</h4>
-  <p>If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{htmlelement("ul")}}/{{htmlelement("ol")}} and {{htmlelement("li")}}. See {{anch("Best practices")}} for a full example.</p>
+  <p>If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{HTMLElement("ul")}}, {{HTMLElement("ol")}} and {{HTMLElement("li")}}. See {{anch("Best practices")}} for a full example.</p>
 </div>
 
 <h3 id="Associated_WAI-ARIA_Roles_States_and_Properties">Associated WAI-ARIA Roles, States, and Properties</h3>
@@ -53,13 +53,13 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p> <a href="https://www.scottohara.me/blog/2018/05/26/aria-lists.html">ARIA Lists</a> — some useful examples and thoughts by Scott O'Hara</p>
+<p><a href="https://www.scottohara.me/blog/2018/05/26/aria-lists.html">ARIA Lists</a> — some useful examples and thoughts by Scott O'Hara</p>
 
 <h2 id="Best_practices">Best practices</h2>
 
 <p>Only use <code>role="list"</code> and <code>role="listitem"</code> if you have to — for example if you don't have control over your HTML but are able to improve accessibility dynamically after the fact with JavaScript.</p>
 
-<p>Unlike the HTML<span class="ILfuVd yZ8quc"> {{htmlelement("ol")}} and {{htmlelement("ul")}}, </span>the ARIA <code>list</code> roles doesn't distinguish between ordered and unordered lists. If at all possible, you<span class="ILfuVd yZ8quc"> should use the appropriate semantic HTML elements to mark up a list ({{htmlelement("ol")}} and {{htmlelement("ul")}}) and list items ({{htmlelement("li")}}). </span><span class="ILfuVd yZ8quc"> For example, our above example should be rewritten as follows:</span></p>
+<p>Unlike the HTML {{HTMLElement("ol")}} and {{HTMLElement("ul")}}, the ARIA <code>list</code> roles doesn't distinguish between ordered and unordered lists. If at all possible, you should use the appropriate semantic HTML elements to mark up a list ({{HTMLElement("ol")}} and {{HTMLElement("ul")}}) and list items ({{HTMLElement("li")}}). For example, our above example should be rewritten as follows:</p>
 
 <pre class="brush: html">&lt;ul&gt;
   &lt;li&gt;List item 1&lt;/li&gt;
@@ -75,19 +75,19 @@ tags:
   &lt;li&gt;List item 3&lt;/li&gt;
 &lt;/ol&gt;</pre>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: The ARIA list/listitem roles don't distinguish between ordered and unordered lists.</p>
 </div>
 
 <p>As an aside, note that if you are using the semantic HTML elements of ol or ul and apply a role of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_presentation_role">presentation</a>, each child <code>li</code> element inherits the <code>presentation</code> role because ARIA requires the <code>listitem</code> elements to have the parent <code>list</code> element. So, the <code>li</code> elements are not exposed to assistive technologies, but elements contained inside of those <code>li</code> elements, including nested lists, are visible to assistive technologies.</p>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: If you are marking up a list of items that will function as a tabbed interface, you should instead use the <code>tab</code>, <code>tabpanel</code>, and <code>tablist</code> roles.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="col">Specification</th>
@@ -109,9 +109,9 @@ tags:
 <ul>
  <li><a href="https://wicg.github.io/aom/spec/">Accessibility Object Model</a></li>
  <li><a href="https://w3c.github.io/html-aria/">ARIA in HTML</a></li>
- <li><span class="ILfuVd yZ8quc">{{htmlelement("ul")}}</span></li>
- <li><span class="ILfuVd yZ8quc">{{htmlelement("ol")}}</span></li>
- <li><span class="ILfuVd yZ8quc">{{htmlelement("li")}}</span></li>
+ <li>{{HTMLElement("ul")}}</li>
+ <li>{{HTMLElement("ol")}}</li>
+ <li>{{HTMLElement("li")}}</li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Listitem_role">ARIA: listitem role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">ARIA: group role</a></li>
 </ul>

--- a/files/en-us/web/accessibility/aria/roles/listitem_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/listitem_role/index.html
@@ -10,7 +10,7 @@ tags:
   - Role
   - listitem
 ---
-<p class="summary">The ARIA <code>listitem</code> role can be used to identify an item inside a list of items. It is normally used in conjunction with the <code>list</code> role, which is used to identify a list container.</p>
+<p>The ARIA <code>listitem</code> role can be used to identify an item inside a list of items. It is normally used in conjunction with the <code>list</code> role, which is used to identify a list container.</p>
 
 <pre class="brush: html">&lt;section role="list"&gt;
   &lt;div role="listitem"&gt;List item 1&lt;/div&gt;
@@ -23,23 +23,19 @@ tags:
 
 <p>Any content that consists of an outer container with a list of elements inside it can be identified to assistive technologies using the <code>list</code> and <code>listitem</code> containers respectively.</p>
 
-<p>There are no hard and fast rules about which elements you should use to markup the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.</p>
+<p>There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.</p>
 
-<div class="warning">
-<p><strong>Warning</strong>: If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{htmlelement("ul")}}/{{htmlelement("ol")}} and {{htmlelement("li")}}. See {{anch("Best practices")}} for a full example.</p>
+<div class="notecard warning">
+<p><strong>Warning</strong>: If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{HTMLElement("ul")}}/{{HTMLElement("ol")}} and {{HTMLElement("li")}}. See {{anch("Best practices")}} for a full example.</p>
 </div>
 
 <h3 id="Associated_WAI-ARIA_Roles_States_and_Properties">Associated WAI-ARIA Roles, States, and Properties</h3>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role">list</a></dt>
- <dd>
- <p>A list of items. Elements with role <code>list</code> must have one or more elements with the role <code>listitem</code> as children, a one or more elements with the role of <code>group</code> that have one or more elements with the <code>listitem</code> role as children.</p>
- </dd>
+ <dd><p>A list of items. Elements with role <code>list</code> must have one or more elements with the role <code>listitem</code> as children, a one or more elements with the role of <code>group</code> that have one or more elements with the <code>listitem</code> role as children.</p></dd>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role" rel="nofollow">group</a></dt>
- <dd>
- <p>A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a pages table of contents.</p>
- </dd>
+ <dd><p>A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a pages table of contents.</p></dd>
 </dl>
 
 <h3 id="Keyboard_Interactions">Keyboard Interactions</h3>
@@ -52,13 +48,13 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p> <a href="https://www.scottohara.me/blog/2018/05/26/aria-lists.html">ARIA Lists</a> — some useful examples and thoughts by Scott O'Hara</p>
+<p><a href="https://www.scottohara.me/blog/2018/05/26/aria-lists.html">ARIA Lists</a> — some useful examples and thoughts by Scott O'Hara</p>
 
 <h2 id="Best_practices">Best practices</h2>
 
 <p>Only use <code>role="list"</code> and <code>role="listitem"</code> if you have to — for example if you don't have control over your HTML but are able to improve accessibility dynamically after the fact with JavaScript.</p>
 
-<p>If at all possible, you should use the appropriate semantic HTML elements to mark up a list and listitems — {{htmlelement("ol")}}/{{htmlelement("ul")}} and {{htmlelement("li")}}. For example, our above example should be rewritten as follows:</p>
+<p>If at all possible, you should use the appropriate semantic HTML elements to mark up a list and listitems — {{HTMLElement("ol")}}, {{HTMLElement("ul")}} and {{HTMLElement("li")}}. For example, our above example should be rewritten as follows:</p>
 
 <pre class="brush: html">&lt;ul&gt;
   &lt;li&gt;List item 1&lt;/li&gt;
@@ -74,17 +70,17 @@ tags:
   &lt;li&gt;List item 3&lt;/li&gt;
 &lt;/ol&gt;</pre>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: The ARIA list/listitem roles don't distinguish between ordered and unordered lists.</p>
 </div>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: If you are marking up a list of items that will function as a tabbed interface, you should instead use the <code>tab</code>, <code>tabpanel</code>, and <code>tablist</code> roles.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="col">Specification</th>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

- remove useless className
- standardize macros spell case


> Anything else that could help us review it
