### PR TITLE
Add WebXR Hit Test reference docs - pt 4

### DIFF
--- a/files/en-us/web/api/xrframe/createanchor/index.md
+++ b/files/en-us/web/api/xrframe/createanchor/index.md
@@ -15,6 +15,8 @@ browser-compat: api.XRFrame.createAnchor
 
 The **`createAnchor()`** method of the {{domxref("XRFrame")}} interface creates a free-floating {{domxref("XRAnchor")}} which will be fixed relative to the real world.
 
+See {{domxref("XRHitTestResult.createAnchor()")}} for creating an anchor from a hit test result that is attached to a real world object.
+
 ## Syntax
 
 ```js
@@ -53,3 +55,7 @@ frame.createAnchor(anchorPose, referenceSpace).then((anchor) => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("XRHitTestResult.createAnchor()")}}

--- a/files/en-us/web/api/xrframe/gethittestresults/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresults/index.md
@@ -12,7 +12,7 @@ browser-compat: api.XRFrame.getHitTestResults
 ---
 {{APIRef("WebXR Device API")}}
 
-The **`getHitTestResults()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRHitResult")}} objects containing hit test results for a given {{domxref("XRHitTestSource")}}.
+The **`getHitTestResults()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRHitTestResult")}} objects containing hit test results for a given {{domxref("XRHitTestSource")}}.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ getHitTestResults(hitTestSource)
 
 ### Return value
 
-An array of {{domxref("XRHitResult")}} objects.
+An array of {{domxref("XRHitTestResult")}} objects.
 
 ## Examples
 

--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -12,7 +12,7 @@ browser-compat: api.XRFrame.getHitTestResultsForTransientInput
 ---
 {{APIRef("WebXR Device API")}}
 
-The **`getHitTestResultsForTransientInput()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRTransientInputHitResult")}} objects containing transient input hit test results for a given {{domxref("XRTransientInputHitTestSource")}}.
+The **`getHitTestResultsForTransientInput()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRTransientInputHitTestResult")}} objects containing transient input hit test results for a given {{domxref("XRTransientInputHitTestSource")}}.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ getHitTestResultsForTransientInput(hitTestSource)
 
 ### Return value
 
-An array of {{domxref("XRTransientInputHitResult")}} objects.
+An array of {{domxref("XRTransientInputHitTestResult")}} objects.
 
 ## Examples
 

--- a/files/en-us/web/api/xrhittestresult/createanchor/index.md
+++ b/files/en-us/web/api/xrhittestresult/createanchor/index.md
@@ -1,0 +1,57 @@
+---
+title: XRHitTestResult.createAnchor()
+slug: Web/API/XRHitTestResult/createAnchor
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - VR
+  - XR
+  - WebXR
+browser-compat: api.XRHitTestResult.createAnchor
+---
+{{APIRef("WebXR Device API")}}
+
+The **`createAnchor()`** method of the {{domxref("XRHitTestResult")}} interface creates an {{domxref("XRAnchor")}} from a hit test result that is attached to a real world object.
+
+## Syntax
+
+```js
+createAnchor()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} resolving to an {{domxref("XRAnchor")}} object.
+
+## Examples
+
+### Creating an anchor from a hit test result
+
+Once you found intersections on real-world surfaces by using hit testing, you can create an {{domxref("XRAnchor")}} to attach a virtual object to that location.
+
+```js
+hitTestResult.createAnchor().then((anchor) => {
+  // add anchored objects to the scene
+}, (error) => {
+  console.error("Could not create anchor: " + error);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRAnchor")}}
+- {{domxref("XRFrame.createAnchor()")}}

--- a/files/en-us/web/api/xrhittestresult/createanchor/index.md
+++ b/files/en-us/web/api/xrhittestresult/createanchor/index.md
@@ -27,13 +27,13 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} resolving to an {{domxref("XRAnchor")}} object.
+A {{jsxref("Promise")}} resolving with an {{domxref("XRAnchor")}} object.
 
 ## Examples
 
 ### Creating an anchor from a hit test result
 
-Once you found intersections on real-world surfaces by using hit testing, you can create an {{domxref("XRAnchor")}} to attach a virtual object to that location.
+The following example starts with an {{domxref("XRHitTestResult")}} retrieved by calling {{domxref("XRFrame.getHitTestResults()")}}. After calling `createAnchor()`, the Promise resolves with an {{domxref("XRAnchor")}} to attach a virtual object to that location.
 
 ```js
 hitTestResult.createAnchor().then((anchor) => {

--- a/files/en-us/web/api/xrhittestresult/getpose/index.md
+++ b/files/en-us/web/api/xrhittestresult/getpose/index.md
@@ -1,0 +1,57 @@
+---
+title: XRHitTestResult.getPose()
+slug: Web/API/XRHitTestResult/getPose
+tags:
+  - API
+  - Method
+  - Reference
+  - AR
+  - VR
+  - XR
+  - WebXR
+browser-compat: api.XRHitTestResult.getPose
+---
+{{APIRef("WebXR Device API")}}
+
+The **`getPose()`** method of the {{domxref("XRHitTestResult")}} interface returns the {{domxref("XRPose")}} of the hit test result relative to the given base space.
+
+## Syntax
+
+```js
+getPose(baseSpace)
+```
+
+### Parameters
+
+- `baseSpace`
+  - : An {{domxref("XRSpace")}} to use as the base or origin for the purposes of computing the relative position and orientation.
+
+### Return value
+
+Returns an {{domxref("XRPose")}} object.
+
+## Examples
+
+### Getting the hit test result's pose
+
+Use `getPose()` to query a single hit test result's pose.
+
+```js
+let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+
+if (hitTestResults.length > 0) {
+  let pose = hitTestResults[0].getPose(referenceSpace);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRFrame.getPose()")}}

--- a/files/en-us/web/api/xrhittestresult/getpose/index.md
+++ b/files/en-us/web/api/xrhittestresult/getpose/index.md
@@ -24,7 +24,7 @@ getPose(baseSpace)
 ### Parameters
 
 - `baseSpace`
-  - : An {{domxref("XRSpace")}} to use as the base or origin for the purposes of computing the relative position and orientation.
+  - : An {{domxref("XRSpace")}} to use as the base or origin for computing the relative position and orientation of hit test results.
 
 ### Return value
 
@@ -34,7 +34,7 @@ Returns an {{domxref("XRPose")}} object.
 
 ### Getting the hit test result's pose
 
-Use `getPose()` to query a single hit test result's pose.
+The following example uses `getPose()` to query a single hit test result's pose.
 
 ```js
 let hitTestResults = xrFrame.getHitTestResults(hitTestSource);

--- a/files/en-us/web/api/xrhittestresult/index.md
+++ b/files/en-us/web/api/xrhittestresult/index.md
@@ -1,0 +1,93 @@
+---
+title: XRHitTestResult
+slug: Web/API/XRHitTestResult
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRHitTestResult
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRHitTestResult`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) contains a single result of a hit test. You can get an array of `XRHitTestResult` objects for a frame by calling {{domxref("XRFrame.getHitTestResults()")}}.
+
+## Properties
+
+None.
+
+## Methods
+
+- {{domxref("XRHitTestResult.createAnchor()")}}
+  - : Creates an {{domxref("XRAnchor")}} from the hit test result.
+- {{domxref("XRHitTestResult.getPose()")}}
+  - : Returns the {{domxref("XRPose")}} of the hit test result relative to the given base space.
+
+## Examples
+
+### Getting `XRHitTestResult` objects within the frame loop
+
+To get hit test results, you need to provide a {{domxref("XRHitTestSource")}}. See {{domxref("XRSession.requestHitTestSource()")}} for more information.
+
+```js
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let hitTestSource = null;
+
+xrSession.requestHitTestSource({
+  space : viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
+  offsetRay : new XRRay({y: 0.5})
+}).then((viewerHitTestSource) => {
+  hitTestSource = viewerHitTestSource;
+});
+
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+
+  // do things with the hit test results
+}
+```
+
+### Getting the hit test result's pose
+
+Use {{domxref("XRHitTestResult.getPose", "getPose()")}} to query the result's pose.
+
+```js
+let hitTestResults = xrFrame.getHitTestResults(hitTestSource);
+
+if (hitTestResults.length > 0) {
+  let pose = hitTestResults[0].getPose(referenceSpace);
+}
+```
+
+### Creating an anchor from a hit test result
+
+Once you found intersections on real-world surfaces using hit testing, you can create an {{domxref("XRAnchor")}} to attach a virtual object to that location.
+
+```js
+hitTestResult.createAnchor().then((anchor) => {
+  // add anchored objects to the scene
+}, (error) => {
+  console.error("Could not create anchor: " + error);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRTransientInputHitTestResult")}}
+- {{domxref("XRPose")}}
+- {{domxref("XRAnchor")}}

--- a/files/en-us/web/api/xrhittestresult/index.md
+++ b/files/en-us/web/api/xrhittestresult/index.md
@@ -22,7 +22,7 @@ None.
 ## Methods
 
 - {{domxref("XRHitTestResult.createAnchor()")}}
-  - : Creates an {{domxref("XRAnchor")}} from the hit test result.
+  - : Returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRAnchor")}} created from the hit test result.
 - {{domxref("XRHitTestResult.getPose()")}}
   - : Returns the {{domxref("XRPose")}} of the hit test result relative to the given base space.
 
@@ -30,7 +30,7 @@ None.
 
 ### Getting `XRHitTestResult` objects within the frame loop
 
-To get hit test results, you need to provide a {{domxref("XRHitTestSource")}}. See {{domxref("XRSession.requestHitTestSource()")}} for more information.
+In addition to showing `XRHitTestResult` within a frame loop, this example demonstrates a few things you must do before requesting this object. While setting up the session, specify `"hit-test"` as one of the `requiredFeatures`. Next, call {{domxref("XRSession.requestHitTestSource()")}} with the desired references. (Obtain this by calling {{domxref("XRSession.requestReferenceSpace()")}}.) This returns a {{domxref("XRHitTestSource")}}. That you will use in the frame loop to get `XRHitTestResult` objects. 
 
 ```js
 const xrSession = navigator.xr.requestSession("immersive-ar", {
@@ -68,7 +68,7 @@ if (hitTestResults.length > 0) {
 
 ### Creating an anchor from a hit test result
 
-Once you found intersections on real-world surfaces using hit testing, you can create an {{domxref("XRAnchor")}} to attach a virtual object to that location.
+Once you find intersections on real-world surfaces using hit testing, you can create an {{domxref("XRAnchor")}} to attach a virtual object to that location.
 
 ```js
 hitTestResult.createAnchor().then((anchor) => {


### PR DESCRIPTION
Part 4 documents `XRHitTestResult` and its two methods `getPose()` and `createAnchor()`.

Specs:
- https://immersive-web.github.io/hit-test/#xr-hit-test-result-interface
- https://immersive-web.github.io/anchors/#anchor-creation