### PR TITLE
Fix lack of one space after an OR operator

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.html
@@ -257,7 +257,7 @@ if (shoppingDone) { // don't need to explicitly specify '=== true'
 
 <p>In this case the condition inside <code>if(...)</code>  will always evaluate to true since 7 (or any other non-zero value) always evaluates to <code>true</code>. This condition is actually saying "if x equals 5, or 7 is true — which it always is". This is logically not what we want! To make this work you've got to specify a complete test either side of each OR operator:</p>
 
-<pre class="brush: js">if (x === 5 || x === 7 || x === 10 ||x === 20) {
+<pre class="brush: js">if (x === 5 || x === 7 || x === 10 || x === 20) {
   // run my code
 }</pre>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
None that I know of


> What was wrong/why is this fix needed? (quick summary only)
To have consistent code style around all OR operators


> Anything else that could help us review it
Not really, very minor change