### PR TITLE
Fix misstatement about return value in Number.parseInt() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
@@ -42,7 +42,7 @@ Number.parseInt(string, radix)
 An integer parsed from the given `string`.
 
 If the `radix` is smaller than `2` or bigger than
-`36`, and the first non-whitespace character cannot be converted to a number,
+`36`, or the first non-whitespace character cannot be converted to a number,
 {{jsxref("NaN")}} is returned.
 
 ## Polyfill


### PR DESCRIPTION
Confirmed by https://tc39.es/ecma262/#sec-parseint-string-radix, step 8 and steps 10 to 13. Fixes https://github.com/mdn/content/issues/8294.