### PR TITLE
Fix typo in page macro making it try to include itself

### DIFF
--- a/files/en-us/web/api/rtcrtpcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.html
@@ -38,9 +38,9 @@ browser-compat: api.RTCRtpCapabilities
 
 <p>The <code>codecs</code> array is an array of objects conforming to the dictionary {{domxref("RTCRtpCodecCapability")}}. Each of these objects describes a single codec and its basic capabilities. Its properties are:</p>
 
-<p>{{page("/en-US/docs/Web/API/RTCRtpCodecCapabilities", "Properties")}}</p>
+<p>{{page("/en-US/docs/Web/API/RTCRtpCodecCapability", "Properties")}}</p>
 
-<p>The browser will only report distinct capability combinations separately. If two sets of capabilities can be described as one, they will be. That means that, for instance, if there are two entries for the H.264 codec (as identified by the {{domxref("RTCRtpCodecCapabilities.mimeType", "mimeType")}} being "video/H264"), there are other values in the capabilities objects indicating how they're different in some way.</p>
+<p>The browser will only report distinct capability combinations separately. If two sets of capabilities can be described as one, they will be. That means that, for instance, if there are two entries for the H.264 codec (as identified by the {{domxref("RTCRtpCodecCapability.mimeType", "mimeType")}} being "video/H264"), there are other values in the capabilities objects indicating how they're different in some way.</p>
 
 <div class="notecard note">
 <p>The MIME type strings used by RTP differ from those used elsewhere. See {{RFC(3555, "", 4)}} for the complete IANA registry of these types.</p>


### PR DESCRIPTION
There are two different dictionaries, `RTCRtpCapabilities` and `RTCRtpCapbility`, differing only by the number (plural/singular).

The former was trying to include the latter, but a typo was making it including itself, failing.