### PR TITLE
L in the object name `Locale` should be upper case

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -37,10 +37,10 @@ The _locale_'s Unicode locale identifier string.
 The `locale` object is a JavaScript representation of a concept
 Unicode locale identifier. Information about a particular locale (language, script,
 calendar type, etc.) can be encoded in a locale identifier string. To make it easier
-to work with these locale identifiers, the `locale` object was
+to work with these locale identifiers, the `Locale` object was
 introduced to JavaScript. Calling the `toString` method on a Locale object
 will return the identifier string for that particular Locale. The
-`toString` method allows `locale` instances to be
+`toString` method allows `Locale` instances to be
 provided as an argument to existing `Intl` constructors, serialized in
 JSON, or any other context where an exact string representation is useful.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -34,7 +34,7 @@ The _locale_'s Unicode locale identifier string.
 
 ## Description
 
-The `locale` object is a JavaScript representation of a concept
+The `Locale` object is a JavaScript representation of a concept
 Unicode locale identifier. Information about a particular locale (language, script,
 calendar type, etc.) can be encoded in a locale identifier string. To make it easier
 to work with these locale identifiers, the `Locale` object was


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

`locale` should be `Locale` as an object name.

> Anything else that could help us review it
