### PR TITLE
Drop/replace outdated links in “Firefox” page

### DIFF
--- a/files/en-us/mozilla/firefox/index.html
+++ b/files/en-us/mozilla/firefox/index.html
@@ -33,15 +33,13 @@ tags:
 
 <h3 id="Firefox_Nightly">Firefox Nightly</h3>
 
-<p>Each night we build Firefox from the latest code in <a href="/en-US/docs/Mozilla/Developer_guide/mozilla-central">mozilla-central</a>. These builds are for Firefox developers or those who want to try out the very latest cutting edge features while they're still under active development.</p>
+<p>Each night we build Firefox from the latest code in <a href="https://hg.mozilla.org/mozilla-central/">mozilla-central</a>. These builds are for Firefox developers or those who want to try out the very latest cutting edge features while they're still under active development.</p>
 
 <p><a href="https://nightly.mozilla.org/">Download Firefox Nightly</a></p>
 
 <h3 id="Firefox_Developer_Edition">Firefox Developer Edition</h3>
 
 <p>This is a version of Firefox tailored for developers. Firefox Developer Edition has all the latest developer tools that have reached beta. We also add some extra features for developers that are only available in this channel. It uses its own path and profile, so that you can run it alongside Release or Beta Firefox.</p>
-
-<p><a href="/en-US/docs/Mozilla/Firefox/Developer_Edition">Learn more about Firefox Developer Edition</a>.</p>
 
 <p><a href="https://www.mozilla.org/firefox/developer/">Download Firefox Developer Edition</a></p>
 
@@ -61,17 +59,11 @@ tags:
 
 <p>Firefox ESR is the long-term support edition of Firefox for desktop for use by organizations including schools, universities, businesses and others who need extended support for mass deployments.</p>
 
-<p><a href="/en-US/docs/Mozilla/Firefox/Firefox_ESR">Learn more about Firefox Extended Support Release</a>.</p>
-
 <p><a href="https://www.mozilla.org/firefox/organizations/all/">Download Firefox ESR</a></p>
 
 <h2 id="Contents">Contents</h2>
 
 <p>{{LandingPageListSubpages}}</p>
-
-<h2 id="Firefox_profiles">Firefox profiles</h2>
-
-<p>If you find yourself using multiple Firefox channels—or just multiple configurations—on a regular basis, you should read how to <a href="/en-US/docs/Mozilla/Firefox/Multiple_profiles">use multiple Firefox profiles</a> by turning Firefox's Profile Manager and other profile management tools to your advantage.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
All the links dropped or replaced in this change are for source that moved to the archived-content repo and so that have now been deleted from the production site.

The only replacement is for “mozilla-central” — changed to a direct link to the Mercurial repo (rather than the intro page that had been in MDN). Fixes https://github.com/mdn/content/issues/8293