### PR TITLE
Added missing information to the Grid Masonry Layout Guide.

### DIFF
--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -11,9 +11,9 @@ tags:
 
 Level 3 of the [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout) specification includes a `masonry` value for {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}. This guide details what masonry layout is, and how to use it.
 
-> **Warning:** This feature is only implemented in Firefox, and can be enabled by setting the flag `layout.css.grid-template-masonry-value.enabled` to `true`, in order to allow testing and providing of feedback.
+> **Warning:** This feature is only implemented in Firefox, and can be enabled by setting the flag `layout.css.grid-template-masonry-value.enabled` to `true` in `about:config`, in order to allow testing and providing of feedback.
 
-Masonry layout is a layout method where one axis uses a typical strict grid layout, of most often columns, and the other a masonry layout. On the masonry axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to completely fill the gaps.
+Masonry layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other a masonry layout. On the masonry axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to completely fill the gaps.
 
 ## Creating a masonry layout
 
@@ -28,7 +28,7 @@ To create the most common masonry layout, your columns will be the grid axis and
 }
 ```
 
-The child elements of this container will now lay out item by item along the rows, as they would with regular grid layout autoplacement. However, as they move onto a new row the items will display according the masonry algorithm. Items will load into the column with the most room causing a tightly packed layout without strict row tracks.
+The child elements of this container will now lay out item by item along the rows, as they would with regular grid layout autoplacement. However, as they move onto a new row the items will display according to the masonry algorithm. Items will load into the column with the most room causing a tightly packed layout without strict row tracks.
 
 {{EmbedGHLiveSample("css-examples/grid/masonry/block-axis.html", '100%', 800)}}
 


### PR DESCRIPTION
layout.css.grid-template-masonry-value.enable to true may be sounds incomplete. (ref: <a href="https://www.smashingmagazine.com/native-css-masonry-layout-css-grid/#:~:text=enable%20the,about%3Aconfig" target="_blank">Native CSS Masonry Layout In CSS Grid</a>)
There are 2 other grammar suggestions, I might be wrong.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
