### PR TITLE
Fixed erroneous macro in AbstractRange

### DIFF
--- a/files/en-us/web/api/abstractrange/index.html
+++ b/files/en-us/web/api/abstractrange/index.html
@@ -132,7 +132,7 @@ let fragment = r.cloneContents();
 
 <p>In this example, the start of the specified range is found within the text node below the section's heading, which means that the new <code>DocumentFragment</code> will need to contain an {{HTMLElement("h2")}} and, below it, a text node.</p>
 
-<p>The range's end is located below the {{domxref("p")}} element, so that will be needed within the new fragment. So will the text node containing the word "A", since that's included in the range. Finally, an <code>&lt;em&gt;</code> and a text node below it will be added below the <code>&lt;p&gt;</code> as well.</p>
+<p>The range's end is located below the {{HTMLElement("p")}} element, so that will be needed within the new fragment. So will the text node containing the word "A", since that's included in the range. Finally, an <code>&lt;em&gt;</code> and a text node below it will be added below the <code>&lt;p&gt;</code> as well.</p>
 
 <p>The contents of the text nodes are then determined by the offsets into those text nodes given when calling {{domxref("Range.setStart", "setStart()")}} and {{domxref("Range.setEnd", "setEnd()")}}. Given the offset of 11 into the heading's text, that node will contain "An interesting thing...". Similarly, the last text node will contain "ve", given the request for the first two characters of the ending node.</p>
 


### PR DESCRIPTION
Looking for something else, I notice a `domxref` macro trying to link to an HTML element. This fixes this.