### PR TITLE
FF92 ReleaseNote: Support for selectionchange events in text controls

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -59,6 +59,10 @@ tags:
 
 <h4 id="DOM">DOM</h4>
 
+<ul>
+  <li>You can now monitor for changes to text selections in {{HTMLElement("input")}} or {{HTMLElement("textarea")}} by listening for <code>selectionchange</code> events in {{domxref("HTMLInputElement.selectionchange_event", "HTMLInputElement")}} and {{domxref("HTMLTextAreaElement/selectionchange_event", "HTMLTextAreaElement")}}, respectively ({{bug(1648944)}}).</li>
+</ul>
+
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
 
 <h4 id="removals_media">Removals</h4>


### PR DESCRIPTION
This is release note for https://bugzilla.mozilla.org/show_bug.cgi?id=1648944, tracked in #7755

The actual work (including new docs for `selectionchange` events) is done in #8222