### PR TITLE
Remove id attributes, part 1

### DIFF
--- a/files/en-us/web/api/abstractrange/index.html
+++ b/files/en-us/web/api/abstractrange/index.html
@@ -148,7 +148,7 @@ let fragment = r.cloneContents();
 
 <pre class="brush: html">&lt;p&gt;&lt;strong&gt;This&lt;/strong&gt; is a paragraph.&lt;/p&gt;</pre>
 
-<p id="JavaScript">Imagine using a {{domxref("Range")}} to extract the word "paragraph" from this. The code to do that looks like the following:</p>
+<p>Imagine using a {{domxref("Range")}} to extract the word "paragraph" from this. The code to do that looks like the following:</p>
 
 <pre class="brush: js">let paraNode = document.querySelector("p");
 let paraTextNode = paraNode.childNodes[1];

--- a/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
@@ -96,11 +96,15 @@ if (ball.x + ball.vx &gt; canvas.width || ball.x + ball.vx &lt; 0) {
 
 <h3 id="First_demo">First demo</h3>
 
-<p>Let's see how it looks in action so far. Move your mouse into the canvas to start the animation.</p>
+<p>Let's see how it looks in action so far.</p>
 
-<pre class="brush: html hidden">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+<h4>HTML</h4>
 
-<pre class="brush: js hidden">var canvas = document.getElementById('canvas');
+<pre class="brush: html">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+
+<h4>JavaScript</h4>
+
+<pre class="brush: js">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var raf;
 
@@ -148,7 +152,11 @@ canvas.addEventListener('mouseout', function(e) {
 
 ball.draw();</pre>
 
-<p>{{EmbedLiveSample("First_demo", "610", "310")}}</p>
+<h4>Result</h4>
+
+<p>Move your mouse into the canvas to start the animation.</p>
+
+<p>{{EmbedLiveSample("First_demo", "610", "340")}}</p>
 
 <h2 id="Acceleration">Acceleration</h2>
 
@@ -159,10 +167,15 @@ ball.vy += .25;</pre>
 
 <p>This slows down the vertical velocity each frame, so that the ball will just bounce on the floor in the end.</p>
 
-<div id="Second_demo">
-<pre class="brush: html hidden">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+<h3>Second demo</h3>
 
-<pre class="brush: js hidden">var canvas = document.getElementById('canvas');
+<h4>HTML</h4>
+
+<pre class="brush: html">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+
+<h4>JavaScript</h4>
+
+<pre class="brush: js">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var raf;
 
@@ -211,8 +224,10 @@ canvas.addEventListener('mouseout', function(e) {
 });
 
 ball.draw();</pre>
-</div>
-<p>{{EmbedLiveSample("Second_demo", "610", "310")}}</p>
+
+<h4>Result</h4>
+
+<p>{{EmbedLiveSample("Second_demo", "610", "340")}}</p>
 
 <h2 id="Trailing_effect">Trailing effect</h2>
 
@@ -221,10 +236,15 @@ ball.draw();</pre>
 <pre class="brush: js">ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
 ctx.fillRect(0, 0, canvas.width, canvas.height);</pre>
 
-<div id="Third_demo">
-<pre class="brush: html hidden">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+<h3>Third demo</h3>
 
-<pre class="brush: js hidden">var canvas = document.getElementById('canvas');
+<h4>HTML</h4>
+
+<pre class="brush: html">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+
+<h4>JavaScript</h4>
+
+<pre class="brush: js">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var raf;
 
@@ -274,15 +294,22 @@ canvas.addEventListener('mouseout', function(e) {
 });
 
 ball.draw();</pre>
-</div>
 
-<p>{{EmbedLiveSample("Third_demo", "610", "310")}}</p>
+<h4>Result</h4>
+
+<p>{{EmbedLiveSample("Third_demo", "610", "340")}}</p>
 
 <h2 id="Adding_mouse_control">Adding mouse control</h2>
 
 <p>To get some control over the ball, we can make it follow our mouse using the <code><a href="/en-US/docs/Web/API/Element/mousemove_event">mousemove</a></code> event, for example. The <code><a href="/en-US/docs/Web/API/Element/click_event">click</a></code> event releases the ball and lets it bounce again.</p>
 
-<pre class="brush: html hidden">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+<h3>Fourth demo</h3>
+
+<h4>HTML</h4>
+
+<pre class="brush: html">&lt;canvas id="canvas" style="border: 1px solid" width="600" height="300"&gt;&lt;/canvas&gt;</pre>
+
+<h4>JavaScript</h4>
 
 <pre class="brush: js">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
@@ -350,9 +377,11 @@ canvas.addEventListener('mouseout', function(e) {
 ball.draw();
 </pre>
 
+<h4>Result</h4>
+
 <p>Move the ball using your mouse and release it with a click.</p>
 
-<p>{{EmbedLiveSample("Adding_mouse_control", "610", "310")}}</p>
+<p>{{EmbedLiveSample("Fourth_demo", "610", "340")}}</p>
 
 <h2 id="Breakout">Breakout</h2>
 

--- a/files/en-us/web/api/canvaspattern/settransform/index.html
+++ b/files/en-us/web/api/canvaspattern/settransform/index.html
@@ -73,9 +73,9 @@ img.onload = function() {
 <pre
   class="brush: js">const matrix = new DOMMatrix([1, .2, .8, 1, 0, 0]);</pre>
 
-<p>Edit the code below and see your changes update live in the canvas:</p>
+<h4>Editable demo</h4>
 
-<div id="Playable_code">
+<p>Here's an editable demo of the code snippet above. Try changing the argument to <code>SetTransform()</code> to see the  effect it had.</p>
 
   <pre class="brush: html hidden">&lt;canvas id="canvas" width="400" height="200" class="playable-canvas"&gt;&lt;/canvas&gt;
 &lt;svg id="svg1" style="display:none"&gt;&lt;/svg&gt;
@@ -121,9 +121,8 @@ edit.addEventListener('click', function() {
 textarea.addEventListener('input', drawCanvas);
 window.addEventListener('load', drawCanvas);
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Playable_code', 700, 380) }}</p>
+<p>{{ EmbedLiveSample('Editable_demo', 700, 400) }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
@@ -51,9 +51,9 @@ ctx.fillRect(10, 10, 30, 30);
 ctx.scrollPathIntoView();
 </pre>
 
-<p>Edit the code below to see your changes update live in the canvas:</p>
+<h4>Editable demo</h4>
 
-<div id="Playable_code">
+<p>Edit the code below to see your changes update live in the canvas:</p>
 
 <pre class="brush: html hidden">&lt;canvas id="canvas" width="400" height="200" class="playable-canvas"&gt;
 &lt;input id="button" type="range" min="1" max="12"&gt;
@@ -92,9 +92,8 @@ edit.addEventListener("click", function() {
 textarea.addEventListener("input", drawCanvas);
 window.addEventListener("load", drawCanvas);
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Playable_code', 700, 360) }}</p>
+<p>{{ EmbedLiveSample('Editable_demo', 700, 400) }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/closeevent/index.html
+++ b/files/en-us/web/api/closeevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.CloseEvent
 <dl>
  <dt>{{domxref("CloseEvent.code")}} {{readOnlyInline}}</dt>
  <dd>Returns an <code>unsigned short</code> containing the close code sent by the server. The following values are permitted status codes. The following definitions are sourced from the IANA website [<a href="https://www.iana.org/assignments/websocket/websocket.xml#close-code-number">Ref</a>]. Note that the 1xxx codes are only WebSocket-internal and not for the same meaning by the transported data (like when the application-layer protocol is invalid). The only permitted codes to be specified in Firefox are 1000 and 3000 to 4999 [<a href="https://searchfox.org/mozilla-central/rev/bf81d741ff5dd11bb364ef21306da599032fd479/dom/websocket/WebSocket.cpp#2533">Source</a>, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1467107">Bug</a>].
- <table class="standard-table" id="Status_codes">
+ <table class="standard-table">
   <tbody>
    <tr>
     <td class="header">Status code</td>

--- a/files/en-us/web/api/cryptokey/index.html
+++ b/files/en-us/web/api/cryptokey/index.html
@@ -54,7 +54,7 @@ browser-compat: api.CryptoKey
   <li><code><a href="/en-US/docs/Web/API/HmacKeyGenParams">HmacKeyGenParams</a></code> if the algorithm is HMAC.</li>
  </ul>
  </dd>
- <dt id="usages"><code>CryptoKey.usages</code></dt>
+ <dt><code>CryptoKey.usages</code></dt>
  <dd>
  <p>An {{jsxref("Array")}} of strings, indicating what can be done with the key. Possible values for array elements are:</p>
 

--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.html
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.html
@@ -56,7 +56,6 @@ The stylesheet declaration for the body's background color is modified via JavaS
 
 <p>To change a particular element's style, you can adapt the following example for the element(s) you want to style.</p>
 
-<div id="Example2">
 <pre class="brush: html">&lt;html&gt;
 &lt;head&gt;
 &lt;title&gt;simple style example&lt;/title&gt;
@@ -93,9 +92,8 @@ function resetStyle(elemId) {
 &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Example2') }}</p>
+<p>{{ EmbedLiveSample('Modify_an_element_style') }}</p>
 
 <p>The {{domxref("window.getComputedStyle", "getComputedStyle()")}} method on the <code>document.defaultView</code> object returns all styles that have actually been computed for an element.</p>
 
@@ -103,9 +101,10 @@ function resetStyle(elemId) {
 
 <p>The <code>style</code> object represents an individual style statement. The style object is accessed from the <code>document</code> or from the elements to which that style is applied. It represents the <em>in-line</em> styles on a particular element.</p>
 
+<h3>Setting style properties</h3>
+
 <p>More important than the two properties noted here is the use of the <code>style</code> object to set individual style properties on an element:</p>
 
-<div id="DOM_Style_Object_code_sample">
 <pre class="brush: html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
  &lt;head&gt;
@@ -128,9 +127,8 @@ function resetStyle(elemId) {
  &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('DOM_Style_Object_code_sample') }}</p>
+<p>{{ EmbedLiveSample('Setting_style_properties') }}</p>
 
 <p>The <strong>media</strong> and <strong>type</strong> of the style may or may not be given.</p>
 

--- a/files/en-us/web/api/css_painting_api/index.html
+++ b/files/en-us/web/api/css_painting_api/index.html
@@ -51,6 +51,8 @@ tags:
 
 <p>To draw directly into an element's background using JavaScript in our CSS, we define a paint worklet using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function, tell the document to include the worklet using the paintWorklet addModule() method, then include the image we created using the CSS <code><a href="/en-US/docs/Web/CSS/paint()">paint()</a></code> function.</p>
 
+<h3>Paint worklet</h3>
+
 <p>We create our PaintWorklet called 'hollowHighlights' using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function:</p>
 
 <pre class="brush: js">registerPaint('hollowHighlights', class {
@@ -115,10 +117,11 @@ tags:
   }
 });</pre>
 
-<div id="hollowExample">
+<h3>Using the paint worklet</h3>
+
 <p>We then include the paintWorklet:</p>
 
-<pre class="brush: html hidden">&lt;ul&gt;
+<pre class="brush: html">&lt;ul&gt;
     &lt;li&gt;item 1&lt;/li&gt;
     &lt;li&gt;item 2&lt;/li&gt;
     &lt;li&gt;item 3&lt;/li&gt;
@@ -160,10 +163,12 @@ li:nth-of-type(3n+1) {
    --boxColor: hsla(255, 90%, 60%, 1.0);
    background-image: paint(hollowHighlights, stroke, 1px);
 }</pre>
-</div>
+
 <p>We've included a custom property in the selector block defining a boxColor. Custom properties are accessible to the PaintWorklet.</p>
 
-<p>{{EmbedLiveSample("hollowExample", 300, 300)}}</p>
+<h3>Result</h3>
+
+<p>{{EmbedLiveSample("Using_the_paint_worklet", 300, 300)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/css_properties_and_values_api/guide/index.html
+++ b/files/en-us/web/api/css_properties_and_values_api/guide/index.html
@@ -44,34 +44,15 @@ tags:
 
 <p>In this example, the custom property <code>--registered</code> has been registered using the syntax <code>&lt;color&gt;</code> and then used in a linear gradient. That property is then transitioned on hover or focus to a different color. Notice that with the registered property the transition works, but that it doesn't with the unregistered property!</p>
 
-<pre class="brush: css">.registered {
-  --registered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--registered));
-  transition: --registered 1s ease-in-out;
-}
+<h3>HTML</h3>
 
-.registered:hover,
-.registered:focus {
-  --registered: #b4d455;
-}
-
-.unregistered {
-  --unregistered: #c0ffee;
-  background-image: linear-gradient(to right, #fff, var(--unregistered));
-  transition: --unregistered 1s ease-in-out;
-}
-
-.unregistered:hover,
-.unregistered:focus {
-  --unregistered: #b4d455;
-}</pre>
-
-<div id="registered">
-<pre class="brush: html hidden">&lt;button class="registered"&gt;Background Registered&lt;/button&gt;
+<pre class="brush: html">&lt;button class="registered"&gt;Background Registered&lt;/button&gt;
 &lt;button class="unregistered"&gt;Background Not Registered&lt;/button&gt;
 </pre>
 
-<pre class="brush: css hidden">.registered {
+<h3>CSS</h3>
+
+<pre class="brush: css">.registered {
   --registered: #c0ffee;
   background-image: linear-gradient(to right, #fff, var(--registered));
   transition: --registered 1s ease-in-out;
@@ -102,15 +83,18 @@ button {
 
 </pre>
 
-<pre class="brush: js hidden">window.CSS.registerProperty({
+<h3>JavaScript</h3>
+
+<pre class="brush: js">window.CSS.registerProperty({
   name: '--registered',
   syntax: '&lt;color&gt;',
   inherits: false,
   initialValue: 'red',
 });</pre>
-</div>
 
-<p>{{EmbedLiveSample("registered", 320, 320)}}</p>
+<h3>Result</h3>
+
+<p>{{EmbedLiveSample("Using_registered_custom_properties", 320, 320)}}</p>
 
 <p>While not functionally accurate, a good way to think about the difference between the unregistered property in the above example and the registered property is the difference between a {{cssxref('custom-ident')}} and a number when trying to animate {{cssxref('height')}}. You cannot transition or animate from <code>auto</code> to a number because the browser doesn't know what the value of <code>auto</code> is until it's calculated. With an unregisterd property, the browser likewise doesn't know what the value <em>may be</em> until it's calculated, and because of that, it can't set up a transition from one value to another. When registered, though, you've told the browser what type of value it should expect, and because it knows that, it can then set up the transitions properly.</p>
 

--- a/files/en-us/web/api/css_typed_om_api/guide/index.html
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.html
@@ -19,8 +19,11 @@ tags:
 
 <h2 id="computedStyleMap">computedStyleMap()</h2>
 
-<div id="example1">
 <p>With the CSS Typed OM API, we can access all the CSS properties and values — including custom properties — that are impacting an element. Let's see how this works by creating our first example, which explores {{domxref('Element.computedStyleMap()', 'computedStyleMap()')}}.</p>
+
+<h3>Getting all the properties and values</h3>
+
+<h4>HTML</h4>
 
 <p>We start with some HTML: a paragraph with a link, as well as a definition list to which we will add all the CSS Property / Value pairs.</p>
 
@@ -28,6 +31,8 @@ tags:
    &lt;a href="https://example.com"&gt;Link&lt;/a&gt;
 &lt;/p&gt;
 &lt;dl id="regurgitation"&gt;&lt;/dl&gt;</pre>
+
+<h4>JavaScript</h4>
 
 <p>We add JavaScript to grab our unstyled link and return back a definition list of all the default CSS property values impacting the link using <code>computedStyleMap()</code>.</p>
 
@@ -55,18 +60,18 @@ for (const [prop, val] of defaultComputedStyles) {
 
 <p>The <code>computedStyleMap()</code> method returns a {{domxref('StylePropertyMapReadOnly')}} object containing the <code><a href="/en-US/docs/Web/API/StylePropertyMapReadOnly/size">size</a></code> property, which indicates how many properties are in the map. We iterate through the style map, creating a <code><a href="/en-US/docs/Web/HTML/Element/dt">&lt;dt&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/dd">&lt;dd&gt;</a></code> for each property and value respectively.</p>
 
+<h4>Result</h4>
+
 <p>In <a href="/en-US/docs/Web/API/Element/computedStyleMap#browser_compatibility">browsers that support <code>computedStyleMap()</code></a>, you'll see a list of all the CSS properties and values. In other browsers, you'll just see a link.</p>
 
-<p>{{EmbedLiveSample("example1", 120, 300)}}</p>
+<p>{{EmbedLiveSample("Getting_all_the_properties_and_values", 120, 300)}}</p>
 
 <p>Did you realize how many default CSS properties a link had? Update the JavaScript on line 2 to select the {{htmlelement("p")}} rather than the {{htmlelement("a")}}. You'll notice a difference in the <code><a href="/en-US/docs/Web/CSS/margin-top">margin-top</a></code> and <code><a href="/en-US/docs/Web/CSS/margin-bottom">margin-bottom</a></code> default computed values.</p>
-</div>
 
 <h3 id=".get_method_custom_properties">.get() method / custom properties</h3>
 
 <p>Let's update our example to only retrieve a few properties and values. Let's start by adding some CSS to our example, including a custom property and an inheritable property:</p>
 
-<div id="example2">
 <pre class="brush: css">p {
   font-weight: bold;
 }
@@ -108,8 +113,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 }
 </pre>
 
-<p>{{EmbedLiveSample("example2", 120, 300)}}</p>
-</div>
+<p>{{EmbedLiveSample(".get_method_custom_properties", 120, 300)}}</p>
 
 <p>We included {{cssxref('border-left-color')}} to demonstrate that, had we included all the properties, every value that defaults to <code><a href="/en-US/docs/Web/CSS/color_value">currentcolor</a></code> (including {{cssxref('caret-color')}}, {{cssxref('outline-color')}}, {{cssxref('text-decoration-color')}}, {{cssxref('column-rule-color')}}, etc.) would return <code>rgb(255, 0, 0)</code>. The link has inherited <code>font-weight: bold;</code> from the paragraph's styles, listing it as <code>font-weight: 700</code>. Custom properties, like our <code>--color: red</code> , are properties. As such, they are accessible via <code>get()</code>.</p>
 
@@ -184,7 +188,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <p>For those of you using a non-supporting browser, the above output should looks something like this:</p>
 
-<table id="regurgitation">
+<table>
  <thead>
   <tr>
    <th>Property</th>
@@ -270,9 +274,8 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <p>As noted above, <code>StylePropertyMapReadOnly.get('--customProperty')</code> returns a {{domxref('CSSUnparsedValue')}}. We can parse <code>CSSUnparsedValue</code> object instances with the inherited {{domxref('CSSStyleValue.parse()')}} and {{domxref('CSSStyleValue.parseAll()')}} methods.</p>
 
-<p>Let's examine a CSS example with several custom properties, transforms, <code>calc()</code>s, and other features. We'll take a look at that their types are by employing short JavaScript snippets outputting to {{domxref('console.log()')}}:</p>
+<p>Let's examine a CSS example with several custom properties, transforms, <code>calc()</code>s, and other features. We'll take a look at what their types are by employing short JavaScript snippets outputting to {{domxref('console.log()')}}:</p>
 
-<div id="example3">
 <pre class="brush: css">:root {
     --mainColor: hsl(198, 43%, 42%);
     --black: hsl(0, 0%, 16%);
@@ -339,13 +342,6 @@ console.log( parsedUnit );
 console.log( parsedUnit.unit );
 console.log( parsedUnit.value );
 </pre>
-</div>
-
-<p class="hidden">For this example to work, the example must be closed out here.</p>
-
-<p>{{EmbedLiveSample("example3", 120, 300)}}</p>
-
-<p>We've created a blue button with a magic wand background image.</p>
 
 <p>We grab our <code>StylePropertyMapReadOnly</code> with the following JavaScript:</p>
 

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -17,7 +17,7 @@ browser-compat: api.CSSGroupingRule
 <p><em>This interface also inherits properties from {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="cssRules">{{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}</dt>
+ <dt">{{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}</dt>
  <dd>Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.</dd>
 </dl>
 
@@ -26,9 +26,9 @@ browser-compat: api.CSSGroupingRule
 <p><em>This interface also inherits methods from {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="deleteRule">{{domxref("CSSGroupingRule.deleteRule")}}</dt>
+ <dt>{{domxref("CSSGroupingRule.deleteRule")}}</dt>
  <dd>Deletes a rule from the style sheet.</dd>
- <dt id="insertRule">{{domxref("CSSGroupingRule.insertRule")}}</dt>
+ <dt>{{domxref("CSSGroupingRule.insertRule")}}</dt>
  <dd>Inserts a new style rule into the current style sheet.</dd>
 </dl>
 

--- a/files/en-us/web/api/csskeyframesrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/index.html
@@ -31,9 +31,9 @@ browser-compat: api.CSSKeyframesRule
 <p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="appendRule">{{domxref("CSSKeyframesRule.appendRule()")}}</dt>
+ <dt>{{domxref("CSSKeyframesRule.appendRule()")}}</dt>
  <dd>Inserts a new keyframe rule into the current CSSKeyframesRule. The parameter is a {{domxref("DOMString")}} containing a keyframe in the same format as an entry of a {{cssxref("@keyframes")}} at-rule. If it contains more than one keyframe rule, a {{domxref("DOMException")}} with a <code>SYNTAX_ERR</code> is thrown.</dd>
- <dt id="deleteRule">{{domxref("CSSKeyframesRule.deleteRule()")}}</dt>
+ <dt>{{domxref("CSSKeyframesRule.deleteRule()")}}</dt>
  <dd>Deletes a keyframe rule from the current CSSKeyframesRule. The parameter is the index of the keyframe to be deleted, expressed as a {{domxref("DOMString")}} resolving as a number between <code>0%</code> and <code>100%</code>.</dd>
  <dt>{{domxref("CSSKeyframesRule.findRule()")}}</dt>
  <dd>Returns a keyframe rule corresponding to the given key. The key is a {{domxref("DOMString")}} containing an index of the keyframe to be returned, resolving to a percentage between <code>0%</code> and <code>100%</code>. If no such keyframe exists, <code>findRule</code> returns <code>null</code>.</dd>

--- a/files/en-us/web/api/cssnamespacerule/index.html
+++ b/files/en-us/web/api/cssnamespacerule/index.html
@@ -19,7 +19,7 @@ browser-compat: api.CSSNamespaceRule
 <p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="cssRules">{{domxref("CSSNamespaceRule.namespaceURI")}}</dt>
+ <dt>{{domxref("CSSNamespaceRule.namespaceURI")}}</dt>
  <dd>Returns a {{ domxref("DOMString") }} containing the text of the URI of the given namespace.</dd>
  <dt>{{domxref("CSSNamespaceRule.prefix")}}</dt>
  <dd>Returns a {{ domxref("DOMString") }} with the name of the prefix associated to this namespace. If there is no such prefix, returns an empty string.</dd>

--- a/files/en-us/web/api/cssrule/index.html
+++ b/files/en-us/web/api/cssrule/index.html
@@ -35,13 +35,13 @@ browser-compat: api.CSSRule
 <p>The <code>CSSRule</code> interface specifies the properties common to all rules, while properties unique to specific rule types are specified in the more specialized interfaces for those rules' respective types.</p>
 
 <dl>
- <dt id="cssText">{{domxref("CSSRule.cssText")}}</dt>
+ <dt>{{domxref("CSSRule.cssText")}}</dt>
  <dd>Represents the textual representation of the rule, e.g. "<code>h1,h2 { font-size: 16pt }</code>" or "<code>@import 'url'</code>". To access or modify parts of the rule (e.g. the value of "font-size" in the example) use the properties on the {{anch("Type constants", "specialized interface for the rule's type")}}.</dd>
- <dt id="parentRule">{{domxref("CSSRule.parentRule")}} {{readonlyinline}}</dt>
+ <dt>{{domxref("CSSRule.parentRule")}} {{readonlyinline}}</dt>
  <dd>Returns the containing rule, otherwise <code>null</code>. E.g. if this rule is a style rule inside an {{cssxref("@media")}} block, the parent rule would be that {{domxref("CSSMediaRule")}}.</dd>
- <dt id="parentStyleSheet">{{domxref("CSSRule.parentStyleSheet")}} {{readonlyinline}}</dt>
+ <dt>{{domxref("CSSRule.parentStyleSheet")}} {{readonlyinline}}</dt>
  <dd>Returns the {{domxref("CSSStyleSheet")}} object for the style sheet that contains this rule</dd>
- <dt id="type">{{domxref("CSSRule.type")}} {{readonlyinline}}{{deprecated_inline}}</dt>
+ <dt>{{domxref("CSSRule.type")}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>Returns one of the Type constants to determine which type of rule is represented.</dd>
 </dl>
 

--- a/files/en-us/web/api/cssstylerule/index.html
+++ b/files/en-us/web/api/cssstylerule/index.html
@@ -20,9 +20,9 @@ browser-compat: api.CSSStyleRule
 <p><em>Inherits properties from its ancestor {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt id="selectorText">{{domxref("CSSStyleRule.selectorText")}}</dt>
+ <dt>{{domxref("CSSStyleRule.selectorText")}}</dt>
  <dd>Returns the textual representation of the selector for this rule, e.g. <code>"h1,h2"</code>.</dd>
- <dt id="style">{{domxref("CSSStyleRule.style")}} {{readonlyinline}}</dt>
+ <dt>{{domxref("CSSStyleRule.style")}} {{readonlyinline}}</dt>
  <dd>Returns the {{domxref("CSSStyleDeclaration")}} object for the rule.</dd>
  <dt>{{domxref("CSSStyleRule.styleMap")}} {{readonlyinline}}</dt>
  <dd>Returns a {{domxref('StylePropertyMap')}} object which provides access to the rule's property-value pairs.</dd>

--- a/files/en-us/web/api/customelementregistry/whendefined/index.html
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.html
@@ -32,12 +32,9 @@ browser-compat: api.CustomElementRegistry.whenDefined
 <h3 id="Return_value">Return value</h3>
 
 <p>A {{jsxref("Promise")}} that will be fulfilled with the <a
-    href="/en-US/docs/Web/API/Window/customElements"
-    id="custom-elements-api:custom-element-4">custom element</a>'s constructor when a <a
-    href="/en-US/docs/Web/API/Window/customElements"
-    id="custom-elements-api:custom-element-5">custom element</a> becomes defined with the
-  given name. (If such a <a href="/en-US/docs/Web/API/Window/customElements"
-    id="custom-elements-api:custom-element-6">custom element</a> is already defined, the
+    href="/en-US/docs/Web/API/Window/customElements">custom element</a>'s constructor when a <a
+    href="/en-US/docs/Web/API/Window/customElements">custom element</a> becomes defined with the
+  given name. (If such a <a href="/en-US/docs/Web/API/Window/customElements">custom element</a> is already defined, the
   returned promise will be immediately fulfilled.)</p>
 
 <h3 id="Exceptions">Exceptions</h3>

--- a/files/en-us/web/api/datatransfer/getdata/index.html
+++ b/files/en-us/web/api/datatransfer/getdata/index.html
@@ -98,8 +98,7 @@ function drop(dropevent) {
 
 <h3 id="Result">Result</h3>
 
-<p id="EmbedLiveSample('Example'_''_''_''_'WebAPIDataTransfergetData')">{{
-    EmbedLiveSample('Example', 600) }}</p>
+<div>{{EmbedLiveSample('Example', 600) }}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/document/animationcancel_event/index.html
+++ b/files/en-us/web/api/document/animationcancel_event/index.html
@@ -53,7 +53,7 @@ browser-compat: api.Document.animationcancel_event
   console.log('Animation canceled');
 };</pre>
 
-<p id="Live_example"><a href="/en-US/docs/Web/API/HTMLElement/animationcancel_event#live_example">See a live example of this event.</a></p>
+<p><a href="/en-US/docs/Web/API/HTMLElement/animationcancel_event#live_example">See a live example of this event.</a></p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -36,8 +36,7 @@ browser-compat: api.Document.cookie
 
 <h3 id="Write_a_new_cookie">Write a new cookie</h3>
 
-<pre class="brush: js"
-	id="new-cookie_syntax"><var>document</var>.cookie = <var>newCookie</var>;</pre>
+<pre class="brush: js"><var>document</var>.cookie = <var>newCookie</var>;</pre>
 
 <p>In the code above, <code>newCookie</code> is a string of form
 	<code><var>key</var>=<var>value</var></code>. Note that you can only set/update a
@@ -47,7 +46,7 @@ browser-compat: api.Document.cookie
 	<li>Any of the following cookie attribute values can optionally follow the key-value
 		pair, specifying the cookie to set/update, and preceded by a semi-colon separator:
 		<ul>
-			<li id="new-cookie_path">
+			<li>
 				<div><code>;path=<var>path</var></code> (e.g., '<code>/</code>',
 					'<code>/mydir</code>') If not specified, defaults to the current path
 					of the current document location.</div>
@@ -57,7 +56,7 @@ browser-compat: api.Document.cookie
 					instead of as if they were delimiters surrounding the actual path
 					string. This has been fixed.</p></div>
 			</li>
-			<li id="new-cookie_domain"><code>;domain=<var>domain</var></code> (e.g.,
+			<li><code>;domain=<var>domain</var></code> (e.g.,
 				'<code>example.com</code>' or '<code>subdomain.example.com</code>'). If
 				not specified, this defaults to the host portion of the current document
 				location. Contrary to earlier specifications, leading dots in domain names
@@ -67,10 +66,10 @@ browser-compat: api.Document.cookie
 					the domain of the JavaScript origin. Setting cookies to foreign
 					domains will be silently ignored.</p></div>
 			</li>
-			<li id="new-cookie_max-age">
+			<li>
 				<code>;max-age=<var>max-age-in-seconds</var></code> (e.g.,
 				<code>60*60*24*365</code> or 31536000 for a year)</li>
-			<li id="new-cookie_expires">
+			<li>
 				<code>;expires=<var>date-in-GMTString-format</var></code> If neither
 				<code>expires</code> nor <code>max-age</code> specified it will expire at
 				the end of session.
@@ -87,10 +86,10 @@ browser-compat: api.Document.cookie
 						value.</li>
 				</ul>
 			</li>
-			<li id="new-cookie_secure"><code>;secure</code> Cookie to only be transmitted
+			<li><code>;secure</code> Cookie to only be transmitted
 				over secure protocol as https. Before Chrome 52, this flag could appear
 				with cookies from http domains.</li>
-			<li id="new-cookie_samesite"><code>;samesite</code> <a
+			<li><code>;samesite</code> <a
 					href="/en-US/docs/Web/HTTP/Cookies#samesite_cookies">SameSite</a>
 				prevents the browser from sending this cookie along with cross-site
 				requests. Possible values are <code>lax</code>,

--- a/files/en-us/web/api/document/elementfrompoint/index.html
+++ b/files/en-us/web/api/document/elementfrompoint/index.html
@@ -72,7 +72,7 @@ browser-compat: api.Document.elementFromPoint
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush:html" id="ExampleCode">&lt;p id="para1"&gt;Some text here&lt;/p&gt;
+<pre class="brush:html">&lt;p id="para1"&gt;Some text here&lt;/p&gt;
 &lt;button onclick="changeColor('blue');"&gt;Blue&lt;/button&gt;
 &lt;button onclick="changeColor('red');"&gt;Red&lt;/button&gt;
 </pre>

--- a/files/en-us/web/api/domexception/index.html
+++ b/files/en-us/web/api/domexception/index.html
@@ -52,69 +52,69 @@ browser-compat: api.DOMException
 </div>
 
 <dl>
- <dt><a id="exception-IndexSizeError"><code>IndexSizeError</code></a></dt>
+ <dt><code>IndexSizeError</code></dt>
  <dd>The index is not in the allowed range. For example, this can be thrown by the {{ domxref("Range") }} object. (Legacy code value: <code>1</code> and legacy constant name: <code>INDEX_SIZE_ERR</code>)</dd>
- <dt><code><a id="exception-HierarchyRequestError">HierarchyRequestError</a></code></dt>
+ <dt><code>HierarchyRequestError</code></dt>
  <dd>The node tree hierarchy is not correct. (Legacy code value: <code>3</code> and legacy constant name: <code>HIERARCHY_REQUEST_ERR</code>)</dd>
- <dt><a id="exception-WrongDocumentError"><code>WrongDocumentError</code></a></dt>
+ <dt><code>WrongDocumentError</code></dt>
  <dd>The object is in the wrong {{ domxref("Document") }}. (Legacy code value: <code>4</code> and legacy constant name: <code>WRONG_DOCUMENT_ERR</code>)</dd>
- <dt><a id="exception-InvalidCharacterError"><code>InvalidCharacterError</code></a></dt>
+ <dt><code>InvalidCharacterError</code></dt>
  <dd>The string contains invalid characters. (Legacy code value: <code>5</code> and legacy constant name: <code>INVALID_CHARACTER_ERR</code>)</dd>
- <dt><a id="exception-NoModificationAllowedError"><code>NoModificationAllowedError</code></a></dt>
+ <dt><code>NoModificationAllowedError</code></dt>
  <dd>The object cannot be modified. (Legacy code value: <code>7</code> and legacy constant name: <code>NO_MODIFICATION_ALLOWED_ERR</code>)</dd>
- <dt><a id="exception-NotFoundError"><code>NotFoundError</code></a></dt>
+ <dt><code>NotFoundError</code></dt>
  <dd>The object cannot be found here. (Legacy code value: <code>8</code> and legacy constant name: <code>NOT_FOUND_ERR</code>)</dd>
- <dt><a id="exception-NotSupportedError"><code>NotSupportedError</code></a></dt>
+ <dt><code>NotSupportedError</code></dt>
  <dd>The operation is not supported. (Legacy code value: <code>9</code> and legacy constant name: <code>NOT_SUPPORTED_ERR</code>)</dd>
- <dt><a id="exception-InvalidStateError"><code>InvalidStateError</code></a></dt>
+ <dt><code>InvalidStateError</code></dt>
  <dd>The object is in an invalid state. (Legacy code value: <code>11</code> and legacy constant name: <code>INVALID_STATE_ERR</code>)</dd>
- <dt><a id="exception-InUseAttributeError"><code>InUseAttributeError</code></a></dt>
+ <dt><code>InUseAttributeError</code></dt>
  <dd>The attribute is in use. (Legacy code value: <code>10</code> and legacy constant name: <code>INUSE_ATTRIBUTE_ERR</code>)</dd>
- <dt><a id="exception-SyntaxError"><code>SyntaxError</code></a></dt>
+ <dt><code>SyntaxError</code></dt>
  <dd>The string did not match the expected pattern. (Legacy code value: <code>12</code> and legacy constant name: <code>SYNTAX_ERR</code>)</dd>
- <dt><a id="exception-InvalidModificationError"><code>InvalidModificationError</code></a></dt>
+ <dt><code>InvalidModificationError</code></dt>
  <dd>The object cannot be modified in this way. (Legacy code value: <code>13</code> and legacy constant name: <code>INVALID_MODIFICATION_ERR</code>)</dd>
- <dt><a id="exception-NamespaceError"><code>NamespaceError</code></a></dt>
+ <dt><code>NamespaceError</code></dt>
  <dd>The operation is not allowed by Namespaces in XML. (Legacy code value: <code>14</code> and legacy constant name: <code>NAMESPACE_ERR</code>)</dd>
- <dt><a id="exception-InvalidAccessError"><code>InvalidAccessError</code></a></dt>
+ <dt><code>InvalidAccessError</code></dt>
  <dd>The object does not support the operation or argument. (Legacy code value: <code>15</code> and legacy constant name: <code>INVALID_ACCESS_ERR</code>)</dd>
- <dt><a id="exception-TypeMismatchError"><code>TypeMismatchError</code></a> {{deprecated_inline}}</dt>
+ <dt><code>TypeMismatchError</code> {{deprecated_inline}}</dt>
  <dd>The type of the object does not match the expected type. (Legacy code value: <code>17</code> and legacy constant name: <code>TYPE_MISMATCH_ERR</code>) This value is deprecated; the JavaScript {{jsxref("TypeError")}} exception is now raised instead of a <code>DOMException</code> with this value.</dd>
- <dt><a id="exception-SecurityError"><code>SecurityError</code></a></dt>
+ <dt><code>SecurityError</code></dt>
  <dd>The operation is insecure. (Legacy code value: <code>18</code> and legacy constant name: <code>SECURITY_ERR</code>)</dd>
- <dt><a id="exception-NetworkError"><code>NetworkError</code></a> {{experimental_inline}}</dt>
+ <dt><code>NetworkError</code> {{experimental_inline}}</dt>
  <dd>A network error occurred. (Legacy code value: <code>19</code> and legacy constant name: <code>NETWORK_ERR</code>)</dd>
- <dt><a id="exception-AbortError"><code>AbortError</code></a> {{experimental_inline}}</dt>
+ <dt><code>AbortError</code> {{experimental_inline}}</dt>
  <dd>The operation was aborted. (Legacy code value: <code>20</code> and legacy constant name: <code>ABORT_ERR</code>)</dd>
- <dt><a id="exception-URLMismatchError"><code>URLMismatchError</code></a> {{experimental_inline}}</dt>
+ <dt><code>URLMismatchError</code> {{experimental_inline}}</dt>
  <dd>The given URL does not match another URL. (Legacy code value: <code>21</code> and legacy constant name: <code>URL_MISMATCH_ERR</code>)</dd>
- <dt><a id="exception-QuotaExceededError"><code>QuotaExceededError</code></a> {{experimental_inline}}</dt>
+ <dt><code>QuotaExceededError</code> {{experimental_inline}}</dt>
  <dd>The quota has been exceeded. (Legacy code value: <code>22</code> and legacy constant name: <code>QUOTA_EXCEEDED_ERR</code>)</dd>
- <dt><a id="exception-TimeoutError"><code>TimeoutError</code></a></dt>
+ <dt><code>TimeoutError</code></dt>
  <dd>The operation timed out. (Legacy code value: <code>23</code> and legacy constant name: <code>TIMEOUT_ERR</code>)</dd>
- <dt><a id="exception-InvalidNodeTypeError"><code>InvalidNodeTypeError</code></a> {{experimental_inline}}</dt>
+ <dt><code>InvalidNodeTypeError</code> {{experimental_inline}}</dt>
  <dd>The node is incorrect or has an incorrect ancestor for this operation. (Legacy code value: <code>24</code> and legacy constant name: <code>INVALID_NODE_TYPE_ERR</code>)</dd>
- <dt><a id="exception-DataCloneError"><code>DataCloneError</code></a> {{experimental_inline}}</dt>
+ <dt><code>DataCloneError</code> {{experimental_inline}}</dt>
  <dd>The object can not be cloned. (Legacy code value: <code>25</code> and legacy constant name: <code>DATA_CLONE_ERR</code>)</dd>
- <dt><a id="exception-EncodingError"><code>EncodingError</code></a> {{experimental_inline}}</dt>
+ <dt><code>EncodingError</code> {{experimental_inline}}</dt>
  <dd>The encoding or decoding operation failed (No legacy code value and constant name).</dd>
- <dt><a id="exception-NotReadableError"><code>NotReadableError</code></a> {{experimental_inline}}</dt>
+ <dt><code>NotReadableError</code> {{experimental_inline}}</dt>
  <dd>The input/output read operation failed (No legacy code value and constant name).</dd>
- <dt><a id="exception-UnknownError"><code>UnknownError</code></a> {{experimental_inline}}</dt>
+ <dt><code>UnknownError</code> {{experimental_inline}}</dt>
  <dd>The operation failed for an unknown transient reason (e.g. out of memory) (No legacy code value and constant name).</dd>
- <dt><a id="exception-ConstraintError"><code>ConstraintError</code></a> {{experimental_inline}}</dt>
+ <dt><code>ConstraintError</code> {{experimental_inline}}</dt>
  <dd>A mutation operation in a transaction failed because a constraint was not satisfied (No legacy code value and constant name).</dd>
- <dt><a id="exception-DataError"><code>DataError</code></a> {{experimental_inline}}</dt>
+ <dt><code>DataError</code> {{experimental_inline}}</dt>
  <dd>Provided data is inadequate (No legacy code value and constant name).</dd>
- <dt><a id="exception-TransactionInactiveError"><code>TransactionInactiveError</code></a> {{experimental_inline}}</dt>
+ <dt><code>TransactionInactiveError</code> {{experimental_inline}}</dt>
  <dd>A request was placed against a transaction that is currently not active or is finished (No legacy code value and constant name).</dd>
- <dt><a id="exception-ReadOnlyError"><code>ReadOnlyError</code></a> {{experimental_inline}}</dt>
+ <dt><code>ReadOnlyError</code> {{experimental_inline}}</dt>
  <dd>The mutating operation was attempted in a "readonly" transaction (No legacy code value and constant name).</dd>
- <dt><a id="exception-VersionError"><code>VersionError</code></a> {{experimental_inline}}</dt>
+ <dt><code>VersionError</code> {{experimental_inline}}</dt>
  <dd>An attempt was made to open a database using a lower version than the existing version (No legacy code value and constant name).</dd>
- <dt><a id="exception-OperationError"><code>OperationError</code></a> {{experimental_inline}}</dt>
+ <dt><code>OperationError</code> {{experimental_inline}}</dt>
  <dd>The operation failed for an operation-specific reason (No legacy code value and constant name).</dd>
- <dt><a id="exception-NotAllowedError"><code>NotAllowedError</code></a></dt>
+ <dt><code>NotAllowedError</code></dt>
  <dd>The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission (No legacy code value and constant name).</dd>
 </dl>
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.html
+++ b/files/en-us/web/api/domparser/parsefromstring/index.html
@@ -23,7 +23,7 @@ browser-compat: api.DOMParser.parseFromString
   <dd>The {{domxref("DOMString")}} to be parsed. It must contain either an
     {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("xhtml+xml")}}, or
     {{Glossary("svg")}} document.</dd>
-  <dt id="Argument02"><code><var>mimeType</var></code></dt>
+  <dt><code><var>mimeType</var></code></dt>
   <dd>
     <p>A {{domxref("DOMString")}}. This string determines whether the XML parser or the HTML parser is used to parse the string. Valid values are:</p>
     <ul>

--- a/files/en-us/web/api/element/clientleft/index.html
+++ b/files/en-us/web/api/element/clientleft/index.html
@@ -43,39 +43,45 @@ browser-compat: api.Element.clientLeft
 <pre class="brush: js">var <var>left</var> = <var>element</var>.clientLeft;
 </pre>
 
+
 <h2 id="Example">Example</h2>
 
-<div id="offsetContainer"
-	style="margin: 40px 50px 50px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: relative; display: inline-block;">
-	<div id="idDiv"
-		style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;">
-		<p id="PaddingTopLabel"
-			style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-			padding-top</p>
+<p>In the following example, the client area has a white background and a 24px black <code>border-left</code>. The <code>clientLeft</code> value is the distance from where the margin (yellow) area ends and the padding and content areas (white) begin: that is, 24px.</p>
 
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-			incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-			nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-		</p>
+<h3>HTML</h3>
 
-		<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-			fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-			culpa qui officia deserunt mollit anim id est laborum.</p>
+<pre class="brush: html">
+&lt;div id="container"&gt;
+  &lt;div id="contained"&gt;
+    &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+	  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+	  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+</pre>
 
-		<p id="PaddingBottomLabel"
-			style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-			padding-bottom</p>
-	</div>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: -32px; position: absolute; top: 85px;">Left</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 170px; position: absolute; top: -24px;">Top</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 370px; position: absolute; top: 85px;">Right</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 164px; position: absolute; top: 203px;">Bottom</strong>
-	<em>margin-top</em> <em>margin-bottom</em> <em>border-top</em> <em>border-bottom</em>
-</div>
+<h3>CSS</h3>
+
+<pre class="brush: css">
+
+#container {
+	margin: 3rem;
+	background-color: rgb(255, 255, 204);
+	border: 4px dashed black;
+}
+
+#contained {
+	margin: 1rem;
+	border-left: 24px black solid;
+	padding: 0px 28px;
+	overflow: auto;
+	background-color: white;
+}
+</pre>
+
+<h3>Result</h3>
+
+{{EmbedLiveSample("Example", 400, 350)}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/element/clienttop/index.html
+++ b/files/en-us/web/api/element/clienttop/index.html
@@ -40,42 +40,42 @@ browser-compat: api.Element.clientTop
 
 <h2 id="Example">Example</h2>
 
-<p>In the following illustration, the client area is show in white. (The segments labeled
-	"Top", "Right", etc. have no significance regarding the client area.) The clientTop
-	value is the distance from where the margin (yellow) area ends and the padding and
-	content areas (white) begin.</p>
+<p>In the following example, the client area has a white background and a 24px black <code>border-top</code>. The <code>clientTop</code> value is the distance from where the margin (yellow) area ends and the padding and content areas (white) begin: that is, 24px.</p>
 
-<div id="offsetContainer"
-	style="margin: 40px 50px 50px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: relative; display: inline-block;">
-	<div id="idDiv"
-		style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;">
-		<p id="PaddingTopLabel"
-			style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-			padding-top</p>
+<h3>HTML</h3>
 
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-			incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-			nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-		</p>
+<pre class="brush: html">
+&lt;div id="container"&gt;
+  &lt;div id="contained"&gt;
+    &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+	  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+	  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+</pre>
 
-		<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-			fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-			culpa qui officia deserunt mollit anim id est laborum.</p>
+<h3>CSS</h3>
 
-		<p id="PaddingBottomLabel"
-			style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-			padding-bottom</p>
-	</div>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: -32px; position: absolute; top: 85px;">Left</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 170px; position: absolute; top: -24px;">Top</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 370px; position: absolute; top: 85px;">Right</strong>
-	<strong
-		style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 164px; position: absolute; top: 203px;">Bottom</strong>
-	<em>margin-top</em> <em>margin-bottom</em> <em>border-top</em> <em>border-bottom</em>
-</div>
+<pre class="brush: css">
+
+#container {
+	margin: 3rem;
+	background-color: rgb(255, 255, 204);
+	border: 4px dashed black;
+}
+
+#contained {
+	margin: 1rem;
+	border-top: 24px black solid;
+	padding: 0px 28px;
+	overflow: auto;
+	background-color: white;
+}
+</pre>
+
+<h3>Result</h3>
+
+{{EmbedLiveSample("Example", 400, 350)}}
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/api/element/scrollheight/index.html
+++ b/files/en-us/web/api/element/scrollheight/index.html
@@ -15,6 +15,8 @@ browser-compat: api.Element.scrollHeight
   measurement of the height of an element's content, including content not visible on the
   screen due to overflow.</p>
 
+<p><img src="scrollheight.png"></p>
+
 <p>The <code>scrollHeight</code> value is equal to the minimum height the element would
   require in order to fit all the content in the viewport without using a vertical
   scrollbar. The height is measured in the same way as {{domxref("Element.clientHeight",
@@ -38,35 +40,6 @@ browser-compat: api.Element.scrollHeight
 
 <p>An integer corresponding to the scrollHeight pixel value of the element.</p>
 
-<h2 id="Example">Example</h2>
-
-<div id="offsetContainer"
-  style="margin: 0px 40px 50px;background-color: rgb(255, 255, 204);border: 4px dashed black;color: black;position: relative;display: inline-block;min-width: 300px;">
-  <div id="idDiv"
-    style="margin: 24px auto;border: 24px black solid;padding: 0px 15px;width: 220px;height: 120px;overflow: auto;background-color: white;font-size: 13px!important;font-family: Arial, sans-serif;">
-    <p id="PaddingTopLabel"
-      style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-      padding-top</p>
-
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-      incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-
-    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
-      qui officia deserunt mollit anim id est laborum.</p>
-
-    <p id="PaddingBottomLabel"
-      style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">
-      padding-bottom</p>
-  </div>
-  <strong style="position: absolute; left: -12%; top: 50%; transform: translateY(-50%); color: blue; font-weight: bold; font-size: 14px;">Left</strong> <strong style="position: absolute; left: 50%; top: -15%; transform: translateX(-50%); color: blue; font-weight: bold; font-size: 14px;">Top</strong> <strong style="position: absolute;right: -15%;top: 50%;transform: translateY(-50%);color: blue;font-weight: bold;font-size: 14px;">Right</strong>
-  <strong style="position: absolute;left: 50%;bottom: -15%;transform: translateX(-50%);color: blue;font-weight: bold;font-size: 14px;">Bottom</strong>
-  <em style="position: absolute;left: 50%;top: 0;transform: translateX(-50%);font-size: 14px;">margin-top</em> <em style="position: absolute;left: 50%;bottom: 0;transform: translateX(-50%);font-size: 14px;">margin-bottom</em> <em style="position: absolute;left: 50%;top: 14%;transform: translateX(-50%);font-size: 14px;color: white;">border-top</em> <em style="position: absolute;left: 50%;bottom: 14%;transform: translateX(-50%);font-size: 14px;color: white;">border-bottom</em>
-</div>
-
-<p><img src="scrollheight.png"></p>
-
 <h2 id="Problems_and_solutions">Problems and solutions</h2>
 
 <h3 id="Determine_if_an_element_has_been_totally_scrolled">Determine if an element has
@@ -85,7 +58,9 @@ browser-compat: api.Element.scrollHeight
 window.getComputedStyle(element).overflowY !== 'hidden'
 </pre>
 
-<h2 id="scrollHeight_Demo">scrollHeight Demo</h2>
+<h2>Examples</h2>
+
+<h3>Checking that the user has read a text</h3>
 
 <p>Associated with the {{domxref("GlobalEventHandlers/onscroll", "onscroll")}} event, this
   equivalence can be useful to determine whether a user has read a text or not (see also
@@ -95,7 +70,7 @@ window.getComputedStyle(element).overflowY !== 'hidden'
   <p>The checkbox in the demo below is disabled, and so cannot be checked to show agreement
     until the content of the textarea has been scrolled through.</p>
 
-<h3 id="HTML">HTML</h3>
+<h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;form name="registration"&gt;
   &lt;p&gt;
@@ -130,7 +105,7 @@ nascetur ridiculus mus. Cras vulputate libero sed arcu iaculis nec lobortis orci
   &lt;/p&gt;
 &lt;/form&gt;</pre>
 
-<h3 id="CSS">CSS</h3>
+<h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">#notice {
   display: inline-block;
@@ -149,7 +124,7 @@ nascetur ridiculus mus. Cras vulputate libero sed arcu iaculis nec lobortis orci
   border-radius: 5px;
 }</pre>
 
-<h3 id="JavaScript">JavaScript</h3>
+<h4 id="JavaScript">JavaScript</h4>
 
 <pre class="brush: js">function checkReading () {
   if (checkReading.read) {
@@ -171,7 +146,7 @@ onload = function () {
   checkReading.call(oToBeRead);
 }</pre>
 
-<p>{{EmbedLiveSample('scrollHeight_Demo', '640', '400')}}</p>
+<p>{{EmbedLiveSample('Checking_that_the_user_has_read_a_text', '640', '400')}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/element/scrolltop/index.html
+++ b/files/en-us/web/api/element/scrolltop/index.html
@@ -42,22 +42,59 @@ var <var>intElemScrollTop</var> = someElement.scrollTop;
  <li>If set to a value greater than the maximum available for the element, <code>scrollTop</code> settles itself to the maximum value.</li>
 </ul>
 
-<h2 id="Example">Example</h2>
+<h2>Examples</h2>
 
-<div id="offsetContainer" style="margin: 40px 50px 50px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: relative; display: inline-block;">
-<div id="idDiv" style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;">
-<p id="PaddingTopLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-top</p>
-<em><strong>If you can see this, scrollTop = 0</strong></em>
+<h3>Scrolling an element</h3>
 
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-<strong><em>If you can see this, scrollTop is &gt; 0</em></strong>
+<p>In this example, try scrolling the inner container with the dashed border, and see how the value of <code>scrollTop</code> changes.</p>
 
-<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-<strong><em>If you can see this, scrollTop is maxed-out</em></strong>
+<h4>HTML</h4>
 
-<p id="PaddingBottomLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-bottom</p>
-</div>
-<strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: -32px; position: absolute; top: 85px;">Left</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 170px; position: absolute; top: -24px;">Top</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 370px; position: absolute; top: 85px;">Right</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 164px; position: absolute; top: 203px;">Bottom</strong> <em>margin-top</em> <em>margin-bottom</em> <em>border-top</em> <em>border-bottom</em></div>
+<pre class="brush: html">
+
+&lt;div id="container"&gt;
+  &lt;div id="scroller"&gt;
+      &lt;p&gt;Far out in the uncharted backwaters of the unfashionable end
+      of the western spiral arm of the Galaxy lies a small unregarded
+      yellow sun. Orbiting this at a distance of roughly ninety-two million
+      miles is an utterly insignificant little blue green planet whose
+      ape-descended life forms are so amazingly primitive that they still
+      think digital watches are a pretty neat idea.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;div id="output"&gt;scrollTop: 0&lt;/div&gt;
+</pre>
+
+<h4>CSS</h4>
+
+<pre class="brush: css">
+#scroller {
+  overflow: scroll;
+  height: 150px;
+  width: 150px;
+  border: 5px dashed orange;
+}
+
+#output {
+  padding: 1rem 0;
+}
+</pre>
+
+<h4>JavaScript</h4>
+
+<pre class="brush: js">
+const scroller = document.querySelector("#scroller");
+const output = document.querySelector("#output");
+
+scroller.addEventListener("scroll", event => {
+  output.textContent = `scrollTop: ${scroller.scrollTop}`;
+});
+</pre>
+
+<h4>Result</h4>
+
+{{EmbedLiveSample("Scrolling_an_element", 400, 250)}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/eventtarget/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.html
@@ -28,7 +28,7 @@ browser-compat: api.EventTarget.EventTarget
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js" id="ct-20">class MyEventTarget extends EventTarget {
+<pre class="brush: js">class MyEventTarget extends EventTarget {
   constructor(mySecret) {
     super();
     this._secret = mySecret;

--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
@@ -26,7 +26,7 @@ browser-compat: api.FeaturePolicy.allowedFeatures
 
 <h3 id="Parameters">Parameters</h3>
 
-<p id="Feature_name">None.</p>
+<p>None.</p>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/filesystementrysync/index.html
+++ b/files/en-us/web/api/filesystementrysync/index.html
@@ -68,12 +68,12 @@ browser-compat: api.FileSystemEntrySync
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_filesystem"><code>filesystem</code></a></td>
+   <td><code>filesystem</code></td>
    <td><code>readonly FileSystemSync</code></td>
    <td>The file system where the entry resides.</td>
   </tr>
   <tr>
-   <td><a id="attr_fullpath" name="fullpath"><code>fullpath</code></a></td>
+   <td><code>fullpath</code></td>
    <td><code>readonly DOMString</code></td>
    <td>
     <p>The full absolute path from the root to the entry.</p>
@@ -82,17 +82,17 @@ browser-compat: api.FileSystemEntrySync
     </td>
   </tr>
   <tr>
-   <td><a id="attr_root" name="attr_isDirectory"><code>isDirectory</code></a></td>
+   <td><code>isDirectory</code></td>
    <td><code>readonly boolean</code></td>
    <td>True if FileSystemEntrySync is a directory.</td>
   </tr>
   <tr>
-   <td><a id="attr_isfile"><code>isFile</code></a></td>
+   <td><code>isFile</code></td>
    <td><code>readonly boolean</code></td>
    <td>True if the FileSystemEntrySync is a file.</td>
   </tr>
   <tr>
-   <td><a id="attr_name"><code>name</code></a></td>
+   <td><code>name</code></td>
    <td><code>readonly DOMString</code></td>
    <td>The name of the entry, excluding the path leading to it.</td>
   </tr>

--- a/files/en-us/web/api/fontface/load/index.html
+++ b/files/en-us/web/api/fontface/load/index.html
@@ -30,8 +30,7 @@ browser-compat: api.FontFace.load
 <h3 id="Return_value">Return value</h3>
 
 <p>A {{jsxref('Promise')}} that resolves with a reference to the current
-  <code>FontFace</code> object when the font loads or rejects with a <a
-    href="/en-US/docs/Web/API/DOMException#exception-networkerror">NetworkError</a> if the
+  <code>FontFace</code> object when the font loads or rejects with a <code>NetworkError</code> {{domxref("DOMException")}} if the
   loading process fails.</p>
 
 <h3 id="Exceptions">Exceptions</h3>

--- a/files/en-us/web/api/gamepad/axes/index.html
+++ b/files/en-us/web/api/gamepad/axes/index.html
@@ -22,8 +22,7 @@ browser-compat: api.Gamepad.axes
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><span class="idlInterface" id="idl-def-Gamepad"><span class="idlAttribute">readonly    attribute <span class="idlAttrType">double[]</span>            <span class="idlAttrName">axes</span>;</span></span></pre>
+<pre class="brush: js">const axes = gamepad.axes;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepad/buttons/index.html
+++ b/files/en-us/web/api/gamepad/buttons/index.html
@@ -32,8 +32,7 @@ browser-compat: api.Gamepad.buttons
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">readonly    attribute GamepadButton[]     buttons;</pre>
+<pre class="brush: js">const buttons = gamepad.buttons;</pre>
 
 <h2 id="Example">Example</h2>
 
@@ -93,8 +92,6 @@ browser-compat: api.Gamepad.buttons
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
-<div id="compat-mobile"> </div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/connected/index.html
+++ b/files/en-us/web/api/gamepad/connected/index.html
@@ -22,8 +22,7 @@ browser-compat: api.Gamepad.connected
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js"><span class="idlInterface" id="idl-def-Gamepad"><span class="idlAttribute"> readonly    attribute <span class="idlAttrType">boolean</span>             <span class="idlAttrName">connected</span>;</span></span></pre>
+<pre class="brush: js">const connected = gamepad.connected;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -27,7 +27,7 @@ browser-compat: api.Gamepad.displayId
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var myDisplayId = gamepadInstance.displayId;</pre>
+<pre class="brush: js">const displayId = gamepadInstance.displayId;</pre>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/api/gamepad/id/index.html
+++ b/files/en-us/web/api/gamepad/id/index.html
@@ -32,8 +32,7 @@ browser-compat: api.Gamepad.id
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js"><span class="idlInterface" id="idl-def-Gamepad"><span class="idlAttribute">readonly    attribute <span class="idlAttrType">DOMString</span>           <span class="idlAttrName">id</span>;</span></span></pre>
+<pre class="brush: js">const id = gamepad.id;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepad/index/index.html
+++ b/files/en-us/web/api/gamepad/index/index.html
@@ -22,8 +22,7 @@ browser-compat: api.Gamepad.index
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js"><span class="idlInterface" id="idl-def-Gamepad"><span class="idlAttribute">readonly    attribute <span class="idlAttrType">long</span>                <span class="idlAttrName">index</span>;</span></span></pre>
+<pre class="brush: js">const index = gamepad.index;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepad/timestamp/index.html
+++ b/files/en-us/web/api/gamepad/timestamp/index.html
@@ -30,8 +30,7 @@ browser-compat: api.Gamepad.timestamp
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js"><span class="idlInterface" id="idl-def-Gamepad"><span class="idlAttribute">readonly    attribute <span class="idlAttrType">DOMHighResTimeStamp</span> <span class="idlAttrName">timestamp</span>;</span></span></pre>
+<pre class="brush: js">const timestamp = gamepad.timestamp;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gamepadbutton/value/index.html
+++ b/files/en-us/web/api/gamepadbutton/value/index.html
@@ -23,8 +23,7 @@ browser-compat: api.GamepadButton.value
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js"><span class="idlInterface" id="idl-def-GamepadButton"><span class="idlAttribute">    readonly    attribute <span class="idlAttrType">double</span>  <span class="idlAttrName">value</span>;</span></span></pre>
+<pre class="brush: js">const value = gamepadButton.value;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/gestureevent/index.html
+++ b/files/en-us/web/api/gestureevent/index.html
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.GestureEvent
 ---
-<p id="Summary">{{APIRef("DOM Events")}}</p>
+<div>{{APIRef("DOM Events")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -26,7 +26,6 @@ browser-compat: api.GlobalEventHandlers
 
 <p>These event handlers are defined on the {{domxref("GlobalEventHandlers")}} mixin, and implemented by {{domxref("HTMLElement")}}, {{domxref("Document")}}, {{domxref("Window")}}, as well as by {{domxref("WorkerGlobalScope")}} for Web Workers.</p>
 
-<div id="Properties">
 <dl>
  <dt>{{domxref("GlobalEventHandlers.onabort")}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{domxref("HTMLMediaElement/abort_event", "abort")}} event is raised.</dd>
@@ -205,7 +204,6 @@ browser-compat: api.GlobalEventHandlers
  <dt>{{domxref("GlobalEventHandlers.onwaiting")}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("waiting")}} event is raised.</dd>
 </dl>
-</div>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onblur/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onblur/index.html
@@ -66,7 +66,7 @@ function inputFocus() {
 <p>Try clicking in and out of the form field, and watch its contents change accordingly.
 </p>
 
-<p id="Result">{{EmbedLiveSample('Example')}}</p>
+<p>{{EmbedLiveSample('Example')}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onfocus/index.html
@@ -70,7 +70,7 @@ function inputFocus() {
 <p>Try clicking in and out of the form field, and watch its contents change accordingly.
 </p>
 
-<p id="Result">{{EmbedLiveSample('Example')}}</p>
+<p>{{EmbedLiveSample('Example')}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/history_api/example/index.html
+++ b/files/en-us/web/api/history_api/example/index.html
@@ -4,7 +4,7 @@ slug: Web/API/History_API/Example
 ---
 <p>This is an example of an AJAX website composed only of three pages (<em>first_page.php</em>, <em>second_page.php</em> and <em>third_page.php</em>). To see how it works, please create the following files (or git clone <a href="https://github.com/giabao/mdn-ajax-nav-example">https://github.com/giabao/mdn-ajax-nav-example.git</a> ):</p>
 
-<div class="note" id="const_compatibility"><p><strong>Note:</strong> For fully integrating the {{HTMLElement("form")}} elements within this <em>mechanism</em>, please take a look at the paragraph <a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files">Submitting forms and uploading files</a>.</p></div>
+<div class="note"><p><strong>Note:</strong> For fully integrating the {{HTMLElement("form")}} elements within this <em>mechanism</em>, please take a look at the paragraph <a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files">Submitting forms and uploading files</a>.</p></div>
 
 <p><strong>first_page.php</strong>:</p>
 

--- a/files/en-us/web/api/htmlaudioelement/msaudiocategory/index.html
+++ b/files/en-us/web/api/htmlaudioelement/msaudiocategory/index.html
@@ -2,7 +2,7 @@
 title: HTMLAudioElement.msAudioCategory
 slug: Web/API/HTMLAudioElement/msAudioCategory
 ---
-<p id="Summary">{{APIRef("Audio element")}}</p>
+<div>{{APIRef("Audio element")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlaudioelement/msaudiodevicetype/index.html
+++ b/files/en-us/web/api/htmlaudioelement/msaudiodevicetype/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLAudioElement/msAudioDeviceType
 tags:
   - msAudioDeviceType
 ---
-<p id="Summary">{{APIRef("Audio element")}}</p>
+<div>{{APIRef("Audio element")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlelement/change_event/index.html
+++ b/files/en-us/web/api/htmlelement/change_event/index.html
@@ -49,7 +49,6 @@ tags:
 
 <h3 id="select_element">&lt;select&gt; element</h3>
 
-<div id="select-example">
 <h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;label&gt;Choose an ice cream flavor:
@@ -86,11 +85,10 @@ selectElement.addEventListener('change', (event) =&gt; {
   result.textContent = `You like ${event.target.value}`;
 });
 </pre>
-</div>
 
 <h4 id="Result">Result</h4>
 
-<p>{{ EmbedLiveSample('select-example', '100%', '75px') }}</p>
+<p>{{ EmbedLiveSample('select_element', '100%', '75px') }}</p>
 
 <h3 id="Text_input_element">Text input element</h3>
 

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.html
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.html
@@ -98,7 +98,7 @@ browser-compat: api.SubtleCrypto.deriveBits
   <dd>Raised if the <em>length</em> parameter of the <code>deriveBits()</code> call is null, and also in some cases if the <em>length</em> parameter is not a multiple of 8.</dd>
   <dt>{{exception("InvalidAccessError")}}</dt>
   <dd>Raised when the base key is not a key for the requested derivation algorithm or if
-    the <a href="/en-US/docs/Web/API/CryptoKey#usages"><code>usages</code></a> value of that key doesn't contain
+    the <a href="/en-US/docs/Web/API/CryptoKey"><code>CryptoKey.usages</code></a> value of that key doesn't contain
     <code>deriveKey</code>.</dd>
   <dt>{{exception("NotSupported")}}</dt>
   <dd>Raised when trying to use an algorithm that is either unknown or isn't suitable for


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/7899.

When the `id` is used in a live sample the fixes to these can get quite complex. I've usually tried to address this by adding extra headings to demarcate live samples, which (I think) can also help make the pages more explicit and less "magical".