### PR TITLE
Remove developer.mozilla prefix on URLs

### DIFF
--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -26,7 +26,7 @@ var domException = new DOMException(message, name);</pre>
   <dd>A description of the exception. If not present, the empty string <code>''</code> is
     used.</dd>
   <dt><code>name</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("DOMString")}}. If the specified name is a <a href="/en-US/docs/Web/API/DOMException#error_names">standard error name</a>, then getting the <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMException/code"><code>code</code></a> property of the <code>DOMException</code> object will return the code number corresponding to the specified name.</dd>
+  <dd>A {{domxref("DOMString")}}. If the specified name is a <a href="/en-US/docs/Web/API/DOMException#error_names">standard error name</a>, then getting the <a href="/en-US/docs/Web/API/DOMException/code"><code>code</code></a> property of the <code>DOMException</code> object will return the code number corresponding to the specified name.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/navigator/online_and_offline_events/index.html
+++ b/files/en-us/web/api/navigator/online_and_offline_events/index.html
@@ -35,7 +35,7 @@ tags:
 
 <blockquote cite="https://www.whatwg.org/specs/web-apps/current-work/#offline">The <code>navigator.onLine</code> attribute must return false if the user agent will not contact the network when the user follows links or when a script requests a remote page (or knows that such an attempt would fail)...</blockquote>
 
-<p>Firefox 2 updates this property when switching to/from the browser's Offline mode.  <a href="https://developer.mozilla.org/en-US/Firefox/Releases/41#Miscellaneous">Firefox 41</a> updates this property also when the OS reports a change in network connectivity on Windows, Linux, and OS X.</p>
+<p>Firefox 2 updates this property when switching to/from the browser's Offline mode.  <a href="/en-US/Firefox/Releases/41#Miscellaneous">Firefox 41</a> updates this property also when the OS reports a change in network connectivity on Windows, Linux, and OS X.</p>
 
 <p>This property existed in older versions of Firefox and Internet Explorer (the specification based itself off of these prior implementations), so you can begin using it immediately. Network status autodetection was implemented in Firefox 2.</p>
 
@@ -43,7 +43,7 @@ tags:
 
 <p><a href="/en-US/docs/Firefox_3_for_developers">Firefox 3</a> introduces two new events: "<a href="/en-US/docs/Web/API/document.ononline"><code>online</code></a>" and "<a href="/en-US/docs/Web/API/document.onoffline"><code>offline</code></a>". These two events are fired on the <code>&lt;body&gt;</code> of each page when the browser switches between online and offline mode. Additionally, the events bubble up from <code>document.body</code>, to <code>document</code>, ending at <code>window</code>. Both events are non-cancellable (you can't prevent the user from coming online, or going offline).</p>
 
-<p><a href="https://developer.mozilla.org/en-US/Firefox/Releases/41#Miscellaneous">Firefox 41</a> fires these events when the OS reports a change in network connectivity on Windows, Linux, and OS X.</p>
+<p><a href="/en-US/Firefox/Releases/41#Miscellaneous">Firefox 41</a> fires these events when the OS reports a change in network connectivity on Windows, Linux, and OS X.</p>
 
 <p>You can register listeners for these events in a few familiar ways:</p>
 

--- a/files/en-us/web/api/ndefmessage/ndefmessage/index.html
+++ b/files/en-us/web/api/ndefmessage/ndefmessage/index.html
@@ -32,7 +32,7 @@ browser-compat: api.NDEFMessage.NDEFMessage
       <dt><code>lang</code> {{optional_inline}}</dt>
       <dd>A valid <a href="https://www.rfc-editor.org/info/bcp47">BCP47</a> language tag.</dd>
       <dt><code>mediaType</code> {{optional_inline}}</dt>
-      <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+      <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
       <dt><code>recordType</code></dt>
       <dd>A string indicating the type of data stored in <code>data</code>. It must be one of the following values:
         <dl>
@@ -41,7 +41,7 @@ browser-compat: api.NDEFMessage.NDEFMessage
           <dt><code>"empty"</code></dt>
           <dd>An empty {{domxref("NDEFRecord")}}.</dd>
           <dt><code>"mime"</code></dt>
-          <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+          <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
           <dt><code>"smart-poster"</code></dt>
           <dd>A smart poster as defined by the <a href="https://w3c.github.io/web-nfc/#bib-ndef-smartposter">NDEF-SMARTPOSTER</a> specification.</dd>
           <dt><code>"text"</code></dt>

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -34,7 +34,7 @@ browser-compat: api.NDEFReader.write
       <dt><code>lang</code> {{optional_inline}}</dt>
       <dd>A valid <a href="https://www.rfc-editor.org/info/bcp47">BCP47</a> language tag.</dd>
       <dt><code>mediaType</code> {{optional_inline}}</dt>
-      <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+      <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
       <dt><code>recordType</code></dt>
       <dd>A string indicating the type of data stored in <code>data</code>. It must be one of the following values:
         <dl>
@@ -43,7 +43,7 @@ browser-compat: api.NDEFReader.write
           <dt><code>"empty"</code></dt>
           <dd>An empty {{domxref("NDEFRecord")}}.</dd>
           <dt><code>"mime"</code></dt>
-          <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+          <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
           <dt><code>"smart-poster"</code></dt>
           <dd>A smart poster as defined by the <a href="https://w3c.github.io/web-nfc/#bib-ndef-smartposter">NDEF-SMARTPOSTER</a> specification.</dd>
           <dt><code>"text"</code></dt>

--- a/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.html
+++ b/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.html
@@ -38,7 +38,7 @@ browser-compat: api.NDEFReadingEvent.NDEFReadingEvent
           <dt><code>lang</code> {{optional_inline}}</dt>
           <dd>A valid <a href="https://www.rfc-editor.org/info/bcp47">BCP47</a> language tag.</dd>
           <dt><code>mediaType</code> {{optional_inline}}</dt>
-          <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+          <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
           <dt><code>recordType</code></dt>
           <dd>A string indicating the type of data stored in <code>data</code>. It must be one of the following values:
             <dl>
@@ -47,7 +47,7 @@ browser-compat: api.NDEFReadingEvent.NDEFReadingEvent
               <dt><code>"empty"</code></dt>
               <dd>An empty {{domxref("NDEFRecord")}}.</dd>
               <dt><code>"mime"</code></dt>
-              <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+              <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
               <dt><code>"smart-poster"</code></dt>
               <dd>A smart poster as defined by the <a href="https://w3c.github.io/web-nfc/#bib-ndef-smartposter">NDEF-SMARTPOSTER</a> specification.</dd>
               <dt><code>"text"</code></dt>

--- a/files/en-us/web/api/ndefrecord/lang/index.html
+++ b/files/en-us/web/api/ndefrecord/lang/index.html
@@ -2,9 +2,9 @@
 title: NDEFRecord.lang
 slug: Web/API/NDEFRecord/lang
 tags:
-- NDEF
-- Reference
-- Web NFC
+  - NDEF
+  - Reference
+  - Web NFC
 browser-compat: api.NDEFRecord.lang
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
@@ -35,9 +35,6 @@ browser-compat: api.NDEFRecord.lang
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang">HTML
-      <code>lang</code> attribute</a>, that declares content langauge of the document or
-    its elements</li>
-  <li>HTTP headers that declare content language: {{HTTPHeader("Content-Language")}} and
-    {{HTTPHEader("Accept-Language")}}</li>
+  <li><a href="/en-US/docs/Web/HTML/Global_attributes/lang">HTML <code>lang</code> attribute</a>, that declares content langauge of the document or its elements</li>
+  <li>HTTP headers that declare content language: {{HTTPHeader("Content-Language")}} and {{HTTPHEader("Accept-Language")}}</li>
 </ul>

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.html
@@ -35,7 +35,7 @@ browser-compat: api.NDEFRecord.NDEFRecord
       <dt><code>lang</code> {{optional_inline}}</dt>
       <dd>A valid <a href="https://www.rfc-editor.org/info/bcp47">BCP47</a> language tag.</dd>
       <dt><code>mediaType</code> {{optional_inline}}</dt>
-      <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+      <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
       <dt><code>recordType</code></dt>
       <dd>A string indicating the type of data stored in <code>data</code>. It must be one of the following values:
         <dl>
@@ -44,7 +44,7 @@ browser-compat: api.NDEFRecord.NDEFRecord
           <dt><code>"empty"</code></dt>
           <dd>An empty {{domxref("NDEFRecord")}}.</dd>
           <dt><code>"mime"</code></dt>
-          <dd>A valid <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
+          <dd>A valid <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME type</a>.</dd>
           <dt><code>"smart-poster"</code></dt>
           <dd>A smart poster as defined by the <a href="https://w3c.github.io/web-nfc/#bib-ndef-smartposter">NDEF-SMARTPOSTER</a> specification.</dd>
           <dt><code>"text"</code></dt>

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -1083,7 +1083,7 @@ Please note that LCH hue is not the same as HSL hue and LCH chroma is not the sa
 
 CSS Color 4 introduced this notation.
 Colors specified via the [`color()`](<https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color()>) function can specify a color in any of the predefined color spaces,
-as well as custom color spaces, defined via the [`@color-profile`](https://developer.mozilla.org/en-US/docs/Web/CSS/@color-profile) rule.
+as well as custom color spaces, defined via the [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) rule.
 
 ## Interpolation
 

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -28,11 +28,8 @@ function f(a, b, ...theArgs) {
 
 ## Description
 
-A function definition's last parameter can be prefixed with "`...`" (three
-U+002E FULL STOP characters), which will cause all remaining (user supplied) parameters
-to be placed within a ["standard"
-JavaScript array.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array). Only the last parameter in a function definition can be a rest
-parameter.
+A function definition's last parameter can be prefixed with "`...`" (three U+002E FULL STOP characters), which will cause all remaining (user supplied) parameters to be placed within a ["standard" JavaScript array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
+Only the last parameter in a function definition can be a rest parameter.
 
 ```js
 function myFun(a,  b, ...manyMoreArgs) {


### PR DESCRIPTION
This removes the `https://developer.mozilla.org/` prefix on URLS that use them. They aren't needed. A couple of these showed up the last few days being fixed - this removes all the ones that are left.