### PR TITLE
Remove 2 non-documented mixins in InterfaceData.json

### DIFF
--- a/files/jsondata/InterfaceData.json
+++ b/files/jsondata/InterfaceData.json
@@ -2022,7 +2022,7 @@
     },
     "URL": {
       "inh": "",
-      "impl": ["URLUtils", "URLUtilsSearchParams"]
+      "impl": []
     },
     "USSDReceivedEvent": {
       "inh": "Event",


### PR DESCRIPTION
URL's mixins are no more (if ever) documented on MDN.

This deletes their remnant in InterfaceData.json used for the sidebar creation.

This will clean about 40 MacroPagesError flaws.


(Note: I know that for the moment this InterfaceData.json is not yet in use, but this is not critical, I just want to get this in before I forget about it)