### PR TITLE
Improved SVG <symbol> example

### DIFF
--- a/files/en-us/web/svg/element/symbol/index.html
+++ b/files/en-us/web/svg/element/symbol/index.html
@@ -10,7 +10,7 @@ browser-compat: svg.elements.symbol
 
 <p>The <strong><code>&lt;symbol&gt;</code></strong> element is used to define graphical template objects which can be instantiated by a {{SVGElement("use")}} element.</p>
 
-<p>The use of <code>symbol</code> elements for graphics that are used multiple times in the same document adds structure and semantics. Documents that are rich in structure may be rendered graphically, as speech, or as Braille, and thus promote accessibility.</p>
+<p>The use of <code>&lt;symbol&gt;</code> elements for graphics that are used multiple times in the same document adds structure and semantics. Documents that are rich in structure may be rendered graphically, as speech, or as Braille, and thus promote accessibility.</p>
 
 <div id="Example">
 <div class="hidden">

--- a/files/en-us/web/svg/element/symbol/index.html
+++ b/files/en-us/web/svg/element/symbol/index.html
@@ -17,8 +17,7 @@ browser-compat: svg.elements.symbol
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
 
-<pre class="brush: html">&lt;svg viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
+<pre class="brush: html">&lt;svg viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Our symbol in its own coordinate system --&gt;
   &lt;symbol id="myDot" width="10" height="10" viewBox="0 0 2 2"&gt;
     &lt;circle cx="1" cy="1" r="1" /&gt;
@@ -28,11 +27,11 @@ browser-compat: svg.elements.symbol
   &lt;path d="M0,10 h80 M10,0 v20 M25,0 v20 M40,0 v20 M55,0 v20 M70,0 v20" fill="none" stroke="pink" /&gt;
 
   &lt;!-- All instances of our symbol --&gt;
-  &lt;use xlink:href="#myDot" x="5"  y="5" style="opacity:1.0" /&gt;
-  &lt;use xlink:href="#myDot" x="20" y="5" style="opacity:0.8" /&gt;
-  &lt;use xlink:href="#myDot" x="35" y="5" style="opacity:0.6" /&gt;
-  &lt;use xlink:href="#myDot" x="50" y="5" style="opacity:0.4" /&gt;
-  &lt;use xlink:href="#myDot" x="65" y="5" style="opacity:0.2" /&gt;
+  &lt;use href="#myDot" x="5"  y="5" style="opacity:1.0" /&gt;
+  &lt;use href="#myDot" x="20" y="5" style="opacity:0.8" /&gt;
+  &lt;use href="#myDot" x="35" y="5" style="opacity:0.6" /&gt;
+  &lt;use href="#myDot" x="50" y="5" style="opacity:0.4" /&gt;
+  &lt;use href="#myDot" x="65" y="5" style="opacity:0.2" /&gt;
 &lt;/svg&gt;</pre>
 
 <p>{{EmbedLiveSample('Example', 150, '100%')}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

No issue.

> What was wrong/why is this fix needed? (quick summary only)

The example still uses the deprecated `xlink:href` attribute instead of the standard `href`.
This can be useful for backwards compatibility but I don't think it should be in the example.
We could add a note about this but I don't think it's necessary as there is already one on the `<use>` page.

> Anything else that could help us review it

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#attr-xlink