### PR TITLE
Add spec and compat sections for `structuredClone`

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/structuredclone/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/structuredclone/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - structuredClone
   - WindowOrWorkerGlobalScope
+browser-compat: api.WindowWorkerGlobalScope.structuredClone
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -57,8 +58,13 @@ console.assert(clone.name === "MDN"); // they do have the same values
 console.assert(clone.itself === clone); // and the circular reference is preserved
 </pre>
 
-  
-<!-- TODO(lucacasonato): Add "Specifications" and "Compat" tables when https://github.com/mdn/browser-compat-data/pull/11967 is released. -->
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/11967 has been merged, and is part of the currently in use (4.0.0) BCD release.
