### PR TITLE
fix a return value which isn't a Boolean wrapper object

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
@@ -33,7 +33,7 @@ Atomics.isLockFree(size)
 
 ### Return value
 
-A {{jsxref("Boolean")}} indicating whether the operation is lock free.
+A `true` or `false` value indicating whether the operation is lock free.
 
 ## Examples
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The return value isn't a Boolean (wrapper) object.
It should be `true` or `false` primitive.

> Anything else that could help us review it
