### PR TITLE
Update IndexedDB terminology links

### DIFF
--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -16,7 +16,7 @@ browser-compat: api.IDBCursor
 <p><strong>Note:</strong> Not to be confused with {{domxref("IDBCursorWithValue")}} which is just an <strong><code>IDBCursor</code></strong> interface with an additional <strong><code>value</code></strong> property.</p>
 </div>
 
-<p>The <strong><code>IDBCursor</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database.</p>
+<p>The <strong><code>IDBCursor</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> for traversing or iterating over multiple records in a database.</p>
 
 <p>The cursor has a source that indicates which index or object store it is iterating over. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. The cursor enables an application to asynchronously process all the records in the cursor's range.</p>
 

--- a/files/en-us/web/api/idbcursorsync/index.html
+++ b/files/en-us/web/api/idbcursorsync/index.html
@@ -16,7 +16,7 @@ tags:
 <p><strong>Warning:</strong> The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
-<p>The <code>IDBCursorSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> for iterating over multiple records in a database. You can have only one instance of <code>IDBCursorSync</code> representing a cursor, but you can have an unlimited number of cursors at the same time. Operations are performed on the underlying index or object store. It enables an application to synchronously process all the records in the cursor's range.</p>
+<p>The <code>IDBCursorSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> for iterating over multiple records in a database. You can have only one instance of <code>IDBCursorSync</code> representing a cursor, but you can have an unlimited number of cursors at the same time. Operations are performed on the underlying index or object store. It enables an application to synchronously process all the records in the cursor's range.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -50,12 +50,12 @@ tags:
   <tr>
    <td><a name="attr_direction"><code>direction</code></a></td>
    <td><code>readonly unsigned short</code></td>
-   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_direction">direction</a> of traversal of the cursor. See Constants for possible values.</td>
+   <td>The direction of traversal of the cursor. See Constants for possible values.</td>
   </tr>
   <tr>
    <td><a name="attr_key"><code>key</code></a></td>
    <td><code>readonly any</code></td>
-   <td>The key for the record at the cursor's <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_position">position</a>.</td>
+   <td>The key for the record at the cursor's position.</td>
   </tr>
   <tr>
    <td><a name="attr_value"><code>value</code></a></td>
@@ -65,9 +65,9 @@ tags:
 
     <dl>
      <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#data_err">DATA_ERR</a></code></dt>
-     <dd>If the underlying object store uses <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_in-line_key">in-line keys</a> and the property at the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> does not match the key in this cursor's position.</dd>
+     <dd>If the underlying object store uses <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#in-line_key">in-line keys</a> and the property at the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> does not match the key in this cursor's position.</dd>
      <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#not_allowed_err">NOT_ALLOWED_ERR</a></code></dt>
-     <dd>If the underlying index or object store does not support updating the record because it is open in the <code><a href="/en-US/docs/Web/API/IDBObjectStoreSync#const_read_only">READ_ONLY</a></code> or <code><a href="/en-US/docs/Web/API/IDBCursorSync#const_snapshot_read">SNAPSHOT_READ</a></code> mode, or if an index record cannot be changed because the underlying index is <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_auto-populated">auto-populated</a>.</dd>
+     <dd>If the underlying index or object store does not support updating the record because it is open in the <code><a href="/en-US/docs/Web/API/IDBObjectStoreSync#const_read_only">READ_ONLY</a></code> or <code><a href="/en-US/docs/Web/API/IDBCursorSync#const_snapshot_read">SNAPSHOT_READ</a></code> mode, or if an index record cannot be changed because the underlying index is auto-populated.</dd>
      <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#serial_err">SERIAL_ERR</a></code></dt>
      <dd>If the data being stored could not be serialized by the internal structured cloning algorithm.</dd>
     </dl>

--- a/files/en-us/web/api/idbcursorwithvalue/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/index.html
@@ -14,7 +14,7 @@ browser-compat: api.IDBCursorWithValue
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
-<p>The <strong><code>IDBCursorWithValue</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_cursor">cursor</a> for traversing or iterating over multiple records in a database. It is the same as the {{domxref("IDBCursor")}}, except that it includes the <code>value</code> property.</p>
+<p>The <strong><code>IDBCursorWithValue</code></strong> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> for traversing or iterating over multiple records in a database. It is the same as the {{domxref("IDBCursor")}}, except that it includes the <code>value</code> property.</p>
 
 <p>The cursor has a source that indicates which index or object store it is iterating over. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. The cursor enables an application to asynchronously process all the records in the cursor's range.</p>
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.html
@@ -58,16 +58,16 @@ browser-compat: api.IDBDatabase.createObjectStore
         <tr>
           <td><code>keyPath</code></td>
           <td>The <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key
               path</a> to be used by the new object store. If empty or not specified, the
             object store is created without a key path and uses <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_outofline_key">out-of-line
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#out-of-line_key">out-of-line
               keys</a>. You can also pass in an array as a <code>keyPath</code>.</td>
         </tr>
         <tr>
           <td><code>autoIncrement</code></td>
           <td>If <code>true</code>, the object store has a <a
-              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keygenerator">key
+              href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_generator">key
               generator</a>. Defaults to <code>false</code>.</td>
         </tr>
       </tbody>

--- a/files/en-us/web/api/idbdatabase/index.html
+++ b/files/en-us/web/api/idbdatabase/index.html
@@ -16,12 +16,12 @@ browser-compat: api.IDBDatabase
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
-<p>The <strong><code>IDBDatabase</code></strong> interface of the IndexedDB API provides a <a href="/en-US/docs/Web/API/IndexedDB_API#database_connection">connection to a database</a>; you can use an <code>IDBDatabase</code> object to open a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_transaction">transaction</a> on your database then create, manipulate, and delete objects (data) in that database. The interface provides the only way to get and manage versions of the database.</p>
+<p>The <strong><code>IDBDatabase</code></strong> interface of the IndexedDB API provides a <a href="/en-US/docs/Web/API/IndexedDB_API#database_connection">connection to a database</a>; you can use an <code>IDBDatabase</code> object to open a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction">transaction</a> on your database then create, manipulate, and delete objects (data) in that database. The interface provides the only way to get and manage versions of the database.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <div class="note">
-<p><strong>Note:</strong> Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
+<p><strong>Note:</strong> Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology/Basic_Terminology#transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
 </div>
 
 <p>{{InheritanceDiagram}}</p>
@@ -34,7 +34,7 @@ browser-compat: api.IDBDatabase
  <dt>{{domxref("IDBDatabase.version")}} {{readonlyInline}}</dt>
  <dd>A 64-bit integer that contains the version of the connected database. When a database is first created, this attribute is an empty string.</dd>
  <dt>{{domxref("IDBDatabase.objectStoreNames")}} {{readonlyInline}}</dt>
- <dd>A {{ domxref("DOMStringList") }} that contains a list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store">object stores</a> currently in the connected database.</dd>
+ <dd>A {{ domxref("DOMStringList") }} that contains a list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object stores</a> currently in the connected database.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/idbdatabase/index.html
+++ b/files/en-us/web/api/idbdatabase/index.html
@@ -21,7 +21,7 @@ browser-compat: api.IDBDatabase
 <p>{{AvailableInWorkers}}</p>
 
 <div class="note">
-<p><strong>Note:</strong> Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology/Basic_Terminology#transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
+<p><strong>Note:</strong> Everything you do in IndexedDB always happens in the context of a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction">transaction</a>, representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.</p>
 </div>
 
 <p>{{InheritanceDiagram}}</p>

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.html
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBDatabase.objectStoreNames
 <div>
   <p>The <strong><code>objectStoreNames</code></strong> read-only property of the
     {{domxref("IDBDatabase")}} interface is a {{ domxref("DOMStringList") }} containing a
-    list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store">object
+    list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object
       stores</a> currently in the connected database.</p>
 
   <p>{{AvailableInWorkers}}</p>
@@ -31,7 +31,7 @@ browser-compat: api.IDBDatabase.objectStoreNames
 <h3 id="Value">Value</h3>
 
 <p>A {{ domxref("DOMStringList") }} containing a list of
-    the names of the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store"
+    the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store"
    >object stores</a>currently
     in the connected database.</p>
 

--- a/files/en-us/web/api/idbdatabasesync/index.html
+++ b/files/en-us/web/api/idbdatabasesync/index.html
@@ -15,7 +15,7 @@ tags:
 <p><strong>Warning:</strong> The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
-<p>The <code>DatabaseSync</code> interface in the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a synchronous <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_database_connection">connection to a database</a>.</p>
+<p>The <code>DatabaseSync</code> interface in the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> represents a synchronous <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">connection to a database</a>.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -92,9 +92,9 @@ tags:
  <dt>name</dt>
  <dd>The name of a new object store.</dd>
  <dt>keypath</dt>
- <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> used by the new object store. If a null path is specified, then the object store does not have a key path, and uses out-of-line keys.</dd>
+ <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> used by the new object store. If a null path is specified, then the object store does not have a key path, and uses out-of-line keys.</dd>
  <dt>autoIncrement</dt>
- <dd>If true, the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_generator">key generator</a>; if false, it does not use one.</dd>
+ <dd>If true, the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_generator">key generator</a>; if false, it does not use one.</dd>
 </dl>
 
 <h5 id="Returns">Returns</h5>

--- a/files/en-us/web/api/idbfactory/index.html
+++ b/files/en-us/web/api/idbfactory/index.html
@@ -23,7 +23,7 @@ browser-compat: api.IDBFactory
 
 <dl>
  <dt>{{domxref("IDBFactory.open")}}</dt>
- <dd>The current method to request opening a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_database_connection">connection to a database</a>.</dd>
+ <dd>The current method to request opening a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">connection to a database</a>.</dd>
  <dt>{{domxref("IDBFactory.deleteDatabase")}}</dt>
  <dd>A method to request the deletion of a database.</dd>
  <dt>{{domxref("IDBFactory.cmp")}}</dt>

--- a/files/en-us/web/api/idbfactory/open/index.html
+++ b/files/en-us/web/api/idbfactory/open/index.html
@@ -15,7 +15,7 @@ browser-compat: api.IDBFactory.open
   <p>{{APIRef("IndexedDB")}}</p>
   <p>The <strong><code>open()</code></strong> method of the {{domxref("IDBFactory")}}
     interface requests opening a <a
-      href="/en-US/docs/Web/API/IndexedDB_API#gloss_database_connection">connection to a database</a>.
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">connection to a database</a>.
   </p>
 
   <p>The method returns an {{domxref("IDBOpenDBRequest")}} object immediately, and

--- a/files/en-us/web/api/idbfactorysync/index.html
+++ b/files/en-us/web/api/idbfactorysync/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h3 id="open">open()</h3>
 
-<p>Opens and returns a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_database_connection">connection to a database</a>. Blocks the calling thread until the connection object is ready to return. If there is already a database with the specified name, it uses that one; otherwise, it creates the database using the specified name and description.</p>
+<p>Opens and returns a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">connection to a database</a>. Blocks the calling thread until the connection object is ready to return. If there is already a database with the specified name, it uses that one; otherwise, it creates the database using the specified name and description.</p>
 
 <pre>IDBDatabaseSync open (
   in DOMString name,

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -13,7 +13,7 @@ browser-compat: api.IDBIndex
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
-<p><code>IDBIndex</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides asynchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_index">index</a> in a database. An index is a kind of object store for looking up records in another object store, called the referenced object store. You use this interface to retrieve data.</p>
+<p><code>IDBIndex</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides asynchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">index</a> in a database. An index is a kind of object store for looking up records in another object store, called the referenced object store. You use this interface to retrieve data.</p>
 
 <p>You can retrieve records in an object store through the primary key or by using an index. An index lets you look up records in an object store using properties of the values in the object stores records other than the primary key</p>
 
@@ -35,7 +35,7 @@ browser-compat: api.IDBIndex
  <dt>{{domxref("IDBIndex.objectStore")}} {{readonlyInline}}</dt>
  <dd>The name of the object store referenced by this index.</dd>
  <dt>{{domxref("IDBIndex.keyPath")}} {{readonlyInline}}</dt>
- <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> of this index. If null, this index is not <a href="/en-US/docs/Web/API/IDBIndex#gloss_auto-populated">auto-populated</a>.</dd>
+ <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this index. If null, this index is not auto-populated.</dd>
  <dt>{{domxref("IDBIndex.multiEntry")}} {{readonlyInline}}</dt>
  <dd>Affects how the index behaves when the result of evaluating the index's key path yields an array. If <code>true</code>, there is one record in the index for each item in an array of keys. If <code>false</code>, then there is one record for each key that is an array.</dd>
  <dt>{{domxref("IDBIndex.unique")}} {{readonlyInline}}</dt>
@@ -58,7 +58,7 @@ browser-compat: api.IDBIndex
  <dt>{{domxref("IDBIndex.getAllKeys()")}}</dt>
  <dd>Returns an {{domxref("IDBRequest")}} object, in a separate thread, finds all matching keys in the referenced object store that correspond to the given key or are in range, if <code>key</code> is an {{domxref("IDBKeyRange")}}.</dd>
  <dt>{{domxref("IDBIndex.openCursor()")}}</dt>
- <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> over the specified key range.</dd>
+ <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> over the specified key range.</dd>
  <dt>{{domxref("IDBIndex.openKeyCursor()")}}</dt>
  <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a cursor over the specified key range, as arranged by this index.</dd>
 </dl>

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBIndex.keyPath
 <div>
   <p>The <strong><code>keyPath</code></strong> property of the {{domxref("IDBIndex")}}
     interface returns the <a
-      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#keypath">key
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key
       path</a> of the current index. If null, this index is not auto-populated.
   </p>
 

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -17,9 +17,8 @@ browser-compat: api.IDBIndex.keyPath
 <div>
   <p>The <strong><code>keyPath</code></strong> property of the {{domxref("IDBIndex")}}
     interface returns the <a
-      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
-      path</a> of the current index. If null, this index is not <a
-      href="/en-US/docs/Web/API/IDBIndex#gloss_auto-populated">auto-populated</a>.
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#keypath">key
+      path</a> of the current index. If null, this index is not auto-populated.
   </p>
 
   <p>{{AvailableInWorkers}}</p>

--- a/files/en-us/web/api/idbindex/opencursor/index.html
+++ b/files/en-us/web/api/idbindex/opencursor/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBIndex.openCursor
 <div>
   <p>The <strong><code>openCursor()</code></strong> method of the {{domxref("IDBIndex")}}
     interface returns an {{domxref("IDBRequest")}} object, and, in a separate thread,
-    creates a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> over the specified key
+    creates a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> over the specified key
     range.</p>
 </div>
 

--- a/files/en-us/web/api/idbindexsync/index.html
+++ b/files/en-us/web/api/idbindexsync/index.html
@@ -15,7 +15,7 @@ tags:
 <p><strong>Warning:</strong> The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
-<p>The <code>IDBIndexSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides synchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_index">index</a> in a database.</p>
+<p>The <code>IDBIndexSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides synchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">index</a> in a database.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -59,7 +59,7 @@ tags:
   <tr>
    <td><code><a name="attr_keyPath">keyPath</a></code></td>
    <td><code>readonly DOMString</code></td>
-   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> of this index. If this attribute is null, this index is not <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_auto-populated">auto-populated</a>.</td>
+   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this index. If this attribute is null, this index is not auto-populated.</td>
   </tr>
   <tr>
    <td><code><a name="attr_name">name</a></code></td>
@@ -69,7 +69,7 @@ tags:
   <tr>
    <td><code><a name="attr_storeName">storeName</a></code></td>
    <td><code>readonly DOMString</code></td>
-   <td>This index's <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_referenced_object_store">referenced object store</a>.</td>
+   <td>This index's referenced <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object store</a>.</td>
   </tr>
   <tr>
    <td><code><a name="attr_unique">unique</a></code></td>
@@ -176,7 +176,7 @@ tags:
 
 <h3 id="openCursor">openCursor()</h3>
 
-<p>Creates a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> over the records of this index. The range of the new cursor matches the specified <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_range">key range</a>; if the key range is not specified or is null, then the range includes all the records.</p>
+<p>Creates a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> over the records of this index. The range of the new cursor matches the specified <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_range">key range</a>; if the key range is not specified or is null, then the range includes all the records.</p>
 
 <pre>void openCursor (
   in optional IDBKeyRange range,

--- a/files/en-us/web/api/idbobjectstore/index.html
+++ b/files/en-us/web/api/idbobjectstore/index.html
@@ -21,9 +21,9 @@ browser-compat: api.IDBObjectStore
 
 <dl>
  <dt>{{domxref("IDBObjectStore.indexNames")}} {{readonlyInline}}</dt>
- <dd>A list of the names of <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_index">indexes</a> on objects in this object store.</dd>
+ <dd>A list of the names of <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes</a> on objects in this object store.</dd>
  <dt>{{domxref("IDBObjectStore.keyPath")}} {{readonlyInline}}</dt>
- <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> of this object store. If this attribute is <code>null</code>, the application must provide a key for each modification operation.</dd>
+ <dd>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this object store. If this attribute is <code>null</code>, the application must provide a key for each modification operation.</dd>
  <dt>{{domxref("IDBObjectStore.name")}}</dt>
  <dd>The name of this object store.</dd>
  <dt>{{domxref("IDBObjectStore.transaction")}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/idbobjectstore/indexnames/index.html
+++ b/files/en-us/web/api/idbobjectstore/indexnames/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBObjectStore.indexNames
 <div>
   <p>The <strong><code>indexNames</code></strong> read-only property of the
     {{domxref("IDBObjectStore")}} interface returns a list of the names of <a
-      href="/en-US/docs/Web/API/IndexedDB_API#gloss_index">indexes</a> on objects
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes</a> on objects
     in this object store.</p>
 
   <p>{{AvailableInWorkers}}</p>

--- a/files/en-us/web/api/idbobjectstore/keypath/index.html
+++ b/files/en-us/web/api/idbobjectstore/keypath/index.html
@@ -17,7 +17,7 @@ browser-compat: api.IDBObjectStore.keyPath
 <div>
   <p>The <strong><code>keyPath</code></strong> read-only property of the
     {{domxref("IDBObjectStore")}} interface returns the <a
-      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key
+      href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key
       path</a> of this object store.</p>
 </div>
 

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -14,7 +14,7 @@ tags:
 <p><strong>Warning:</strong> The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
-<p>The <code>IDBObjectStoreSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides synchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store">object store</a> of a database.</p>
+<p>The <code>IDBObjectStoreSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides synchronous access to an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object store</a> of a database.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -61,12 +61,12 @@ tags:
   <tr>
    <td><code><a name="attr_indexNames">indexNames</a></code></td>
    <td><code>readonly DOMStringList</code></td>
-   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_index">indexes</a> on this object store.</td>
+   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes</a> on this object store.</td>
   </tr>
   <tr>
    <td><code><a name="attr_keyPath">keyPath</a></code></td>
    <td><code>readonly DOMString</code></td>
-   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_path">key path</a> of this object store. If this attribute is set to null, then the application must provide a key for each modification operation.</td>
+   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this object store. If this attribute is set to null, then the application must provide a key for each modification operation.</td>
   </tr>
   <tr>
    <td><code><a name="attr_mode">mode</a></code></td>
@@ -142,7 +142,7 @@ tags:
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#constraint_err">CONSTRAINT_ERR</a></code></dt>
  <dd>If a record exists in this index with a key corresponding to the <em>key</em> parameter or the index is auto-populated, or if no record exists with a key corresponding to the <em>value</em> parameter in the index's referenced object store.</dd>
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#data_err">DATA_ERR</a></code></dt>
- <dd>If this object store uses <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_out-of-line_key">out-of-line keys</a>, and the <em>key</em> parameter was not passed.</dd>
+ <dd>If this object store uses <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#out-of-line_key">out-of-line keys</a>, and the <em>key</em> parameter was not passed.</dd>
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#serial_err">SERIAL_ERR</a></code></dt>
  <dd>If the data being stored could not be serialized by the internal structured cloning algorithm.</dd>
 </dl>
@@ -212,7 +212,7 @@ tags:
 
 <h3 id="openCursor()">openCursor()</h3>
 
-<p>Creates a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> over the records of this object store. The range of the new cursor matches the specified <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_range">key range</a>; if the key range is not specified or is null, then the range includes all the records.</p>
+<p>Creates a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor">cursor</a> over the records of this object store. The range of the new cursor matches the specified <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_range">key range</a>; if the key range is not specified or is null, then the range includes all the records.</p>
 
 <pre>CursorSync openCursor (
   in optional KeyRange range,
@@ -311,7 +311,7 @@ tags:
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#constraint_err">CONSTRAINT_ERR</a></code></dt>
  <dd>If noOverwrite was true, and a record exists in this index for the given key or this index is auto-populated; or if no record exists with the given key in the index's referenced object store.</dd>
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#data_err">DATA_ERR</a></code></dt>
- <dd>If this object store uses <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_out-of-line_key">out-of-line</a> keys and no <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_key_generator">key generator</a>, but no key was given.</dd>
+ <dd>If this object store uses <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#out-of-line_key">out-of-line</a> keys and no <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_generator">key generator</a>, but no key was given.</dd>
  <dt><code><a href="/en-US/docs/Web/API/IDBDatabaseException#serial_err">SERIAL_ERR</a></code></dt>
  <dd>If the data being stored could not be serialized by the internal structured cloning algorithm.</dd>
 </dl>

--- a/files/en-us/web/api/idbtransactionsync/index.html
+++ b/files/en-us/web/api/idbtransactionsync/index.html
@@ -15,7 +15,7 @@ tags:
 <p><strong>Warning:</strong> The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
-<p>The <code>IDBTransactionSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides a synchronous <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_transaction">transaction</a> on a database. When an application creates an IDBTransactionSync object, it blocks until the browser is able to reserve the require database objects.</p>
+<p>The <code>IDBTransactionSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> provides a synchronous <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction">transaction</a> on a database. When an application creates an IDBTransactionSync object, it blocks until the browser is able to reserve the require database objects.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -47,12 +47,12 @@ tags:
   <tr>
    <td><a name="attr_db"><code>db</code></a></td>
    <td><code><a href="/en-US/docs/Web/API/IDBDatabaseSync">IDBDatabaseSync</a></code></td>
-   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_database_connection">database connection</a> that this transaction is associated with.</td>
+   <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">database connection</a> that this transaction is associated with.</td>
   </tr>
   <tr>
    <td><a name="attr_static"><code>static</code></a></td>
    <td><code>boolean</code></td>
-   <td>If true, this transaction is <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_static">static</a>; if false, this transaction is <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_dynamic">dynamic</a>.</td>
+   <td>If true, this transaction is static; if false, this transaction is dynamic.</td>
   </tr>
  </tbody>
 </table>
@@ -97,7 +97,7 @@ tags:
 
 <h3 id="objectStore()">objectStore()</h3>
 
-<p>Returns an <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_object_store">object store</a> that has already been added to the scope of this transaction.</p>
+<p>Returns an <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object store</a> that has already been added to the scope of this transaction.</p>
 
 <pre><code>IDBObjectStoreSync objectStore(
   in DOMString name

--- a/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
@@ -31,9 +31,9 @@ tags:
   <p><strong>IndexedDB databases store key-value pairs.</strong> The values can be complex structured objects, and keys can be properties of those objects. You can create indexes that use any property of the objects for quick searching, as well as sorted enumeration. Keys can be binary objects.</p>
  </li>
  <li>
-  <p><strong>IndexedDB is built on a transactional database model</strong>. Everything you do in IndexedDB always happens in the context of a <a href="#gloss_transaction">transaction</a>. The IndexedDB API provides lots of objects that represent indexes, tables, cursors, and so on, but each of these is tied to a particular transaction. Thus, you cannot execute commands or open cursors outside of a transaction. Transactions have a well-defined lifetime, so attempting to use a transaction after it has completed throws exceptions. Also, transactions auto-commit and cannot be committed manually.</p>
+  <p><strong>IndexedDB is built on a transactional database model</strong>. Everything you do in IndexedDB always happens in the context of a <a href="#transaction">transaction</a>. The IndexedDB API provides lots of objects that represent indexes, tables, cursors, and so on, but each of these is tied to a particular transaction. Thus, you cannot execute commands or open cursors outside of a transaction. Transactions have a well-defined lifetime, so attempting to use a transaction after it has completed throws exceptions. Also, transactions auto-commit and cannot be committed manually.</p>
 
-  <p>This transaction model is really useful when you consider what might happen if a user opened two instances of your web app in two different tabs simultaneously. Without transactional operations, the two instances could interfere with each other's modifications. If you are not familiar with transactions in a database, read the <a class="link-https" href="https://en.wikipedia.org/wiki/Database_transaction">Wikipedia article on transactions</a>. Also see <a href="#gloss_transaction">transaction</a> under the Definitions section.</p>
+  <p>This transaction model is really useful when you consider what might happen if a user opened two instances of your web app in two different tabs simultaneously. Without transactional operations, the two instances could interfere with each other's modifications. If you are not familiar with transactions in a database, read the <a class="link-https" href="https://en.wikipedia.org/wiki/Database_transaction">Wikipedia article on transactions</a>. Also see <a href="#transaction">transaction</a> under the Definitions section.</p>
  </li>
  <li>
   <p><strong>The IndexedDB API is mostly asynchronous.</strong> The API doesn't give you data by returning values; instead, you have to pass a callback function. You don't "store" a value into the database, or "retrieve" a value out of the database through synchronous means. Instead, you "request" that a database operation happens. You get notified by a DOM event when the operation finishes, and the type of event you get lets you know if the operation succeeded or failed. This sounds a little complicated at first, but there are sanity measures baked in. It's not that different from the way that <a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a> works.</p>
@@ -89,105 +89,116 @@ tags:
 
 <h3 id="database">Database</h3>
 
-<dl>
- <dt><a name="gloss_database">database</a></dt>
- <dd>A repository of information, typically comprising one or more <a href="#gloss_object_store"><em>object stores</em></a>. Each database must have the following:
+<h4>database</h4>
+
+<p>A repository of information, typically comprising one or more <a href="#object_store"><em>object stores</em></a>. Each database must have the following:
  <ul>
   <li>Name. This identifies the database within a specific origin and stays constant throughout its lifetime. The name can be any string value (including an empty string).</li>
   <li>
-   <p>Current <a href="#gloss_version"><em>version</em></a>. When a database is first created, its version is the integer 1 if not specified otherwise. Each database can have only one version at any given time.</p>
+   <p>Current <a href="#version"><em>version</em></a>. When a database is first created, its version is the integer 1 if not specified otherwise. Each database can have only one version at any given time.</p>
   </li>
  </ul>
- </dd>
- <dt><a name="durable">durable</a></dt>
- <dd>
- <p>In Firefox, IndexedDB used to be <strong>durable</strong>, meaning that in a readwrite transaction {{domxref("IDBTransaction.oncomplete")}} was fired only when all data was guaranteed to have been flushed to disk.</p>
+</p>
 
- <p>As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see {{Bug("1112702")}}), which is the same behavior as other IndexedDB-supporting browsers. In this case the {{Event("complete")}} event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk. The event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk. Since such catastrophic events are rare, most consumers should not need to concern themselves further.</p>
+<h4>database connection</h4>
 
- <div class="note">
+<p>An operation created by opening a <em><a href="#database">database</a></em>. A given database can have multiple connections at the same time.</p>
+
+<h4>durable</h4>
+
+<p>In Firefox, IndexedDB used to be <strong>durable</strong>, meaning that in a readwrite transaction {{domxref("IDBTransaction.oncomplete")}} was fired only when all data was guaranteed to have been flushed to disk.</p>
+
+<p>As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see {{Bug("1112702")}}), which is the same behavior as other IndexedDB-supporting browsers. In this case the {{Event("complete")}} event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk. The event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk. Since such catastrophic events are rare, most consumers should not need to concern themselves further.</p>
+
+<div class="note">
  <p><strong>Note:</strong> In Firefox, if you wish to ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the <code>complete</code> event by creating a transaction using the experimental (non-standard) <code>readwriteflush</code> mode (see {{domxref("IDBDatabase.transaction")}}.) This is currently experimental, and can only be used if the <code>dom.indexedDB.experimental</code> pref is set to <code>true</code> in <code>about:config</code>.</p>
- </div>
- </dd>
- <dt><a name="gloss_object_store">object store</a></dt>
- <dd>
- <p>The mechanism by which data is stored in the database. The object store persistently holds records, which are key-value pairs. Records within an object store are sorted according to the <em><a href="#gloss_key">keys</a></em> in an ascending order.</p>
+</div>
 
- <p>Every object store must have a name that is unique within its database. The object store can optionally have a <em><a href="#gloss_keygenerator">key generator</a></em> and a <em><a href="#gloss_keypath">key path</a></em>. If the object store has a key path, it is using <em><a href="#gloss_inline_key">in-line keys</a></em>; otherwise, it is using <em><a href="#gloss_outofline_key">out-of-line keys</a></em>.</p>
+<h4>index</h4>
 
- <p>For the reference documentation on object store, see {{domxref("IDBObjectStore")}}.</p>
- </dd>
- <dt><a name="gloss_version">version</a></dt>
- <dd>When a database is first created, its version is the integer 1. Each database has one version at a time; a database can't exist in multiple versions at once. The only way to change the version is by opening it with a greater version than the current one.</dd>
- <dt><a name="gloss_database_connection">database connection</a></dt>
- <dd>An operation created by opening a <em><a href="#gloss_database">database</a></em>. A given database can have multiple connections at the same time.</dd>
- <dt><a name="gloss_transaction">transaction</a></dt>
- <dd>
- <p>An atomic set of data-access and data-modification operations on a particular database. It is how you interact with the data in a database. In fact, any reading or changing of data in the database must happen in a transaction.</p>
+<p>An index is a specialized object store for looking up records in another object store, called the <em>referenced object store</em>. The index is a persistent key-value storage where the value part of its records is the key part of a record in the referenced object store. The records in an index are automatically populated whenever records in the referenced object store are inserted, updated, or deleted. Each record in an index can point to only one record in its referenced object store, but several indexes can reference the same object store. When the object store changes, all indexes that refer to the object store are automatically updated.</p>
 
- <p>A database connection can have several active transactions associated with it at a time, so long as the writing transactions do not have overlapping <a href="#scope"><em>scopes</em></a>. The scope of transactions, which is defined at creation, determines which object stores the transaction can interact with and remains constant for the lifetime of the transaction. So, for example, if a database connection already has a writing transaction with a scope that just covers the <code>flyingMonkey</code> object store, you can start a second transaction with a scope of the <code>unicornCentaur</code> and <code>unicornPegasus</code> object stores. As for reading transactions, you can have several of them — even overlapping ones.</p>
+<p>Alternatively, you can also look up records in an object store using the <a href="#key"> key</a><em>.</em></p>
 
- <p>Transactions are expected to be short-lived, so the browser can terminate a transaction that takes too long, in order to free up storage resources that the long-running transaction has locked. You can abort the transaction, which rolls back the changes made to the database in the transaction. And you don't even have to wait for the transaction to start or be active to abort it.</p>
+<p>To learn more on using indexes, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#using_an_index">Using IndexedDB</a>. For the reference documentation on index, see <a href="/en-US/docs/Web/API/IDBKeyRange" rel="internal">IDBKeyRange</a>.</p>
 
- <p>The three modes of transactions are: <code>readwrite</code>, <code>readonly</code>, and <code>versionchange</code>. The only way to create and delete object stores and indexes is by using a <a href="/en-US/docs/Web/API/IDBDatabase/versionchange_event"><code>versionchange</code></a> transaction. To learn more about transaction types, see the reference article for <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB</a>.</p>
+<h4>object store</h4>
 
- <p>Because everything happens within a transaction, it is a very important concept in IndexedDB. To learn more about transactions, especially on how they relate to versioning, see {{domxref("IDBTransaction")}}, which also has reference documentation.</p>
- </dd>
- <dt><a name="gloss_request">request</a></dt>
- <dd>The operation by which reading and writing on a database is done. Every request represents one read or write operation.</dd>
- <dt><a name="gloss_index">index</a></dt>
- <dd>
- <p>An index is a specialized object store for looking up records in another object store, called the <em>referenced object store</em>. The index is a persistent key-value storage where the value part of its records is the key part of a record in the referenced object store. The records in an index are automatically populated whenever records in the referenced object store are inserted, updated, or deleted. Each record in an index can point to only one record in its referenced object store, but several indexes can reference the same object store. When the object store changes, all indexes that refer to the object store are automatically updated.</p>
+<p>The mechanism by which data is stored in the database. The object store persistently holds records, which are key-value pairs. Records within an object store are sorted according to the <em><a href="#key">keys</a></em> in an ascending order.</p>
 
- <p>Alternatively, you can also look up records in an object store using the <a href="#gloss_key"> key</a><em>.</em></p>
+<p>Every object store must have a name that is unique within its database. The object store can optionally have a <em><a href="#key_generator">key generator</a></em> and a <em><a href="#key_path">key path</a></em>. If the object store has a key path, it is using <em><a href="#in-line_key">in-line keys</a></em>; otherwise, it is using <em><a href="#out-of-line_key">out-of-line keys</a></em>.</p>
 
- <p>To learn more on using indexes, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#using_an_index">Using IndexedDB</a>. For the reference documentation on index, see <a href="/en-US/docs/Web/API/IDBKeyRange" rel="internal">IDBKeyRange</a>.</p>
- </dd>
-</dl>
+<p>For the reference documentation on object store, see {{domxref("IDBObjectStore")}}.</p>
+
+<h4>request</h4>
+
+<p>The operation by which reading and writing on a database is done. Every request represents one read or write operation.</p>
+
+<h4>transaction</h4>
+
+<p>An atomic set of data-access and data-modification operations on a particular database. It is how you interact with the data in a database. In fact, any reading or changing of data in the database must happen in a transaction.</p>
+
+<p>A database connection can have several active transactions associated with it at a time, so long as the writing transactions do not have overlapping <a href="#scope"><em>scopes</em></a>. The scope of transactions, which is defined at creation, determines which object stores the transaction can interact with and remains constant for the lifetime of the transaction. So, for example, if a database connection already has a writing transaction with a scope that just covers the <code>flyingMonkey</code> object store, you can start a second transaction with a scope of the <code>unicornCentaur</code> and <code>unicornPegasus</code> object stores. As for reading transactions, you can have several of them — even overlapping ones.</p>
+
+<p>Transactions are expected to be short-lived, so the browser can terminate a transaction that takes too long, in order to free up storage resources that the long-running transaction has locked. You can abort the transaction, which rolls back the changes made to the database in the transaction. And you don't even have to wait for the transaction to start or be active to abort it.</p>
+
+<p>The three modes of transactions are: <code>readwrite</code>, <code>readonly</code>, and <code>versionchange</code>. The only way to create and delete object stores and indexes is by using a <a href="/en-US/docs/Web/API/IDBDatabase/versionchange_event"><code>versionchange</code></a> transaction. To learn more about transaction types, see the reference article for <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB</a>.</p>
+
+<p>Because everything happens within a transaction, it is a very important concept in IndexedDB. To learn more about transactions, especially on how they relate to versioning, see {{domxref("IDBTransaction")}}, which also has reference documentation.</p>
+
+<h4>version</h4>
+
+<p>When a database is first created, its version is the integer 1. Each database has one version at a time; a database can't exist in multiple versions at once. The only way to change the version is by opening it with a greater version than the current one.</p>
 
 <h3 id="key">Key and value</h3>
 
-<dl>
- <dt><a name="gloss_key">key</a></dt>
- <dd>
- <p>A data value by which stored values are organized and retrieved in the object store. The object store can derive the key from one of three sources: a <em><a href="#gloss_keygenerator">key generator</a></em>, a <em><a href="#gloss_keypath">key path</a></em>, or an explicitly specified value. The key must be of a data type that has a number that is greater than the one before it. Each record in an object store must have a key that is unique within the same store, so you cannot have multiple records with the same key in a given object store.</p>
+<h4>in-line key</h4>
 
- <p>A key can be one of the following types: <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">date</a>, float, a binary blob, and <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a>. For arrays, the key can range from an empty value to infinity. And you can include an array within an array.</p>
+<p>A key that is stored as part of the stored value. It is found using a <em>key path</em>. An in-line key can be generated using a generator. After the key has been generated, it can then be stored in the value using the key path or it can also be used as a key.</p>
 
- <p>Alternatively, you can also look up records in an object store using the <em><a href="#gloss_index">index</a>.</em></p>
- </dd>
- <dt><a name="gloss_keygenerator">key generator</a></dt>
- <dd>A mechanism for producing new keys in an ordered sequence. If an object store does not have a key generator, then the application must provide keys for records being stored. Generators are not shared between stores. This is more a browser implementation detail, because in web development, you don't really create or access key generators.</dd>
- <dt><a name="gloss_inline_key">in-line key</a></dt>
- <dd>A key that is stored as part of the stored value. It is found using a <em>key path</em>. An in-line key can be generated using a generator. After the key has been generated, it can then be stored in the value using the key path or it can also be used as a key.</dd>
- <dt><a name="gloss_outofline_key">out-of-line key</a></dt>
- <dd>A key that is stored separately from the value being stored.</dd>
- <dt><a name="gloss_keypath">key path</a></dt>
- <dd>Defines where the browser should extract the key from in the object store or index. A valid key path can include one of the following: an empty string, a JavaScript identifier, or multiple JavaScript identifiers separated by periods or an array containing any of those. It cannot include spaces.</dd>
- <dt><a name="gloss_value">value</a></dt>
- <dd>
- <p>Each record has a value, which could include anything that can be expressed in JavaScript, including <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean" rel="internal">boolean</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number" rel="internal">number</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">date</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" rel="internal">array</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp" rel="internal">regexp</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a>, and null.</p>
+<h4>key</h4>
 
- <p>When an object or array is stored, the properties and values in that object or array can also be anything that is a valid value.</p>
+<p>A data value by which stored values are organized and retrieved in the object store. The object store can derive the key from one of three sources: a <em><a href="#key_generator">key generator</a></em>, a <em><a href="#key_path">key path</a></em>, or an explicitly specified value. The key must be of a data type that has a number that is greater than the one before it. Each record in an object store must have a key that is unique within the same store, so you cannot have multiple records with the same key in a given object store.</p>
 
- <p><a href="/en-US/docs/Web/API/Blob">Blobs</a> and files can be stored, cf. <a href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a>.</p>
- </dd>
-</dl>
+<p>A key can be one of the following types: <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">date</a>, float, a binary blob, and <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a>. For arrays, the key can range from an empty value to infinity. And you can include an array within an array.</p>
+
+<p>Alternatively, you can also look up records in an object store using the <em><a href="#index">index</a>.</em></p>
+
+<h4>key generator</h4>
+
+<p>A mechanism for producing new keys in an ordered sequence. If an object store does not have a key generator, then the application must provide keys for records being stored. Generators are not shared between stores. This is more a browser implementation detail, because in web development, you don't really create or access key generators.</p>
+
+<h4>key path</h4>
+
+<p>Defines where the browser should extract the key from in the object store or index. A valid key path can include one of the following: an empty string, a JavaScript identifier, or multiple JavaScript identifiers separated by periods or an array containing any of those. It cannot include spaces.</p>
+
+<h4>out-of-line key</h4>
+
+<p>A key that is stored separately from the value being stored.</p>
+
+<h4>value</h4>
+
+<p>Each record has a value, which could include anything that can be expressed in JavaScript, including <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean" rel="internal">boolean</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number" rel="internal">number</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">date</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" rel="internal">array</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp" rel="internal">regexp</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a>, and null.</p>
+
+<p>When an object or array is stored, the properties and values in that object or array can also be anything that is a valid value.</p>
+
+<p><a href="/en-US/docs/Web/API/Blob">Blobs</a> and files can be stored, cf. <a href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a>.</p>
 
 <h3 id="range">Range and scope</h3>
 
-<dl>
- <dt id="scope"><a id="gloss_scope">scope</a></dt>
- <dd>The set of object stores and indexes to which a transaction applies. The scopes of read-only transactions can overlap and execute at the same time. On the other hand, the scopes of writing transactions cannot overlap. You can still start several transactions with the same scope at the same time, but they just queue up and execute one after another.</dd>
- <dt id="cursor"><a id="gloss_cursor">cursor</a></dt>
- <dd>A mechanism for iterating over multiple records with a <em>key range</em>. The cursor has a source that indicates which index or object store it is iterating. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. For the reference documentation on cursors, see {{domxref("IDBCursor")}}.</dd>
- <dt id="key_range"><a id="gloss_keyrange">key range</a></dt>
- <dd>
- <p>A continuous interval over some data type used for keys. Records can be retrieved from object stores and indexes using keys or a range of keys. You can limit or filter the range using lower and upper bounds. For example, you can iterate over all values of a key between x and y.</p>
+<h4>cursor</h4>
 
- <p>For the reference documentation on key range, see {{domxref("IDBKeyRange")}}.</p>
- </dd>
-</dl>
+<p>A mechanism for iterating over multiple records with a <em>key range</em>. The cursor has a source that indicates which index or object store it is iterating. It has a position within the range, and moves in a direction that is increasing or decreasing in the order of record keys. For the reference documentation on cursors, see {{domxref("IDBCursor")}}.</p>
+
+<h4>key range</h4>
+
+<p>A continuous interval over some data type used for keys. Records can be retrieved from object stores and indexes using keys or a range of keys. You can limit or filter the range using lower and upper bounds. For example, you can iterate over all values of a key between x and y.</p>
+
+<p>For the reference documentation on key range, see {{domxref("IDBKeyRange")}}.</p>
+
+<h4>scope</h4>
+
+<p>The set of object stores and indexes to which a transaction applies. The scopes of read-only transactions can overlap and execute at the same time. On the other hand, the scopes of writing transactions cannot overlap. You can still start several transactions with the same scope at the same time, but they just queue up and execute one after another.</p>
 
 <h2 id="next">Next steps</h2>
 

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -142,7 +142,7 @@ request.onupgradeneeded = function(event) {
 
 <h3 id="Structuring_the_database">Structuring the database</h3>
 
-<p>Now to structure the database. IndexedDB uses object stores rather than tables, and a single database can contain any number of object stores. Whenever a value is stored in an object store, it is associated with a key. There are several different ways that a key can be supplied depending on whether the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keypath">key path</a> or a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_keygenerator">key generator</a>.</p>
+<p>Now to structure the database. IndexedDB uses object stores rather than tables, and a single database can contain any number of object stores. Whenever a value is stored in an object store, it is associated with a key. There are several different ways that a key can be supplied depending on whether the object store uses a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> or a <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_generator">key generator</a>.</p>
 
 <p>The following table shows the different ways the keys are supplied:</p>
 
@@ -283,7 +283,7 @@ request.onupgradeneeded = function (event) {
 
 <ul>
  <li>When defining the scope, specify only the object stores you need. This way, you can run multiple transactions with non-overlapping scopes concurrently.</li>
- <li>Only specify a <code>readwrite</code> transaction mode when necessary. You can concurrently run multiple <code>readonly</code> transactions with overlapping scopes, but you can have only one <code>readwrite</code> transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
+ <li>Only specify a <code>readwrite</code> transaction mode when necessary. You can concurrently run multiple <code>readonly</code> transactions with overlapping scopes, but you can have only one <code>readwrite</code> transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
 </ul>
 
 <h3 id="Adding_data_to_the_database">Adding data to the database</h3>
@@ -360,7 +360,7 @@ request.onsuccess = function(event) {
 
 <ul>
  <li>When defining the <a href="#scope">scope</a>, specify only the object stores you need. This way, you can run multiple transactions with non-overlapping scopes concurrently.</li>
- <li>Only specify a readwrite transaction mode when necessary. You can concurrently run multiple readonly transactions with overlapping scopes, but you can have only one readwrite transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#gloss_transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
+ <li>Only specify a readwrite transaction mode when necessary. You can concurrently run multiple readonly transactions with overlapping scopes, but you can have only one readwrite transaction for an object store. To learn more, see the definition for <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction">transaction</a> in the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology">IndexedDB key characteristics and basic terminology</a> article.</li>
 </ul>
 
 <h3 id="Updating_an_entry_in_the_database">Updating an entry in the database</h3>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/7899.

https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology used `id` on `dt` elements to provide anchors so other pages could link to definitions of terms. I've converted these to use headings and updated all the links I could find. a few links didn't have targets so I just removed them.

Really these should probably be glossary terms, but I didn't go that far in this PR.

