### PR TITLE
Fix inconsistency of links in Web/Tutorials

### DIFF
--- a/files/en-us/web/tutorials/index.html
+++ b/files/en-us/web/tutorials/index.html
@@ -34,14 +34,14 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML</a></dt>
  <dd>This module sets the stage, getting you used to important concepts and syntax, looking at applying HTML to text, how to create hyperlinks, and how to use HTML to structure a webpage.</dd>
- <dt><strong><a href="/en-US/docs/Web/HTML/Element">MDN HTML element reference</a></strong></dt>
+ <dt><a href="/en-US/docs/Web/HTML/Element">MDN HTML element reference</a></dt>
  <dd>A comprehensive reference for HTML elements, and how the different browsers support them.</dd>
 </dl>
 
 <dl>
- <dt><strong><a href="https://www.theblogstarter.com/html-for-beginners">Creating a Simple Web Page with HTML</a> </strong></dt>
+ <dt><a href="https://www.theblogstarter.com/html-for-beginners" rel="external">Creating a Simple Web Page with HTML</a></dt>
  <dd>An HTML guide for beginners that includes explanations of common tags, including HTML5 tags. Also includes a step-by-step guide to creating a basic web page with code examples.</dd>
- <dt><strong><a href="https://wikiversity.org/wiki/Web_Design/HTML_Challenges" rel="external">HTML Challenges</a> </strong></dt>
+ <dt><a href="https://wikiversity.org/wiki/Web_Design/HTML_Challenges" rel="external">HTML Challenges</a></dt>
  <dd>Use these challenges to hone your HTML skills (for example, "Should I use an &lt;h2&gt; element or a &lt;strong&gt; element?"), focusing on meaningful markup.</dd>
 </dl>
 
@@ -65,7 +65,7 @@ tags:
 </dl>
 
 <dl>
- <dt><strong><a href="/en-US/docs/Learn/HTML/Howto/Author_fast-loading_HTML_pages">Tips for authoring fast-loading HTML pages</a></strong></dt>
+ <dt><a href="/en-US/docs/Learn/HTML/Howto/Author_fast-loading_HTML_pages">Tips for authoring fast-loading HTML pages</a></dt>
  <dd>Optimize web pages to provide a more responsive site for visitors and reduce the load on your web server and Internet connection.</dd>
 </dl>
 
@@ -89,7 +89,7 @@ tags:
  </dd>
  <dt><a href="/en-US/docs/Learn/CSS/Styling_text">Styling text</a></dt>
  <dd>Here we look at text styling fundamentals, including setting font, boldness, and italics, line and letter spacing, and drop shadows and other text features. We round off the module by looking at applying custom fonts to your page, and styling lists and links.</dd>
- <dt><strong><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS Questions</a></strong></dt>
+ <dt><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS Questions</a></dt>
  <dd>Common questions and answers for beginners.</dd>
 </dl>
 
@@ -98,37 +98,37 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a></dt>
  <dd>At this point we've already looked at CSS fundamentals, how to style text, and how to style and manipulate the boxes that your content sits inside. Now it's time to look at how to place your boxes in the right place in relation to the viewport, and one another. We have covered the necessary prerequisites so can now dive deep into CSS layout, looking at different display settings, traditional layout methods involving float and positioning, and new fangled layout tools like flexbox.</dd>
- <dt><strong><a href="/en-US/docs/Web/CSS/Reference">CSS reference</a></strong></dt>
+ <dt><a href="/en-US/docs/Web/CSS/Reference">CSS reference</a></dt>
  <dd>Complete reference to CSS, with details on support by Firefox and other browsers.</dd>
 </dl>
 
 <dl>
- <dt><strong><a href="https://www.alistapart.com/articles/fluidgrids/" rel="external">Fluid Grids</a></strong></dt>
+ <dt><a href="https://www.alistapart.com/articles/fluidgrids/" rel="external">Fluid Grids</a></dt>
  <dd>Design layouts that fluidly resize with the browser window, while still using a typographic grid.</dd>
- <dt><strong><a href="https://en.wikiversity.org/wiki/Web_Design/CSS_challenges" rel="external">CSS Challenges</a> </strong></dt>
+ <dt><a href="https://en.wikiversity.org/wiki/Web_Design/CSS_challenges" rel="external">CSS Challenges</a></dt>
  <dd>Flex your CSS skills, and see where you need more practice.</dd>
 </dl>
 
 <h3 id="Advanced_level_2">Advanced level</h3>
 
 <dl>
- <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></strong></dt>
+ <dt><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></dt>
  <dd>Apply rotation, skewing, scaling, and translation using CSS.</dd>
- <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transitions</a></strong></dt>
+ <dt><a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transitions</a></dt>
  <dd>CSS transitions, part of the draft CSS3 specification, provide a way to animate changes to CSS properties, instead of having the changes take effect instantly.</dd>
 </dl>
 
 <dl>
- <dt><strong><a href="https://www.html5rocks.com/tutorials/webfonts/quick/" rel="external">Quick Guide to Implement Web Fonts  (with @font-face)</a> </strong></dt>
+ <dt><a href="https://www.html5rocks.com/tutorials/webfonts/quick/" rel="external">Quick Guide to Implement Web Fonts  (with @font-face)</a></dt>
  <dd>The @font-face feature from CSS3 allows you to use custom typefaces on the web in an accessible, manipulatable, and scalable way.</dd>
- <dt><strong><a href="https://davidwalsh.name/starting-css" rel="external">Starting to Write CSS</a> </strong></dt>
+ <dt><a href="https://davidwalsh.name/starting-css" rel="external">Starting to Write CSS</a></dt>
  <dd>An introduction to tools and methodologies to write more succinct, maintainable, and scalable CSS.</dd>
 </dl>
 
 <dl>
  <dt><a href="/en-US/docs/Web/API/Canvas_API/Tutorial">Canvas tutorial</a></dt>
  <dd>Learn how to draw graphics using scripting using the canvas element.</dd>
- <dt><strong><a href="https://html5doctor.com/" rel="external">HTML5 Doctor</a></strong></dt>
+ <dt><a href="https://html5doctor.com/" rel="external">HTML5 Doctor</a></dt>
  <dd>Articles about using HTML5 right now.</dd>
 </dl>
 
@@ -146,10 +146,10 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics">Getting started with JavaScript</a></dt>
  <dd>What is JavaScript and how can it help you?</dd>
- <dt><strong><a href="https://www.codecademy.com/">Codecademy</a> </strong></dt>
+ <dt><a href="https://www.codecademy.com/" rel="external">Codecademy</a></dt>
  <dd>Codecademy is an easy way to learn how to code JavaScript. It's interactive and you can do it with your friends.</dd>
- <dt><a href="https://learn.freecodecamp.org/">freeCodeCamp</a></dt>
- <dd>freeCodeCamp teaches a variety of languages and frameworks for web development. It also has a <a href="https://freecodecamp.org/forum">forum</a>, an <a href="https://coderadio.freecodecamp.org">internet radio station</a>, and a <a href="https://freecodecamp.org/news">blog</a>.</dd>
+ <dt><a href="https://freecodecamp.org/learn/" rel="external">freeCodeCamp</a></dt>
+ <dd>freeCodeCamp teaches a variety of languages and frameworks for web development. It also has a <a href="https://freecodecamp.org/forum" rel="external">forum</a>, an <a href="https://coderadio.freecodecamp.org" rel="external">internet radio station</a>, and a <a href="https://freecodecamp.org/news" rel="external">blog</a>.</dd>
 </dl>
 
 <h3 id="Intermediate_level_3">Intermediate level</h3>
@@ -162,13 +162,13 @@ tags:
 </dl>
 
 <dl>
- <dt><strong><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-Introduction to JavaScript</a></strong></dt>
+ <dt><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-Introduction to JavaScript</a></dt>
  <dd>A recap of the JavaScript programming language aimed at intermediate-level developers.</dd>
- <dt><strong><a href="https://eloquentjavascript.net/" rel="external">Eloquent JavaScript</a></strong></dt>
+ <dt><a href="https://eloquentjavascript.net/" rel="external">Eloquent JavaScript</a></dt>
  <dd>A comprehensive guide to intermediate and advanced JavaScript methodologies.</dd>
- <dt><strong><a href="http://speakingjs.com/es5/" rel="external">Speaking JavaScript</a> </strong></dt>
+ <dt><a href="https://speakingjs.com/es5/" rel="external">Speaking JavaScript</a></dt>
  <dd>For programmers who want to learn JavaScript quickly and properly, and for JavaScript programmers who want to deepen their skills and/or look up specific topics.</dd>
- <dt><strong><a href="https://www.addyosmani.com/resources/essentialjsdesignpatterns/book/" rel="external">Essential JavaScript Design Patterns</a> </strong></dt>
+ <dt><a href="https://www.addyosmani.com/resources/essentialjsdesignpatterns/book/" rel="external">Essential JavaScript Design Patterns</a></dt>
  <dd>An introduction to essential JavaScript design patterns.</dd>
 </dl>
 
@@ -177,20 +177,20 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Guide">JavaScript Guide</a></dt>
  <dd>A comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.</dd>
- <dt><strong><a href="https://github.com/getify/You-Dont-Know-JS" rel="external">You Don't Know JS</a> </strong></dt>
+ <dt><a href="https://github.com/getify/You-Dont-Know-JS" rel="external">You Don't Know JS</a></dt>
  <dd>A series of books diving deep into the core mechanisms of the JavaScript language.</dd>
- <dt><strong><a href="https://bonsaiden.github.io/JavaScript-Garden/" rel="external">JavaScript Garden</a></strong></dt>
+ <dt><a href="https://bonsaiden.github.io/JavaScript-Garden/" rel="external">JavaScript Garden</a></dt>
  <dd>Documentation of the most quirky parts of JavaScript.</dd>
- <dt><strong><a href="https://exploringjs.com/es6/" rel="external">Exploring ES6</a> </strong></dt>
+ <dt><a href="https://exploringjs.com/es6/" rel="external">Exploring ES6</a></dt>
  <dd>Reliable and in-depth information on ECMAScript 2015.</dd>
 </dl>
 
 <dl>
- <dt><strong><a href="https://shichuan.github.io/javascript-patterns" rel="external">JavaScript Patterns</a></strong></dt>
+ <dt><a href="https://shichuan.github.io/javascript-patterns" rel="external">JavaScript Patterns</a></dt>
  <dd>A JavaScript pattern and antipattern collection that covers function patterns, jQuery patterns, jQuery plugin patterns, design patterns, general patterns, literals and constructor patterns, object creation patterns, code reuse patterns, DOM.</dd>
- <dt><strong><a href="https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/">How browsers work</a></strong></dt>
+ <dt><a href="https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/" rel="external">How browsers work</a></dt>
  <dd>A detailed research article describing different modern browsers, their engines, page rendering etc.</dd>
- <dt><a href="https://github.com/bolshchikov/js-must-watch">JavaScript Videos</a> </dt>
+ <dt><a href="https://github.com/bolshchikov/js-must-watch" rel="external">JavaScript Videos</a></dt>
  <dd>A collection of JavaScript videos to watch.</dd>
 </dl>
 
@@ -198,5 +198,5 @@ tags:
 
 <dl>
  <dt><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions">WebExtensions</a></dt>
- <dd>WebExtensions is a cross-browser system for developing browser add-ons. To a large extent, the system is compatible with the <a class="external-icon external" href="https://developer.chrome.com/extensions">extension API</a> supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/">Microsoft Edge</a> with <a href="https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/">just a few changes</a>. The API is also fully compatible with <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox">multiprocess Firefox</a>.</dd>
+ <dd>WebExtensions is a cross-browser system for developing browser add-ons. To a large extent, the system is compatible with the <a href="https://developer.chrome.com/extensions" rel="external">extension API</a> supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/" rel="external">Microsoft Edge</a> with <a href="https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/" rel="external">just a few changes</a>. The API is also fully compatible with <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox">multiprocess Firefox</a>.</dd>
 </dl>


### PR DESCRIPTION
- remove `<strong>` tags around links
- http->https
- add `rel='external'`
- change https://learn.freecodecamp.org/ to https://freecodecamp.org/learn/
