### PR TITLE
Add WebXR Hit Test reference docs - pt 5

### DIFF
--- a/files/en-us/web/api/xrtransientinputhittestresult/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/index.md
@@ -32,7 +32,7 @@ None.
 
 ### Accessing transient input hit test results
 
-There are two arrays involved when accessing transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, in order to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you need the `results` property.
+Two arrays are used to access transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you dereference the `results` property on one of the `XRTransientInputHitTestResult` objects.
 
 ```js
 // frame loop

--- a/files/en-us/web/api/xrtransientinputhittestresult/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/index.md
@@ -20,9 +20,9 @@ You can get an array of `XRHitTestResult` objects for a frame by calling {{domxr
 ## Properties
 
 - {{domxref("XRTransientInputHitTestResult.inputSource")}} {{readOnlyInline}}
-  - : The {{domxref("XRInputSource")}} that was used to compute the `results` array.
+  - : Represents the {{domxref("XRInputSource")}} that was used to compute the `results` array.
 - {{domxref("XRTransientInputHitTestResult.results")}} {{readOnlyInline}}
-  - : An array of {{domxref("XRHitTestResult")}} objects containing the hit test results for the input source ordered by the distance along the ray used to perform the hit test, with the closest result at 0th position.
+  - : Represents an array of {{domxref("XRHitTestResult")}} objects containing the hit test results for the input source, ordered by the distance along the ray used to perform the hit test, with the closest result at position 0.
 
 ## Methods
 

--- a/files/en-us/web/api/xrtransientinputhittestresult/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/index.md
@@ -1,0 +1,79 @@
+---
+title: XRTransientInputHitTestResult
+slug: Web/API/XRTransientInputHitTestResult
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRTransientInputHitTestResult
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRTransientInputHitTestResult`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) contains an array of results of a hit test for transient input, grouped by input source.
+
+You can get an array of `XRHitTestResult` objects for a frame by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}.
+
+## Properties
+
+- {{domxref("XRTransientInputHitTestResult.inputSource")}} {{readOnlyInline}}
+  - : The {{domxref("XRInputSource")}} that was used to compute the `results` array.
+- {{domxref("XRTransientInputHitTestResult.results")}} {{readOnlyInline}}
+  - : An array of {{domxref("XRHitTestResult")}} objects containing the hit test results for the input source ordered by the distance along the ray used to perform the hit test, with the closest result at 0th position.
+
+## Methods
+
+None.
+
+## Examples
+
+### Accessing transient input hit test results
+
+There are two arrays involved when accessing transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, in order to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you need the `results` property.
+
+```js
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  hitTestResults.forEach(resultsPerInputSource => {
+    resultsPerInputSource.results.forEach(hitTest => {
+      // do something with the hit test
+      hitTest.getPose(referenceSpace);
+    });
+  });
+ }
+ ```
+
+### Filtering input sources
+
+The {{domxref("XRTransientInputHitTestResult.inputSource", "inputSource")}} property allows you to filter hit test results by input source.
+
+```js
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  hitTestResults.forEach(resultsPerInputSource => {
+    if (resultsPerInputSource.inputSource == myPreferredInputSource) {
+      // act on hit test results from the preferred input source
+    }
+  }
+ }
+ ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRHitTestResult")}}
+- {{domxref("XRInputSource")}}

--- a/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
@@ -25,7 +25,7 @@ An {{domxref("XRInputSource")}} object.
 
 ### Filtering input sources
 
-The {{domxref("XRTransientInputHitTestResult.inputSource", "inputSource")}} property allows you to filter hit test results by input source.
+The `inputSource` property allows you to filter hit test results by input source.
 
 ```js
 // frame loop

--- a/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
@@ -1,0 +1,53 @@
+---
+title: XRTransientInputHitTestResult.inputSource
+slug: Web/API/XRTransientInputHitTestResult/inputSource
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRTransientInputHitTestResult.inputSource
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`inputSource`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface is an {{domxref("XRInputSource")}} object that was used to compute the {{domxref("XRTransientInputHitTestResult.results", "results")}} array.
+
+### Value
+
+An {{domxref("XRInputSource")}} object.
+
+## Examples
+
+### Filtering input sources
+
+The {{domxref("XRTransientInputHitTestResult.inputSource", "inputSource")}} property allows you to filter hit test results by input source.
+
+```js
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  hitTestResults.forEach(resultsPerInputSource => {
+    if (resultsPerInputSource.inputSource == myPreferredInputSource) {
+      // act on hit test results from the preferred input source
+    }
+  }
+ }
+ ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRInputSource")}}

--- a/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
@@ -15,9 +15,9 @@ browser-compat: api.XRTransientInputHitTestResult.inputSource
 ---
 {{APIRef("WebXR Device API")}}
 
-The _read-only_ **`inputSource`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface is an {{domxref("XRInputSource")}} object that was used to compute the {{domxref("XRTransientInputHitTestResult.results", "results")}} array.
+The _read-only_ **`inputSource`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface represents an {{domxref("XRInputSource")}} object that was used to compute the {{domxref("XRTransientInputHitTestResult.results", "results")}} array.
 
-### Value
+## Value
 
 An {{domxref("XRInputSource")}} object.
 

--- a/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
@@ -1,0 +1,54 @@
+---
+title: XRTransientInputHitTestResult.results
+slug: Web/API/XRTransientInputHitTestResult/results
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRTransientInputHitTestResult.results
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`results`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface is an array of {{domxref("XRHitTestResult")}} objects with the hit test results for the input source ordered by the distance along the ray used to perform the hit test, with the closest result at 0th position.
+
+### Value
+
+An array of {{domxref("XRHitTestResult")}} objects.
+
+## Examples
+
+### Accessing transient input hit test results
+
+There are two arrays involved when accessing transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, in order to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you need the `results` property.
+
+```js
+// frame loop
+function onXRFrame(time, xrFrame) {
+  let hitTestResults = xrFrame.getHitTestResultsForTransientInput(transientHitTestSource);
+
+  hitTestResults.forEach(resultsPerInputSource => {
+    resultsPerInputSource.results.forEach(hitTest => {
+      // do something with the hit test
+      hitTest.getPose(referenceSpace);
+    });
+  });
+ }
+ ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRHitTestResult")}}

--- a/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
@@ -15,9 +15,9 @@ browser-compat: api.XRTransientInputHitTestResult.results
 ---
 {{APIRef("WebXR Device API")}}
 
-The _read-only_ **`results`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface is an array of {{domxref("XRHitTestResult")}} objects with the hit test results for the input source ordered by the distance along the ray used to perform the hit test, with the closest result at 0th position.
+The _read-only_ **`results`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface represents an array of {{domxref("XRHitTestResult")}} objects containing the hit test results for the input source, ordered by the distance along the ray used to perform the hit test, with the closest result at position 0.
 
-### Value
+## Value
 
 An array of {{domxref("XRHitTestResult")}} objects.
 

--- a/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
@@ -25,7 +25,7 @@ An array of {{domxref("XRHitTestResult")}} objects.
 
 ### Accessing transient input hit test results
 
-There are two arrays involved when accessing transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, in order to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you need the `results` property.
+Two arrays are used to access transient input hit test results. First, you get an array of `XRTransientInputHitTestResult` objects by calling {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}. Second, to get to the actual {{domxref("XRHitTestResult")}} objects for an input source, you dereference the `results` property on one of the `XRTransientInputHitTestResult` objects.
 
 ```js
 // frame loop


### PR DESCRIPTION
Part 5 documents `XRTransientInputHitTestResult` and its two properties `inputSource` and `results`.

Spec: https://immersive-web.github.io/hit-test/#xr-transient-input-hit-test-result-interface