### PR TITLE
Clarify in CacheStorage doc why it’s unavailable in Private mode

### DIFF
--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -33,7 +33,7 @@ browser-compat: api.CacheStorage
 <p>You can access <code>CacheStorage</code> through the global {{domxref("WindowOrWorkerGlobalScope.caches", "caches")}} property.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu. Furthermore, CacheStorage requires disk access in Firefox, due to which it may be unavailable in private mode. </p>
+  <p><strong>Note:</strong> <code>CacheStorage</code> always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu. Furthermore, because <code>CacheStorage</code> requires disk access, it may be unavailable in private mode in Firefox.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -33,7 +33,7 @@ browser-compat: api.CacheStorage
 <p>You can access <code>CacheStorage</code> through the global {{domxref("WindowOrWorkerGlobalScope.caches", "caches")}} property.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
+  <p><strong>Note:</strong> CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu. Furthermore, CacheStorage requires disk access in Firefox, due to which it may be unavailable in private mode. </p>
 </div>
 
 <div class="notecard note">
@@ -187,4 +187,5 @@ try {
  <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers</a></li>
  <li>{{domxref("Cache")}}</li>
  <li>{{domxref("WindowOrWorkerGlobalScope.caches")}}</li>
+ <li><a href="/en-US/docs/Web/API/Web_Storage_API#private_browsing_incognito_modes">Private Browsing / Incognito modes</a></li>
 </ul>

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -33,7 +33,7 @@ browser-compat: api.CacheStorage
 <p>You can access <code>CacheStorage</code> through the global {{domxref("WindowOrWorkerGlobalScope.caches", "caches")}} property.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> <code>CacheStorage</code> always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu. Furthermore, because <code>CacheStorage</code> requires disk access, it may be unavailable in private mode in Firefox.</p>
+  <p><strong>Note:</strong> <code>CacheStorage</code> always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu. Furthermore, because <code>CacheStorage</code> requires file-system access, it may be unavailable in private mode in Firefox.</p>
 </div>
 
 <div class="notecard note">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #8111 

> What was wrong/why is this fix needed? (quick summary only)
As reported, CacheStorage won't work in private mode and this wasn't explicitly noted. Thanks @Trinovantes for the bug report and the suggested fix

> Anything else that could help us review it
I have intentionally not added the requested guard code as that would have required further explanation.