### PR TITLE
Fix fragment in page macro

### DIFF
--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
@@ -2,19 +2,19 @@
 title: PaymentRequestUpdateEvent.updateWith()
 slug: Web/API/PaymentRequestUpdateEvent/updateWith
 tags:
-- API
-- Change
-- Experimental
-- Method
-- Payment Change
-- Payment Details
-- Payment Request API
-- PaymentRequestUpdateEvent
-- Reference
-- Secure context
-- Web Payments
-- payment
-- updateWith
+  - API
+  - Change
+  - Experimental
+  - Method
+  - Payment Change
+  - Payment Details
+  - Payment Request API
+  - PaymentRequestUpdateEvent
+  - Reference
+  - Secure context
+  - Web Payments
+  - payment
+  - updateWith
 browser-compat: api.PaymentRequestUpdateEvent.updateWith
 ---
 <p>{{APIRef("Payment Request API")}}{{securecontext_header}}</p>
@@ -34,7 +34,7 @@ browser-compat: api.PaymentRequestUpdateEvent.updateWith
   <dt><code>details</code></dt>
   <dd>A {{domxref("PaymentDetailsUpdate")}} object specifying the changes applied to the
     payment request:
-    {{page("/en-US/docs/Web/API/PaymentDetailsUpdate", "propertylist")}}
+    {{page("/en-US/docs/Web/API/PaymentDetailsUpdate", "Properties")}}
   </dd>
 </dl>
 


### PR DESCRIPTION
The fragment listed in the macro was not found on the page to transclude. This fixes this.


Note: with this PR, all MacroExecutionErrors have been fixed, or have a PR (3 of them, including this one, still need to land for the number to be 0).