### PR TITLE
Fix part of Array.prototype.splice() doc to align with spec

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -42,7 +42,7 @@ splice(start, deleteCount, item1, item2, itemN)
     case, the origin `-1`, meaning `-n` is the index of
     the `n`th last element, and is therefore equivalent
     to the index of `array.length - n`.) If
-    `array.length + start` is less than `0`,
+    `start` is `negative infinity`,
     it will begin from index `0`.
 
 - `deleteCount` {{optional_inline}}


### PR DESCRIPTION
See source here:
https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.splice (specifically, steps 3-7).

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
Original sentence: If `array.length + start` is less than `0`, it will begin from index `0`.
Does make sense; and does not match the documentation: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.splice (specifically see steps 3-7).

I believe this sentence was supposed to address the first part of the `if` `else if` `else` that determines start as defined in the spec (as the `else if` and the `else` are documented earlier on the page); thus I have edited this sentence to reflect this.


> Anything else that could help us review it
