### PR TITLE
Games/Anatomy: Broken link to artillery.com blog

### DIFF
--- a/files/en-us/games/anatomy/index.html
+++ b/files/en-us/games/anatomy/index.html
@@ -304,7 +304,7 @@ main(); // Start the cycle</pre>
   main(performance.now()); // Start the cycle
 })();</pre>
 
-<p>Another alternative is to do certain things less often. If a portion of your update loop is difficult to compute but insensitive to time, you might consider scaling back its frequency and, ideally, spreading it out into chunks throughout that lengthened period. An implicit example of this is found over at The Artillery Blog for Artillery Games, where they <a href="http://blog.artillery.com/2012/10/browser-garbage-collection-and-framerate.html">adjust their rate of garbage generation</a> to optimize garbage collection. Obviously, cleaning up resources is not time sensitive (especially if tidying is more disruptive than the garbage itself).</p>
+<p>Another alternative is to do certain things less often. If a portion of your update loop is difficult to compute but insensitive to time, you might consider scaling back its frequency and, ideally, spreading it out into chunks throughout that lengthened period. An implicit example of this was found over at The Artillery Blog for Artillery Games, where they <a href="https://web.archive.org/web/20161021030645/http://blog.artillery.com/2012/10/browser-garbage-collection-and-framerate.html">adjust their rate of garbage generation</a> to optimize garbage collection. Obviously, cleaning up resources is not time sensitive (especially if tidying is more disruptive than the garbage itself).</p>
 
 <p>This may also apply to some of your own tasks. Those are good candidates to throttle when available resources become a concern.</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Broken external link (company no longer exists)

> Anything else that could help us review it

*sends cyber hugs*

---

(Long time reader, first time caller)

I'm not sure how to deal with a broken link to an external blog, but wanted to make the issue known.

The external post itself _maybe_ contains useful information.
Artillery (author) has [closed its doors](https://www.linkedin.com/company/artillery-games-inc-). 
The domain name appears to have been poached/squatted.

I changed link to a copy on archive.org.

Feel free to roast me/suggest a better edit.
