### PR TITLE
Add WebXR Hit Test reference docs - pt 6

### DIFF
--- a/files/en-us/web/api/xrray/direction/index.md
+++ b/files/en-us/web/api/xrray/direction/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRRay.direction
 
 The _read-only_ **`direction`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector, normalized to a length of 1.0.
 
-### Value
+## Value
 
 A {{domxref("DOMPointReadOnly")}} object.
 

--- a/files/en-us/web/api/xrray/direction/index.md
+++ b/files/en-us/web/api/xrray/direction/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRRay.direction
 ---
 {{APIRef("WebXR Device API")}}
 
-The _read-only_ **`direction`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector, normalized to a length of 1.0.
+The _read-only_ **`direction`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector, normalized to a [unit vector](https://en.wikipedia.org/wiki/Unit_vector) with a length of 1.0.
 
 ## Value
 

--- a/files/en-us/web/api/xrray/direction/index.md
+++ b/files/en-us/web/api/xrray/direction/index.md
@@ -1,0 +1,49 @@
+---
+title: XRRay.direction
+slug: Web/API/XRRay/direction
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRRay.direction
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`direction`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector, normalized to a length of 1.0.
+
+### Value
+
+A {{domxref("DOMPointReadOnly")}} object.
+
+## Examples
+
+### Using the `direction` property
+
+The `direction` property contains the normalized ray’s 3-dimensional directional vector.
+
+```js
+let origin = {x : 10.0, y : 10.0, z : 10.0, w : 1.0};
+let direction = {x : 10.0, y : 0.0, z : 0.0, w : 0.0};
+let ray = new XRRay(origin, direction);
+
+ray.direction;
+// returns DOMPointReadOnly {x : 1.0, y : 0.0, z : 0.0, w : 0.0}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMPointReadOnly")}}

--- a/files/en-us/web/api/xrray/index.md
+++ b/files/en-us/web/api/xrray/index.md
@@ -24,11 +24,11 @@ The **`XRRay`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_De
 
 ## Properties
 
-- {{domxref("XRRay.direction")}} {{ReadOnlyInline}}
+- {{domxref("XRRay.direction")}}{{ReadOnlyInline}}
   - : A {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector.
-- {{domxref("XRRay.matrix")}} {{ReadOnlyInline}}
-  - : A {{jsxref("Float32Array")}} matrix which represents a transform that can be used to position objects along the `XRRay`.
-- {{domxref("XRRay.origin")}} {{ReadOnlyInline}}
+- {{domxref("XRRay.matrix")}}{{ReadOnlyInline}}
+  - : A transform that can be used to position objects along the `XRRay`. This is a 4 by 4 matrix given as a 16 element {{jsxref("Float32Array")}} in column major order.
+- {{domxref("XRRay.origin")}}{{ReadOnlyInline}}
   - : A {{domxref("DOMPointReadOnly")}} representing the 3-dimensional point in space that the ray originates from, in meters.
 
 ## Methods

--- a/files/en-us/web/api/xrray/index.md
+++ b/files/en-us/web/api/xrray/index.md
@@ -1,0 +1,70 @@
+---
+title: XRRay
+slug: Web/API/XRRay
+tags:
+  - API
+  - Interface
+  - Reference
+  - WebXR
+  - XR
+  - AR
+  - VR
+browser-compat: api.XRRay
+---
+{{APIRef("WebXR Device API")}} {{secureContext_header}}
+
+The **`XRRay`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) is a geometric ray described by an origin point and a direction vector.
+
+`XRRay` objects can be passed to {{domxref("XRSession.requestHitTestSource()")}} or {{domxref("XRSession.requestHitTestSourceForTransientInput()")}} to perform hit testing.
+
+## Constructor
+
+- {{domxref("XRRay.XRRay", "XRRay()")}}
+  - : Creates a new `XRRay` object.
+
+## Properties
+
+- {{domxref("XRRay.direction")}} {{ReadOnlyInline}}
+  - : A {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector.
+- {{domxref("XRRay.matrix")}} {{ReadOnlyInline}}
+  - : A {{jsxref("Float32Array")}} matrix which represents a transform that can be used to position objects along the `XRRay`.
+- {{domxref("XRRay.origin")}} {{ReadOnlyInline}}
+  - : A {{domxref("DOMPointReadOnly")}} representing the 3-dimensional point in space that the ray originates from, in meters.
+
+## Methods
+
+None.
+
+## Examples
+
+### Using `XRRay` to request a hit test source
+
+The {{domxref("XRSession.requestHitTestSource()")}} method takes an `XRRay` object for its `offsetRay` option. In this example, the hit test source is positioned slightly above the viewer as the application has some UI elements at the bottom while wanting to maintain the perception of a centered cursor.
+
+```js
+const xrSession = navigator.xr.requestSession("immersive-ar", {
+   requiredFeatures: ["local", "hit-test"]
+});
+
+let hitTestSource = null;
+
+xrSession.requestHitTestSource({
+  space: viewerSpace, // obtained from xrSession.requestReferenceSpace("viewer");
+  offsetRay: new XRRay({y: 0.5})
+}).then((viewerHitTestSource) => {
+  hitTestSource = viewerHitTestSource;
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession.requestHitTestSource()")}}
+- {{domxref("XRHitTestResult")}}

--- a/files/en-us/web/api/xrray/matrix/index.md
+++ b/files/en-us/web/api/xrray/matrix/index.md
@@ -1,0 +1,50 @@
+---
+title: XRRay.matrix
+slug: Web/API/XRRay/matrix
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRRay.matrix
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`matrix`** property of the {{DOMxRef("XRRay")}} interface is a {{jsxref("Float32Array")}} matrix which represents a transform that can be used to position objects along the `XRRay`.
+
+The transform from a ray originates at [0, 0, 0] and extends down the negative z-axis to the ray described by the `XRRay`'s `origin` and `direction`.
+
+### Value
+
+A {{jsxref("Float32Array")}} object.
+
+## Examples
+
+### Using the `matrix` property
+
+The `matrix` property can be used to position graphical representations of the ray when rendering.
+
+```js
+let origin = {x : 10.0, y : 10.0, z : 10.0, w : 1.0};
+let direction = {x : 10.0, y : 0.0, z : 0.0, w : 0.0};
+let ray = new XRRay(origin, direction);
+
+// Render the ray using the `ray.matrix` transform
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Float32Array")}}

--- a/files/en-us/web/api/xrray/matrix/index.md
+++ b/files/en-us/web/api/xrray/matrix/index.md
@@ -15,13 +15,13 @@ browser-compat: api.XRRay.matrix
 ---
 {{APIRef("WebXR Device API")}}
 
-The _read-only_ **`matrix`** property of the {{DOMxRef("XRRay")}} interface is a {{jsxref("Float32Array")}} matrix which represents a transform that can be used to position objects along the `XRRay`.
+The _read-only_ **`matrix`** property of the {{DOMxRef("XRRay")}} interface is a transform that can be used to position objects along the `XRRay`. This is a 4 by 4 matrix given as a 16 element {{jsxref("Float32Array")}} in column major order.
 
 The transform from a ray originates at [0, 0, 0] and extends down the negative z-axis to the ray described by the `XRRay`'s `origin` and `direction`.
 
 ## Value
 
-A {{jsxref("Float32Array")}} object.
+A 16 element {{jsxref("Float32Array")}} object representing a 4 by 4 matrix in column major order.
 
 ## Examples
 

--- a/files/en-us/web/api/xrray/matrix/index.md
+++ b/files/en-us/web/api/xrray/matrix/index.md
@@ -19,7 +19,7 @@ The _read-only_ **`matrix`** property of the {{DOMxRef("XRRay")}} interface is a
 
 The transform from a ray originates at [0, 0, 0] and extends down the negative z-axis to the ray described by the `XRRay`'s `origin` and `direction`.
 
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object.
 

--- a/files/en-us/web/api/xrray/origin/index.md
+++ b/files/en-us/web/api/xrray/origin/index.md
@@ -1,0 +1,49 @@
+---
+title: XRRay.origin
+slug: Web/API/XRRay/origin
+tags:
+  - API
+  - AR
+  - Augmented Reality
+  - Experimental
+  - Property
+  - Reference
+  - VR
+  - WebXR
+  - WebXR Device API
+browser-compat: api.XRRay.origin
+---
+{{APIRef("WebXR Device API")}}
+
+The _read-only_ **`origin`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the 3-dimensional point in space that the ray originates from, in meters.
+
+### Value
+
+A {{domxref("DOMPointReadOnly")}} object.
+
+## Examples
+
+### Using the `origin` property
+
+The `origin` property contains the 3-dimensional point in space that the ray originates from, in meters.
+
+```js
+let origin = {x : 10.0, y : 10.0, z : 10.0, w : 1.0};
+let direction = {x : 10.0, y : 0.0, z : 0.0, w : 0.0};
+let ray = new XRRay(origin, direction);
+
+ray.origin;
+// returns DOMPointReadOnly {x : 10.0, y : 10.0, z : 10.0, w : 1.0}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMPointReadOnly")}}

--- a/files/en-us/web/api/xrray/origin/index.md
+++ b/files/en-us/web/api/xrray/origin/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRRay.origin
 
 The _read-only_ **`origin`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the 3-dimensional point in space that the ray originates from, in meters.
 
-### Value
+## Value
 
 A {{domxref("DOMPointReadOnly")}} object.
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -25,9 +25,9 @@ new XRRay(transform)
 ### Parameters
 
 - `origin` {{optional_inline}}
-  - : A point object defining the 3-dimensional point in space that the ray originates from, in meters. The origin's `w` property must be 1.0. Initialized by default to `{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }`.
+  - : A point object defining the 3-dimensional point in space that the ray originates from, in meters. All dimensions are optional, however, if provided, the origin's `w` property must be 1.0. The object is initialized to `{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }` by default.
 - `direction` {{optional_inline}}
-  - : A vector object defining the ray’s 3-dimensional directional vector. The direction's `w` property must be 0.0 and the vector must be normalized to have a length of 1.0. Initialized by default to: `{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }`.
+  - : A vector object defining the ray’s 3-dimensional directional vector. All dimensions are optional, however, if provided, the direction's `w` property must be 0.0. The object is initialized to: `{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }` by default.
 - `transform` {{optional_inline}}
   - : An {{domxref("XRRigidTransform")}} object representing the position and orientation of the ray.
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -1,0 +1,86 @@
+---
+title: XRRay()
+slug: Web/API/XRRay/XRRay
+tags:
+  - API
+  - Constructor
+  - Reference
+  - WebXR
+  - XR
+browser-compat: api.XRRay.XRRay
+---
+{{APIRef("WebXR Device API")}}
+
+The **`XRRay()`** constructor creates and returns a new {{domxref("XRRay")}} object which is a geometric ray described by an origin point and a direction vector.
+
+## Syntax
+
+```js
+new XRRay()
+new XRRay(origin)
+new XRRay(origin, direction)
+new XRRay(transform)
+```
+
+### Parameters
+
+- `origin` {{optional_inline}}
+  - : A point object defining the 3-dimensional point in space that the ray originates from, in meters. The origin's `w` property must be 1.0. Initialized by default to `{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }`.
+- `direction` {{optional_inline}}
+  - : A vector object defining the ray’s 3-dimensional directional vector. The direction's `w` property must be 0.0 and the vector must be normalized to have a length of 1.0. Initialized by default to: `{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }`.
+- `transform` {{optional_inline}}
+  - : An {{domxref("XRRigidTransform")}} object representing the position and orientation of the ray.
+
+### Return value
+
+A newly-created {{domxref("XRRay")}} object.
+
+### Exceptions
+
+A `TypeError` is thrown,
+
+- if all of `direction`'s `x`, `y`, and `z` coordinates are zero.
+- if `direction`'s `w` coordinate is not 0.0.
+- if `origin`'s `w` coordinate is not 1.0.
+
+## Example
+
+### Creating `XRRay` objects
+
+The `XRRay()` constructor allows to create new rays by either providing an `origin` point and a `direction` vector, or by passing in an {{domxref("XRRigidTransform")}} object.
+
+```js
+// Default configuration
+let ray1 = new XRRay();
+
+// Specifying origin, leaving direction as default
+let ray2 = new XRRay({y: 0.5});
+
+// Specifying both, origin and direction
+let origin = {x : 10.0, y : 10.0, z : 10.0, w : 1.0};
+let direction = {x : 10.0, y : 0.0, z : 0.0, w : 0.0};
+let ray3 = new XRRay(origin, direction);
+
+// Using DOMPoint.fromPoint
+let ray4 = new XRRay(DOMPoint.fromPoint(origin),
+                     DOMPoint.fromPoint(direction));
+
+// Using rigid transform
+let rigidTransform = new XRRigidTransform(
+        DOMPoint.fromPoint(origin),
+        DOMPoint.fromPoint(direction));
+let ray5 = new XRRay(rigidTransform);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMPoint")}}
+- {{domxref("DOMPoint.fromPoint()")}}

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -11,7 +11,7 @@ browser-compat: api.XRRay.XRRay
 ---
 {{APIRef("WebXR Device API")}}
 
-The **`XRRay()`** constructor creates and returns a new {{domxref("XRRay")}} object which is a geometric ray described by an origin point and a direction vector.
+The **`XRRay()`** constructor creates a new {{domxref("XRRay")}} object which is a geometric ray described by an origin point and a direction vector.
 
 ## Syntax
 
@@ -47,7 +47,7 @@ A `TypeError` is thrown,
 
 ### Creating `XRRay` objects
 
-The `XRRay()` constructor allows to create new rays by either providing an `origin` point and a `direction` vector, or by passing in an {{domxref("XRRigidTransform")}} object.
+The `XRRay()` constructor allows to creating new rays by either providing an `origin` point and a `direction` vector, or by passing in an {{domxref("XRRigidTransform")}} object.
 
 ```js
 // Default configuration

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -22,8 +22,8 @@ browser-compat: api.XRRigidTransform.XRRigidTransform
 {{APIRef("WebXR Device API")}}
 
 The
-**`XRRigidTransform()`** constructor creates and
-returns a new {{domxref("XRRigidTransform")}} object, representing the position and
+**`XRRigidTransform()`** constructor creates
+a new {{domxref("XRRigidTransform")}} object, representing the position and
 orientation of a point or object. Among other things,
 `XRRigidTransform` is used when providing a transform to translate between
 coordinate systems across spaces.

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -22,7 +22,7 @@ browser-compat: api.XRRigidTransform.XRRigidTransform
 {{APIRef("WebXR Device API")}}
 
 The
-**` XRRigidTransform``() `** constructor creates and
+**`XRRigidTransform()`** constructor creates and
 returns a new {{domxref("XRRigidTransform")}} object, representing the position and
 orientation of a point or object. Among other things,
 `XRRigidTransform` is used when providing a transform to translate between


### PR DESCRIPTION
The sixth and final part for WebXR Hit Testing documents `XRRay` and its constructor `XRRay()` plus the interface's properties `direction`, `matrix` and `origin`.

Spec: https://immersive-web.github.io/hit-test/#geometric-primitives