### PR TITLE
Explicitly listing possible values for RTCIceCandidateStats.protocol

### DIFF
--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
@@ -2,19 +2,19 @@
 title: RTCIceCandidateStats.protocol
 slug: Web/API/RTCIceCandidateStats/protocol
 tags:
-- API
-- Candidate
-- ICE
-- Media
-- Property
-- Protocol
-- RTCIceCandidateStats
-- Reference
-- Statistics
-- Stats
-- Transport
-- WebRTC
-- WebRTC API
+  - API
+  - Candidate
+  - ICE
+  - Media
+  - Property
+  - Protocol
+  - RTCIceCandidateStats
+  - Reference
+  - Statistics
+  - Stats
+  - Transport
+  - WebRTC
+  - WebRTC API
 browser-compat: api.RTCIceCandidateStats.protocol
 ---
 <div>{{APIRef("WebRTC")}}</div>
@@ -30,10 +30,14 @@ browser-compat: api.RTCIceCandidateStats.protocol
 
 <h3 id="Value">Value</h3>
 
-<p>The value is one of the members of the {{domxref("RTCIceProtocol")}} enumerated string
-  type:</p>
+<p>The value is one of the following string:</p>
 
-<p>{{page("/en-US/docs/Web/API/RTCIceProtocol", "Values")}}</p>
+<dl>
+    <dt><code>tcp</code></dt>
+    <dd>The candidate, if selected, would use {{Glossary("TCP")}} as the transport protocol for its data. The {{domxref("RTCIceCandidate.tcpType", "tcpType")}} property provides additional information about the kind of TCP candidate represented by the object.</dd>
+    <dt><code>udp</code></dt>
+    <dd>The candidate will use the {{Glossary("UDP")}} transport protocol for its data. This is the preferred protocol for media interactions because of its better performance profile.</dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
The `{{page}}` was macro because the other page, a dictionary, was deleted.

I just included the two possible values.