### PR TITLE
Fixed broken link

### DIFF
--- a/files/en-us/web/api/webrtc_api/connectivity/index.html
+++ b/files/en-us/web/api/webrtc_api/connectivity/index.html
@@ -143,4 +143,4 @@ tags:
 
 <h2 id="The_entire_exchange_in_a_complicated_diagram">The entire exchange in a complicated diagram</h2>
 
-<p><a href="https://hacks.mozilla.org/wp-content/uploads/2013/07/webrtc-complete-diagram.png"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png"></a></p>
+<p><a href="https://web.archive.org/web/20140904054020/https://hacks.mozilla.org/wp-content/uploads/2013/07/webrtc-complete-diagram.png"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png"></a></p>

--- a/files/en-us/web/api/webrtc_api/connectivity/index.html
+++ b/files/en-us/web/api/webrtc_api/connectivity/index.html
@@ -143,4 +143,4 @@ tags:
 
 <h2 id="The_entire_exchange_in_a_complicated_diagram">The entire exchange in a complicated diagram</h2>
 
-<p><a href="https://web.archive.org/web/20140904054020/https://hacks.mozilla.org/wp-content/uploads/2013/07/webrtc-complete-diagram.png"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png"></a></p>
+<p><a href="https://hacks.mozilla.org/2013/07/webrtc-and-the-ocean-of-acronyms/"><img alt="A complete architectural diagram showing the whole WebRTC process." src="webrtc-complete-diagram.png"></a></p>


### PR DESCRIPTION
"Link rot" has claimed another victim.

The original link returns a 404 when opened. Replacing it with a Wayback Machine permalink to the last usable snapshot of the page.