### PR TITLE
FF92: selectionchange_event - can be fired on textarea and input

### DIFF
--- a/files/en-us/web/api/document/selectionchange_event/index.html
+++ b/files/en-us/web/api/document/selectionchange_event/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Document.selectionchange_event
 ---
 <p>{{APIRef}}</p>
 
-<p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the current text selection on a document is changed.</p>
+<p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the current {{domxref("Selection")}} of a {{domxref("Document")}} is changed.</p>
 
 <table class="properties">
  <tbody>
@@ -34,6 +34,13 @@ browser-compat: api.Document.selectionchange_event
   </tr>
  </tbody>
 </table>
+
+<p>The event can be handled by adding an event listener for <code>selectionchange</code> or using the global {{domxref("GlobalEventHandlers.onselectionchange","onselectionchange")}} event handler.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This event is not quite the same as the <code>selectionchange</code> events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed.
+  See {{domxref("GlobalEventHandlers.onselectionchange")}} for more information.</p>
+</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -4,7 +4,6 @@ slug: Web/API/GlobalEventHandlers/onselectionchange
 tags:
   - API
   - Event Handler
-  - Experimental
   - GlobalEventHandlers
   - Property
   - Reference
@@ -13,22 +12,29 @@ tags:
   - onselectionchange
 browser-compat: api.GlobalEventHandlers.onselectionchange
 ---
-<div>{{ApiRef('DOM')}} {{SeeCompatTable}}</div>
+<div>{{ApiRef('DOM')}}</div>
 
-<p>The <code><strong>onselectionchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes {{event("selectionchange")}} events.</p>
+<p>The <code><strong>onselectionchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for <code>selectionchange</code> events.</p>
 
-<p>The <code>selectionchange</code> event fires when the text selected on a webpage changes.</p>
+<p>The {{domxref("HTMLTextAreaElement.selectionchange_event")}} and {{domxref("HTMLInputElement.selectionchange_event")}} events are fired, respectively, when the text selection within a {{HTMLElement("textarea")}} or {{HTMLElement("input")}} element is changed or the caret moves.</p>
+
+<p>The {{domxref("Document.selectionchange_event")}} is fired when the {{domxref("Selection")}} of a {{domxref("Document")}} is changed.
+  The {{domxref("Selection")}} consists of a starting position and (optionally) a range of HTML nodes from that position.
+  Clicking or starting a selection outside of a text field will generally fire this event.</p>
+
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><em>object</em>.onselectionchange = <em>functionRef</em>;
+<pre class="brush: js">document.onselectionchange = <em>functionRef</em>;
 </pre>
 
 <h3 id="Value">Value</h3>
 
-<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>. The function receives a {{domxref("FocusEvent")}} object as its sole argument.</p>
+<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>. The function receives an {{domxref("Event")}} object as its sole argument.</p>
 
 <h2 id="Example">Example</h2>
+
+<h3 id="getting_the_changed_document_selection">Getting the changed Document Selection</h3>
 
 <pre class="brush: js">let selection;
 
@@ -38,6 +44,24 @@ document.onselectionchange = function() {
 };</pre>
 
 <p>For a full example, see our <a href="https://github.com/chrisdavidmills/selection-api-examples/#key-quote-generator-see-it-running-live">Key quote generator</a> demo.</p>
+
+<h3 id="using_selectionchange_with_text_controls">Getting selectionchange within a text control</h3>
+
+<p>To get information about the selection on a text in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} use the <code>selectionStart</code>, <code>selectionEnd</code>, and <code>selectionDirection</code> properties of {{domxref("HTMLInputElement")}} or {{domxref("HTMLTextAreaElement")}}, as appropriate.
+The code fragment shows how to do this (for either type), using an element with the id <code>myinput</code>.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> We don't use {{domxref("Selection")}} here, because we're interested in the selected text, not the {{domxref("Document")}}.</p>
+</div>
+
+<pre class="brush: js">let myinput = document.getElementById("myinput");
+  
+myinput.addEventListener("selectionchange", () => {
+  document.getElementById("start").textContent = myinput.selectionStart;
+  document.getElementById("end").textContent = myinput.selectionEnd;
+  document.getElementById("direction").textContent = myinput.selectionDirection;
+});
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -16,12 +16,11 @@ browser-compat: api.GlobalEventHandlers.onselectionchange
 
 <p>The <code><strong>onselectionchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for <code>selectionchange</code> events.</p>
 
-<p>The {{domxref("HTMLTextAreaElement.selectionchange_event")}} and {{domxref("HTMLInputElement.selectionchange_event")}} events are fired, respectively, when the text selection within a {{HTMLElement("textarea")}} or {{HTMLElement("input")}} element is changed or the caret moves.</p>
-
 <p>The {{domxref("Document.selectionchange_event")}} is fired when the {{domxref("Selection")}} of a {{domxref("Document")}} is changed.
   The {{domxref("Selection")}} consists of a starting position and (optionally) a range of HTML nodes from that position.
   Clicking or starting a selection outside of a text field will generally fire this event.</p>
 
+<p>The {{domxref("HTMLTextAreaElement.selectionchange_event")}} and {{domxref("HTMLInputElement.selectionchange_event")}} events are fired, respectively, when the text selection within a {{HTMLElement("textarea")}} or {{HTMLElement("input")}} element is changed or the caret moves.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -36,32 +35,49 @@ browser-compat: api.GlobalEventHandlers.onselectionchange
 
 <h3 id="getting_the_changed_document_selection">Getting the changed Document Selection</h3>
 
-<pre class="brush: js">let selection;
+<p>This code fragment shows how you can get <code>selectionchange</code> events on the {{domxref("Document")}}.
+This will include events fired on text controls, which will bubble up to this handler.</p>
 
-document.onselectionchange = function() {
+<pre class="brush: js">document.onselectionchange = function() {
   console.log('New selection made');
-  selection = document.getSelection();
+  let selection = document.getSelection();
 };</pre>
 
 <p>For a full example, see our <a href="https://github.com/chrisdavidmills/selection-api-examples/#key-quote-generator-see-it-running-live">Key quote generator</a> demo.</p>
 
-<h3 id="using_selectionchange_with_text_controls">Getting selectionchange within a text control</h3>
+<h3 id="Using_selectionchange_with_a_text_control">Using selectionchange with a text control</h3>
 
-<p>To get information about the selection on a text in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} use the <code>selectionStart</code>, <code>selectionEnd</code>, and <code>selectionDirection</code> properties of {{domxref("HTMLInputElement")}} or {{domxref("HTMLTextAreaElement")}}, as appropriate.
-The code fragment shows how to do this (for either type), using an element with the id <code>myinput</code>.</p>
+<p>The example below show how to get the start, end, and direction text selected in a {{HTMLElement("textarea")}}.
+  It uses {{domxref("HTMLTextAreaElement")}} properties <code>selectionStart</code>, <code>selectionEnd</code>, and <code>selectionDirection</code> (for an {{HTMLElement("input")}} element you would use properties with the same name on {{domxref("HTMLInputElement")}}).</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> We don't use {{domxref("Selection")}} here, because we're interested in the selected text, not the {{domxref("Document")}}.</p>
+  <p><strong>Note:</strong> We don't use {{domxref("Selection")}} here, because it contains information about selected {{domxref("Document")}} nodes, not the selected text.</p>
 </div>
 
-<pre class="brush: js">let myinput = document.getElementById("myinput");
-  
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">&lt;div&gt;Enter and select text here:&lt;br&gt;&lt;textarea id="mytext" rows="2" cols="20"&gt;&lt;/textarea&gt;&lt;/div&gt;
+&lt;div&gt;selectionStart: &lt;span id="start"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionEnd: &lt;span id="end"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionDirection: &lt;span id="direction"&gt;&lt;/span&gt;&lt;/div&gt;
+</pre>
+
+<h4 id="JavaScript">JavaScript</h4>
+
+<pre class="brush: js">const myinput = document.getElementById("mytext");
+
 myinput.addEventListener("selectionchange", () => {
-  document.getElementById("start").textContent = myinput.selectionStart;
-  document.getElementById("end").textContent = myinput.selectionEnd;
-  document.getElementById("direction").textContent = myinput.selectionDirection;
+  document.getElementById("start").textContent = mytext.selectionStart;
+  document.getElementById("end").textContent = mytext.selectionEnd;
+  document.getElementById("direction").textContent = mytext.selectionDirection;
 });
 </pre>
+
+<h4 id="Result">Result</h4>
+
+<p>{{EmbedLiveSample("Using selectionchange with a text control")}}</p>
+
+
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -47,7 +47,7 @@ This will include events fired on text controls, which will bubble up to this ha
 
 <h3 id="Using_selectionchange_with_a_text_control">Using selectionchange with a text control</h3>
 
-<p>The example below show how to get the start, end, and direction text selected in a {{HTMLElement("textarea")}}.
+<p>The example below shows how to get the start, end, and direction of text selected in a {{HTMLElement("textarea")}}.
   It uses {{domxref("HTMLTextAreaElement")}} properties <code>selectionStart</code>, <code>selectionEnd</code>, and <code>selectionDirection</code> (for an {{HTMLElement("input")}} element you would use properties with the same name on {{domxref("HTMLInputElement")}}).</p>
 
 <div class="notecard note">

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -372,6 +372,8 @@ browser-compat: api.HTMLInputElement
  <dt><code><a href="/en-US/docs/Web/API/HTMLInputElement/search_event">search</a></code></dt>
  <dd>Fired when a search is initiated on an {{HTMLElement("input")}} of <code>type="search"</code>.<br>
  Also available via the <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onsearch">onsearch</a></code> event handler property.</dd>
+ <dt>{{domxref("HTMLInputElement/selectionchange_event", "selectionchange")}} event{{experimental_inline}}</dt>
+ <dd>Fires when the text selection in a {{HTMLElement("input")}} element has been changed.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
@@ -1,0 +1,86 @@
+---
+title: 'HTMLInputElement: selectionchange event'
+slug: Web/API/HTMLInputElement/selectionchange_event
+tags:
+  - API
+  - Event
+  - Reference
+  - Selection
+  - Selection API
+  - selectionchange
+  - Experimental
+browser-compat: api.HTMLInputElement.selectionchange_event
+---
+<p>{{APIRef}}{{SeeCompatTable}}</p>
+
+<p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the text selection within an {{HTMLElement("input")}} element is changed.
+  Ths includes both changes in the selected range of characters, or if the caret moves.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th>Bubbles</th>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th>Cancelable</th>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th>Interface</th>
+   <td>{{domxref("Event")}}</td>
+  </tr>
+  <tr>
+   <th>Event handler property</th>
+   <td>{{domxref("GlobalEventHandlers.onselectionchange", "onselectionchange")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<p>The event is usually processed by adding an event listener on the {{HTMLElement("input")}}, and in the handler function read the {{domxref("HTMLInputElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
+
+<p>It is also possible to add a listener on the global {{domxref("GlobalEventHandlers.onselectionchange","onselectionchange")}} event handler, and within the handler function use {{domxref("Document.getSelection()")}} to get the {{domxref("Selection", "Selection")}}. However this is not very useful for getting changes to <em>text</em> selections.</p>
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>The example below show how to get the text selected in an {{HTMLElement("input")}} element.</p>
+
+<h3 id="HTML">HTML</h3>
+
+<pre class="brush: html">&lt;div&gt;Enter and select text here:&lt;br&gt;&lt;input id="mytext" rows="2" cols="20"&gt;&lt;/textarea&gt;&lt;/div&gt;
+&lt;div&gt;selectionStart: &lt;span id="start"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionEnd: &lt;span id="end"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionDirection: &lt;span id="direction"&gt;&lt;/span&gt;&lt;/div&gt;
+</pre>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<pre class="brush: js">const myinput = document.getElementById("mytext");
+
+myinput.addEventListener("selectionchange", () => {
+  document.getElementById("start").textContent = mytext.selectionStart;
+  document.getElementById("end").textContent = mytext.selectionEnd;
+  document.getElementById("direction").textContent = mytext.selectionDirection;
+});
+</pre>
+
+<h3 id="Result">Result</h3>
+
+<p>{{EmbedLiveSample("Examples")}}</p>
+
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{domxref("GlobalEventHandlers.onselectionchange")}}</li>
+</ul>

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
@@ -37,7 +37,7 @@ browser-compat: api.HTMLInputElement.selectionchange_event
  </tbody>
 </table>
 
-<p>The event is usually processed by adding an event listener on the {{HTMLElement("input")}}, and in the handler function read the {{domxref("HTMLInputElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
+<p>The event is usually processed by adding an event listener on the {{HTMLElement("input")}}, and in the handler function read by the {{domxref("HTMLInputElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
 
 <p>It is also possible to add a listener on the global {{domxref("GlobalEventHandlers.onselectionchange","onselectionchange")}} event handler, and within the handler function use {{domxref("Document.getSelection()")}} to get the {{domxref("Selection", "Selection")}}. However this is not very useful for getting changes to <em>text</em> selections.</p>
 

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
@@ -44,7 +44,7 @@ browser-compat: api.HTMLInputElement.selectionchange_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>The example below show how to get the text selected in an {{HTMLElement("input")}} element.</p>
+<p>The example below shows how to get the text selected in an {{HTMLElement("input")}} element.</p>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLInputElement.selectionchange_event
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the text selection within an {{HTMLElement("input")}} element is changed.
-  Ths includes both changes in the selected range of characters, or if the caret moves.</p>
+  This includes both changes in the selected range of characters, or if the caret moves.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/htmltextareaelement/index.html
+++ b/files/en-us/web/api/htmltextareaelement/index.html
@@ -188,6 +188,8 @@ browser-compat: api.HTMLTextAreaElement
 <dl>
  <dt>{{domxref("HTMLElement/input_event", "input")}} event</dt>
  <dd>Fires when the <code>value</code> of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element has been changed.</dd>
+ <dt>{{domxref("HTMLTextAreaElement/selectionchange_event", "selectionchange")}} event{{experimental_inline}}</dt>
+ <dd>Fires when the text selection in a {{HTMLElement("textarea")}} element has been changed.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
@@ -44,7 +44,7 @@ browser-compat: api.HTMLTextAreaElement.selectionchange_event
 
 <h2 id="Examples">Examples</h2>
 
-<p>The example below show how to get the text selected in an {{HTMLElement("textarea")}} element.</p>
+<p>The example below shows how to get the text selected in an {{HTMLElement("textarea")}} element.</p>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
@@ -37,7 +37,7 @@ browser-compat: api.HTMLTextAreaElement.selectionchange_event
  </tbody>
 </table>
 
-<p>The event is usually processed by adding an event listener on the {{HTMLElement("textarea")}}, and in the handler function read the {{domxref("HTMLTextAreaElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
+<p>The event is usually processed by adding an event listener on the {{HTMLElement("textarea")}}, and in the handler function read by the {{domxref("HTMLTextAreaElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
 
 <p>It is also possible to add a listener on the global {{domxref("GlobalEventHandlers.onselectionchange","onselectionchange")}} event handler, and within the handler function use {{domxref("Document.getSelection()")}} to get the {{domxref("Selection", "Selection")}}. However this is not very useful for getting changes to <em>text</em> selections.</p>
 

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
@@ -14,7 +14,7 @@ browser-compat: api.HTMLTextAreaElement.selectionchange_event
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the text selection within an {{HTMLElement("textarea")}} element is changed.
-  Ths includes both changes in the selected range of characters, or if the caret moves.</p>
+  This includes both changes in the selected range of characters, or if the caret moves.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.html
@@ -1,0 +1,86 @@
+---
+title: 'HTMLTextAreaElement: selectionchange event'
+slug: Web/API/HTMLTextAreaElement/selectionchange_event
+tags:
+  - API
+  - Event
+  - Reference
+  - Selection
+  - Selection API
+  - selectionchange
+  - Experimental
+browser-compat: api.HTMLTextAreaElement.selectionchange_event
+---
+<p>{{APIRef}}{{SeeCompatTable}}</p>
+
+<p>The <code><strong>selectionchange</strong></code> event of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is fired when the text selection within an {{HTMLElement("textarea")}} element is changed.
+  Ths includes both changes in the selected range of characters, or if the caret moves.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th>Bubbles</th>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th>Cancelable</th>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th>Interface</th>
+   <td>{{domxref("Event")}}</td>
+  </tr>
+  <tr>
+   <th>Event handler property</th>
+   <td>{{domxref("GlobalEventHandlers.onselectionchange", "onselectionchange")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<p>The event is usually processed by adding an event listener on the {{HTMLElement("textarea")}}, and in the handler function read the {{domxref("HTMLTextAreaElement")}} <code>selectionStart</code>, <code>selectionEnd</code> and <code>selectionDirection</code> properties.</p>
+
+<p>It is also possible to add a listener on the global {{domxref("GlobalEventHandlers.onselectionchange","onselectionchange")}} event handler, and within the handler function use {{domxref("Document.getSelection()")}} to get the {{domxref("Selection", "Selection")}}. However this is not very useful for getting changes to <em>text</em> selections.</p>
+
+
+<h2 id="Examples">Examples</h2>
+
+<p>The example below show how to get the text selected in an {{HTMLElement("textarea")}} element.</p>
+
+<h3 id="HTML">HTML</h3>
+
+<pre class="brush: html">&lt;div&gt;Enter and select text here:&lt;br&gt;&lt;textarea id="mytext" rows="2" cols="20"&gt;&lt;/textarea&gt;&lt;/div&gt;
+&lt;div&gt;selectionStart: &lt;span id="start"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionEnd: &lt;span id="end"&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;div&gt;selectionDirection: &lt;span id="direction"&gt;&lt;/span&gt;&lt;/div&gt;
+</pre>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<pre class="brush: js">const myinput = document.getElementById("mytext");
+
+myinput.addEventListener("selectionchange", () => {
+  document.getElementById("start").textContent = mytext.selectionStart;
+  document.getElementById("end").textContent = mytext.selectionEnd;
+  document.getElementById("direction").textContent = mytext.selectionDirection;
+});
+</pre>
+
+<h3 id="Result">Result</h3>
+
+<p>{{EmbedLiveSample("Examples")}}</p>
+
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{domxref("GlobalEventHandlers.onselectionchange")}}</li>
+</ul>

--- a/files/en-us/web/events/index.html
+++ b/files/en-us/web/events/index.html
@@ -325,7 +325,7 @@ tags:
 			<p><a href="/en-US/docs/Web/API/Selection">Selection API</a> events related to selecting text.</p>
 		</td>
 		<td>
-			<p>Events (<code>selectionchange</code>) fired on {{domxref("HTMLTextAreaElement/selectionchange_event", "HTMLTextAreaElement")}}, {{domxref("HTMLInputElement/selectionchange_event", "HTMLInputElement")}}.</p>
+			<p>Event (<code>selectionchange</code>) fired on {{domxref("HTMLTextAreaElement/selectionchange_event", "HTMLTextAreaElement")}}, {{domxref("HTMLInputElement/selectionchange_event", "HTMLInputElement")}}.</p>
 		</td>
 	</tr>
 

--- a/files/en-us/web/events/index.html
+++ b/files/en-us/web/events/index.html
@@ -322,10 +322,10 @@ tags:
 	<tr>
 		<td>Text selection</td>
 		<td>
-			<p>Events related to <a href="/en-US/docs/Web/API/Selection">selecting text</a>.</p>
+			<p><a href="/en-US/docs/Web/API/Selection">Selection API</a> events related to selecting text.</p>
 		</td>
 		<td>
-			<p>Events fired on <a href="/en-US/docs/Web/API/Document#selection_events"><code>Document</code></a>.</p>
+			<p>Events (<code>selectionchange</code>) fired on {{domxref("HTMLTextAreaElement/selectionchange_event", "HTMLTextAreaElement")}}, {{domxref("HTMLInputElement/selectionchange_event", "HTMLInputElement")}}.</p>
 		</td>
 	</tr>
 


### PR DESCRIPTION
FF92 adds support for this [spec change](https://github.com/w3c/selection-api/pull/141). Essentially the `selectedchange` event used to just be fired on document and tell you something about the selected nodes (in a `Selection` object). The spec change means that you can use the same event to find out about selection within a text control (input or text area)

The change adds information in the global `onselectionchanged` handler to note the new events. There are also new event docs added for HTMLInputElement/HTMLTextAreaElement. BCD follows in https://github.com/mdn/browser-compat-data/pull/12126.

This is first part of docs for #7755