### PR TITLE
Fix bad note names

### DIFF
--- a/files/en-us/web/api/angle_instanced_arrays/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/index.html
@@ -15,7 +15,7 @@ browser-compat: api.ANGLE_instanced_arrays
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "<code>ANGLE</code>" suffix.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "<code>ANGLE</code>" suffix.</p>
 
 <p>Despite the name "ANGLE", this extension works on any device if the hardware supports it and not just on Windows when using the ANGLE library. "ANGLE" just indicates that this extension has been written by the ANGLE library authors.</p>
 </div>

--- a/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
+++ b/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
@@ -17,7 +17,7 @@ tags:
     JavaScript.</p>
 
 <div class="note">
-  <p><strong>Important</strong>: This method is obsolete, and has been renamed to
+  <p><strong>Note:</strong> This method is obsolete, and has been renamed to
     {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}. See also
     {{domxref("ScriptProcessorNode")}}.</p>
 </div>

--- a/files/en-us/web/api/audioworkletprocessor/process/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.html
@@ -30,7 +30,7 @@ browser-compat: api.AudioWorkletProcessor.process
   invoked to do so.</p>
 
 <div class="notecard note">
-  <p><strong>Important:</strong> Currently, audio data blocks are always 128 frames
+  <p><strong>Note:</strong> Currently, audio data blocks are always 128 frames
     long—that is, they contain 128 32-bit floating-point samples for each of the inputs'
     channels. However, plans are already in place to revise the specification to allow the
     size of the audio blocks to be changed depending on circumstances (for example, if the

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
@@ -125,7 +125,7 @@ tags:
 <p>In this example, we'll use the <code>rotate()</code> method to first rotate a rectangle from the canvas origin and then from the center of the rectangle itself with the help of <code>translate()</code>.</p>
 
 <div class="note">
-<p><strong>Reminder</strong>: Angles are in radians, not degrees. To convert, we are using: <code>radians = (Math.PI/180)*degrees</code>.</p>
+<p><strong>Note:</strong> Angles are in radians, not degrees. To convert, we are using: <code>radians = (Math.PI/180)*degrees</code>.</p>
 </div>
 
 <pre class="brush: js; highlight:[9, 23]">function draw() {

--- a/files/en-us/web/api/clipboard/index.html
+++ b/files/en-us/web/api/clipboard/index.html
@@ -30,7 +30,7 @@ browser-compat: api.Clipboard
 <p>All of the Clipboard API methods operate asynchronously; they return a {{jsxref("Promise")}} which is resolved once the clipboard access has been completed. The promise is rejected if clipboard access is denied.</p>
 
 <div class="notecard note">
-<p>The <strong>clipboard </strong>is a data buffer that is used for short-term, data storage and/or data transfers, this can be between documents or applications<br>
+<p><strong>Note:</strong> The <strong>clipboard </strong>is a data buffer that is used for short-term, data storage and/or data transfers, this can be between documents or applications<br>
   It is usually implemented as an anonymous, temporary <a href="https://en.wikipedia.org/wiki/Data_buffer" title="Data buffer">data buffer</a>, sometimes called the paste buffer, that can be accessed from most or all programs within the environment via defined <a href="https://en.wikipedia.org/wiki/Application_programming_interface" title="Application programming interface">programming interfaces</a>.</p>
 
 <p>A typical application accesses clipboard functionality by mapping <a href="https://en.wikipedia.org/wiki/User_input" title="User input">user input</a> such as <a href="https://en.wikipedia.org/wiki/Keybinding">keybindings</a>, <a href="https://en.wikipedia.org/wiki/Menu_(computing)" title="Menu (computing)">menu selections</a>, etc. to these interfaces.</p>

--- a/files/en-us/web/api/closeevent/initcloseevent/index.html
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.html
@@ -21,7 +21,7 @@ browser-compat: api.CloseEvent.initCloseEvent
 	Once dispatched, it doesn't do anything anymore.</p>
 
 <div class="note">
-	<p><strong>Do not use this method anymore as it is deprecated.</strong></p>
+	<p><strong>Note:</strong> Do not use this method any more as it is deprecated.</p>
 
 	<p>Instead use specific event constructors, like {{domxref("CloseEvent.MouseEvent", "CloseEvent()")}}.
 		The page on <a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a> gives more information about the way to use these.

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -45,7 +45,7 @@ browser-compat: api.CSSStyleSheet
 <dl>
  <dt>{{domxref("CSSStyleSheet.cssRules")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.
-    <div class="notecard note"><p><strong>Note: </strong>In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in a<code>SecurityError</code>.</p></div>
+    <div class="notecard note"><p><strong>Note:</strong> In some browsers, if a stylesheet is loaded from a different domain, accessing <code>cssRules</code> results in a<code>SecurityError</code>.</p></div>
 
  </dd>
  <dt>{{domxref("CSSStyleSheet.ownerRule")}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/document/adoptnode/index.html
+++ b/files/en-us/web/api/document/adoptnode/index.html
@@ -68,7 +68,7 @@ iframeImages.forEach(function(imgEl) {
 </ul>
 
 <div class="notecard note">
-  <p><strong>Best Practice:</strong> Although Firefox doesn't currently enforce this rule,
+  <p><strong>Note:</strong> Although Firefox doesn't currently enforce this rule,
     we encourage you to follow this rule for improved future compatibility.</p>
 </div>
 

--- a/files/en-us/web/api/document_object_model/index.html
+++ b/files/en-us/web/api/document_object_model/index.html
@@ -19,9 +19,8 @@ tags:
 
 <p>Nodes can also have event handlers attached to them. Once an event is triggered, the event handlers get executed.</p>
 
-<div class="notecard note">
-<p><strong>To learn more</strong> about what the DOM is and how it represents documents, see our article <a href="/en-US/docs/Web/API/Document_Object_Model/Introduction">Introduction to the DOM</a>.</p>
-</div>
+<p>To learn more about what the DOM is and how it represents documents, see our article <a href="/en-US/docs/Web/API/Document_Object_Model/Introduction">Introduction to the DOM</a>.</p>
+
 
 <h2 id="DOM_interfaces">DOM interfaces</h2>
 

--- a/files/en-us/web/api/element/mousewheel_event/index.html
+++ b/files/en-us/web/api/element/mousewheel_event/index.html
@@ -19,7 +19,7 @@ browser-compat: api.Element.mousewheel_event
 <p>The <em>obsolete</em> and <em>non-standard</em> <code><strong>mousewheel</strong></code> event is fired asynchronously at an {{domxref("Element")}} to provide updates while a mouse wheel or similar device is operated. The <code>mousewheel</code> event was never part of any standard, and while it was implemented by several browsers, it was never implemented by Firefox.</p>
 
 <div class="notecard note">
-<p><strong>Important:</strong> Instead of this obsolete event, use the standard {{domxref("Element.wheel_event", "wheel")}} event.</p>
+<p><strong>Note:</strong> Instead of this obsolete event, use the standard {{domxref("Element.wheel_event", "wheel")}} event.</p>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/api/element/mozmousepixelscroll_event/index.html
+++ b/files/en-us/web/api/element/mozmousepixelscroll_event/index.html
@@ -21,7 +21,7 @@ browser-compat: api.Element.MozMousePixelScroll_event
 <p>The Firefox-only, <em>non-standard</em>, and <em>obsolete</em> <strong><code>MozMousePixelScroll</code></strong> event is fired at an {{domxref("Element")}} asynchronously when a mouse wheel or similar device is operated. It's represented by the {{ domxref("MouseScrollEvent") }} interface.</p>
 
 <div class="notecard note">
-<p><strong>Important:</strong> Do not use this non-standard and obsolete event. Instead, you should always use the standard {{domxref("Element.wheel_event", "wheel")}} event.</p>
+<p><strong>Note:</strong> Do not use this non-standard and obsolete event. Instead, you should always use the standard {{domxref("Element.wheel_event", "wheel")}} event.</p>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/api/event/comparison_of_event_targets/index.html
+++ b/files/en-us/web/api/event/comparison_of_event_targets/index.html
@@ -67,11 +67,7 @@ tags:
 <h3 id="Use_of_explicitOriginalTarget_and_originalTarget">Use of <code>explicitOriginalTarget</code> and <code>originalTarget</code></h3>
 
 <div class="notecard note">
-<p><strong>TODO:</strong> Only available in a Mozilla-based browser?</p>
-</div>
-
-<div class="notecard note">
-<p><strong>TODO:</strong> Only suitable for extension-developers?</p>
+<p><strong>Note:</strong> These properties are only available in Mozilla-based browsers.</p>
 </div>
 
 <h3 id="Examples">Examples</h3>

--- a/files/en-us/web/api/event/initevent/index.html
+++ b/files/en-us/web/api/event/initevent/index.html
@@ -21,12 +21,10 @@ browser-compat: api.Event.initEvent
   before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
   dispatched, it doesn't do anything anymore.</p>
 
-<div class="note">
   <p><strong>Do not use this method anymore as it is deprecated.</strong></p>
 
   <p>Instead use specific event constructors, like {{domxref("Event.Event", "Event()")}}.
     The page on <a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a> gives more information about the way to use these.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/ext_blend_minmax/index.html
+++ b/files/en-us/web/api/ext_blend_minmax/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_blend_minmax
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are <code>gl.MIN</code> and <code>gl.MAX</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are <code>gl.MIN</code> and <code>gl.MAX</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/ext_color_buffer_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_float/index.html
@@ -16,7 +16,7 @@ browser-compat: api.EXT_color_buffer_float
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts only.</p>
+<p><strong>Note:</strong> This extension is available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts only.</p>
 
 <p>For {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, see the {{domxref("EXT_color_buffer_half_float")}} and {{domxref("WEBGL_color_buffer_float")}} extensions.</p>
 </div>

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_color_buffer_half_float
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. On WebGL 2, it's an alternative to using the {{domxref("EXT_color_buffer_float")}} extension on platforms that support 16-bit floating point render targets but not 32-bit floating point render targets.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. On WebGL 2, it's an alternative to using the {{domxref("EXT_color_buffer_float")}} extension on platforms that support 16-bit floating point render targets but not 32-bit floating point render targets.</p>
 
 <p>The {{domxref("OES_texture_half_float")}} extension implicitly enables this extension.</p>
 </div>

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_disjoint_timer_query
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts .</p>
+<p><strong>Note:</strong> This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts .</p>
 
 <p>In WebGL 2, the {{domxref("getQueryObject")}} was renamed to {{domxref("getQueryParameter")}}.<br>
  In WebGL 2, other queries (such as occlusion queries and primitive queries) are possible using {{domxref("WebGLQuery")}} objects.</p>

--- a/files/en-us/web/api/ext_float_blend/index.html
+++ b/files/en-us/web/api/ext_float_blend/index.html
@@ -22,7 +22,7 @@ browser-compat: api.EXT_float_blend
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. However, to use it, you need to enable the use of 32-bit floating-point draw buffers by  enabling the extension {{domxref("WEBGL_color_buffer_float")}} (for WebGL1) or {{domxref("EXT_color_buffer_float")}} (for WebGL2). Doing so automatically enables <code>EXT_float_blend</code> as well.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. However, to use it, you need to enable the use of 32-bit floating-point draw buffers by  enabling the extension {{domxref("WEBGL_color_buffer_float")}} (for WebGL1) or {{domxref("EXT_color_buffer_float")}} (for WebGL2). Doing so automatically enables <code>EXT_float_blend</code> as well.</p>
 </div>
 
 <p>With this extension enabled, calling {{domxref("WebGLRenderingContext.drawArrays", "drawArrays()")}} or {{domxref("WebGLRenderingContext.drawElements", "drawElements()")}} with blending enabled and a draw buffer with 32-bit floating-point components will no longer result in an <code>INVALID_OPERATION</code> error.</p>

--- a/files/en-us/web/api/ext_frag_depth/index.html
+++ b/files/en-us/web/api/ext_frag_depth/index.html
@@ -16,7 +16,7 @@ browser-compat: api.EXT_frag_depth
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL <code>#version 300 es</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL <code>#version 300 es</code>.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/ext_shader_texture_lod/index.html
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_shader_texture_lod
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL <code>#version 300 es</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL <code>#version 300 es</code>.</p>
 </div>
 
 <h2 id="GLSL_built-in_functions">GLSL built-in functions</h2>

--- a/files/en-us/web/api/ext_srgb/index.html
+++ b/files/en-us/web/api/ext_srgb/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_sRGB
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are: <code>gl.SRGB</code>, <code>gl.SRGB8</code>, <code>gl.SRGB8_ALPHA8</code> and <code>gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are: <code>gl.SRGB</code>, <code>gl.SRGB8</code>, <code>gl.SRGB8_ALPHA8</code> and <code>gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/ext_texture_compression_bptc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_bptc/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_texture_compression_bptc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> Support depends on the system's graphics driver. There is no support on Windows.</p>
+<p><strong>Note:</strong> Support depends on the system's graphics driver. There is no support on Windows.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>

--- a/files/en-us/web/api/ext_texture_compression_rgtc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_rgtc/index.html
@@ -15,7 +15,7 @@ browser-compat: api.EXT_texture_compression_rgtc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> Support depends on the system's graphics driver. There is no support on Windows.</p>
+<p><strong>Note:</strong> Support depends on the system's graphics driver. There is no support on Windows.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
@@ -17,7 +17,7 @@ browser-compat: api.EXT_texture_filter_anisotropic
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/ext_texture_norm16/index.html
+++ b/files/en-us/web/api/ext_texture_norm16/index.html
@@ -21,7 +21,7 @@ browser-compat: api.EXT_texture_norm16
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.html
@@ -23,8 +23,7 @@ browser-compat: api.FileReader.readAsArrayBuffer
   contains an {{jsxref("ArrayBuffer")}} representing the file's data.</p>
 
 <div class="notecard note">
-  <p><strong>Newer API available</strong><br>
-    The {{domxref("Blob.arrayBuffer()")}} method is a newer promise-based API to read a
+  <p><strong>Note:</strong> The {{domxref("Blob.arrayBuffer()")}} method is a newer promise-based API to read a
     file as an array buffer.</p>
 </div>
 

--- a/files/en-us/web/api/filereader/readastext/index.html
+++ b/files/en-us/web/api/filereader/readastext/index.html
@@ -19,8 +19,7 @@ browser-compat: api.FileReader.readAsText
   a text string.</p>
 
 <div class="notecard note">
-  <p><strong>Newer API available</strong><br>
-    The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as
+  <p><strong>Note:</strong> The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as
     text.</p>
 </div>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
@@ -11,11 +11,7 @@ browser-compat: api.GlobalEventHandlers.onmousewheel
         href="/en-US/docs/Web/Guide/Events/Event_handlers">event handler</a> for the
     {{event("mousewheel")}} event.</p>
 
-<div class="note">
-    <p><strong>Do not use this wheel event.</strong> This interface is non-standard and
-        deprecated. It was used in non-Gecko browsers only. Instead use the standard
-        {{event("wheel")}} event.</p>
-</div>
+<p>Instead of using this event, use the standard {{event("wheel")}} event.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmlelement/dataset/index.html
+++ b/files/en-us/web/api/htmlelement/dataset/index.html
@@ -16,11 +16,11 @@ browser-compat: api.HTMLElement.dataset
 <p>The <strong><code>dataset</code></strong> read-only property
 of the {{DOMxRef("HTMLElement")}} interface provides read/write access to <a
 href="/en-US/docs/Web/HTML/Global_attributes/data-*">custom data attributes</a>
-(<code>data-<var>*</var></code>) on elements.</span> It exposes a map of strings
+(<code>data-<var>*</var></code>) on elements. It exposes a map of strings
 ({{domxref("DOMStringMap")}}) with an entry for each <code>data-*</code> attribute.</p>
 
 <div class="notecard note">
-  <p>The <code>dataset</code> property itself can be read, but not directly written.
+  <p><strong>Note:</strong> The <code>dataset</code> property itself can be read, but not directly written.
     Instead, all writes must be to the individual properties within the
     <code>dataset</code>, which in turn represent the data attributes.</p>
 </div>
@@ -99,10 +99,8 @@ href="/en-US/docs/Web/HTML/Global_attributes/data-*">custom data attributes</a>
 
 <ul>
   <li>When the attribute is set, its value is always converted to a string.
-    <div class="notecard note">
-      <p><strong>For example:</strong> <code>element.dataset.example = null</code> is
+      <p>For example: <code>element.dataset.example = null</code> is
         converted into <code>data-example="null"</code>.</p>
-    </div>
   </li>
   <li>To remove an attribute, you can use the <a
       href="/en-US/docs/Web/JavaScript/Reference/Operators/delete"><code>delete</code>

--- a/files/en-us/web/api/htmlelement/offsetparent/index.html
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.html
@@ -18,10 +18,8 @@ browser-compat: api.HTMLElement.offsetParent
   <code>body</code> if there are no ancestor table elements either.</p>
 
 <div class="notecard note">
-  <p><strong>NOTE: </strong></p>
-
-  <p><strong><code>offsetParent</code> returns <code>null</code> in the following
-      situations:</strong></p>
+  <p><strong>Note:</strong> <code>offsetParent</code> returns <code>null</code> in the following
+      situations:</p>
 
   <ul>
     <li>The element or its parent element has the <code>display</code> property set to

--- a/files/en-us/web/api/htmlimageelement/image/index.html
+++ b/files/en-us/web/api/htmlimageelement/image/index.html
@@ -21,9 +21,8 @@ browser-compat: api.HTMLImageElement.Image
     "document.createElement('img')")}}.</p>
 
 <div class="notecard note">
-  <p><strong>Disambiguation:</strong> <a
-      href="/en-US/docs/Web/CSS/image/image()"><code>image()</code>, the CSS function
-      notation</a>.</p>
+  <p><strong>Note:</strong> This function should not be confused with the CSS <a
+      href="/en-US/docs/Web/CSS/image/image()"><code>image()</code></a> function.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/keyboardevent/charcode/index.html
+++ b/files/en-us/web/api/keyboardevent/charcode/index.html
@@ -16,8 +16,8 @@ browser-compat: api.KeyboardEvent.charCode
   {{domxref("KeyboardEvent")}} interface returns the Unicode value of a character key
   pressed during a {{Event("keypress")}} event.</p>
 
-<div class="notecard note">
-  <p><strong>Do not use this property, as it is deprecated.</strong> Instead, get the
+<div class="notecard warning">
+  <p><strong>Warning:</strong> Do not use this property, as it is deprecated. Instead, get the
     Unicode value of the character using the {{domxref("KeyboardEvent.key", "key")}}
     property.</p>
 </div>

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.html
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.html
@@ -19,14 +19,14 @@ tags:
   <code>initKeyEvent()</code> must be called to set the event before it is <a
     href="/en-US/docs/Web/API/EventTarget/dispatchEvent">dispatched</a>.</p>
 
-<div class="note">
-  <p><strong>Do not use this method anymore, use the
+<div class="warning">
+  <p><strong>Warning:</strong> Do not use this method. Use the
       {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}} constructor
-      instead.</strong><br>
+      instead.<br>
     <br>
     This method is based on the key events spec in the <a class="external"
     href="https://www.w3.org/TR/1999/WD-DOM-Level-2-19990923/events.html">early versions
-    of DOM 2 Events</a>, later removed from that spec.Favor the modern constructor structure as
+    of DOM 2 Events</a>, later removed from that spec. Prefer the modern constructor structure as
     the only cross-browser way of building events.
   </p>
 </div>

--- a/files/en-us/web/api/mousescrollevent/index.html
+++ b/files/en-us/web/api/mousescrollevent/index.html
@@ -15,8 +15,8 @@ browser-compat: api.MouseScrollEvent
 
 <p>The <strong><code>MouseScrollEvent</code></strong> interface represents events that occur due to the user moving a mouse wheel or similar input device.</p>
 
-<div class="note">
-<p><strong>Do not use this interface for wheel events.</strong></p>
+<div class="warning">
+<p><strong>Warning:</strong> Do not use this interface for wheel events.</p>
 
 <p>Like {{domxref("MouseWheelEvent")}}, this interface is non-standard and deprecated. It was used in Gecko-based browsers only. Instead use the standard <em>{{domxref("WheelEvent")}}.</em></p>
 </div>

--- a/files/en-us/web/api/mousewheelevent/index.html
+++ b/files/en-us/web/api/mousewheelevent/index.html
@@ -13,8 +13,8 @@ browser-compat: api.MouseWheelEvent
 
 <p>The <strong><code>MouseWheelEvent</code></strong> interface represents events that occur due to the user turning a mouse wheel.</p>
 
-<div class="note">
-<p><strong>Do not use this interface for wheel events.</strong></p>
+<div class="warning">
+<p><strong>Warning:</strong> Do not use this interface for wheel events.</p>
 
 <p>Like {{domxref("MouseScrollEvent")}}, this interface is non-standard and deprecated. It was used in non-Gecko browsers only. Instead use the standard <em>{{domxref("WheelEvent")}}.</em></p>
 </div>

--- a/files/en-us/web/api/navigation_timing_api/index.html
+++ b/files/en-us/web/api/navigation_timing_api/index.html
@@ -17,7 +17,7 @@ tags:
 <p>The <strong>Navigation Timing API</strong> provides data that can be used to measure the performance of a web site. Unlike JavaScript-based libraries that have historically been used to collect similar information, the Navigation Timing API can be much more accurate and reliable.</p>
 
 <div class="notecard note">
-<p><strong>This article currently describes Navigation Timing Level 1.</strong> There is a specification for Level 2, but it is not yet covered here.</p>
+<p><strong>Note:</strong> This article currently describes Navigation Timing Level 1. There is a specification for Level 2, but it is not yet covered here.</p>
 </div>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>

--- a/files/en-us/web/api/node/appendchild/index.html
+++ b/files/en-us/web/api/node/appendchild/index.html
@@ -28,8 +28,7 @@ browser-compat: api.Node.appendChild
   node.</p>
 
 <div class="notecard note">
-  <p><strong>Newer API available!</strong><br>
-    The {{domxref("Element.append()")}} method supports multiple arguments and
+  <p><strong>Note:</strong> The {{domxref("Element.append()")}} method supports multiple arguments and
     appending strings.</p>
 </div>
 

--- a/files/en-us/web/api/oes_element_index_uint/index.html
+++ b/files/en-us/web/api/oes_element_index_uint/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_element_index_uint
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.</p>
 </div>
 
 <h2 id="Extended_methods">Extended methods</h2>

--- a/files/en-us/web/api/oes_fbo_render_mipmap/index.html
+++ b/files/en-us/web/api/oes_fbo_render_mipmap/index.html
@@ -16,7 +16,7 @@ browser-compat: api.OES_fbo_render_mipmap
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}.  <br>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}.  <br>
  In WebGL2, the functionality of this extension is available in the WebGL 2 context by default.</p>
 </div>
 

--- a/files/en-us/web/api/oes_standard_derivatives/index.html
+++ b/files/en-us/web/api/oes_standard_derivatives/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_standard_derivatives
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constant is available as <code>gl.FRAGMENT_SHADER_DERIVATIVE_HINT</code> and it requires GLSL <code>#version 300 es</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constant is available as <code>gl.FRAGMENT_SHADER_DERIVATIVE_HINT</code> and it requires GLSL <code>#version 300 es</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/oes_texture_float/index.html
+++ b/files/en-us/web/api/oes_texture_float/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_texture_float
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.</p>
 </div>
 
 <h2 id="Extended_methods">Extended methods</h2>

--- a/files/en-us/web/api/oes_texture_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_float_linear/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_texture_float_linear
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Linear_filtering">Linear filtering</h2>

--- a/files/en-us/web/api/oes_texture_half_float/index.html
+++ b/files/en-us/web/api/oes_texture_half_float/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_texture_half_float
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is <code>gl.HALF_FLOAT</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is <code>gl.HALF_FLOAT</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_texture_half_float_linear
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Linear_filtering">Linear filtering</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/index.html
@@ -15,7 +15,7 @@ browser-compat: api.OES_vertex_array_object
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "<code>OES</code>" suffix.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "<code>OES</code>" suffix.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/ovr_multiview2/index.html
+++ b/files/en-us/web/api/ovr_multiview2/index.html
@@ -24,7 +24,7 @@ browser-compat: api.OVR_multiview2
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> Support depends on the system's graphics driver (Windows+ANGLE and Android are supported; Windows+GL, Mac, Linux are not supported).</p>
+<p><strong>Note:</strong> Support depends on the system's graphics driver (Windows+ANGLE and Android are supported; Windows+GL, Mac, Linux are not supported).</p>
 
 <p>This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts as it needs GLSL 3.00 and texture arrays.<br>
 <br>

--- a/files/en-us/web/api/page_visibility_api/index.html
+++ b/files/en-us/web/api/page_visibility_api/index.html
@@ -20,7 +20,7 @@ tags:
 <p>The Page Visibility API provides events you can watch for to know when a document becomes visible or hidden, as well as features to look at the current visibility state of the page.</p>
 
 <div class="note">
-<p><strong>Notes:</strong> The Page Visibility API is especially useful for saving resources and improving performance by letting a page avoid performing unnecessary tasks when the document isn't visible.</p>
+<p><strong>Note:</strong> The Page Visibility API is especially useful for saving resources and improving performance by letting a page avoid performing unnecessary tasks when the document isn't visible.</p>
 </div>
 
 <p>When the user minimizes the window or switches to another tab, the API sends a {{event("visibilitychange")}} event to let listeners know the state of the page has changed. You can detect the event and perform some actions or behave differently. For example, if your web app is playing a video, it can pause the video when the user puts the tab into the background, and resume playback when the user returns to the tab. The user doesn't lose their place in the video, the video's soundtrack doesn't interfere with audio in the new foreground tab, and the user doesn't miss any of the video in the meantime.</p>

--- a/files/en-us/web/api/paymentcurrencyamount/value/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/value/index.html
@@ -30,7 +30,7 @@ browser-compat: api.PaymentCurrencyAmount.value
   discount.</p>
 
 <div class="notecard note">
-  <p><strong>Important note:</strong> The number given in this string is always specified
+  <p><strong>Note:</strong> The number given in this string is always specified
     using the period (".") as the decimal point, rather than the comma (","), even if the
     user's locale normally uses the comma. You must convert the entered text to this form
     or it will not be valid.</p>

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -346,7 +346,7 @@ tags:
 </table>
 
 <div class="notecard note">
-<p><strong>Notice:</strong> The <code>button</code> property indicates a change in the state of the button. However, as in the case of touch, when multiple events occur with one event, all of them have the same value.</p>
+<p><strong>Note:</strong> The <code>button</code> property indicates a change in the state of the button. However, as in the case of touch, when multiple events occur with one event, all of them have the same value.</p>
 </div>
 
 <h2 id="Pointer_capture">Pointer capture</h2>

--- a/files/en-us/web/api/storagemanager/estimate/index.html
+++ b/files/en-us/web/api/storagemanager/estimate/index.html
@@ -33,7 +33,7 @@ browser-compat: api.StorageManager.estimate
 <p>A {{jsxref('Promise')}} that resolves to an object which conforms to the {{domxref('StorageEstimate')}} dictionary. This dictionary contains estimates of how much space is available to the origin in {{domxref("StorageEstimate.quota")}}, as well as how much is currently used in {{domxref("StorageEstimate.usage")}}.</p>
 
 <div class="notecard note">
-<p><strong>The returned values are not exact;</strong> between compression, deduplication, and obfuscation for security reasons, they will be imprecise.</p>
+<p><strong>Note:</strong> The returned values are not exact: between compression, deduplication, and obfuscation for security reasons, they will be imprecise.</p>
 </div>
 
 <p>You may find that the <code>quota</code> varies from origin to origin. This variance is based on factors such as:</p>

--- a/files/en-us/web/api/svganimatedstring/animval/index.html
+++ b/files/en-us/web/api/svganimatedstring/animval/index.html
@@ -8,7 +8,7 @@ browser-compat: api.SVGAnimatedString.animVal
 <p>AnimVal attribute or animVal property contains the same value as the <a href="/en-US/docs/new?slug=baseVal&amp;parent=6389"><strong>baseVal</strong></a> property.<span class="field"><span class="_animVal doc">If the given attribute or property is being animated, contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, then it contains the same value as </span></span>baseVal</p>
 
 <div class="note">
-<p>The <strong>animVal</strong> property is a read only property. Internet Explorer 9 supports script-based SVG animation but it does not support declarative-based SVG animation. As a result, the <strong>animVal</strong> property contains the same value as the <strong>baseVal</strong> property.</p>
+<p><strong>Note:</strong> The <strong>animVal</strong> property is a read only property. Internet Explorer 9 supports script-based SVG animation but it does not support declarative-based SVG animation. As a result, the <strong>animVal</strong> property contains the same value as the <strong>baseVal</strong> property.</p>
 </div>
 
 <h2 class="alert" id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/uievent/inituievent/index.html
+++ b/files/en-us/web/api/uievent/inituievent/index.html
@@ -20,8 +20,8 @@ browser-compat: api.UIEvent.initUIEvent
   before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
   dispatched, it doesn't do anything anymore.</p>
 
-<div class="note">
-  <p><strong>Do not use this method anymore as it is deprecated.</strong></p>
+<div class="warning">
+  <p><strong>Warning:</strong> Do not use this method anymore as it is deprecated.</p>
 
   <p>Instead use specific event constructors, like {{domxref("UIEvent.UIEvent",
     "UIEvent()")}}. The page on <a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a> gives more information about the way to use these.</p>

--- a/files/en-us/web/api/web_authentication_api/index.html
+++ b/files/en-us/web/api/web_authentication_api/index.html
@@ -32,7 +32,7 @@ tags:
 </ul>
 
 <div class="notecard note">
-<p><strong>Please note:</strong> Both <code>create()</code> and <code>get()</code> require a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a> (i.e. the server is connected by HTTPS or is the localhost), and will not be available for use if the browser is not operating in a secure context.</p>
+<p><strong>Note:</strong> Both <code>create()</code> and <code>get()</code> require a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a> (i.e. the server is connected by HTTPS or is the localhost), and will not be available for use if the browser is not operating in a secure context.</p>
 </div>
 
 <p>In their most basic forms, both <code>create()</code> and <code>get()</code> receive a very large random number called the "challenge" from the server and they return the challenge signed by the private key back to the server. This proves to the server that a user is in possession of the private key required for authentication without revealing any secrets over the network.</p>

--- a/files/en-us/web/api/webgl_color_buffer_float/index.html
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.html
@@ -15,7 +15,7 @@ browser-compat: api.WEBGL_color_buffer_float
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} contexts only. For {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}}, use the {{domxref("EXT_color_buffer_float")}} extension.</p>
+<p><strong>Note:</strong> This extension is available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} contexts only. For {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}}, use the {{domxref("EXT_color_buffer_float")}} extension.</p>
 
 <p>The {{domxref("OES_texture_float")}} extension implicitly enables this extension.</p>
 </div>

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.html
@@ -18,7 +18,7 @@ browser-compat: api.WEBGL_compressed_texture_astc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> ASTC compression is typically available on Mali ARM GPUs, Intel GPUs, and Nividia Tegra chips.</p>
+<p><strong>Note:</strong> ASTC compression is typically available on Mali ARM GPUs, Intel GPUs, and Nividia Tegra chips.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_compressed_texture_etc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_compressed_texture_etc1
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_compressed_texture_pvrtc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> PVRTC is typically only available on mobile devices with PowerVR chipsets. It is used in all generations of the iPhone, iPod Touch and iPad and supported on certain Android devices that use a PowerVR GPU.</p>
+<p><strong>Note:</strong> PVRTC is typically only available on mobile devices with PowerVR chipsets. It is used in all generations of the iPhone, iPod Touch and iPad and supported on certain Android devices that use a PowerVR GPU.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_compressed_texture_s3tc
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_compressed_texture_s3tc_srgb
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.html
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_debug_renderer_info
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts or not work at all. In Firefox, if <code>privacy.resistFingerprinting</code> is set to <code>true</code>, this extensions is disabled.</p>
+<p><strong>Note:</strong> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts or not work at all. In Firefox, if <code>privacy.resistFingerprinting</code> is set to <code>true</code>, this extensions is disabled.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>

--- a/files/en-us/web/api/webgl_debug_shaders/index.html
+++ b/files/en-us/web/api/webgl_debug_shaders/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WEBGL_debug_shaders
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts.</p>
+<p><strong>Note:</strong> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts.</p>
 
 <p>This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>

--- a/files/en-us/web/api/webgl_depth_texture/index.html
+++ b/files/en-us/web/api/webgl_depth_texture/index.html
@@ -15,7 +15,7 @@ browser-compat: api.WEBGL_depth_texture
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is <code>gl.UNSIGNED_INT_24_8</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is <code>gl.UNSIGNED_INT_24_8</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_draw_buffers/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/index.html
@@ -15,7 +15,7 @@ browser-compat: api.WEBGL_draw_buffers
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constants are available without the "WEBGL" suffix and the new GLSL built-ins require GLSL <code>#version 300 es</code>.</p>
+<p><strong>Note:</strong> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constants are available without the "WEBGL" suffix and the new GLSL built-ins require GLSL <code>#version 300 es</code>.</p>
 </div>
 
 <h2 id="Constants">Constants</h2>

--- a/files/en-us/web/api/webgl_lose_context/index.html
+++ b/files/en-us/web/api/webgl_lose_context/index.html
@@ -15,7 +15,7 @@ browser-compat: api.WEBGL_lose_context
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
 
 <div class="note">
-<p><strong>Availability:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
+<p><strong>Note:</strong> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.</p>
 </div>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/webgl_multi_draw/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/index.html
@@ -23,7 +23,7 @@ as it reduces binding costs in the renderer and speeds up GPU thread time with u
 </ul>
 
 <div class="note">
-  <p><strong>Availability:</strong> This extension is available to both,
+  <p><strong>Note:</strong> This extension is available to both,
   {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} and
   {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.</p>
   <p>In shader code, the directive <code>#extension GL_ANGLE_multi_draw</code>

--- a/files/en-us/web/api/webglvertexarrayobject/index.html
+++ b/files/en-us/web/api/webglvertexarrayobject/index.html
@@ -22,7 +22,7 @@ browser-compat: api.WebGLVertexArrayObject
 </ul>
 
 <div class="note">
-<p><strong>WebGL 1:</strong> The {{domxref("OES_vertex_array_object")}} extension allows you to use vertex array objects in a WebGL 1 context.</p>
+<p><strong>Note:</strong> The {{domxref("OES_vertex_array_object")}} extension allows you to use vertex array objects in a WebGL 1 context.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.html
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.html
@@ -37,7 +37,7 @@ tags:
 <p>The handshake is the "Web" in WebSockets. It's the bridge from HTTP to WebSockets. In the handshake, details of the connection are negotiated, and either party can back out before completion if the terms are unfavorable. The server must be careful to understand everything the client asks for, otherwise security issues can occur.</p>
 
 <div class="notecard note">
-<p><strong>Tip:</strong> The request-uri (<code>/chat</code> here) has no defined meaning in the spec. So, many people  use it to let one server handle multiple WebSocket applications. For example, <code>example.com/chat</code> could invoke a multiuser chat app, while <code>/game</code> on the same server might invoke a multiplayer game.</p>
+<p><strong>Note:</strong> The request-uri (<code>/chat</code> here) has no defined meaning in the spec. So, many people  use it to let one server handle multiple WebSocket applications. For example, <code>example.com/chat</code> could invoke a multiuser chat app, while <code>/game</code> on the same server might invoke a multiplayer game.</p>
 </div>
 
 <h3 id="Client_handshake_request">Client handshake request</h3>
@@ -56,7 +56,7 @@ Sec-WebSocket-Version: 13
 <p>The client can solicit extensions and/or subprotocols here; see <a href="#miscellaneous">Miscellaneous</a> for details. Also, common headers like {{HTTPHeader("User-Agent")}}, {{HTTPHeader("Referer")}}, {{HTTPHeader("Cookie")}}, or authentication headers might be there as well. Do whatever you want with those; they don't directly pertain to the WebSocket. It's also safe to ignore them. In many common setups, a reverse proxy has already dealt with them.</p>
 
 <div class="notecard note">
-<p><strong>Tip:</strong> All <strong>browsers</strong> send an <a href="/en-US/docs/Web/HTTP/CORS#origin"><code>Origin</code> header</a>. You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a <a href="/en-US/docs/Web/HTTP/Status#403">403 Forbidden</a> if you don't like what you see. However, be warned that non-browser agents can send a faked <code>Origin</code>. Most applications reject requests without this header.</p>
+<p><strong>Note:</strong> All <strong>browsers</strong> send an <a href="/en-US/docs/Web/HTTP/CORS#origin"><code>Origin</code> header</a>. You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a <a href="/en-US/docs/Web/HTTP/Status#403">403 Forbidden</a> if you don't like what you see. However, be warned that non-browser agents can send a faked <code>Origin</code>. Most applications reject requests without this header.</p>
 </div>
 
 <p>If any header is not understood or has an incorrect value, the server should send a {{HTTPStatus("400")}} ("Bad Request")} response and immediately close the socket. As usual, it may also give the reason why the handshake failed in the HTTP response body, but the message may never be displayed (browsers do not display it). If the server doesn't understand that version of WebSockets, it should send a {{HTTPHeader("Sec-WebSocket-Version")}} header back that contains the version(s) it does understand.  In the example above, it indicates version 13 of the WebSocket protocol.</p>
@@ -176,7 +176,7 @@ for (var i = 0; i &lt; ENCODED.length; i++) {
 <p>A ping or pong is just a regular frame, but it's a <strong>control frame</strong>. Pings have an opcode of <code>0x9</code>, and pongs have an opcode of <code>0xA</code>. When you get a ping, send back a pong with the exact same Payload Data as the ping (for pings and pongs, the max payload length is 125). You might also get a pong without ever sending a ping; ignore this if it happens.</p>
 
 <div class="note">
-<p>If you have gotten more than one ping before you get the chance to send a pong, you only send one pong.</p>
+<p><strong>Note:</strong> If you have gotten more than one ping before you get the chance to send a pong, you only send one pong.</p>
 </div>
 
 <h2 id="Closing_the_connection">Closing the connection</h2>
@@ -186,16 +186,12 @@ for (var i = 0; i &lt; ENCODED.length; i++) {
 <h2 id="Miscellaneous">Miscellaneous</h2>
 
 <div class="note">
-<p>WebSocket codes, extensions, subprotocols, etc. are registered at the <a href="https://www.iana.org/assignments/websocket/websocket.xml">IANA WebSocket Protocol Registry</a>.</p>
+<p><strong>Note:</strong> WebSocket codes, extensions, subprotocols, etc. are registered at the <a href="https://www.iana.org/assignments/websocket/websocket.xml">IANA WebSocket Protocol Registry</a>.</p>
 </div>
 
 <p>WebSocket extensions and subprotocols are negotiated via headers during <a href="#handshake">the handshake</a>. Sometimes extensions and subprotocols very similar, but there is a clear distinction. Extensions control the WebSocket <em>frame</em> and <em>modify</em> the payload, while subprotocols structure the WebSocket <em>payload</em> and <em>never modify</em> anything. Extensions are optional and generalized (like compression); subprotocols are mandatory and localized (like ones for chat and for MMORPG games).</p>
 
 <h3 id="Extensions">Extensions</h3>
-
-<div class="note">
-<p><strong>This section needs expansion. Please edit if you are equipped to do so.</strong></p>
-</div>
 
 <p>Think of an extension as compressing a file before e-mailing it to someone. Whatever you do, you're sending the <em>same</em> data in different forms. The recipient will eventually be able to get the same data as your local copy, but it is sent differently. That's what an extension does. WebSockets defines a protocol and a simple way to send data, but an extension such as compression could allow sending the same data but in a shorter format.</p>
 
@@ -203,14 +199,12 @@ for (var i = 0; i &lt; ENCODED.length; i++) {
 <p>Extensions are explained in sections 5.8, 9, 11.3.2, and 11.4 of the spec.</p>
 </div>
 
-<p><em>TODO</em></p>
-
 <h3 id="Subprotocols">Subprotocols</h3>
 
 <p>Think of a subprotocol as a custom <a href="https://en.wikipedia.org/wiki/XML_schema">XML schema</a> or <a href="https://en.wikipedia.org/wiki/Document_Type_Definition">doctype declaration</a>. You're still using XML and its syntax, but you're additionally restricted by a structure you agreed on. WebSocket subprotocols are just like that. They do not introduce anything fancy, they just establish structure. Like a doctype or schema, both parties must agree on the subprotocol; unlike a doctype or schema, the subprotocol is implemented on the server and cannot be externally referred to by the client.</p>
 
 <div class="note">
-<p>Subprotocols are explained in sections 1.9, 4.2, 11.3.4, and 11.5 of the spec.</p>
+<p><strong>Note:</strong> Subprotocols are explained in sections 1.9, 4.2, 11.3.4, and 11.5 of the spec.</p>
 </div>
 
 <p>A client has to ask for a specific subprotocol. To do so, it will send something like this <em>as part of the original handshake</em>:</p>
@@ -242,7 +236,7 @@ Sec-WebSocket-Protocol: wamp
 <p>If you want your server to obey certain subprotocols, then naturally you'll need extra code on the server. Let's imagine we're using a subprotocol <code>json</code>. In this subprotocol, all data is passed as <a href="https://en.wikipedia.org/wiki/JSON">JSON</a>. If the client solicits this protocol and the server wants to use it, the server needs to have a JSON parser. Practically speaking, this will be part of a library, but the server needs to pass the data around.</p>
 
 <div class="note">
-<p><strong>Tip:</strong> To avoid name conflict, it's recommended to make your subprotocol name part of a domain string. If you are building a custom chat app that uses a proprietary format exclusive to Example Inc., then you might use this: <code>Sec-WebSocket-Protocol: chat.example.com</code>. Note that this isn't required, it's just an optional convention, and you can use any string you wish.</p>
+<p><strong>Note:</strong> To avoid name conflict, it's recommended to make your subprotocol name part of a domain string. If you are building a custom chat app that uses a proprietary format exclusive to Example Inc., then you might use this: <code>Sec-WebSocket-Protocol: chat.example.com</code>. Note that this isn't required, it's just an optional convention, and you can use any string you wish.</p>
 </div>
 
 <h2 id="Related">Related</h2>

--- a/files/en-us/web/api/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/index.html
@@ -14,11 +14,11 @@ browser-compat: api.WheelEvent
 <p>The <strong><code>WheelEvent</code></strong> interface represents events that occur due to the user moving a mouse wheel or similar input device.</p>
 
 <div class="notecard warning">
-<p><strong>Important: This is the standard wheel event interface to use.</strong> Old versions of browsers implemented the non-standard and non-cross-browser-compatible {{DOMxRef("MouseWheelEvent")}} and {{DOMxRef("MouseScrollEvent")}} interfaces. Use this interface and avoid the non-standard ones.</p>
+<p><strong>Note: This is the standard wheel event interface to use.</strong> Old versions of browsers implemented the non-standard and non-cross-browser-compatible {{DOMxRef("MouseWheelEvent")}} and {{DOMxRef("MouseScrollEvent")}} interfaces. Use this interface and avoid the non-standard ones.</p>
 </div>
 
 <div class="notecard note">
-<p><strong>Do not confuse the {{domxref("Element/wheel_event", "wheel")}} event with the {{domxref("Element/scroll_event", "scroll")}} event:</strong> The default action of a <code>wheel</code> event is implementation-defined. Thus, a <code>wheel</code> event doesn't necessarily dispatch a <code>scroll</code> event. Even when it does, that doesn't mean that the <code>delta*</code> values in the <code>wheel</code> event necessarily reflect the content's scrolling direction. Therefore, do not rely on <code>delta*</code> properties to get the content's scrolling direction. Instead, detect value changes to {{DOMxRef("Element.scrollLeft", "scrollLeft")}} and {{DOMxRef("Element.scrollTop", "scrollTop")}} of the target in the <code>scroll</code> event.</p>
+<p><strong>Note:</strong> Do not confuse the {{domxref("Element/wheel_event", "wheel")}} event with the {{domxref("Element/scroll_event", "scroll")}} event. The default action of a <code>wheel</code> event is implementation-defined. Thus, a <code>wheel</code> event doesn't necessarily dispatch a <code>scroll</code> event. Even when it does, that doesn't mean that the <code>delta*</code> values in the <code>wheel</code> event necessarily reflect the content's scrolling direction. Therefore, do not rely on <code>delta*</code> properties to get the content's scrolling direction. Instead, detect value changes to {{DOMxRef("Element.scrollLeft", "scrollLeft")}} and {{DOMxRef("Element.scrollTop", "scrollTop")}} of the target in the <code>scroll</code> event.</p>
 </div>
 
 <p>{{InheritanceDiagram}}</p>

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -21,7 +21,7 @@ browser-compat: api.Window.open
   resource is loaded into it.</p>
 
 <div class="notecard note">
-   <p>Note that for brevity, this document will generally use the term "window" as a
+   <p><strong>Note:</strong> For brevity, this document will generally use the term "window" as a
    shorthand for "a browsing context in a tab or window".</p>
 </div>
 
@@ -112,9 +112,8 @@ function openRequestedPopup() {
   special value <code>_blank</code> for <code><var>windowName</var></code>.</p>
 
 <div class="notecard note">
-  <p id="Note_on_use_of_window_open">Note on the use of <code>window.open()</code> to
-    reopen an existing window with name <code><var>windowName</var></code> : This
-    functionality is not valid for all browsers and more with variable conditions.
+  <p><strong>Note:</strong> The use of <code>window.open()</code> to
+    reopen an existing window with name <code><var>windowName</var></code> is not valid for all browsers and more with variable conditions.
     <s>Firefox (50.0.1) functions as described: from the same domain+port reopen with same
       name will access the previously created window</s>. Google Chrome (55.0.2883.87 m )
     on the other hand will do it only from the same parent (as if the window was created
@@ -139,7 +138,7 @@ function openRequestedPopup() {
   main window.</p>
 
 <div class="notecard note">
-  <p><strong>Tip</strong>: Note that in some browsers, users can override the
+  <p><strong>Note:</strong> In some browsers, users can override the
     <code><var>windowFeatures</var></code> settings and enable (or prevent the disabling
     of) features. Further, control of some window features is available only on some browsers
     and platforms (See <a href="#popup_condition">popup condition</a> section)
@@ -276,7 +275,7 @@ function openRequestedPopup() {
     If <code><var>windowFeatures</var></code> is non-empty, <code>resizable</code>
     defaults to on.
     <div class="notecard note">
-      <p><strong>Tip</strong>: For accessibility reasons, it is strongly recommended to
+      <p><strong>Note:</strong> For accessibility reasons, it is strongly recommended to
         set this feature always on</p>
     </div>
   </dd>
@@ -289,8 +288,8 @@ function openRequestedPopup() {
     <br>
     See <a href="#note_on_scrollbars">note on scrollbars</a>.
     <div class="notecard note">
-      <p><strong>Tip</strong>: For accessibility reasons, it is strongly encouraged to set
-        this feature always on</p>
+      <p><strong>Note:</strong> For accessibility reasons, it is strongly encouraged to set
+        this feature always on.</p>
     </div>
   </dd>
 </dl>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8180.

The focus of this one is notes which did have a structure like `<p><strong>Thing</strong></p>`, but *Thing* wasn't "Note:".

There are actually three commits here: the first manually fixes up some notes just so the scripts could work better, the second auto-fixes `<p><strong>Availability:</strong></p>` and the third fixes a few different choices, like `<p><strong>Tip</strong></p>` and `<p><strong>Notes</strong></p>` etc.

In a few places I thought the text flowed better without them being notes, and in a few I felt warnings were more appropriate.