### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -144,7 +144,7 @@ function doSomething(onContent, onError) {
 ### Optional chaining with expressions
 
 You can also use the optional chaining operator when accessing properties with an expression using 
-[the bracket notation of the property accessor](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors#bracket_notation):
+[the bracket notation of the property accessor](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation):
 
 ```js
 let nestedProp = obj?.['prop' + 'Name'];


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
Property accessors link is broken in the optional chaining doc. Just a case mismatch


> Anything else that could help us review it
Thanks, you are the best and also the greatest.