### PR TITLE
Fix typo in a code comment

### DIFF
--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.md
@@ -66,7 +66,7 @@ precedence and associativity](/en-US/docs/Web/JavaScript/Reference/Operators/Ope
 ```js
 var a, b, c;
 
-a = b = 3, c = 4; // Returns 4 in console
+a = b = 3, c = 4; // Returns 3 in console
 console.log(a); // 3 (left-most)
 
 var x, y, z;


### PR DESCRIPTION
Fix typo in a code comment
The console result is 3 not 4 as is stated in the first comment.