### PR TITLE
Adds GamepadButton.touched

### DIFF
--- a/files/en-us/web/api/gamepadbutton/index.html
+++ b/files/en-us/web/api/gamepadbutton/index.html
@@ -5,8 +5,6 @@ tags:
   - API
   - Gamepad API
   - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
   - Reference
 browser-compat: api.GamepadButton
 ---
@@ -16,54 +14,39 @@ browser-compat: api.GamepadButton
 
 <p>A <code>GamepadButton</code> object is returned by querying any value of the array returned by the <code>buttons</code> property of the {{domxref("Gamepad")}} interface.</p>
 
-<div class="note">
-<p><strong>Note:</strong> This is the case in Firefox Gecko 28 and later; Chrome and earlier Firefox versions still return an array of double values when this property is accessed.</p>
-</div>
-
 <h2 id="Properties">Properties</h2>
 
 <dl>
  <dt>{{domxref("GamepadButton.value")}} {{readonlyInline}}</dt>
  <dd>A double value used to represent the current state of analog buttons, such as the triggers on many modern gamepads. The values are normalized to the range 0.0 —1.0, with 0.0 representing a button that is not pressed, and 1.0 representing a button that is fully pressed.</dd>
+ <dt>{{domxref("GamepadButton.touched")}} {{readonlyInline}}</dt>
+ <dd>A boolean value indicating whether the button is currently touched (<code>true</code>) or not touched (<code>false</code>).</dd>
  <dt>{{domxref("GamepadButton.pressed")}} {{readonlyInline}}</dt>
  <dd>A boolean value indicating whether the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).</dd>
 </dl>
 
 <h2 id="Example">Example</h2>
 
-<p>The following code is taken from my Gamepad API button demo (you can <a href="https://chrisdavidmills.github.io/gamepad-buttons/">view the demo live</a>, and <a href="https://github.com/chrisdavidmills/gamepad-buttons/tree/master">find the source code</a> on Github.) Note the code fork — in Chrome {{domxref("Navigator.getGamepads")}} needs a <code>webkit</code> prefix and the button values are stored as an array of double values, whereas in Firefox {{domxref("Navigator.getGamepads")}} doesn't need a prefix, and the button values are stored as an array of {{domxref("GamepadButton")}} objects; it is the {{domxref("GamepadButton.value")}} or {{domxref("GamepadButton.pressed")}} properties of these we need to access, depending on what type of buttons they are. In this simple example I've just allowed either.</p>
+<p>The button values in the following example are stored as an array of {{domxref("GamepadButton")}} objects. This simple example checks to see if the {{domxref("GamepadButton.value")}} of a button is greater than <code>0</code>, or if the {{domxref("GamepadButton.pressed")}} property indicates the button has been pressed.</p>
 
 <pre class="brush: js">function gameLoop() {
-  if(navigator.webkitGetGamepads) {
-    var gp = navigator.webkitGetGamepads()[0];
 
-    if(gp.buttons[0] == 1) {
-      b--;
-    } else if(gp.buttons[1] == 1) {
-      a++;
-    } else if(gp.buttons[2] == 1) {
-      b++;
-    } else if(gp.buttons[3] == 1) {
-      a--;
-    }
-  } else {
-    var gp = navigator.getGamepads()[0];
+  let gp = navigator.getGamepads()[0];
 
-    if(gp.buttons[0].value &gt; 0 || gp.buttons[0].pressed == true) {
-      b--;
-    } else if(gp.buttons[1].value &gt; 0 || gp.buttons[1].pressed == true) {
-      a++;
-    } else if(gp.buttons[2].value &gt; 0 || gp.buttons[2].pressed == true) {
-      b++;
-    } else if(gp.buttons[3].value &gt; 0 || gp.buttons[3].pressed == true) {
-      a--;
-    }
+  if(gp.buttons[0].value &gt; 0 || gp.buttons[0].pressed == true) {
+    b--;
+  } else if(gp.buttons[1].value &gt; 0 || gp.buttons[1].pressed == true) {
+    a++;
+  } else if(gp.buttons[2].value &gt; 0 || gp.buttons[2].pressed == true) {
+    b++;
+  } else if(gp.buttons[3].value &gt; 0 || gp.buttons[3].pressed == true) {
+    a--;
   }
 
   ball.style.left = a*2 + "px";
   ball.style.top = b*2 + "px";
 
-  var start = rAF(gameLoop);
+  let start = rAF(gameLoop);
 };</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/gamepadbutton/pressed/index.html
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.html
@@ -5,8 +5,6 @@ tags:
   - API
   - Gamepad API
   - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
   - Property
   - Reference
 browser-compat: api.GamepadButton.pressed
@@ -18,13 +16,9 @@ browser-compat: api.GamepadButton.pressed
   the button is currently pressed (<code>true</code>) or unpressed (<code>false</code>).
 </p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre class="brush: js">var isPressed = navigator.getGamepads()[0].pressed;</pre>
-
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">var gp = navigator.getGamepads()[0]; // Get the first gamepad object
+<pre class="brush: js">let gp = navigator.getGamepads()[0]; // Get the first gamepad object
 
 if(gp.buttons[0].pressed == true) {
   // respond to button being pressed

--- a/files/en-us/web/api/gamepadbutton/touched/index.html
+++ b/files/en-us/web/api/gamepadbutton/touched/index.html
@@ -11,9 +11,9 @@ browser-compat: api.GamepadButton.touched
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
-<p>The <code><strong>GamepadButton.touched</strong></code> property of the
+<p>The <code><strong>touched</strong></code> property of the
   {{domxref("GamepadButton")}} interface returns a <code>boolean</code> indicating whether
-  a button capable of detecting touch is currently touched (<code>true</code>) or not being touched (<code>false</code>).
+  a button capable of detecting touch is currently touched (<code>true</code>) or not touched (<code>false</code>).
 </p>
 
 <p>If the button is not capable of detecting touch but can return an analog value, the property will be <code>true</code> if the value is greater than <code>0</code>, and <code>false</code> otherwise. If the button is not capable of detecting touch and can only report a digital value, then it should mirror the {{domxref("GamepadButton.pressed")}} property.</p>

--- a/files/en-us/web/api/gamepadbutton/touched/index.html
+++ b/files/en-us/web/api/gamepadbutton/touched/index.html
@@ -1,0 +1,46 @@
+---
+title: GamepadButton.touched
+slug: Web/API/GamepadButton/touched
+tags:
+  - API
+  - Gamepad API
+  - Games
+  - Property
+  - Reference
+browser-compat: api.GamepadButton.touched
+---
+<p>{{APIRef("Gamepad API")}}</p>
+
+<p>The <code><strong>GamepadButton.touched</strong></code> property of the
+  {{domxref("GamepadButton")}} interface returns a <code>boolean</code> indicating whether
+  a button capable of detecting touch is currently touched (<code>true</code>) or not being touched (<code>false</code>).
+</p>
+
+<p>If the button is not capable of detecting touch but can return an analog value, the property will be <code>true</code> if the value is greater than <code>0</code>, and <code>false</code> otherwise. If the button is not capable of detecting touch and can only report a digital value, then it should mirror the {{domxref("GamepadButton.pressed")}} property.</p>
+
+
+<h2 id="Value">Value</h2>
+
+<p>A {{jsxref("Boolean")}}. True if touched.</p>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush: js">let gp = navigator.getGamepads()[0]; // Get the first gamepad object
+
+if(gp.buttons[0].touched == true) {
+  // respond to button being touched
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API">Using the Gamepad API</a></li>
+</ul>

--- a/files/en-us/web/api/gamepadbutton/value/index.html
+++ b/files/en-us/web/api/gamepadbutton/value/index.html
@@ -5,8 +5,6 @@ tags:
   - API
   - Gamepad API
   - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
   - Property
   - Reference
 browser-compat: api.GamepadButton.value
@@ -21,13 +19,9 @@ browser-compat: api.GamepadButton.value
 	<code>0.0</code> representing a button that is not pressed, and 1.0 representing a
 	button that is fully pressed.</p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre class="brush: js">const value = gamepadButton.value;</pre>
-
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">var gp = navigator.getGamepads()[0];
+<pre class="brush: js">let gp = navigator.getGamepads()[0];
 
 if(gp.buttons[0].value &gt; 0) {
   // respond to analog button being pressed in
@@ -35,7 +29,7 @@ if(gp.buttons[0].value &gt; 0) {
 
 <h2 id="Value">Value</h2>
 
-<p>A {{domxref("double")}}.</p>
+<p>A double.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Adds the `touched` property of the `GamepadButton` interface. Also tidies up the pages according to how property pages look now and removes some old code and information about the `-webkit` prefixed version.

Reviewer @jpmedley 