### PR TITLE
Fix WebGL by example pages

### DIFF
--- a/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.html
@@ -15,9 +15,9 @@ tags:
 
 <p>In this example, we see how to draw simple rectangles and squares using WebGL scissoring operations. Scissoring establishes a clipping region outside which drawing will not occur.</p>
 
-<p>{{EmbedLiveSample("basic-scissoring-source",660,425)}}</p>
+<h2 id="Clearing_the_drawing_buffer_when_scissoring_applies">Clearing the drawing buffer when scissoring applies</h2>
 
-<h3 id="Clearing_the_drawing_buffer_when_scissoring_applies">Clearing the drawing buffer when scissoring applies</h3>
+<p>{{EmbedLiveSample("Clearing_the_drawing_buffer_when_scissoring_applies",660,425)}}</p>
 
 <p>This is a simple demonstration of a rendering with {{domxref("WebGLRenderingContext.scissor","scissor()")}}.</p>
 
@@ -31,7 +31,6 @@ tags:
 
 <p>The scissoring stage of the pipeline is disabled by default. We enable it here using the {{domxref("WebGLRenderingContext.enable","enable()")}} method (you will also use <code>enable()</code> to activate many other features of WebGL; hence, the use of the<code> SCISSOR_TEST</code> constant as an argument in this case). This again demonstrates the typical order of commands in {{Glossary("WebGL")}}. We first tweak WebGL state. In this case, enabling the scissor test and establishing a rectangular mask. Only when the WebGL state has been satisfactorily tweaked, we execute the drawing command (in this case, <code>clear()</code>) that starts the processing of fragments down the graphics pipeline.</p>
 
-<div id="basic-scissoring-source">
 <pre class="brush: html">&lt;p&gt;Result of scissoring.&lt;/p&gt;
 &lt;canvas&gt;Your browser does not seem to support
     HTML5 canvas.&lt;/canvas&gt;
@@ -51,7 +50,7 @@ canvas {
 }
 </pre>
 
-<pre class="brush: js" id="livesample-js">window.addEventListener("load", function setupWebGL (evt) {
+<pre class="brush: js">window.addEventListener("load", function setupWebGL (evt) {
   "use strict"
   window.removeEventListener(evt.type, setupWebGL, false);
   var paragraph = document.querySelector("p");
@@ -85,6 +84,5 @@ canvas {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/basic-scissoring">GitHub</a>.</p>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Color_masking","Learn/WebGL/By_example/Canvas_size_and_WebGL")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
@@ -12,9 +12,7 @@ tags:
 
 <p>This example describes repeated pieces of code that will be hidden from now on, as well as defining a JavaScript utility function to make WebGL initialization easier.</p>
 
-<p>{{EmbedLiveSample("Boilerplate_code_for_setting_up_WebGL_rendering_context",660,400)}}</p>
-
-<h2 id="Boilerplate_code_for_setting_up_WebGL_rendering_context">Boilerplate code for setting up WebGL rendering context</h3>
+<h2 id="Boilerplate_code_for_setting_up_WebGL_rendering_context">Boilerplate code for setting up WebGL rendering context</h2>
 
 <p>By now you are quite used to seeing the same pieces of {{Glossary("HTML")}}, {{Glossary("CSS")}}, and {{Glossary("JavaScript")}} repeated again and again. So we are going to hide them from now on. This would allow us to focus on the interesting pieces of code that are most relevant for learning {{Glossary("WebGL")}}.</p>
 

--- a/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
@@ -12,11 +12,9 @@ tags:
 
 <p>This WebGL example explores the effect of setting (or not setting) the canvas size to its element size in {{Glossary("CSS")}} pixels, as it appears in the browser window.</p>
 
-<div id="canvas-size-and-webgl">
-<p>{{EmbedLiveSample("canvas-size-and-webgl-source",660,180)}}</p>
+<h2 id="Effect_of_canvas_size_on_rendering_with_WebGL">Effect of canvas size on rendering with WebGL</h2>
 
-<div id="canvas-size-and-webgl-intro">
-<h3 id="Effect_of_canvas_size_on_rendering_with_WebGL">Effect of canvas size on rendering with WebGL</h3>
+<p>{{EmbedLiveSample("Effect_of_canvas_size_on_rendering_with_WebGL",660,180)}}</p>
 
 <p>With {{domxref("WebGLRenderingContext.scissor()","scissor()")}} and {{domxref("WebGLRenderingContext.clear()","clear()")}} we can demonstrate how the WebGL drawing buffer is affected by the size of the canvas.</p>
 
@@ -25,9 +23,7 @@ tags:
 <p>In contrast, no such assignment is done for the second canvas. The internal {{domxref("HTMLCanvasElement.width","width")}} and {{domxref("HTMLCanvasElement.height","height")}} properties of the canvas remain at default values, which are different than the actual size of the canvas {{domxref("Element")}} in the browser window.</p>
 
 <p>The effect is clearly visible when using {{domxref("WebGLRenderingContext.scissor()","scissor()")}} and {{domxref("WebGLRenderingContext.clear()","clear()")}} to draw a square in the center of the canvas, by specifying its position and size in pixels. In the first canvas, we get the desired result. In the second, the square has the wrong shape, size, and position.</p>
-</div>
 
-<div id="canvas-size-and-webgl-source">
 <pre class="brush: html">&lt;p&gt;Compare the two canvases.&lt;/p&gt;
 &lt;canvas&gt;Your browser does not seem to support
     HTML5 canvas.&lt;/canvas&gt;
@@ -75,7 +71,5 @@ canvas {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/canvas-size-and-webgl">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Basic_scissoring","Learn/WebGL/By_example/Boilerplate_1")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
@@ -11,20 +11,16 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_with_colors","Learn/WebGL/By_example/Simple_color_animation")}}</p>
 
-<div id="clearing-by-clicking">
 <p>This example demonstrates how to combine user interaction with WebGL graphics operations by clearing the rendering context with a random color when the user clicks.</p>
 
-<p>{{EmbedLiveSample("clearing-by-clicking-source",660,425)}}</p>
+<h2 id="Clearing_the_rendering_context_with_random_colors">Clearing the rendering context with random colors</h2>
 
-<div id="clearing-by-clicking-intro">
-<h3 id="Clearing_the_rendering_context_with_random_colors">Clearing the rendering context with random colors</h3>
+<p>{{EmbedLiveSample("Clearing_the_rendering_context_with_random_colors",660,425)}}</p>
 
 <p>This example provides a simple illustration of how to combine {{Glossary("WebGL")}} and user interaction. Every time the user clicks the canvas or the button, the canvas is cleared with a new randomly chosen color.</p>
 
 <p>Note how we embed the {{Glossary("WebGL")}} function calls inside the event handler function.</p>
-</div>
 
-<div id="clearing-by-clicking-source">
 <pre class="brush: html">&lt;p&gt;A very simple WebGL program that still shows some color and
     user interaction.&lt;/p&gt;
 &lt;p&gt;You can repeatedly click the empty canvas or the button below
@@ -106,7 +102,5 @@ button {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/clearing-by-clicking">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_with_colors","Learn/WebGL/By_example/Simple_color_animation")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
@@ -11,13 +11,11 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Detect_WebGL","Learn/WebGL/By_example/Clearing_by_clicking")}}</p>
 
-<div id="clearing-with-colors">
 <p>An example showing how to clear a WebGL rendering context to a solid color.</p>
 
-<p>{{EmbedLiveSample("clearing-with-colors-source",660,425)}}</p>
+<h2 id="Clearing_the_WebGL_context_with_a_solid_color">Clearing the WebGL context with a solid color</h2>
 
-<div id="clearing-with-colors-intro">
-<h3 id="Clearing_the_WebGL_context_with_a_solid_color">Clearing the WebGL context with a solid color</h3>
+<p>{{EmbedLiveSample("Clearing_the_WebGL_context_with_a_solid_color",660,425)}}</p>
 
 <p>The simplest graphical {{Glossary("WebGL")}} program. Set up the {{domxref("WebGLRenderingContext","rendering context", "", 1)}} and then just clear it solid green. Note that {{Glossary("CSS")}} sets the background color of the canvas to black, so when the canvas turns green we know that {{Glossary("WebGL")}}'s magic has worked.</p>
 
@@ -26,9 +24,7 @@ tags:
 <p>There are many "dials" and "switches" that affect drawing with {{Glossary("WebGL")}}. The clear color is just the first of many you will get to know. This is why {{Glossary("WebGL")}}/{{Glossary("OpenGL")}} is often called a <em>state machine</em>. By tweaking those "dials" and "switches" you can modify the internal state of the WebGL machine, which in turn changes how input (in this case, a clear command) translates into output (in this case, all pixels are set to green).</p>
 
 <p>Finally, we note that color in WebGL is usually in {{Glossary("RGBA")}} format, that is four numerical components for red, green, blue and alpha (opacity). Therefore, <code>clearColor()</code> takes four arguments.</p>
-</div>
 
-<div id="clearing-with-colors-source">
 <pre class="brush: html">&lt;p&gt;A very simple WebGL program that shows some color.&lt;/p&gt;
 &lt;!-- Text within a canvas element is displayed
     only if canvas is not supported. --&gt;
@@ -92,7 +88,5 @@ window.addEventListener("load", function setupWebGL (evt) {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/clearing-with-colors">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Detect_WebGL","Learn/WebGL/By_example/Clearing_by_clicking")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
@@ -11,13 +11,11 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Simple_color_animation","Learn/WebGL/By_example/Basic_scissoring")}}</p>
 
-<div id="color-masking">
 <p>This WebGL example modifies random colors by applying color masking to limit the range of displayed colors to specific shades.</p>
 
-<p>{{EmbedLiveSample("color-masking-source",660,425)}}</p>
+<h2 id="Masking_random_colors">Masking random colors</h2>
 
-<div id="color-masking-intro">
-<h3 id="Masking_random_colors">Masking random colors</h3>
+<p>{{EmbedLiveSample("Masking_random_colors",660,425)}}</p>
 
 <p>This example modifies the random color animation by applying color masking with {{domxref("WebGLRenderingContext.colorMask()","colorMask()")}}. You can think of the color masking operation as if looking at the colored canvas through some tinted glass or color filter. So, by masking off the blue and green channels, you are only allowing the red component of pixels to be updated, and therefore it is as if you were looking through a red tinted glass.</p>
 
@@ -28,9 +26,7 @@ tags:
 <p>Color masking gives you fine control of updating pixel values on the screen. By limiting the color channels that are written by each drawing command, you can use each channel, for example, to store a different grayscale image. Alternatively, you may use the {{Glossary("RGB")}} components for color, but the alpha component for some custom pixel data of your invention.</p>
 
 <p>Finally, color masking teaches us that {{Glossary("WebGL")}} is not only a state machine, it is also a <em>graphics pipeline</em>. This means that graphics operations in WebGL are done in a certain order, where the output of each operation serves as the input of the next. So, for example, clearing operation sets the value of each pixel to the chosen clear color. Masking occurs later in the pipeline, and modifies the pixel color value, so the final result on the screen is that of the clear color, tinted by the color mask.</p>
-</div>
 
-<div id="color-masking-source">
 <pre class="brush: html">&lt;p&gt;Tinting the displayed colors with color masking.&lt;/p&gt;
 &lt;canvas&gt;Your browser does not seem to support
     HTML5 canvas.&lt;/canvas&gt;
@@ -71,7 +67,7 @@ button {
 }
 </pre>
 
-<pre class="brush: js" id="livesample-js">window.addEventListener("load", function setupAnimation (evt) {
+<pre class="brush: js">window.addEventListener("load", function setupAnimation (evt) {
   "use strict"
   window.removeEventListener(evt.type, setupAnimation, false);
 
@@ -123,7 +119,5 @@ button {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/color-masking">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Simple_color_animation","Learn/WebGL/By_example/Basic_scissoring")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
@@ -11,20 +11,16 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example","Learn/WebGL/By_example/Clearing_with_colors")}}</p>
 
-<div id="detect-webgl">
 <p>This example demonstrates how to detect a {{Glossary("WebGL")}} rendering context and reports the result to the user.</p>
 
-<p>{{EmbedLiveSample("detect-webgl-source",660,150)}}</p>
+<h2 id="Feature-detecting_WebGL">Feature-detecting WebGL</h2>
 
-<div id="detect-webgl-intro">
-<h3 id="Feature-detecting_WebGL">Feature-detecting WebGL</h3>
+<p>{{EmbedLiveSample("Feature-detecting_WebGL",660,150)}}</p>
 
 <p>In this first example we are going to check whether the browser supports {{Glossary("WebGL")}}. To that end we will try to obtain the {{domxref("WebGLRenderingContext","WebGL rendering context","",1)}} from a {{domxref("HTMLCanvasElement","canvas")}} element. The {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}} is an interface, through which you can set and query the state of the graphics machine, send data to the WebGL, and execute draw commands.</p>
 
 <p>Saving the state of the graphics machine within a single context interface is not unique to {{Glossary("WebGL")}}. This is also done in other graphics {{Glossary("API")}}, such as the {{domxref("CanvasRenderingContext2D","canvas 2D rendering context", "", 1)}}. However, the properties and variables you can tweak are different for each {{Glossary("API")}}.</p>
-</div>
 
-<div id="detect-webgl-source">
 <pre class="brush: html">&lt;p&gt;[ Here would go the result of WebGL feature detection ]&lt;/p&gt;
 &lt;button&gt;Press here to detect WebGLRenderingContext&lt;/button&gt;
 </pre>
@@ -68,7 +64,5 @@ window.addEventListener("load", function() {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/detect-webgl">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example","Learn/WebGL/By_example/Clearing_with_colors")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
@@ -13,22 +13,18 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Raining_rectangles","Learn/WebGL/By_example/Hello_vertex_attributes")}}</p>
 
-<div id="hello-glsl">
-<p id="hello-glsl-summary">This WebGL example demonstrates a very basic GLSL shader program that draws a solid color square.</p>
+<p>This WebGL example demonstrates a very basic GLSL shader program that draws a solid color square.</p>
 
 <div class="note">
 <p><strong>Note:</strong> This example will most likely work in all modern desktop browsers. But it may not work in some mobile or older browsers. If the canvas remains blank, you can check the output of the next example, which draws exactly the same thing. But remember to read through the explanations and code on this page, before moving on to the next.</p>
 </div>
 
-<p>{{EmbedLiveSample("hello-glsl-source",660,425)}}</p>
+<h2 id="Hello_World_program_in_GLSL">Hello World program in GLSL</h2>
 
-<div id="hello-glsl-intro">
-<h3 id="Hello_World_program_in_GLSL">Hello World program in GLSL</h3>
+<p>{{EmbedLiveSample("Hello_World_program_in_GLSL",660,425)}}</p>
 
 <p>A very simple first shader program.</p>
-</div>
 
-<div id="hello-glsl-source">
 <pre class="brush: html hidden">&lt;p&gt;Hello World! Hello GLSL!&lt;/p&gt;
 </pre>
 
@@ -54,7 +50,6 @@ button {
   padding : 0.6em;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;script type="x-shader/x-vertex" id="vertex-shader"&gt;
 #version 100
@@ -76,7 +71,7 @@ void main() {
 <pre class="brush: js hidden">;(function(){
 </pre>
 
-<pre class="brush: js" id="livesample-js">"use strict"
+<pre class="brush: js">"use strict"
 window.addEventListener("load", setupWebGL, false);
 var gl,
   program;
@@ -159,7 +154,5 @@ if (program)
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/hello-glsl">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Raining_rectangles","Learn/WebGL/By_example/Hello_vertex_attributes")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
@@ -11,18 +11,14 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_GLSL","Learn/WebGL/By_example/Textures_from_code")}}</p>
 
-<div id="hello-vertex-attributes">
-<p id="hello-vertex-attributes-summary">This WebGL example demonstrates how to combine shader programming and user interaction by sending user input to the shader using vertex attributes.</p>
+<p>This WebGL example demonstrates how to combine shader programming and user interaction by sending user input to the shader using vertex attributes.</p>
 
-<p>{{EmbedLiveSample("hello-vertex-attributes-source",660,425)}}</p>
+<h2 id="Hello_World_program_in_GLSL">Hello World program in GLSL</h2>
 
-<div id="hello-vertex-attributes-intro">
-<h3 id="Hello_World_program_in_GLSL">Hello World program in GLSL</h3>
+<p>{{EmbedLiveSample("Hello_World_program_in_GLSL",660,425)}}</p>
 
 <p>How to send input to a shader program by saving data in GPU memory.</p>
-</div>
 
-<div id="hello-vertex-attributes-source">
 <pre class="brush: html hidden">&lt;p&gt;First encounter with attributes and sending data to GPU. Click
 on the canvas to change the horizontal position of the square.&lt;/p&gt;
 </pre>
@@ -75,7 +71,7 @@ void main() {
 <pre class="brush: js hidden">;(function(){
 </pre>
 
-<pre class="brush: js" id="livesample-js">"use strict"
+<pre class="brush: js">"use strict"
 window.addEventListener("load", setupWebGL, false);
 var gl,
   program;
@@ -169,7 +165,5 @@ function cleanup() {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/hello-vertex-attributes">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_GLSL","Learn/WebGL/By_example/Textures_from_code")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/index.html
@@ -14,7 +14,6 @@ tags:
 
 <p>The examples are sorted according to topic and level of difficulty, covering the WebGL rendering context, shader programming, textures, geometry, user interaction, and more.</p>
 
-
 <h2 id="Examples_by_topic">Examples by topic</h2>
 
 <p>The examples are sorted in order of increasing difficulty. But rather than just presenting them in a single long list, they are additionally divided into topics. Sometimes we revisit a topic several times, such as when needing to discuss it initially at a basic level, and later at intermediate and advanced levels.</p>

--- a/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
@@ -13,22 +13,18 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Scissor_animation","Learn/WebGL/By_example/Hello_GLSL")}}</p>
 
-<div id="raining-rectangles">
 <p>A simple WebGL game that demonstrates clearing with solid colors, scissoring, animation, and user interaction.</p>
 
-<p>{{EmbedLiveSample("raining-rectangles-source",660,425)}}</p>
+<h2 id="Animation_and_user_interaction_with_scissoring">Animation and user interaction with scissoring</h2>
 
-<div>
-<h3 id="Animation_and_user_interaction_with_scissoring">Animation and user interaction with scissoring</h3>
+<p>{{EmbedLiveSample("Animation_and_user_interaction_with_scissoring",660,425)}}</p>
 
 <p>This is a simple game. The objective: try to catch as many of the raining rectangles as you can by clicking on them. In this example, we use an object-oriented approach for the displayed rectangles, which helps to keep the state of the rectangle (its position, color, and so on) organized in one place, and the overall code more compact and reusable.</p>
 
 <p>This example combines clearing the drawing buffer with solid colors and scissoring operations. It is a preview of a full graphical application that manipulates various phases of the {{Glossary("WebGL")}} graphics pipeline and state machine.</p>
 
 <p>In addition, the example demonstrates how to integrate the WebGL function calls within a game loop. The game loop is responsible for drawing the animation frames, and keeping the animation responsive to user input. Here, the game loop is implemented using timeouts.</p>
-</div>
 
-<div id="raining-rectangles-source">
 <pre class="brush: html hidden">&lt;p&gt;You caught
 &lt;strong&gt;0&lt;/strong&gt;.
   You missed
@@ -62,7 +58,7 @@ button {
 <pre class="brush: js hidden">;(function(){
 </pre>
 
-<pre class="brush: js" id="livesample-js">"use strict"
+<pre class="brush: js">"use strict"
 window.addEventListener("load", setupAnimation, false);
 var gl,
   timer,
@@ -173,7 +169,5 @@ function Rectangle () {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/raining-rectangles">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Scissor_animation","Learn/WebGL/By_example/Hello_GLSL")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
@@ -13,18 +13,16 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Boilerplate_1","Learn/WebGL/By_example/Raining_rectangles")}}</p>
 
-<div id="scissor-animation">
 <p>A simple WebGL example in which we have some animation fun using scissoring and clearing operations.</p>
 
-<p>{{EmbedLiveSample("scissor-animation-source",660,425)}}</p>
+<h2 id="Animation_with_scissoring">Animation with scissoring</h2>
 
-<h3 id="Animation_with_scissoring">Animation with scissoring</h3>
+<p>{{EmbedLiveSample("Animation_with_scissoring",660,425)}}</p>
 
 <p>In this example, we are animating squares using {{domxref("WebGLRenderingContext.scissor()","scissor()")}} and {{domxref("WebGLRenderingContext.clear()","clear()")}}. We again establish an animation loop using timers. Note that this time it is the position of the square (the scissoring area) that is updated every frame (we set frame rate to roughly one every 17ms, or roughly 60fps – frames per second).</p>
 
 <p>In contrast, the color of the square (set with {{domxref("WebGLRenderingContext.clearColor()","clearColor")}}) is only updated when a new square is created. This is a nice demonstration of {{Glossary("WebGL")}} as a state machine. For each square, we set its color once, and then update only its position every frame. The clear color state of WebGL remains at the set value, until we change it again when a new square is created.</p>
 
-<div id="scissor-animation-source">
 <pre class="brush: html hidden">&lt;p&gt;WebGL animation by clearing the drawing buffer with solid
 color and applying scissor test.&lt;/p&gt;
 &lt;button id="animation-onoff"&gt;
@@ -60,7 +58,7 @@ button {
 <pre class="brush: js hidden">;(function(){
 </pre>
 
-<pre class="brush: js" id="livesample-js">"use strict"
+<pre class="brush: js">"use strict"
 window.addEventListener("load", setupAnimation, false);
 // Variables to hold the WebGL context, and the color and
 // position of animated squares.
@@ -154,7 +152,5 @@ function getRandomColor() {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/scissor-animation">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Boilerplate_1","Learn/WebGL/By_example/Raining_rectangles")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
@@ -11,20 +11,16 @@ tags:
 ---
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_by_clicking","Learn/WebGL/By_example/Color_masking")}}</p>
 
-<div id="simple-color-animation">
 <p>A very basic color animation created using {{Glossary("WebGL")}}, performed by clearing the drawing buffer with a different random color every second.</p>
 
-<p>{{EmbedLiveSample("simple-color-animation-source",660,425)}}</p>
+<h2 id="Color_animation_with_clear">Color animation with clear</h2>
 
-<div id="simple-color-animation-intro">
-<h3 id="Color_animation_with_clear">Color animation with clear</h3>
+<p>{{EmbedLiveSample("Color_animation_with_clear",660,425)}}</p>
 
 <p>This example provides a simple illustration of color animation with {{Glossary("WebGL")}}, as well as user interaction. The user can start, stop and restart the animation by clicking the button.</p>
 
 <p>This time we put the {{Glossary("WebGL")}} function calls within a timer event handler. A click event handler additionally enables the basic user interaction of starting and stopping the animation. The timer and the timer handler function establish the animation loop, a set of drawing commands that are executed at a regular period (typically, every frame; in this case, once per second).</p>
-</div>
 
-<div id="simple-color-animation-source">
 <pre class="brush: html">&lt;p&gt;A simple WebGL program that shows color animation.&lt;/p&gt;
 &lt;p&gt;You can click the button below to toggle the
     color animation on or off.&lt;/p&gt;
@@ -57,7 +53,7 @@ button {
 }
 </pre>
 
-<pre class="brush: js" id="livesample-js">window.addEventListener("load", function setupAnimation (evt) {
+<pre class="brush: js">window.addEventListener("load", function setupAnimation (evt) {
   "use strict"
   window.removeEventListener(evt.type, setupAnimation, false);
 
@@ -121,7 +117,5 @@ button {
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/simple-color-animation">GitHub</a>.</p>
-</div>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_by_clicking","Learn/WebGL/By_example/Color_masking")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.html
@@ -17,13 +17,12 @@ tags:
 
 <p>This WebGL example provides a simple demonstration of procedural texturing with fragment shaders. That is, using code to generate textures for use in shading WebGL objects.</p>
 
-<p>{{EmbedLiveSample("textures-from-code-source",660,425)}}</p>
+<h2 id="Drawing_textures_with_code">Drawing textures with code</h2>
 
-<h3 id="Drawing_textures_with_code">Drawing textures with code</h3>
+<p>{{EmbedLiveSample("Drawing_textures_with_code",660,425)}}</p>
 
 <p>Texturing a point sprite with calculations done per-pixel in the fragment shader.</p>
 
-<div id="textures-from-code-source">
 <pre class="brush: html hidden">&lt;p&gt;Texture from code. Simple demonstration
     of procedural texturing&lt;/p&gt;
 </pre>
@@ -82,7 +81,7 @@ void main() {
 <pre class="brush: js hidden">;(function(){
 </pre>
 
-<pre class="brush: js" id="livesample-js">"use strict"
+<pre class="brush: js">"use strict"
 window.addEventListener("load", setupWebGL, false);
 var gl,
   program;
@@ -163,6 +162,5 @@ if (program)
 </pre>
 
 <p>The source code of this example is also available on <a href="https://github.com/idofilin/webgl-by-example/tree/master/textures-from-code">GitHub</a>.</p>
-</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_vertex_attributes","Learn/WebGL/By_example/Video_textures")}}</p>

--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
@@ -14,14 +14,10 @@ tags:
 
 <p>{{Previous("Learn/WebGL/By_example/Textures_from_code")}}</p>
 
-<div id="video-textures">
-<p id="video-textures-summary">This example demonstrates how to use video files as textures for WebGL surfaces.</p>
+<p>This example demonstrates how to use video files as textures for WebGL surfaces.</p>
 
-<div id="video-textures-intro">
-<h3 id="Textures_from_video">Textures from video</h3>
+<h2 id="Textures_from_video">Textures from video</h2>
 
 <p>{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}</p>
-</div>
-</div>
 
 <p>{{Previous("Learn/WebGL/By_example/Textures_from_code")}}</p>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/7899.

Fixes to the pages under https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example .

I'm using the H3 instead of the DIV here, but also correcting it to an H2 and moving it after the intro para and back/next buttons, which I think looks better.

I complain a lot about MDN, so: this seems like a really nice series of examples!

