### PR TITLE
Fixed markdown of codes with strong

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.font-src
 {{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`font`\*\***`-src`\*\* directive specifies
+**`font-src`** directive specifies
 valid sources for fonts loaded using {{cssxref("@font-face")}}.
 
 <table class="properties">

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.form-action
 ---
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`form`\*\***`-action`\*\* directive restricts the URLs which can be used as the target of a form submissions from a given context.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`form-action`** directive restricts the URLs which can be used as the target of a form submissions from a given context.
 
 > **Warning:** Whether `form-action` should block redirects after a form submission is [debated](https://github.com/w3c/webappsec-csp/issues/8) and browser implementations of this aspect are inconsistent (e.g. Firefox 57 doesn't block the redirects whereas Chrome 63 does).
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -18,7 +18,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.style-src-attr
 {{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`style`\*\***`-src-attr`\*\* directive
+**`style-src-attr`** directive
 specifies valid sources for inline styles applied to individual DOM elements.
 
 <table class="properties">

--- a/files/en-us/web/javascript/reference/global_objects/atomics/add/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/add/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.add
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.add()`\*\*
+The static **`Atomics.add()`**
 method adds a given value at a given position in the array and returns the old value at
 that position. This atomic operation guarantees that no other write happens until the
 modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.and
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.and()`\*\*
+The static **`Atomics.and()`**
 method computes a bitwise AND with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Atomics.compareExchange
 {{JSRef}}
 
 The static
-**`Atomics`\*\***`.compareExchange()`\*\*
+**`Atomics.compareExchange()`**
 method exchanges a given replacement value at a given position in the array, if a given
 expected value equals the old value.  It returns the old value at that position whether
 it was equal to the expected value or not. This atomic operation guarantees that no

--- a/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Atomics.isLockFree
 {{JSRef}}
 
 The static
-**`Atomics`\*\***`.isLockFree()`\*\*
+**`Atomics.isLockFree()`**
 method is used to determine whether the `Atomics` methods use locks
 or atomic hardware operations when applied to typed arrays with the given element
 byte size.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/load/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/load/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.load
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.load()`\*\*
+The static **`Atomics.load()`**
 method returns a value at a given position in the array.
 
 {{EmbedInteractiveExample("pages/js/atomics-load.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.notify
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.notify()`\*\*
+The static **`Atomics.notify()`**
 method notifies up some agents that are sleeping in the wait queue.
 
 > **Note:** This operation works with a shared {{jsxref("Int32Array")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.or
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.or()`\*\*
+The static **`Atomics.or()`**
 method computes a bitwise OR with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/store/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/store/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.store
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.store()`\*\*
+The static **`Atomics.store()`**
 method stores a given value at the given position in the array and returns that value.
 
 {{EmbedInteractiveExample("pages/js/atomics-store.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/xor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/xor/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.xor
 ---
 {{JSRef}}
 
-The static **`Atomics`\*\***`.xor()`\*\*
+The static **`Atomics.xor()`**
 method computes a bitwise XOR with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Reflect.deleteProperty
 {{JSRef}}
 
 The static
-**`Reflect`\*\***`.deleteProperty()`\*\*
+**`Reflect.deleteProperty()`**
 method allows to delete properties. It is like the [`delete`
 operator](/en-US/docs/Web/JavaScript/Reference/Operators/delete) as a function.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.RegExp.compile
 ---
 {{JSRef}} {{deprecated_header}}
 
-The deprecated **`compile`\*\***`()`\*\*
+The deprecated **`compile()`**
 method is used to (re-)compile a regular expression during execution of a script. It is
 basically the same as the `RegExp` constructor.
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

There are some pages which have a broken codes in the summary of the articles (the top of page).

wrong: **`font`\*\***`-src`\*\*
correct: **`font-src`**

For example:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty

I have replaced such a pattern with a correct one.
