### PR TITLE
Clean up globalStorage references

### DIFF
--- a/files/en-us/mozilla/firefox/releases/13/index.html
+++ b/files/en-us/mozilla/firefox/releases/13/index.html
@@ -43,7 +43,7 @@ tags:
  <li>The {{domxref("WindowOrWorkerGlobalScope/setTimeout")}} and {{domxref("WindowOrWorkerGlobalScope/setInterval")}} methods no longer pass an additional "lateness" argument to the callback routine.</li>
  <li>The {{domxref("Blob","Blob.mozSlice()")}} method has been unprefixed.</li>
  <li>Support for the {{domxref("Blob")}} constructor has been added.</li>
- <li>Support for <a href="/en-US/docs/Web/API/Web_Storage_API#globalstorage"><code>globalStorage</code></a> has been removed.</li>
+ <li>Support for <code>globalStorage</code> has been removed.</li>
  <li>The new {{domxref("DOMRequest")}} interface, used for reporting the status and result of background operations, has been added.</li>
  <li>The {{domxref("HTMLOptionElement", "HTMLOptionElement.index()")}} method now returns <code>0</code> instead of the incorrect <code>-1</code> when the {{HTMLElement("option")}} is inside a {{HTMLElement("datalist")}} HTML element.</li>
  <li>{{domxref("DOMException")}} as defined in DOM Level 4 has been implemented.</li>

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -200,8 +200,6 @@ browser-compat: api.Window
  <dd>Gets the arguments passed to the window (if it's a dialog box) at the time {{domxref("window.showModalDialog()")}} was called. This is an {{Interface("nsIArray")}}.</dd>
  <dt>{{domxref("Window.directories")}} {{deprecated_inline}}</dt>
  <dd>Synonym of {{domxref("window.personalbar")}}</dd>
- <dt>{{domxref("Window.globalStorage")}} {{Non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Multiple storage objects that were used for storing data across multiple pages.</dd>
  <dt>{{domxref("Window.mozAnimationStartTime")}} {{Non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>The time in milliseconds since epoch at which the current animation cycle began. Use {{domxref("Animation.startTime")}} instead.</dd>
  <dt>{{domxref("Window.mozPaintCount")}} {{non-standard_inline}} {{deprecated_inline}}</dt>


### PR DESCRIPTION
The page for this does not exist, so leave just the mention in Firefox
13 release notes.

BCD removal: https://github.com/mdn/browser-compat-data/pull/12183
