### PR TITLE
Adds the assign() method to HTMLSlotElement

### DIFF
--- a/files/en-us/web/api/htmlslotelement/assign/index.html
+++ b/files/en-us/web/api/htmlslotelement/assign/index.html
@@ -1,0 +1,57 @@
+---
+title: HTMLSlotElement.assign()
+slug: Web/API/HTMLSlotElement/assign
+tags:
+- API
+- HTMLSlotElement
+- Method
+- Reference
+- Web Components
+- assign
+- shadow dom
+browser-compat: api.HTMLSlotElement.assign
+---
+<div>{{APIRef("Shadow DOM API")}}</div>
+
+<p>The <strong><code>assign()</code></strong> method of the
+  {{domxref("HTMLSlotElement")}} interface sets the slot's <strong>manually assigned nodes</strong> to an ordered set of slottables. The manually assigned nodes set is initially empty until nodes are assigned using <code>assign()</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre
+  class="brush: js">
+HTMLSlotElement.assign(nodes)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>nodes</code></dt>
+  <dd>A set of {{domxref("Element")}} or {{domxref("Text")}} nodes.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>Undefined.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example, the <code>assign()</code> method is used to display the correct tab in a tabbed application. The function is called and passed the panel to show, which is then assigned to the slot.</p>
+
+<pre class="brush: js">function UpdateDisplayTab(elem, tabIdx) {
+  const shadow = elem.shadowRoot;
+  const slot = shadow.querySelector("slot");
+  const panels = elem.querySelectorAll('tab-panel');
+  if (panels.length && tabIdx && tabIdx &lt;= panels.length ) {
+    slot.assign([panels[tabIdx-1]]);
+  } else {
+    slot.assign([]);
+  }
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLSlotElement.assignedElements
 ---
 <div>{{APIRef("Shadow DOM API")}}</div>
 
-<p>The <strong><code>assignedElements()</code></strong> property of the
+<p>The <strong><code>assignedElements()</code></strong> method of the
   {{domxref("HTMLSlotElement")}} interface returns a sequence of the elements assigned to
   this slot (and no other nodes). If the <code>flatten</code> option is set to
   <code>true</code>, it also returns the assigned elements of any other slots that are
@@ -23,19 +23,22 @@ browser-compat: api.HTMLSlotElement.assignedElements
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">var assignedElements = HTMLSlotElement.assignedElements(<var>options</var>)</pre>
+  class="brush: js">
+HTMLSlotElement.assignedElements()
+HTMLSlotElement.assignedElements(options)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><var>options</var> {{optional_inline}}</dt>
+  <dt><code>options</code> {{optional_inline}}</dt>
   <dd>An object that sets options for the nodes to be returned. The available options are:
-    <ul>
-      <li><code>flatten</code>: A {{jsxref('Boolean')}} indicating whether to return the
+    <dl>
+      <dt><code>flatten</code></dt>
+      <dd>A {{jsxref('Boolean')}} indicating whether to return the
         assigned elements of any available child <code>&lt;slot&gt;</code> elements
-        (<code>true</code>) or not (<code>false</code>). Defaults to <code>false</code>.
+        (<code>true</code>) or not (<code>false</code>). Defaults to <code>false</code>.</dd>
       </li>
-    </ul>
+    </dl>
   </dd>
 </dl>
 

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLSlotElement.assignedNodes
 ---
 <div>{{APIRef("Shadow DOM API")}}</div>
 
-<p>The <strong><code>assignedNodes()</code></strong> property of the
+<p>The <strong><code>assignedNodes()</code></strong> method of the
   {{domxref("HTMLSlotElement")}} interface returns a sequence of the nodes assigned to
   this slot, and if the <code>flatten</code> option is set to <code>true</code>, the
   assigned nodes of any other slots that are descendants of this slot. If no assigned
@@ -21,19 +21,19 @@ browser-compat: api.HTMLSlotElement.assignedNodes
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">var assignedNodes = HTMLSlotElement.assignedNodes(<var>options</var>)</pre>
+  class="brush: js">
+HTMLSlotElement.assignedNodes()
+HTMLSlotElement.assignedNodes(options)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><var>options</var> {{optional_inline}}</dt>
+  <dt><code>options</code> {{optional_inline}}</dt>
   <dd>An object that sets options for the nodes to be returned. The available options are:
-    <ul>
-      <li><code>flatten</code>: A {{jsxref('Boolean')}} indicating whether to return the
-        assigned nodes of any available child <code>&lt;slot&gt;</code> elements
-        (<code>true</code>) or not (<code>false</code>). Defaults to <code>false</code>.
-      </li>
-    </ul>
+    <dl>
+      <dt><code>flatten</code></dt>
+      <dd>A {{jsxref('Boolean')}} indicating whether to return the assigned nodes of any available child <code>&lt;slot&gt;</code> elements (<code>true</code>) or not (<code>false</code>). Defaults to <code>false</code>.</dd>
+    </dl>
   </dd>
 </dl>
 

--- a/files/en-us/web/api/htmlslotelement/index.html
+++ b/files/en-us/web/api/htmlslotelement/index.html
@@ -11,18 +11,20 @@ browser-compat: api.HTMLSlotElement
 ---
 <p>{{APIRef('Web Components')}}</p>
 
-<p>The <strong><code>HTMLSlotElement</code></strong> interface of the <a href="/en-US/docs/Web/Web_Components/Shadow_DOM">Shadow DOM API</a> enables access to the name and assigned nodes of an HTML {{HTMLElement("slot")}} element.</p>
+<p>The <strong><code>HTMLSlotElement</code></strong> interface of the <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">Shadow DOM API</a> enables access to the name and assigned nodes of an HTML {{HTMLElement("slot")}} element.</p>
 
 <h2 id="Properties">Properties</h2>
 
 <dl>
  <dt>{{domxref('HTMLSlotElement.name')}}</dt>
- <dd>{{domxref("DOMString")}}: Can be used to get and set the slot's name.</dd>
+ <dd>A {{domxref("DOMString","string")}} used to get and set the slot's name.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
 
 <dl>
+ <dt>{{domxref('HTMLSlotElement.assign()')}}</dt>
+ <dd>Sets the manually assigned nodes for this slot to the given nodes.</dd>
  <dt>{{domxref('HTMLSlotElement.assignedNodes()')}}</dt>
  <dd>Returns a sequence of the nodes assigned to this slot, and if the <code>flatten</code> option is set to <code>true</code>, the assigned nodes of any other slots that are descendants of this slot. If no assigned nodes are found, it returns the slot's fallback content.</dd>
  <dt>{{domxref('HTMLSlotElement.assignedElements()')}}</dt>

--- a/files/en-us/web/api/htmlslotelement/name/index.html
+++ b/files/en-us/web/api/htmlslotelement/name/index.html
@@ -18,13 +18,13 @@ browser-compat: api.HTMLSlotElement.name
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>name</em> = <em>htmlSlotElement</em>.name
-<em>htmlSlotElement</em>.name = <em>name</em>
+<pre class="brush: js">let name = htmlSlotElement.name
+htmlSlotElement.name = name
 </pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref('DOMString')}}.</p>
+<p>A {{domxref('DOMString','string')}}.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Part of #7756 

Adds the `assign()` method, and also updates other pages so they use the new syntax for method pages/gets them ready for MD.
