### PR TITLE
Change “AJAX” link to Guide page rather than Glossary page

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -17,7 +17,7 @@ browser-compat: api.XMLHttpRequest
 
 <p><code>XMLHttpRequest</code> (XHR) objects are used to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing.</p>
 
-<p><code>XMLHttpRequest</code> is used heavily in <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX">AJAX</a> programming.</p>
+<p><code>XMLHttpRequest</code> is used heavily in <a href="/en-US/docs/Web/Guide/AJAX">AJAX</a> programming.</p>
 
 <p>{{InheritanceDiagram(650, 70)}}</p>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -17,7 +17,7 @@ browser-compat: api.XMLHttpRequest
 
 <p><code>XMLHttpRequest</code> (XHR) objects are used to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing.</p>
 
-<p><code>XMLHttpRequest</code> is used heavily in {{Glossary("AJAX")}} programming.</p>
+<p><code>XMLHttpRequest</code> is used heavily in <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX">AJAX</a> programming.</p>
 
 <p>{{InheritanceDiagram(650, 70)}}</p>
 


### PR DESCRIPTION
A link was redirecting to a non-existent page of AJAX which needs to redirect to correct AJAX page.