### PR TITLE
Bug 1614919 browser.identity.launchWebAuthFlow() exposes redirect_url

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
@@ -37,9 +37,9 @@ browser-compat: webextensions.api.identity
 
 <p>You get the redirect URL by calling {{WebExtAPIRef("identity.getRedirectURL()")}}. This function derives a redirect URL from the add-on's ID.  To simplify testing, set your add-on's ID explicitly using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a></code> key (otherwise, each time you <a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/">temporarily install the add-on</a>, you get a different redirect URL).</p>
 
-<p>{{WebExtAPIRef("identity.getRedirectURL()")}} returns a URL at a fixed domain name and a subdomain derived from the add-on's ID. Some OAuth servers (such as Google) only accept domains with a verified ownership as the redirect URL. As the dummy domain cannot be controlled by extension developers, the default domain cannot always be used.
-Loopback addresses are an accepted alternative that do not require domain validation (based on <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-7.3">RFC 8252, section 7.3</a>). Starting from Firefox 86, the following format is also permitted as a value for the redirect URL (see {{bug(1635344)}} for more details):
-<code>http://127.0.0.1/mozoauth2/[subdomain of URL returned by identity.getRedirectURL()]</code></p>
+<p>{{WebExtAPIRef("identity.getRedirectURL()")}} returns a URL at a fixed domain name and a subdomain derived from the add-on's ID. Some OAuth servers (such as Google) only accept domains with a verified ownership as the redirect URL. As the dummy domain cannot be controlled by extension developers, the default domain cannot always be used.</p>
+
+<p>However, loopback addresses are an accepted alternative that do not require domain validation (based on <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-7.3">RFC 8252, section 7.3</a>). Starting from Firefox 86, a loopback address with the format <code>http://127.0.0.1/mozoauth2/[subdomain of URL returned by identity.getRedirectURL()]</code> is permitted as a value for the redirect URL.</p>
 
 <div class="notecard note">
 <p>Starting with Firefox 75, you must use the redirect URL returned by {{WebExtAPIRef("identity.getRedirectURL()")}}.  Earlier versions allowed you to supply any redirect url.</p>

--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -96,6 +96,9 @@ currencyNames.of('EUR'); // "Euro"</pre>
 <ul>
   <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">Host permissions</a> now grant access to privileged parts of the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs">tabs API</a> ({{bug(1679688)}}).</li>
   <li><code>focused: false</code> is now ignored when set as an option in a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create"><code>windows.create()</code></a> call ({{bug(1253129)}}).</li>
+  <li>{{WebExtAPIRef("identity.getRedirectURL")}} now supports a loopback address, see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/identity#getting_the_redirect_url">Getting the redirect URL</a> for details ({{bug(1614919)}}).
+ </li>
+
 </ul>
 
 <h2 id="Older_versions">Older versions</h2>


### PR DESCRIPTION
Added details of the loopback address's introduction to the release notes
Tidied up the API narrative to remove the link to the bug

Supports Dev-doc-needed for [Bug 1614919](https://bugzilla.mozilla.org/show_bug.cgi?id=1614919)