### PR TITLE
Remove easy ID attributes, part 2

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -95,7 +95,7 @@ browser-compat: api.HTMLInputElement
  </tbody>
 </table>
 
-<table class="standard-table" id="Properties_checkbox_radio">
+<table class="standard-table">
  <caption>Properties that apply only to elements of type <code>checkbox</code> or <code>radio</code></caption>
  <tbody>
   <tr>
@@ -107,7 +107,7 @@ browser-compat: api.HTMLInputElement
    <td><em>A boolean value:</em> <strong>Returns / Sets</strong> the default state of a radio button or checkbox as originally specified in HTML that created this object.</td>
   </tr>
   <tr>
-   <td><code id="indeterminate">indeterminate</code></td>
+   <td><code>indeterminate</code></td>
    <td><em>A boolean value:</em> <strong>Returns</strong> whether the checkbox or radio button is in indeterminate state. For checkboxes, the effect is that the appearance of the checkbox is obscured/greyed in some way as to indicate its state is indeterminate (not checked but not unchecked). Does not affect the value of the <code>checked</code> attribute, and clicking the checkbox will set the value to false.</td>
   </tr>
  </tbody>
@@ -135,7 +135,7 @@ browser-compat: api.HTMLInputElement
  </tbody>
 </table>
 
-<table class="standard-table" id="Properties_file">
+<table class="standard-table">
  <caption>Properties that apply only to elements of type <code>file</code></caption>
  <tbody>
   <tr>
@@ -147,7 +147,7 @@ browser-compat: api.HTMLInputElement
    <td><em>A boolean value:</em> Part of the non-standard Directory Upload API; <strong>indicates</strong> whether or not to allow directories and files both to be selected in the file list. Implemented only in Firefox and is hidden behind a preference.</td>
   </tr>
   <tr>
-   <td><code id="files_prop">files</code></td>
+   <td><code>files</code></td>
    <td><strong>Returns/accepts</strong> a {{domxref("FileList")}} object, which contains a list of {{domxref("File")}} objects representing the files selected for upload.</td>
   </tr>
   <tr>

--- a/files/en-us/web/api/htmlmediaelement/mscleareffects/index.html
+++ b/files/en-us/web/api/htmlmediaelement/mscleareffects/index.html
@@ -4,10 +4,9 @@ slug: Web/API/HTMLMediaElement/msClearEffects
 tags:
   - msClearEffects
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
-
 
 <p>The <code><strong>msClearEffects</strong></code> method of the <a href="/en-US/docs/Web/API/HTMLMediaElement"><em>HTMLMediaElement</em></a>, is a proprietary method specific to Internet Explorer and Microsoft Edge.</p>
 

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.html
@@ -102,8 +102,7 @@ for (var i = 0, L = tracks.length; i &lt; L; i++) { /* tracks.length == 10 */
 
 <dl>
   <dt>length</dt>
-  <dd>Returns the number of text tracks in <code
-      id="text-track-api:texttracklist-4">TextTrackList</code> object.</dd>
+  <dd>Returns the number of text tracks in <code>TextTrackList</code> object.</dd>
 </dl>
 
 <h3 id="methods">methods</h3>
@@ -111,8 +110,7 @@ for (var i = 0, L = tracks.length; i &lt; L; i++) { /* tracks.length == 10 */
 <dl>
   <dt>getTrackById()</dt>
   <dd>The <dfn><code>getTrackById(<var>id</var>)</code></dfn> method returns the first
-    <code id="text-track-api:texttrack-6">TextTrack</code> in the <code
-      id="text-track-api:texttracklist-9">TextTrackList</code> object that matches the id,
+    <code>TextTrack</code> in the <code>TextTrackList</code> object that matches the id,
     or null if there is no match.</dd>
 </dl>
 

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLVideoElement/msStereo3DPackingMode
 tags:
   - msStereo3DPackingMode
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLVideoElement/msStereo3DRenderMode
 tags:
   - msStereo3DRenderMode
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLVideoElement/onMSVideoFormatChanged
 tags:
   - onMsVideoFormatChanged
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLVideoElement/onMSVideoFrameStepCompleted
 tags:
   - onMSVideoFrameStepCompleted
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLVideoElement/onMSVideoOptimalLayoutChanged
 tags:
   - onMSVideoOptimalLayoutChanged
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/idbversionchangeevent/version/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/version/index.html
@@ -28,8 +28,7 @@ browser-compat: api.IDBVersionChangeEvent.version
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><span class="idlInterface" id="idl-def-IDBVersionChangeEvent"><span class="idlAttribute">readonly    attribute <span class="idlAttrType">unsigned long long?</span> <span class="idlAttrName">version</span>;</span></span></pre>
+<pre class="brush: js">const version = iDBVersionChangeEvent.version;</pre>
 
 <h2 id="Value">Value</h2>
 

--- a/files/en-us/web/api/idledeadline/index.html
+++ b/files/en-us/web/api/idledeadline/index.html
@@ -12,27 +12,22 @@ browser-compat: api.IdleDeadline
 ---
 <div>{{APIRef("Background Tasks")}}</div>
 
-<div id="interface_description">
 <p>The <code>IdleDeadline</code> interface is used as the data type of the input parameter to idle callbacks established by calling {{domxref("Window.requestIdleCallback()")}}. It offers a method, {{domxref("IdleDeadline.timeRemaining", "timeRemaining()")}}, which lets you determine how much longer the user agent estimates it will remain idle and a property, {{domxref("IdleDeadline.didTimeout", "didTimeout")}}, which lets you determine if your callback is executing because its timeout duration expired.</p>
 
 <p>To learn more about how request callbacks work, see <a href="/en-US/docs/Web/API/Background_Tasks_API">Collaborative Scheduling of Background Tasks</a>.</p>
-</div>
 
 <h2 id="Properties">Properties</h2>
 
-<dl id="property_definitions">
+<dl>
  <dt>{{domxref("IdleDeadline.didTimeout")}} {{ReadOnlyInline}}</dt>
  <dd>A Boolean whose value is <code>true</code> if the callback is being executed because the timeout specified when the idle callback was installed has expired.</dd>
 </dl>
 
 <h2 id="methods">Methods</h2>
 
-<dl id="method_definitions">
+<dl>
  <dt>{{domxref("IdleDeadline.timeRemaining()")}}</dt>
  <dd>Returns a {{domxref("DOMHighResTimeStamp")}}, which is a floating-point value providing an estimate of the number of milliseconds remaining in the current idle period. If the idle period is over, the value is 0. Your callback can call this repeatedly to see if there's enough time left to do more work before returning.</dd>
-</dl>
-
-<dl id="method_definitions_obsolete">
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/inputdevicecapabilities_api/index.html
+++ b/files/en-us/web/api/inputdevicecapabilities_api/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>The InputDeviceCapabilities API addresses this problem by abstracting the capabilities of input devices. For example, let's say we have a web page that implements both a <code>touchstart</code> and a <code>mousedown</code> event. We can assume that if the touchstart event is triggered that the user's device has a touch interface.  What about when the mousedown event is triggered? It would be useful to know if a <code>touchstart</code> event were also triggered so that we don't take the same action twice. We can do this by checking the sourceCapabilities property of the {{domxref("UIEvent")}}.</p>
 
-<pre class="brush: js" id="example_1">myButton.addEventListener('mousedown', function(e) {
+<pre class="brush: js">myButton.addEventListener('mousedown', function(e) {
   // Touch event case handled above, don't change the style again on tap.
   if (!e.sourceCapabilities.firesTouchEvents)
     myButton.classList.add("pressed");

--- a/files/en-us/web/api/keyboardevent/code/code_values/index.html
+++ b/files/en-us/web/api/keyboardevent/code/code_values/index.html
@@ -1017,7 +1017,7 @@ when using it;</li>
     <li>"(⚠️  No events fired actually)" means that even if technically you have a specific string for this code, no event will be dispatched;</li>
     <li>"(⚠️  Different string on xyz)" means that the same key will have a different name on browser xyz.</li>
 </ul>
-<table class="standard-table" id="keyname_table_mac">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="row">Virtual keycode</th>

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -86,7 +86,7 @@ browser-compat: api.KeyboardEvent.keyCode
  </li>
 </ol>
 
-<p id="keyCode_of_punctuation_keys_on_some_keyboard_layout">Starting in Firefox 60 {{geckoRelease("60.0")}}, Gecko sets <code>keyCode</code> values of punctuation keys as far as possible (when points 7.1 or 7.2 in the above list are reached) with the following rules:</p>
+<p>Starting in Firefox 60 {{geckoRelease("60.0")}}, Gecko sets <code>keyCode</code> values of punctuation keys as far as possible (when points 7.1 or 7.2 in the above list are reached) with the following rules:</p>
 
 <div class="warning">
 <p><strong>Warning:</strong> The purpose of these new additional rules is for making users whose keyboard layouts map unicode characters to punctuation keys in a US keyboard layout can use web applications which support Firefox only with ASCII-capable keyboard layouts or just with a US keyboard layout. Otherwise, the newly mapped <code>keyCode</code> values may be conflict with other keys. For example, if the active keyboard layout is Russian, the <code>keyCode</code> value of <strong>both</strong> the <code>"Period"</code> key and <code>"Slash"</code> key are <code>190</code> (<code>KeyEvent.DOM_VK_PERIOD</code>). If you need to distinguish those keys but you don't want to support all keyboard layouts in the world by yourself, you should probably use {{domxref("KeyboardEvent.code")}}.</p>

--- a/files/en-us/web/api/mediadevices/getusermedia/index.html
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.html
@@ -110,7 +110,7 @@ browser-compat: api.MediaDevices.getUserMedia
   video: { width: 1280, height: 720 }
 }</pre>
 
-    <p id="successCallback">The browser will try to honour this, but may return other
+    <p>The browser will try to honour this, but may return other
       resolutions if an exact match is not available, or the user overrides it.</p>
 
     <p>To <em>require</em> a capability, use the keywords <code>min</code>,

--- a/files/en-us/web/api/mediaerror/msextendedcode/index.html
+++ b/files/en-us/web/api/mediaerror/msextendedcode/index.html
@@ -2,7 +2,7 @@
 title: MediaError.msExtendedCode
 slug: Web/API/MediaError/msExtendedCode
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mediarecorder/ondataavailable/index.html
+++ b/files/en-us/web/api/mediarecorder/ondataavailable/index.html
@@ -55,9 +55,7 @@ browser-compat: api.MediaRecorder.ondataavailable
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><span class="idlInterface" id="idl-def-IDBRequest"><span class="idlAttribute"><span class="idlInterface" id="idl-def-MediaRecorder"><span class="idlAttribute"><em>MediaRecorder</em>.ondataavailable = function(event) { ... }
-<em>MediaRecorder</em>.addEventListener('dataavailable', function(event) { ... })</span></span></span></span>
-</pre>
+<pre class="brush: js">mediaRecorder.ondataavailable = functionRef;</pre>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/mediasessionaction/index.html
+++ b/files/en-us/web/api/mediasessionaction/index.html
@@ -26,28 +26,26 @@ browser-compat: api.MediaSessionAction
 
 <p>Each of the actions is a common media session control request. Implement support for each of these in order to allow that type of action to be performed. The following strings identify the currently available types of media session action:</p>
 
-<div id="action-types">
 <dl>
- <dt><a id="nexttrack"><code>nexttrack</code></a></dt>
+ <dt><code>nexttrack</code></dt>
  <dd>Advances playback to the next track.</dd>
- <dt><a id="pause"><code>pause</code></a></dt>
+ <dt><code>pause</code></dt>
  <dd>Pauses playback of the media.</dd>
- <dt><a id="play"><code>play</code></a></dt>
+ <dt><code>play</code></dt>
  <dd>Begins (or resumes) playback of the media.</dd>
- <dt><a id="previoustrack"><code>previoustrack</code></a></dt>
+ <dt><code>previoustrack</code></dt>
  <dd>Moves back to the previous track.</dd>
- <dt><a id="seekbackward"><code>seekbackward</code></a></dt>
+ <dt><code>seekbackward</code></dt>
  <dd>Seeks backward through the media from the current position. The {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekOffset", "seekOffset")}} specifies the amount of time to seek backward.</dd>
- <dt><a id="seekforward"><code>seekforward</code></a></dt>
+ <dt><code>seekforward</code></dt>
  <dd>Seeks forward from the current position through the media. The {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekOffset", "seekOffset")}} specifies the amount of time to seek forward.</dd>
- <dt><a id="seekto"><code>seekto</code></a></dt>
+ <dt><code>seekto</code></dt>
  <dd>Moves the playback position to the specified time within the media. The time to which to seek is specified in the {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekTime", "seekTime")}}. If you intend to perform multiple <code>seekto</code> operations in rapid succession, you can also specify the {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.fastSeek", "fastSeek")}} property with a value of <code>true</code>. This lets the browser know it can take steps to optimize repeated operations, and is likely to result in improved performance.</dd>
- <dt><a id="skipad"><code>skipad</code></a></dt>
+ <dt><code>skipad</code></dt>
  <dd>Skips past the currently playing advertisement or commercial. This action may or may not be available, depending on the platform and {{Glossary("user agent")}}, or may be disabled due to subscription level or other circumstances.</dd>
- <dt><a id="stop"><code>stop</code></a></dt>
+ <dt><code>stop</code></dt>
  <dd>Halts playback entirely.</dd>
 </dl>
-</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/index.html
@@ -45,25 +45,24 @@ browser-compat: api.MediaSessionActionDetails
 
 <p>Each of the actions is a common media session control request. Implement support for each of these in order to allow that type of action to be performed. The following strings identify the currently available types of media session action:</p>
 
-<div id="action-types">
 <dl>
- <dt><a id="nexttrack"><code>nexttrack</code></a></dt>
+ <dt><code>nexttrack</code></dt>
  <dd>Advances playback to the next track.</dd>
- <dt><a id="pause"><code>pause</code></a></dt>
+ <dt><code>pause</code></dt>
  <dd>Pauses playback of the media.</dd>
- <dt><a id="play"><code>play</code></a></dt>
+ <dt><code>play</code></dt>
  <dd>Begins (or resumes) playback of the media.</dd>
- <dt><a id="previoustrack"><code>previoustrack</code></a></dt>
+ <dt><code>previoustrack</code></dt>
  <dd>Moves back to the previous track.</dd>
- <dt><a id="seekbackward"><code>seekbackward</code></a></dt>
+ <dt><code>seekbackward</code></dt>
  <dd>Seeks backward through the media from the current position. The {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekOffset", "seekOffset")}} specifies the amount of time to seek backward.</dd>
- <dt><a id="seekforward"><code>seekforward</code></a></dt>
+ <dt><code>seekforward</code></dt>
  <dd>Seeks forward from the current position through the media. The {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekOffset", "seekOffset")}} specifies the amount of time to seek forward.</dd>
- <dt><a id="seekto"><code>seekto</code></a></dt>
+ <dt><code>seekto</code></dt>
  <dd>Moves the playback position to the specified time within the media. The time to which to seek is specified in the {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.seekTime", "seekTime")}}. If you intend to perform multiple <code>seekto</code> operations in rapid succession, you can also specify the {{domxref("MediaSessionActionDetails")}} property {{domxref("MediaSessionActionDetails.fastSeek", "fastSeek")}} property with a value of <code>true</code>. This lets the browser know it can take steps to optimize repeated operations, and is likely to result in improved performance.</dd>
- <dt><a id="skipad"><code>skipad</code></a></dt>
+ <dt><code>skipad</code></dt>
  <dd>Skips past the currently playing advertisement or commercial. This action may or may not be available, depending on the platform and {{Glossary("user agent")}}, or may be disabled due to subscription level or other circumstances.</dd>
- <dt><a id="stop"><code>stop</code></a></dt>
+ <dt><code>stop</code></dt>
  <dd>Halts playback entirely.</dd>
 </dl>
 </div>

--- a/files/en-us/web/api/mediastream_image_capture_api/index.html
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.html
@@ -26,7 +26,7 @@ tags:
   })
 </pre>
 
-<p id="sect1">Next, isolate the visual part of the media stream. Do this by calling {{domxref("MediaStream.getVideoTracks()")}}. This returns an array of {{domxref("MediaStreamTrack")}} objects. The code below assumes that the first item in the <code>MediaStreamTrack</code> array is the one to use. You can use the properties of the <code>MediaStreamTrack</code> objects to select the one you need.</p>
+<p>Next, isolate the visual part of the media stream. Do this by calling {{domxref("MediaStream.getVideoTracks()")}}. This returns an array of {{domxref("MediaStreamTrack")}} objects. The code below assumes that the first item in the <code>MediaStreamTrack</code> array is the one to use. You can use the properties of the <code>MediaStreamTrack</code> objects to select the one you need.</p>
 
 <pre class="brush: js">const track = mediaStream.getVideoTracks()[0];</pre>
 

--- a/files/en-us/web/api/mediatrackconstraints/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/index.html
@@ -117,33 +117,33 @@ browser-compat: api.MediaTrackConstraints
 <h3 id="Properties_of_image_tracks">Properties of image tracks</h3>
 
 <dl>
- <dt><span id="whitebalancemode">whiteBalanceMode</span></dt>
+ <dt>whiteBalanceMode</dt>
  <dd>A {{jsxref("String")}} specifying one of <code>"none"</code>, <code>"manual"</code>, <code>"single-shot"</code>, or <code>"continuous"</code>.</dd>
- <dt><span id="exposuremode">exposureMode</span></dt>
+ <dt>exposureMode</dt>
  <dd>A {{jsxref("String")}} specifying one of <code>"none"</code>, <code>"manual"</code>, <code>"single-shot"</code>, or <code>"continuous"</code>.</dd>
- <dt><span id="focusmode">focusMode</span></dt>
+ <dt>focusMode</dt>
  <dd>A {{jsxref("String")}} specifying one of <code>"none"</code>, <code>"manual"</code>, <code>"single-shot"</code>, or <code>"continuous"</code>.</dd>
- <dt><span id="pointsofinterest">pointsOfInterest</span></dt>
+ <dt>pointsOfInterest</dt>
  <dd>The pixel coordinates on the sensor of one or more points of interest. This is either an object in the form { x:<em>value</em>, y:<em>value</em> } or an array of such objects, where <em>value</em> is a double-precision integer.</dd>
- <dt><span id="exposurecompensation">exposureCompensation</span></dt>
+ <dt>exposureCompensation</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying f-stop adjustment by up to ±3. </dd>
- <dt><span id="colortemperature">colorTemperature</span></dt>
+ <dt>colorTemperature</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired color temperature in degrees kelvin.</dd>
- <dt><span id="iso">iso</span></dt>
+ <dt>iso</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired iso setting.</dd>
- <dt><span id="brightness">brightness</span></dt>
+ <dt>brightness</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying a desired brightness setting.</dd>
- <dt><span id="contrast">contrast</span></dt>
+ <dt>contrast</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of difference between light and dark.</dd>
- <dt><span id="saturation">saturation</span></dt>
+ <dt>saturation</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the degree of color intensity.</dd>
- <dt><span id="sharpness">sharpness</span></dt>
+ <dt>sharpness</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the intensity of edges.</dd>
- <dt><span id="focusdistance">focusDistance</span></dt>
+ <dt>focusDistance</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying distance to a focused object.</dd>
- <dt><span id="zoom">zoom</span></dt>
+ <dt>zoom</dt>
  <dd>A <a href="#constraindouble"><code>ConstrainDouble</code></a> (a double-precision integer) specifying the desired focal length.</dd>
- <dt><span id="torch">torch</span></dt>
+ <dt>torch</dt>
  <dd>A boolean value defining whether the fill light is continuously connected, meaning it stays on as long as the track is active.</dd>
 </dl>
 
@@ -160,7 +160,7 @@ browser-compat: api.MediaTrackConstraints
  <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the video height or range of heights which are acceptable and/or required.</dd>
  <dt>{{domxref("MediaTrackConstraints.width", "width")}}</dt>
  <dd>A <a href="#constrainulong"><code>ConstrainULong</code></a> specifying the video width or range of widths which are acceptable and/or required.</dd>
- <dt><span id="resizemode">resizeMode</span></dt>
+ <dt>resizeMode</dt>
  <dd>A <a href="#constraindomstring"><code>ConstrainDOMString</code></a> object specifying a mode or an array of modes the UA can use to derive the resolution of a video track. Allowed values are <code>none</code> and <code>crop-and-scale</code>. <code>none</code> means that the user agent uses the resolution provided by the camera, its driver or the OS. <code>crop-and-scale</code> means that the user agent can use cropping and downscaling on the camera output  in order to satisfy other constraints that affect the resolution.</dd>
 </dl>
 

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.html
@@ -11,7 +11,7 @@ tags:
   - getModifierState
 browser-compat: api.MouseEvent.getModifierState
 ---
-<p id="Summary">{{APIRef("DOM Events")}}</p>
+<div>{{APIRef("DOM Events")}}</div>
 
 <p>The <strong><code>MouseEvent.getModifierState()</code></strong> method returns the
   current state of the specified modifier key: <code>true</code> if the modifier is active

--- a/files/en-us/web/api/mouseevent/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.html
@@ -10,7 +10,7 @@ tags:
 - events
 browser-compat: api.MouseEvent.MouseEvent
 ---
-<p id="Summary">{{APIRef("DOM Events")}}</p>
+<div>{{APIRef("DOM Events")}}</div>
 
 <p>The <strong><code>MouseEvent()</code></strong> constructor creates a new
   {{domxref("MouseEvent")}}.</p>

--- a/files/en-us/web/api/mscandidatewindowhide/index.html
+++ b/files/en-us/web/api/mscandidatewindowhide/index.html
@@ -2,7 +2,7 @@
 title: MSCandidateWindowHide
 slug: Web/API/MSCandidateWindowHide
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mscandidatewindowshow/index.html
+++ b/files/en-us/web/api/mscandidatewindowshow/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MSCandidateWindowShow
 tags:
   - MSCandidateWindowShow
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mscandidatewindowupdate/index.html
+++ b/files/en-us/web/api/mscandidatewindowupdate/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MSCandidateWindowUpdate
 tags:
   - MSCandidateWindowUpdate
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mscapslockwarningoff/index.html
+++ b/files/en-us/web/api/mscapslockwarningoff/index.html
@@ -2,7 +2,7 @@
 title: msCapsLockWarningOff
 slug: Web/API/msCapsLockWarningOff
 ---
-<p id="Summary">{{APIRef("HTML DOM")}}</p>
+<div>{{APIRef("HTML DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msfirstpaint/index.html
+++ b/files/en-us/web/api/msfirstpaint/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsFirstPaint
 tags:
 - msFirstPaint
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msgestureevent/index.html
+++ b/files/en-us/web/api/msgestureevent/index.html
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.MSGestureEvent
 ---
-<p id="Summary">{{APIRef("DOM Events")}}</p>
+<div>{{APIRef("DOM Events")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msgetpropertyenabled/index.html
+++ b/files/en-us/web/api/msgetpropertyenabled/index.html
@@ -4,7 +4,7 @@ slug: Web/API/msGetPropertyEnabled
 tags:
   - msGetPropertyEnabled
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msgetregioncontent/index.html
+++ b/files/en-us/web/api/msgetregioncontent/index.html
@@ -4,7 +4,7 @@ slug: Web/API/msGetRegionContent
 tags:
   - msGetRegionContent
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msgraphicstruststatus/index.html
+++ b/files/en-us/web/api/msgraphicstruststatus/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsGraphicsTrustStatus
 tags:
 - msGraphicsTrustStatus
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msisboxed/index.html
+++ b/files/en-us/web/api/msisboxed/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsIsBoxed
 tags:
 - msIsBoxed
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msplaytodisabled/index.html
+++ b/files/en-us/web/api/msplaytodisabled/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsPlayToDisabled
 tags:
 - msPlayToDisabled
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msplaytopreferredsourceuri/index.html
+++ b/files/en-us/web/api/msplaytopreferredsourceuri/index.html
@@ -2,7 +2,7 @@
 title: msPlayToPreferredSourceUri
 slug: Web/API/MsPlayToPreferredSourceUri
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msplaytoprimary/index.html
+++ b/files/en-us/web/api/msplaytoprimary/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsPlayToPrimary
 tags:
 - msPlayToPrimary
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msplaytosource/index.html
+++ b/files/en-us/web/api/msplaytosource/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsPlayToSource
 tags:
 - msPlayToSource
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msputpropertyenabled/index.html
+++ b/files/en-us/web/api/msputpropertyenabled/index.html
@@ -4,7 +4,7 @@ slug: Web/API/msPutPropertyEnabled
 tags:
   - msPutPropertyEnabled
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msrangecollection/index.html
+++ b/files/en-us/web/api/msrangecollection/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MSRangeCollection
 tags:
   - MSRangeCollection
 ---
-<p id="Summary">{{non-standard_header}}{{APIRef}}</p>
+<div>{{non-standard_header}}{{APIRef}}</div>
 
 <p>The <strong><code>MSRangeCollection</code></strong> object is an array of one or more Range objects.</p>
 

--- a/files/en-us/web/api/msrealtime/index.html
+++ b/files/en-us/web/api/msrealtime/index.html
@@ -4,7 +4,7 @@ slug: Web/API/MsRealTime
 tags:
 - msRealTime
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msregionoverflow/index.html
+++ b/files/en-us/web/api/msregionoverflow/index.html
@@ -5,7 +5,7 @@ tags:
   - Internet Explorer
   - msRegionOverflow
 ---
-<p id="Summary">{{APIRef("DOM")}}</p>
+<div>{{APIRef("DOM")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mssitemodeevent/index.html
+++ b/files/en-us/web/api/mssitemodeevent/index.html
@@ -2,8 +2,6 @@
 title: MSSiteModeEvent
 slug: Web/API/MSSiteModeEvent
 ---
-<p id="Summary"></p>
-
 <p>{{Non-standard_header()}}</p>
 
 <p><code><strong>MSSiteModeEvent</strong></code> provides event properties that are specific to pinned site events.</p>

--- a/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
+++ b/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
@@ -2,7 +2,7 @@
 title: mssitemodejumplistitemremoved event
 slug: Web/API/mssitemodejumplistitemremoved
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/msthumbnailclick/index.html
+++ b/files/en-us/web/api/msthumbnailclick/index.html
@@ -4,7 +4,7 @@ slug: Web/API/msthumbnailclick
 tags:
   - msthumbnailclick
 ---
-<p id="Summary">{{APIRef("HTMLMediaElement")}}</p>
+<div>{{APIRef("HTMLMediaElement")}}</div>
 
 <p>{{Non-standard_header()}}</p>
 

--- a/files/en-us/web/api/mutationevent/index.html
+++ b/files/en-us/web/api/mutationevent/index.html
@@ -21,7 +21,7 @@ browser-compat: api.MutationEvent
 
 <h2 id="Preface">Preface</h2>
 
-<p id="Replacement.3A_mutation_observers">The mutation events have been marked as deprecated in <a href="https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents">the DOM Events specification</a>, as the API's design is flawed (see details in the "DOM Mutation Events Replacement: The Story So Far / Existing Points of Consensus" post to <a href="https://lists.w3.org/Archives/Public/public-webapps/2011JulSep/0779.html">public-webapps</a>).</p>
+<p>The mutation events have been marked as deprecated in <a href="https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents">the DOM Events specification</a>, as the API's design is flawed (see details in the "DOM Mutation Events Replacement: The Story So Far / Existing Points of Consensus" post to <a href="https://lists.w3.org/Archives/Public/public-webapps/2011JulSep/0779.html">public-webapps</a>).</p>
 
 <p><a href="/en-US/docs/Web/API/MutationObserver">Mutation Observers</a> have replaced mutation events in DOM4. They have been supported in <a href="/en-US/docs/Web/API/MutationObserver#browser_compatibility">most popular browsers for some years</a>.</p>
 

--- a/files/en-us/web/api/node/clonenode/index.html
+++ b/files/en-us/web/api/node/clonenode/index.html
@@ -54,7 +54,7 @@ let p_prime = p.cloneNode(true)
 
 <h2 id="Notes">Notes</h2>
 
-<p id="not-event-listeners">Cloning a node copies all of its attributes and their values,
+<p>Cloning a node copies all of its attributes and their values,
   including intrinsic (inline) listeners. It does <em>not</em> copy event listeners added
   using <a
     href="/en-US/docs/Web/API/EventTarget/addEventListener"><code>addEventListener()</code></a> or

--- a/files/en-us/web/api/notificationevent/action/index.html
+++ b/files/en-us/web/api/notificationevent/action/index.html
@@ -23,7 +23,7 @@ browser-compat: api.NotificationEvent.action
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js" id="example-50e7c86c">self.registration.showNotification("New articles available", {
+<pre class="brush: js">self.registration.showNotification("New articles available", {
   actions: [{action: "get", title: "Get now."}]
 });
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{DefaultAPISidebar("Pointer Events")}}</p>
 
-<p>Much of today's web content assumes the user's pointing device will be a mouse. However, since many devices support other types of pointing input devices, such as pen/stylus and touch surfaces, extensions to the existing pointing device event models are needed. <em><a href="#term_pointer_event">Pointer events</a></em> address that need.</p>
+<p>Much of today's web content assumes the user's pointing device will be a mouse. However, since many devices support other types of pointing input devices, such as pen/stylus and touch surfaces, extensions to the existing pointing device event models are needed. <em><a href="#pointer_event">Pointer events</a></em> address that need.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Pointer events are <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a>.</p>
@@ -20,7 +20,7 @@ tags:
 
 <p>Pointer events are DOM events that are fired for a pointing device. They are designed to create a single DOM event model to handle pointing input devices such as a mouse, pen/stylus or touch (such as one or more fingers).</p>
 
-<p>The <em><a href="#term_pointer">pointer</a></em> is a hardware-agnostic device that can target a specific set of screen coordinates. Having a single event model for pointers can simplify creating Web sites and applications and provide a good user experience regardless of the user's hardware. However, for scenarios when device-specific handling is desired, pointer events defines a {{domxref("PointerEvent.pointerType","pointerType property")}} to inspect the device type which produced the event.</p>
+<p>The <em><a href="#pointer">pointer</a></em> is a hardware-agnostic device that can target a specific set of screen coordinates. Having a single event model for pointers can simplify creating Web sites and applications and provide a good user experience regardless of the user's hardware. However, for scenarios when device-specific handling is desired, pointer events defines a {{domxref("PointerEvent.pointerType","pointerType property")}} to inspect the device type which produced the event.</p>
 
 <p>The events needed to handle generic pointer input are analogous to {{domxref("MouseEvent","mouse events")}} (<code>mousedown</code>/<code>pointerdown</code>, <code>mousemove</code>/<code>pointermove</code>, etc.). Consequently, pointer event types are intentionally similar to mouse event types.</p>
 
@@ -28,22 +28,33 @@ tags:
 
 <h2 id="Terminology">Terminology</h2>
 
-<dl>
- <dt>active buttons state</dt>
- <dd>The condition when a <em><a href="#term_pointer">pointer</a></em> has a non-zero value for the <code>buttons</code> property. For example, in the case of a pen, when the pen has physical contact with the digitizer, or at least one button is depressed while hovering.</dd>
- <dt>active pointer</dt>
- <dd>Any <em><a href="#term_pointer">pointer</a></em> input device that can produce events. A pointer is considered active if it can still produce further events. For example, a pen that is a down state is considered active because it can produce additional events when the pen is lifted or moved.</dd>
- <dt id="term_digitizer">digitizer</dt>
- <dd>A sensing device with a surface that can detect contact. Most commonly, the sensing device is a touch-enabled screen that can sense input from an input device such as a pen, stylus, or finger. Some sensing devices can detect the close proximity of the input device, and the state is expressed as a hover following the mouse.</dd>
- <dt id="term_hit_test">hit test</dt>
- <dd>The process the browser uses to determine a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</dd>
- <dt id="term_pointer">pointer</dt>
- <dd>A hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen. Examples of <em>pointer</em> input devices are mouse, pen/stylus, and touch contacts.</dd>
- <dt>pointer capture</dt>
- <dd>Pointer capture allows the events for a pointer to be retargeted to a particular element other than the normal hit test result of the pointer's location.</dd>
- <dt id="term_pointer_event">pointer event</dt>
- <dd>A DOM {{domxref("PointerEvent","event")}} fired for a <em><a href="#term_pointer">pointer</a></em>.</dd>
-</dl>
+<h3>active buttons state</h3>
+
+<p>The condition when a <em><a href="#pointer">pointer</a></em> has a non-zero value for the <code>buttons</code> property. For example, in the case of a pen, when the pen has physical contact with the digitizer, or at least one button is depressed while hovering.</p>
+
+<h3>active pointer</h3>
+
+<p>Any <em><a href="#pointer">pointer</a></em> input device that can produce events. A pointer is considered active if it can still produce further events. For example, a pen that is a down state is considered active because it can produce additional events when the pen is lifted or moved.</p>
+
+<h3>digitizer</h3>
+
+<p>A sensing device with a surface that can detect contact. Most commonly, the sensing device is a touch-enabled screen that can sense input from an input device such as a pen, stylus, or finger. Some sensing devices can detect the close proximity of the input device, and the state is expressed as a hover following the mouse.</p>
+
+<h3>hit test</h3>
+
+<p>The process the browser uses to determine a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</p>
+
+<h3>pointer</h3>
+
+<p>A hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen. Examples of <em>pointer</em> input devices are mouse, pen/stylus, and touch contacts.</p>
+
+<h3>pointer capture</h3>
+
+<p>Pointer capture allows the events for a pointer to be retargeted to a particular element other than the normal hit test result of the pointer's location.</p>
+
+<h3>pointer event</h3>
+
+<p>A DOM {{domxref("PointerEvent","event")}} fired for a <em><a href="#pointer">pointer</a></em>.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 
@@ -98,12 +109,12 @@ tags:
   <tr>
    <td>{{event('pointerover')}}</td>
    <td>{{domxref('GlobalEventHandlers.onpointerover','onpointerover')}}</td>
-   <td>Fired when a pointer is moved into an element's <a href="#term_hit_test">hit test</a> boundaries.</td>
+   <td>Fired when a pointer is moved into an element's <a href="#hit_test">hit test</a> boundaries.</td>
   </tr>
   <tr>
    <td>{{event('pointerenter')}}</td>
    <td>{{domxref('GlobalEventHandlers.onpointerenter','onpointerenter')}}</td>
-   <td>Fired when a pointer is moved into the <a href="#term_hit_test">hit test</a> boundaries of an element or one of its descendants, including as a result of a pointerdown event from a device that does not support hover (see <code>pointerdown</code>).</td>
+   <td>Fired when a pointer is moved into the <a href="#hit_test">hit test</a> boundaries of an element or one of its descendants, including as a result of a pointerdown event from a device that does not support hover (see <code>pointerdown</code>).</td>
   </tr>
   <tr>
    <td>{{event('pointerdown')}}</td>
@@ -128,12 +139,12 @@ tags:
   <tr>
    <td>{{event('pointerout')}}</td>
    <td>{{domxref('GlobalEventHandlers.onpointerout','onpointerout')}}</td>
-   <td>Fired for several reasons including: pointer is moved out of the <a href="#term_hit_test">hit test</a> boundaries of an element; firing the pointerup event for a device that does not support hover (see pointerup); after firing the <code>pointercancel</code> event (see <code>pointercancel</code>); when a pen stylus leaves the hover range detectable by the digitizer.</td>
+   <td>Fired for several reasons including: pointer is moved out of the <a href="#hit_test">hit test</a> boundaries of an element; firing the pointerup event for a device that does not support hover (see pointerup); after firing the <code>pointercancel</code> event (see <code>pointercancel</code>); when a pen stylus leaves the hover range detectable by the digitizer.</td>
   </tr>
   <tr>
    <td>{{event('pointerleave')}}</td>
    <td>{{domxref('GlobalEventHandlers.onpointerleave','onpointerleave')}}</td>
-   <td>Fired when a pointer is moved out of the <a href="#term_hit_test">hit test</a> boundaries of an element. For pen devices, this event is fired when the stylus leaves the hover range detectable by the digitizer.</td>
+   <td>Fired when a pointer is moved out of the <a href="#hit_test">hit test</a> boundaries of an element. For pen devices, this event is fired when the stylus leaves the hover range detectable by the digitizer.</td>
   </tr>
   <tr>
    <td>{{event('gotpointercapture')}}</td>
@@ -351,7 +362,7 @@ tags:
 
 <h2 id="Pointer_capture">Pointer capture</h2>
 
-<p>Pointer capture allows events for a particular {{domxref("PointerEvent","pointer event")}} to be re-targeted to a particular element instead of the normal <a href="#term_hit_test">hit test</a> at a pointer's location. This can be used to ensure that an element continues to receive pointer events even if the pointer device's contact moves off the element (for example by scrolling).</p>
+<p>Pointer capture allows events for a particular {{domxref("PointerEvent","pointer event")}} to be re-targeted to a particular element instead of the normal <a href="#hit_test">hit test</a> at a pointer's location. This can be used to ensure that an element continues to receive pointer events even if the pointer device's contact moves off the element (for example by scrolling).</p>
 
 <p>The following example shows pointer capture being set on an element.</p>
 

--- a/files/en-us/web/api/popstateevent/index.html
+++ b/files/en-us/web/api/popstateevent/index.html
@@ -7,7 +7,7 @@ tags:
   - Reference
 browser-compat: api.PopStateEvent
 ---
-<p id="Summary">{{APIRef("HTML DOM")}}</p>
+<div>{{APIRef("HTML DOM")}}</div>
 
 <p><code><strong>PopStateEvent</strong></code> is an event handler for the
   {{Event("popstate")}} event on the window.</p>

--- a/files/en-us/web/api/pushevent/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/pushevent/index.html
@@ -20,8 +20,7 @@ browser-compat: api.PushEvent.PushEvent
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-	class="brush: js">var myPushEvent = new PushEvent(type, <span class="idlInterface" id="idl-def-PushEvent"><span class="extAttr">eventInitDict</span></span>);</pre>
+<pre class="brush: js">const myPushEvent = new PushEvent(type, eventInitDict);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/7899.

This is another batch of "easy" fixes. The only slightly interesting one here is in https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#terminology, which uses IDs as anchors. I've reorganized it to use headings instead since the anchors are actually used, but only internally in this page. I'm going to do something similar for https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology, but that's more complicated because it has lots of cross-references from other pages, so I'll do that in its own PR.
