### PR TITLE
Describe shorthand syntax for aspect-ratio

### DIFF
--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -16,6 +16,7 @@ The **`aspect-ratio`**  [CSS](/en-US/docs/CSS) property sets a **preferred asp
 
 ```css
 aspect-ratio: 1 / 1;
+aspect-ratio: 1;
 
 /* Global values */
 aspect-ratio: inherit;
@@ -29,7 +30,7 @@ aspect-ratio: unset;
 - {{cssxref("&lt;auto&gt;")}}
   - : [Replaced elements](/en-US/docs/Web/CSS/Replaced_element) with an intrinsic aspect ratio use _that_ aspect ratio, otherwise the box has no preferred aspect ratio. Size calculations involving intrinsic aspect ratio always work with the content box dimensions.
 - {{cssxref("&lt;ratio&gt;")}}
-  - : The box’s preferred aspect ratio is the specified ratio of `width` / `height`. Size calculations involving preferred aspect ratio work with the dimensions of the box specified by `box-sizing`.
+  - : The box’s preferred aspect ratio is the specified ratio of `width` / `height`. If `height` and the preceding slash character are omitted, `height` defaults to `1`. Size calculations involving preferred aspect ratio work with the dimensions of the box specified by `box-sizing`.
 
 ## Formal definition
 
@@ -46,6 +47,7 @@ aspect-ratio: unset;
 ```css
 aspect-ratio: 1 / 1;
 aspect-ratio: 16 / 9;
+aspect-ratio: 0.5;
 ```
 
 ## Mapping width and height to aspect-ratio


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None

> What was wrong/why is this fix needed? (quick summary only)

Existing content for `aspect-ratio` only describes the long form of the syntax for the `<ratio>` type. There is no mention of the single-number short form as described by https://drafts.csswg.org/css-values-4/#ratio-value.

> Anything else that could help us review it
