### PR TITLE
Remove 'highlight:[]' and 'highlight[]' classes

### DIFF
--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
@@ -54,7 +54,7 @@ analyser.getFloatFrequencyData(myDataArray);
 
 <p>For more complete applied examples/information, check out our <a href="https://mdn.github.io/voice-change-o-matic-float-data/">Voice-change-O-matic-float-data</a> demo (see the <a href="https://github.com/mdn/voice-change-o-matic-float-data">source code</a> too).</p>
 
-<pre class="brush: html, highlight:[15, 17, 18, 41]">&lt;!doctype html&gt;
+<pre class="brush: html,">&lt;!doctype html&gt;
 &lt;body&gt;
 &lt;script&gt;
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audiobuffer/duration/index.html
+++ b/files/en-us/web/api/audiobuffer/duration/index.html
@@ -29,7 +29,7 @@ myArrayBuffer.duration;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[22]">// Stereo
+<pre class="brush: js;">// Stereo
 var channels = 2;
 
 // Create an empty two second stereo buffer at the

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.html
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.html
@@ -15,7 +15,7 @@ browser-compat: api.AudioBuffer.getChannelData
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js;highlight[22]">var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
+<pre class="brush: js;">var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
 var nowBuffering = myArrayBuffer.getChannelData(channel);</pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -33,7 +33,7 @@ var nowBuffering = myArrayBuffer.getChannelData(channel);</pre>
 
 <p>In the following example we create a two second buffer, fill it with white noise, and then play it via an {{ domxref("AudioBufferSourceNode") }}. The comments should clearly explain what is going on. You can also <a href="https://mdn.github.io/webaudio-examples/audio-buffer/">run the code live</a>, or <a href="https://github.com/mdn/webaudio-examples">view the source</a>.</p>
 
-<pre class="brush: js;highlight[21]">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+<pre class="brush: js;">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var button = document.querySelector('button');
 var pre = document.querySelector('pre');
 var myScript = document.querySelector('script');

--- a/files/en-us/web/api/audiobuffer/length/index.html
+++ b/files/en-us/web/api/audiobuffer/length/index.html
@@ -27,7 +27,7 @@ myArrayBuffer.length;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[22]">// Stereo
+<pre class="brush: js;">// Stereo
 var channels = 2;
 
 // Create an empty two second stereo buffer at the

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.html
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.html
@@ -29,7 +29,7 @@ myArrayBuffer.numberOfChannels;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[22]">// Stereo
+<pre class="brush: js;">// Stereo
 var channels = 2;
 
 // Create an empty two second stereo buffer at the

--- a/files/en-us/web/api/audiobuffer/samplerate/index.html
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.html
@@ -28,7 +28,7 @@ myArrayBuffer.sampleRate;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[22]">// Stereo
+<pre class="brush: js;">// Stereo
 var channels = 2;
 
 // Create an empty two second stereo buffer at the

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.html
@@ -40,7 +40,7 @@ browser-compat: api.AudioBufferSourceNode.detune
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[18]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 
 const channelCount = 2;
 const frameCount = audioCtx.sampleRate * 2.0; // 2 seconds

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.html
@@ -56,7 +56,7 @@ browser-compat: api.AudioBufferSourceNode.loop
       the source</a>.)</p>
 </div>
 
-<pre class="brush: js;highlight[17]">function getData() {
+<pre class="brush: js;">function getData() {
   source = audioCtx.createBufferSource();
   request = new XMLHttpRequest();
 

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
@@ -65,7 +65,7 @@ browser-compat: api.AudioBufferSourceNode.playbackRate
 &lt;span class="playback-rate-value"&gt;1.0&lt;/span&gt;
 </pre>
 
-<pre class="brush: js;highlight[15]">function getData() {
+<pre class="brush: js;">function getData() {
   source = audioCtx.createBufferSource();
   request = new XMLHttpRequest();
 

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.html
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.html
@@ -66,7 +66,7 @@ browser-compat: api.AudioContext.createMediaStreamSource
             the source</a>.</p>
 </div>
 
-<pre class="brush: js;highlight[23]">var pre = document.querySelector('pre');
+<pre class="brush: js;">var pre = document.querySelector('pre');
 var video = document.querySelector('video');
 var myScript = document.querySelector('script');
 var range = document.querySelector('input');

--- a/files/en-us/web/api/audionode/channelcount/index.html
+++ b/files/en-us/web/api/audionode/channelcount/index.html
@@ -33,7 +33,7 @@ var channels = oscillator.channelCount;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[11]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.html
+++ b/files/en-us/web/api/audionode/channelcountmode/index.html
@@ -49,7 +49,7 @@ browser-compat: api.AudioNode.channelCountMode
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js;highlight[11]">var oscillator = audioCtx.createOscillator();
+<pre class="brush: js;">var oscillator = audioCtx.createOscillator();
 oscillator.channelCountMode = 'explicit';</pre>
 
 <h3 id="Value">Value</h3>
@@ -58,7 +58,7 @@ oscillator.channelCountMode = 'explicit';</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[11]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audionode/connect/index.html
+++ b/files/en-us/web/api/audionode/connect/index.html
@@ -113,7 +113,7 @@ gainNode.connect(audioCtx.destination);
   an {{domxref("OscillatorNode")}} with a slow frequency value. This technique is know as
   an <em>LFO</em>-controlled parameter.</p>
 
-<pre class="brush: js;highlight[8,9]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audionode/context/index.html
+++ b/files/en-us/web/api/audionode/context/index.html
@@ -29,7 +29,7 @@ browser-compat: api.AudioNode.context
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[8,9]">const AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/audionode/numberofinputs/index.html
+++ b/files/en-us/web/api/audionode/numberofinputs/index.html
@@ -28,7 +28,7 @@ browser-compat: api.AudioNode.numberOfInputs
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[8,9,10]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 
 const oscillator = audioCtx.createOscillator();
 const gainNode = audioCtx.createGain();

--- a/files/en-us/web/api/audionode/numberofoutputs/index.html
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.html
@@ -28,7 +28,7 @@ browser-compat: api.AudioNode.numberOfOutputs
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[8,9,10]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 
 const oscillator = audioCtx.createOscillator();
 const gainNode = audioCtx.createGain();

--- a/files/en-us/web/api/audioparam/defaultvalue/index.html
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.html
@@ -28,7 +28,7 @@ browser-compat: api.AudioParam.defaultValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[3]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 const gainNode = audioCtx.createGain();
 const defaultVal = gainNode.gain.defaultValue;
 console.log(defaultVal); // 1

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.html
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.html
@@ -58,7 +58,7 @@ browser-compat: api.AudioParam.exponentialRampToValueAtTime
   is used to fade the gain value up to 1.0, and down to 0, respectively. This is pretty
   useful for fade in/fade out effects:</p>
 
-<pre class="brush: js;highlight[32,37]">// create audio context
+<pre class="brush: js;">// create audio context
 var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audioparam/maxvalue/index.html
+++ b/files/en-us/web/api/audioparam/maxvalue/index.html
@@ -32,7 +32,7 @@ browser-compat: api.AudioParam.maxValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[4]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 const gainNode = audioCtx.createGain();
 console.log(gainNode.gain.maxValue); // 3.4028234663852886e38</pre>
 

--- a/files/en-us/web/api/audioparam/minvalue/index.html
+++ b/files/en-us/web/api/audioparam/minvalue/index.html
@@ -32,7 +32,7 @@ browser-compat: api.AudioParam.minValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[3]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 const gainNode = audioCtx.createGain();
 console.log(gainNode.gain.minValue); // -3.4028234663852886e38
 </pre>

--- a/files/en-us/web/api/audioparam/settargetattime/index.html
+++ b/files/en-us/web/api/audioparam/settargetattime/index.html
@@ -162,7 +162,7 @@ browser-compat: api.AudioParam.setTargetAtTime
   after 1 second, and the length of time the effect lasts being controlled by the
   timeConstant.</p>
 
-<pre class="brush: js;highlight[32,37]">// create audio context
+<pre class="brush: js;">// create audio context
 var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audioparam/setvalueattime/index.html
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.html
@@ -51,7 +51,7 @@ browser-compat: api.AudioParam.setValueAtTime
   to set the gain value equal to <code>currGain</code>, one second from now
   (<code>audioCtx.currentTime + 1</code>.)</p>
 
-<pre class="brush: js;highlight[32,37]">// create audio context
+<pre class="brush: js;">// create audio context
 var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.html
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.html
@@ -89,7 +89,7 @@ browser-compat: api.AudioParam.setValueCurveAtTime
     live</a>.) When this button is pressed, <code>setValueCurveAtTime()</code> is used to
   change the gain value between the values contained in the waveArray array:</p>
 
-<pre class="brush: js;highlight[42]">// create audio context
+<pre class="brush: js;">// create audio context
 var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 

--- a/files/en-us/web/api/audioparam/value/index.html
+++ b/files/en-us/web/api/audioparam/value/index.html
@@ -107,7 +107,7 @@ console.log(source.playbackRate.value === rate);</pre>
 
 <p>This example instantly changes the volume of a {{domxref("GainNode")}} to 40%.</p>
 
-<pre class="brush: js;highlight[3]">const audioCtx = new AudioContext();
+<pre class="brush: js;">const audioCtx = new AudioContext();
 const gainNode = audioCtx.createGain();
 gainNode.gain.value = 0.4;
 //which is identical to:

--- a/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
@@ -48,7 +48,7 @@ browser-compat: api.AudioScheduledSourceNode.onended
 
 <p>The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For an applied example, check out our <a href="https://mdn.github.io/violent-theremin/">Violent Theremin demo</a> (<a href="https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js">see app.js</a> for relevant code).</p>
 
-<pre class="brush: js;highlight[13,14,15]">// create web audio api context
+<pre class="brush: js;">// create web audio api context
   var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
   // create Oscillator node

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -116,7 +116,7 @@ var buffer = audioCtx.createBuffer(1, 22050, 22050);</pre>
     href="https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html">view
     the source</a>.</p>
 
-<pre class="brush: js;highlight[14]">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+<pre class="brush: js;">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 // Create an empty three-second stereo buffer at the sample rate of the AudioContext
 var myArrayBuffer = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -52,7 +52,7 @@ browser-compat: api.BaseAudioContext.createBufferSource
       the source</a>.</p>
 </div>
 
-<pre class="brush: js highlight[31]">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+<pre class="brush: js">var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var button = document.querySelector('button');
 var pre = document.querySelector('pre');
 var myScript = document.querySelector('script');

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -46,7 +46,7 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
   method, which allow you to specify the index of the channel to connect from and the
   index of the channel to connect to.</p>
 
-<pre class="brush: js;highlight[5,12,17]">var ac = new AudioContext();
+<pre class="brush: js;">var ac = new AudioContext();
 ac.decodeAudioData(someStereoBuffer, function(data) {
  var source = ac.createBufferSource();
  source.buffer = data;

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -51,7 +51,7 @@ browser-compat: api.BaseAudioContext.createDelay
   sliders up to the right, then press the play buttons, a delay will be introduced, so the
   looping sounds don't start playing for a short amount of time.</p>
 
-<pre class="brush: js;highlight[4,15,16,21,22]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 
 var synthDelay = audioCtx.createDelay(5.0);

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -49,7 +49,7 @@ browser-compat: api.BaseAudioContext.createDynamicsCompressor
     href="https://github.com/mdn/webaudio-examples/tree/master/compressor-example">view
     the source code</a>).</p>
 
-<pre class="brush: js highlight[6,18,19]">// Create a MediaElementAudioSourceNode
+<pre class="brush: js">// Create a MediaElementAudioSourceNode
 // Feed the HTMLMediaElement into it
 var source = audioCtx.createMediaElementSource(myAudio);
 

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.html
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.html
@@ -24,7 +24,7 @@ browser-compat: api.BaseAudioContext.currentTime
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[8]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 

--- a/files/en-us/web/api/baseaudiocontext/destination/index.html
+++ b/files/en-us/web/api/baseaudiocontext/destination/index.html
@@ -35,7 +35,7 @@ browser-compat: api.BaseAudioContext.destination
       href="https://github.com/mdn/voice-change-o-matic">voice-change-o-matic</a>.</p>
 </div>
 
-<pre class="brush: js;highlight[8]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 

--- a/files/en-us/web/api/baseaudiocontext/listener/index.html
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.html
@@ -34,7 +34,7 @@ browser-compat: api.BaseAudioContext.listener
       href="https://github.com/mdn/panner-node">panner-node</a> demo.</p>
 </div>
 
-<pre class="brush: js;highlight[8]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.html
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.html
@@ -38,7 +38,7 @@ browser-compat: api.BaseAudioContext.sampleRate
     <code>audioCtx.sampleRate</code> into your browser console.</p>
 </div>
 
-<pre class="brush: js;highlight[8]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js;">var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 

--- a/files/en-us/web/api/batterymanager/charging/index.html
+++ b/files/en-us/web/api/batterymanager/charging/index.html
@@ -34,7 +34,7 @@ browser-compat: api.BatteryManager.charging
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js; highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js;">navigator.getBattery().then(function(battery) {
 
     var charging = battery.charging;
 

--- a/files/en-us/web/api/batterymanager/chargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.html
@@ -40,7 +40,7 @@ browser-compat: api.BatteryManager.chargingTime
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js; highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js;">navigator.getBattery().then(function(battery) {
 
    var time = battery.chargingTime;
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.html
@@ -42,7 +42,7 @@ browser-compat: api.BatteryManager.dischargingTime
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js;  highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js; ">navigator.getBattery().then(function(battery) {
 
     var time = battery.dischargingTime;
 

--- a/files/en-us/web/api/batterymanager/level/index.html
+++ b/files/en-us/web/api/batterymanager/level/index.html
@@ -36,7 +36,7 @@ browser-compat: api.BatteryManager.level
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js;  highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js; ">navigator.getBattery().then(function(battery) {
 
     var level = battery.level;
 

--- a/files/en-us/web/api/batterymanager/onchargingchange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingchange/index.html
@@ -36,7 +36,7 @@ browser-compat: api.BatteryManager.onchargingchange
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js;  highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js; ">navigator.getBattery().then(function(battery) {
 
    battery.onchargingchange = chargingChange();
 

--- a/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
@@ -36,7 +36,7 @@ browser-compat: api.BatteryManager.onchargingtimechange
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js;   highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js;  ">navigator.getBattery().then(function(battery) {
 
     battery.onchargingtimechange = chargingTimeChange();
 

--- a/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
@@ -36,7 +36,7 @@ browser-compat: api.BatteryManager.ondischargingtimechange
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js; highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js;">navigator.getBattery().then(function(battery) {
 
     battery.ondischargingtimechange = dischargingTimeChange;
 

--- a/files/en-us/web/api/batterymanager/onlevelchange/index.html
+++ b/files/en-us/web/api/batterymanager/onlevelchange/index.html
@@ -33,7 +33,7 @@ browser-compat: api.BatteryManager.onlevelchange
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[3]">navigator.getBattery().then(function(battery) {
+<pre class="brush: js;">navigator.getBattery().then(function(battery) {
   battery.onlevelchange = function(){
     document.querySelector('#level').textContent = battery.level;
 

--- a/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.html
@@ -44,7 +44,7 @@ ball.draw();</pre>
 
 <p>Now that we have a ball, we are ready to add a basic animation like we have learned in the <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations">last chapter</a> of this tutorial. Again, {{domxref("window.requestAnimationFrame()")}} helps us to control the animation. The ball gets moving by adding a velocity vector to the position. For each frame, we also {{domxref("CanvasRenderingContext2D.clearRect", "clear", "", 1)}} the canvas to remove old circles from prior frames.</p>
 
-<pre class="brush: js; highlight:[8,9,24,25]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var raf;
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -44,7 +44,7 @@ ctx.fillStyle = 'rgba(255, 165, 0, 1)';
 
 <p>In this example, we once again use two <code>for</code> loops to draw a grid of rectangles, each in a different color. The resulting image should look something like the screenshot. There is nothing too spectacular happening here. We use the two variables <code>i</code> and <code>j</code> to generate a unique RGB color for each square, and only modify the red and green values. The blue channel has a fixed value. By modifying the channels, you can generate all kinds of palettes. By increasing the steps, you can achieve something that looks like the color palettes Photoshop uses.</p>
 
-<pre class="brush: js highlight[5,6]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   for (var i = 0; i &lt; 6; i++) {
     for (var j = 0; j &lt; 6; j++) {
@@ -67,7 +67,7 @@ ctx.fillStyle = 'rgba(255, 165, 0, 1)';
 
 <p>This example is similar to the one above, but uses the <code>strokeStyle</code> property to change the colors of the shapes' outlines. We use the <code>arc()</code> method to draw circles instead of squares.</p>
 
-<pre class="brush: js highlight[5,6]">  function draw() {
+<pre class="brush: js">  function draw() {
     var ctx = document.getElementById('canvas').getContext('2d');
     for (var i = 0; i &lt; 6; i++) {
       for (var j = 0; j &lt; 6; j++) {
@@ -114,7 +114,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>In this example, we'll draw a background of four different colored squares. On top of these, we'll draw a set of semi-transparent circles. The <code>globalAlpha</code> property is set at <code>0.2</code> which will be used for all shapes from that point on. Every step in the <code>for</code> loop draws a set of circles with an increasing radius. The final result is a radial gradient. By overlaying ever more circles on top of each other, we effectively reduce the transparency of the circles that have already been drawn. By increasing the step count and in effect drawing more circles, the background would completely disappear from the center of the image.</p>
 
-<pre class="brush: js highlight[15]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   // draw background
   ctx.fillStyle = '#FD0';
@@ -148,7 +148,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>In this second example, we do something similar to the one above, but instead of drawing circles on top of each other, I've drawn small rectangles with increasing opacity. Using <code>rgba()</code> gives you a little more control and flexibility because we can set the fill and stroke style individually.</p>
 
-<pre class="brush: js highlight[16]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // Draw background
@@ -207,7 +207,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>In the example below, 10 straight lines are drawn with increasing line widths. The line on the far left is 1.0 units wide. However, the leftmost and all other odd-integer-width thickness lines do not appear crisp, because of the path's positioning.</p>
 
-<pre class="brush: js highlight[4]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   for (var i = 0; i &lt; 10; i++) {
     ctx.lineWidth = 1 + i;
@@ -260,7 +260,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>The line on the left uses the default <code>butt</code> option. You'll notice that it's drawn completely flush with the guides. The second is set to use the <code>round</code> option. This adds a semicircle to the end that has a radius half the width of the line. The line on the right uses the <code>square</code> option. This adds a box with an equal width and half the height of the line thickness.</p>
 
-<pre class="brush: js highlight[18]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   var lineCap = ['butt', 'round', 'square'];
 
@@ -309,7 +309,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>The example below draws three different paths, demonstrating each of these three <code>lineJoin</code> property settings; the output is shown above.</p>
 
-<pre class="brush: js highlight[6]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   var lineJoin = ['round', 'bevel', 'miter'];
   ctx.lineWidth = 10;
@@ -352,7 +352,7 @@ ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
 
 <p>If you specify a <code>miterLimit</code> value below 4.2 in this demo, none of the visible corners will join with a miter extension, but only with a small bevel near the blue lines; with a <code>miterLimit</code> above 10, most corners in this demo should join with a miter far away from the blue lines, and whose height is decreasing between corners from left to right because they connect with growing angles; with intermediate values, the corners on the left side will only join with a bevel near the blue lines, and the corners on the right side with a miter extension (also with a decreasing height).</p>
 
-<pre class="brush: js highlight[18]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // Clear canvas
@@ -412,7 +412,7 @@ draw();</pre>
 
 <pre class="brush: html hidden">&lt;canvas id="canvas" width="110" height="110"&gt;&lt;/canvas&gt;</pre>
 
-<pre class="brush: js highlight[6]">var ctx = document.getElementById('canvas').getContext('2d');
+<pre class="brush: js">var ctx = document.getElementById('canvas').getContext('2d');
 var offset = 0;
 
 function draw() {
@@ -472,7 +472,7 @@ lineargradient.addColorStop(1, 'black');
 
 <p>In this example, we'll create two different gradients. As you can see here, both the <code>strokeStyle</code> and <code>fillStyle</code> properties can accept a <code>canvasGradient</code> object as valid input.</p>
 
-<pre class="brush: js highlight[5,11]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // Create gradients
@@ -511,7 +511,7 @@ lineargradient.addColorStop(1, 'black');
 
 <p>In this example, we'll define four different radial gradients. Because we have control over the start and closing points of the gradient, we can achieve more complex effects than we would normally have in the "classic" radial gradients we see in, for instance, Photoshop (that is, a gradient with a single center point where the gradient expands outward in a circular shape).</p>
 
-<pre class="brush: js highlight[5,10,15,20]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // Create gradients
@@ -639,7 +639,7 @@ var ptrn = ctx.createPattern(img, 'repeat');
 
 <p>In this last example, we'll create a pattern to assign to the <code>fillStyle</code> property. The only thing worth noting is the use of the image's <code>onload</code> handler. This is to make sure the image is loaded before it is assigned to the pattern.</p>
 
-<pre class="brush: js highlight[10]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // create new image object to use as pattern
@@ -691,7 +691,7 @@ var ptrn = ctx.createPattern(img, 'repeat');
 
 <p>This example draws a text string with a shadowing effect.</p>
 
-<pre class="brush: js highlight[4,5,6,7]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   ctx.shadowOffsetX = 2;
@@ -726,7 +726,7 @@ var ptrn = ctx.createPattern(img, 'repeat');
 
 <p>In this example we are using the <code>evenodd</code> rule.</p>
 
-<pre class="brush: js highlight[6]">function draw() {
+<pre class="brush: js">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   ctx.beginPath();
   ctx.arc(50, 50, 30, 0, Math.PI * 2, true);

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>In this example, we'll use a circular clipping path to restrict the drawing of a set of random stars to a particular region.</p>
 
-<pre class="brush: js;highlight[9]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   ctx.fillRect(0, 0, 150, 150);
   ctx.translate(75, 75);

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -203,7 +203,7 @@ tags:
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight[9,10,16,17]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
     var ctx = canvas.getContext('2d');
@@ -268,7 +268,7 @@ tags:
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight[16]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
     var ctx = canvas.getContext('2d');
@@ -330,7 +330,7 @@ tags:
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight[9,10,11,12,13,14]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
     var ctx = canvas.getContext('2d');
@@ -362,7 +362,7 @@ tags:
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight[9,10,11,12,13,14]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
     var ctx = canvas.getContext('2d');
@@ -532,7 +532,7 @@ new Path2D(d);    // path from SVG path data</pre>
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight[6,9]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
     var ctx = canvas.getContext('2d');

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -155,7 +155,7 @@ tags:
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js highlight:[8,10,12]">function draw() {
+<pre class="brush: js">function draw() {
   var canvas = document.getElementById('canvas');
   if (canvas.getContext) {
      var ctx = canvas.getContext('2d');

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>The text is filled using the current <code>fillStyle</code>.</p>
 
-<pre class="brush: js;highlight[4]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   ctx.font = '48px serif';
   ctx.fillText('Hello world', 10, 50);
@@ -42,7 +42,7 @@ tags:
 
 <p>The text is filled using the current <code>strokeStyle</code>.</p>
 
-<pre class="brush: js;highlight[4]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   ctx.font = '48px serif';
   ctx.strokeText('Hello world', 10, 50);
@@ -86,7 +86,7 @@ baselines, due to glyphs extending far outside the em square." src="baselines.pn
 
 <p>Edit the code below and see your changes update live in the canvas:</p>
 
-<pre class="brush: js;highlight[2]">ctx.font = '48px serif';
+<pre class="brush: js;">ctx.font = '48px serif';
 ctx.textBaseline = 'hanging';
 ctx.strokeText('Hello world', 0, 100);
 </pre>
@@ -144,7 +144,7 @@ window.addEventListener('load', drawCanvas);
 
 <p>The following code snippet shows how you can measure a text and get its width.</p>
 
-<pre class="brush: js;highlight[3]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   var text = ctx.measureText('foo'); // TextMetrics object
   text.width; // 16;

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
@@ -39,7 +39,7 @@ tags:
 
 <p>This example tries to illustrate how the stack of drawing states functions by drawing a set of consecutive rectangles.</p>
 
-<pre class="brush: js; highlight:[5,10,15,18]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   ctx.fillRect(0, 0, 150, 150);   // Draw a rectangle with default settings
@@ -89,7 +89,7 @@ tags:
 
 <p>In the <code>draw()</code> function, we call the <code>fillRect()</code> function nine times using two <code>for</code> loops. In each loop, the canvas is translated, the rectangle is drawn, and the canvas is returned back to its original state. Note how the call to <code>fillRect()</code> uses the same coordinates each time, relying on <code>translate()</code> to adjust the drawing position.</p>
 
-<pre class="brush: js; highlight:[7]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   for (var i = 0; i &lt; 3; i++) {
     for (var j = 0; j &lt; 3; j++) {
@@ -128,7 +128,7 @@ tags:
 <p><strong>Note:</strong> Angles are in radians, not degrees. To convert, we are using: <code>radians = (Math.PI/180)*degrees</code>.</p>
 </div>
 
-<pre class="brush: js; highlight:[9, 23]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // left rectangles, rotate from canvas origin
@@ -184,7 +184,7 @@ tags:
 
 <p>In this last example, we'll draw shapes with different scaling factors.</p>
 
-<pre class="brush: js; highlight:[6,11]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   // draw a simple rectangle, but scale it.
@@ -240,7 +240,7 @@ tags:
 
 <h3 id="Example_for_transform_and_setTransform">Example for <code>transform</code> and <code>setTransform</code></h3>
 
-<pre class="brush: js; highlight:[12,15]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
 
   var sin = Math.sin(Math.PI / 6);

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.html
@@ -133,7 +133,7 @@ img.src = 'data:image/gif;base64,R0lGODlhCwALAIAAAAAA3pn/ZiH5BAEAAAEALAAAAAALAAs
 &lt;/html&gt;
 </pre>
 
-<pre class="brush: js;highlight[5]">function draw() {
+<pre class="brush: js;">function draw() {
   var ctx = document.getElementById('canvas').getContext('2d');
   var img = new Image();
   img.onload = function() {

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.html
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.html
@@ -50,7 +50,7 @@ browser-compat: api.CanvasGradient.addColorStop
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[5,6,7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let gradient = ctx.createLinearGradient(0, 0, 200, 0);

--- a/files/en-us/web/api/canvaspattern/settransform/index.html
+++ b/files/en-us/web/api/canvaspattern/settransform/index.html
@@ -49,7 +49,7 @@ browser-compat: api.CanvasPattern.setTransform
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js highlight:[12]">var canvas = document.getElementById('canvas');
+<pre class="brush: js">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 var svg1 = document.getElementById('svg1');

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
@@ -63,7 +63,7 @@ browser-compat: api.CanvasRenderingContext2D.arc
   make a full circle, the arc begins at an angle of 0 radians (0<strong>°</strong>), and
   ends at an angle of 2π radians (360<strong>°</strong>).</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.querySelector('canvas');
+<pre class="brush: js;">const canvas = document.querySelector('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
@@ -61,7 +61,7 @@ browser-compat: api.CanvasRenderingContext2D.arcTo
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[17]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Tangential lines
@@ -119,7 +119,7 @@ ctx.fill();
   that the arc's second control point and the point specified by <code>lineTo()</code> are
   the same, which produces a totally smooth corner.</p>
 
-<pre class="brush: js; highlight:[14]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const p0 = { x: 230, y: 20  }
 const p1 = { x: 90,  y: 130 }
@@ -160,7 +160,7 @@ ctx.stroke();
 
 <h4 id="JavaScript_3">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
@@ -42,7 +42,7 @@ browser-compat: api.CanvasRenderingContext2D.beginPath
 <p>The <code>beginPath()</code> method is called before beginning each line, so that they
   may be drawn with different colors.</p>
 
-<pre class="brush: js; highlight:[5,12]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // First path

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
@@ -55,7 +55,7 @@ browser-compat: api.CanvasRenderingContext2D.bezierCurveTo
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[14]">// Define canvas and context
+<pre class="brush: js;">// Define canvas and context
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
@@ -107,7 +107,7 @@ ctx.fill();</pre>
   control point is placed at (120, 160), and the second at (180, 10). The curve ends at
   (220, 140).</p>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
@@ -58,7 +58,7 @@ browser-compat: api.CanvasRenderingContext2D.clearRect
   {{HtmlElement("canvas")}} element's <code>width</code> and <code>height</code>
   attributes.</p>
 
-<pre class="brush: js; highlight:[3]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.clearRect(0, 0, canvas.width, canvas.height);</pre>
 
@@ -77,7 +77,7 @@ ctx.clearRect(0, 0, canvas.width, canvas.height);</pre>
 <p>The cleared area is rectangular in shape, with its top-left corner at (10, 10). The
   cleared area has a width of 120 and a height of 100.</p>
 
-<pre class="brush: js; highlight:[19]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Draw yellow background

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
@@ -75,7 +75,7 @@ void <em>ctx</em>.clip(<em>path</em> [, <em>fillRule</em>]);
 <p>The clipping region is a full circle, with its center at (100, 75), and a radius of 50.
 </p>
 
-<pre class="brush: js highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Create circular clipping region
@@ -108,7 +108,7 @@ ctx.fillRect(0, 0, 100, 100);
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js highlight:[8]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Create clipping path

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
@@ -44,7 +44,7 @@ browser-compat: api.CanvasRenderingContext2D.closePath
 
 <p>The triangle's corners are at (20, 140), (120, 10), and (220, 140).</p>
 
-<pre class="brush: js highlight:[8]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();
@@ -77,7 +77,7 @@ ctx.stroke();
 
 <p>The first two arcs create the face's eyes. The last arc creates the mouth.</p>
 
-<pre class="brush: js highlight:[10]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.html
@@ -67,7 +67,7 @@ ImageData <em>ctx</em>.createImageData(<em>imagedata</em>);
   object's {{domxref("ImageData.data", "data")}} property has  a length of 4 × 5,000, or
   20,000.</p>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 const imageData = ctx.createImageData(100, 50);

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
@@ -76,7 +76,7 @@ browser-compat: api.CanvasRenderingContext2D.createLinearGradient
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 // Create a linear gradient

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
@@ -84,7 +84,7 @@ browser-compat: api.CanvasRenderingContext2D.createPattern
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 var img = new Image();

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
@@ -78,7 +78,7 @@ browser-compat: api.CanvasRenderingContext2D.createRadialGradient
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 // Create a radial gradient

--- a/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
@@ -53,7 +53,7 @@ browser-compat: api.CanvasRenderingContext2D.direction
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 ctx.font = '48px serif';

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
@@ -65,7 +65,7 @@ browser-compat: api.CanvasRenderingContext2D.ellipse
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Draw the ellipse
@@ -96,7 +96,7 @@ ctx.stroke();
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6,11,16]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.fillStyle = 'red';

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
@@ -55,7 +55,7 @@ void <em>ctx</em>.fill(<em>path</em> [, <em>fillRule</em>]);
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.rect(10, 10, 150, 100);
 ctx.fill();
@@ -79,7 +79,7 @@ ctx.fill();
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[16]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Create path

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
@@ -62,7 +62,7 @@ browser-compat: api.CanvasRenderingContext2D.fillRect
 <p>The rectangle's top-left corner is at (20, 10). It has a width of 150 and a height of
   100.</p>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.fillStyle = 'green';
 ctx.fillRect(20, 10, 150, 100);
@@ -79,7 +79,7 @@ ctx.fillRect(20, 10, 150, 100);
   the dimensions of the rectangle are set to equal the {{HtmlElement("canvas")}} element's
   <code>width</code> and <code>height</code> attributes.</p>
 
-<pre class="brush: js; highlight:[3]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.fillRect(0, 0, canvas.width, canvas.height);</pre>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CanvasRenderingContext2D.fillStyle
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.fillStyle = 'blue';

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.html
@@ -94,7 +94,7 @@ browser-compat: api.CanvasRenderingContext2D.fillText
 
 <p>The JavaScript code for this example follows.</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.font = '50px serif';
@@ -124,7 +124,7 @@ ctx.fillText('Hello world', 50, 90);
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.font = '50px serif';

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
@@ -105,7 +105,7 @@ browser-compat: api.CanvasRenderingContext2D.filter
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js highlight[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.filter = 'blur(4px)';

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.html
@@ -100,7 +100,7 @@ browser-compat: api.CanvasRenderingContext2D.getImageData
   from off the canvas; only 5,000 of them are opaque black (the color of the drawn
   rectangle).</p>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.rect(10, 10, 100, 100);
 ctx.fill();

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.html
@@ -44,7 +44,7 @@ browser-compat: api.CanvasRenderingContext2D.getLineDash
   strokes consist of lines that are 10 units wide, with spaces of 20 units in between each
   line.</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.setLineDash([10, 20]);

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
@@ -52,7 +52,7 @@ browser-compat: api.CanvasRenderingContext2D.globalAlpha
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.globalAlpha = 0.5;

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
@@ -49,7 +49,7 @@ browser-compat: api.CanvasRenderingContext2D.globalCompositeOperation
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.globalCompositeOperation = 'xor';

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CanvasRenderingContext2D.imageSmoothingEnabled
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight[17,18,21,22]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 
 const ctx = canvas.getContext('2d');
 ctx.font = '16px sans-serif';

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CanvasRenderingContext2D.imageSmoothingQuality
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let img = new Image();

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
@@ -71,7 +71,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInPath
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const result = document.getElementById('result');
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
@@ -57,7 +57,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInStroke
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const result = document.getElementById('result');
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
@@ -53,7 +53,7 @@ browser-compat: api.CanvasRenderingContext2D.lineCap
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
@@ -45,7 +45,7 @@ browser-compat: api.CanvasRenderingContext2D.lineDashOffset
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[15]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.setLineDash([4, 16]);

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
@@ -68,7 +68,7 @@ browser-compat: api.CanvasRenderingContext2D.lineJoin
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.lineWidth = 20;

--- a/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.html
@@ -54,7 +54,7 @@ browser-compat: api.CanvasRenderingContext2D.lineTo
 
 <p>The line begins at (30, 50) and ends at (150, 100).</p>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();       // Start a new path

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
@@ -48,7 +48,7 @@ browser-compat: api.CanvasRenderingContext2D.lineWidth
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.lineWidth = 15;

--- a/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.html
@@ -40,7 +40,7 @@ browser-compat: api.CanvasRenderingContext2D.measureText
 
 <p>... you can get a {{domxref("TextMetrics")}} object using the following code:</p>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let text = ctx.measureText('Hello world');

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
@@ -47,7 +47,7 @@ browser-compat: api.CanvasRenderingContext2D.moveTo
 <p>The first line begins at (50, 50) and ends at (200, 50). The second line begins at (50,
   90) and ends at (280, 120).</p>
 
-<pre class="brush: js; highlight:[5,7]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
@@ -51,7 +51,7 @@ browser-compat: api.CanvasRenderingContext2D.quadraticCurveTo
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Quadratic Bézier curve
@@ -96,7 +96,7 @@ ctx.fill();
 <p>The curve begins at the point specified by <code>moveTo()</code>: (20, 110). The
   control point is placed at (230, 150). The curve ends at (250, 20).</p>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
@@ -66,7 +66,7 @@ browser-compat: api.CanvasRenderingContext2D.rect
 <p>The rectangle's corner is located at (10, 20). It has a width of 150 and a height of
   100.</p>
 
-<pre class="brush: js; highlight:[3]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.rect(10, 20, 150, 100);
 ctx.fill();

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
@@ -38,7 +38,7 @@ browser-compat: api.CanvasRenderingContext2D.resetTransform
   transformation matrix by 45°. The {{domxref("CanvasRenderingContext2D.fillRect()",
   "fillRect()")}} method draws a filled rectangle, adjusted according to that matrix.</p>
 
-<pre class="brush: js; highlight:[9]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Draw a rotated rectangle
@@ -67,7 +67,7 @@ ctx.resetTransform();
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[11]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Skewed rectangles

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
@@ -40,7 +40,7 @@ browser-compat: api.CanvasRenderingContext2D.restore
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js highlight:[11]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Save the default state

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
@@ -48,7 +48,7 @@ browser-compat: api.CanvasRenderingContext2D.rotate
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[14]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Point of transform origin

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
@@ -65,7 +65,7 @@ browser-compat: api.CanvasRenderingContext2D.save
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Save the default state

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
@@ -59,7 +59,7 @@ browser-compat: api.CanvasRenderingContext2D.scale
 <p>Notice that its position on the canvas also changes. Since its specified corner is (10,
   10), its rendered corner becomes (90, 30).</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Scaled rectangle
@@ -100,7 +100,7 @@ ctx.fillRect(10, 10, 8, 20);
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.scale(-1, 1);

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
@@ -43,7 +43,7 @@ void <em>ctx</em>.scrollPathIntoView(<em>path</em>);
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.beginPath();

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.html
@@ -60,7 +60,7 @@ browser-compat: api.CanvasRenderingContext2D.setLineDash
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6, 13]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Dashed line

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
@@ -114,7 +114,7 @@ ctx.setTransform(<em>matrix</em>);
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.setTransform(1, .2, .8, 1, 0, 0);

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
@@ -53,7 +53,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowBlur
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Shadow

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowColor
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Shadow
@@ -92,7 +92,7 @@ ctx.strokeRect(170, 20, 100, 100);
   <code>.16</code>. The alpha of the stroke shadow is <code>.8 * .6</code>, or
   <code>.48</code>.</p>
 
-<pre class="brush: js; highlight:[5,11,16]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Shadow

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
@@ -55,7 +55,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowOffsetX
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Shadow

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
@@ -54,7 +54,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowOffsetY
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[6]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Shadow

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
@@ -50,7 +50,7 @@ void <em>ctx</em>.stroke(<em>path</em>);
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.rect(10, 10, 150, 100);
 ctx.stroke();
@@ -77,7 +77,7 @@ ctx.stroke();
 <p>This code strokes the first path three times, the second path two times, and the third
   path only once.</p>
 
-<pre class="brush: js; highlight:[9,16,23]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // First sub-path

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
@@ -62,7 +62,7 @@ browser-compat: api.CanvasRenderingContext2D.strokeRect
 <p>The rectangle's top-left corner is at (20, 10). It has a width of 160 and a height of
   100.</p>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 ctx.strokeStyle = 'green';
 ctx.strokeRect(20, 10, 160, 100);

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.html
@@ -54,7 +54,7 @@ browser-compat: api.CanvasRenderingContext2D.strokeStyle
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">var canvas = document.getElementById('canvas');
+<pre class="brush: js;">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 ctx.strokeStyle = 'blue';

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.html
@@ -86,7 +86,7 @@ browser-compat: api.CanvasRenderingContext2D.strokeText
 
 <p>The JavaScript code for this example follows.</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.font = '50px serif';
@@ -116,7 +116,7 @@ ctx.strokeText('Hello world', 50, 90);
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.font = '50px serif';

--- a/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
@@ -61,7 +61,7 @@ browser-compat: api.CanvasRenderingContext2D.textAlign
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[13,16,19]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 canvas.width = 350;
 const ctx = canvas.getContext('2d');
 const x = canvas.width / 2;
@@ -102,7 +102,7 @@ ctx.fillText('right-aligned', x, 130);
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js; highlight:[7,10]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.font = '30px serif';

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
@@ -106,7 +106,7 @@ browser-compat: api.CanvasRenderingContext2D.transform
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js; highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 ctx.transform(1, .2, .8, 1, 0, 0);

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
@@ -55,7 +55,7 @@ browser-compat: api.CanvasRenderingContext2D.translate
 <p>The <code>translate()</code> method translates the context by 110 horizontally and 30
   vertically. The first square is shifted by those amounts from its default position.</p>
 
-<pre class="brush: js; highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Moved square

--- a/files/en-us/web/api/console/count/index.html
+++ b/files/en-us/web/api/console/count/index.html
@@ -35,7 +35,7 @@ browser-compat: api.console.count
 
 <p>For example, given code like this:</p>
 
-<pre class="brush: js; highlight[4, 13]">let user = "";
+<pre class="brush: js;">let user = "";
 
 function greet() {
   console.count();
@@ -62,7 +62,7 @@ console.count();</pre>
 <p>If we pass the <code>user</code> variable as the <code>label</code> argument to the
   first invocation of <code>count()</code>, and the string "alice" to the second:</p>
 
-<pre class="brush: js; highlight[4, 13]">let user = "";
+<pre class="brush: js;">let user = "";
 
 function greet() {
   console.count(user);

--- a/files/en-us/web/api/css_object_model/css_declaration_block/index.html
+++ b/files/en-us/web/api/css_object_model/css_declaration_block/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>The following example shows a CSS rule with a declaration block for the {{htmlelement("Heading_elements","&lt;h1&gt;")}} element. The CSS declaration block is the lines between the curly braces.</p>
 
-<pre class="brush: css; highlight[2,5]">h1 {
+<pre class="brush: css;">h1 {
   margin: 0 auto;
   font-family: "Helvetica Neue", "Arial", sans-serif;
   font-style: italic;

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -145,7 +145,7 @@ browser-compat: api.CSSPrimitiveValue.getFloatValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var cs = window.getComputedStyle(document.body);
+<pre class="brush: js;">var cs = window.getComputedStyle(document.body);
 var cssValue = cs.getPropertyCSSValue("margin-top");
 console.log(cssValue.getFloatValue(CSSPrimitiveValue.CSS_CM));</pre>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CSSPrimitiveValue.getRectValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var cs = window.getComputedStyle(document.getElementById("clippedDiv"));
+<pre class="brush: js;">var cs = window.getComputedStyle(document.getElementById("clippedDiv"));
 var cssValue = cs.getPropertyCSSValue("clip");
 console.log(cssValue.getRectValue());</pre>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -56,7 +56,7 @@ browser-compat: api.CSSPrimitiveValue.getRGBColorValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var cs = window.getComputedStyle(document.body);
+<pre class="brush: js;">var cs = window.getComputedStyle(document.body);
 var cssValue = cs.getPropertyCSSValue("color");
 console.log(cssValue.getRGBColorValue());</pre>
 

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -54,7 +54,7 @@ browser-compat: api.CSSPrimitiveValue.getStringValue
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var cs = window.getComputedStyle(document.body);
+<pre class="brush: js;">var cs = window.getComputedStyle(document.body);
 var cssValue = cs.getPropertyCSSValue("display");
 console.log(cssValue.getStringValue());</pre>
 

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -178,7 +178,7 @@ browser-compat: api.CSSPrimitiveValue.primitiveType
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var cs = window.getComputedStyle(document.body);
+<pre class="brush: js;">var cs = window.getComputedStyle(document.body);
 var cssValue = cs.getPropertyCSSValue("color");
 console.log(cssValue.primitiveType);
 </pre>

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -36,7 +36,7 @@ browser-compat: api.CSSValue.cssText
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var styleDeclaration = document.styleSheets[0].cssRules[0].style;
+<pre class="brush: js;.style;
 var cssValue = styleDeclaration.getPropertyCSSValue("color");
 console.log(cssValue.cssText);
 </pre>

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -36,7 +36,7 @@ browser-compat: api.CSSValue.cssText
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;.style;
+<pre class="brush: js;">var styleDeclaration = document.styleSheets[0].cssRules[0].style;
 var cssValue = styleDeclaration.getPropertyCSSValue("color");
 console.log(cssValue.cssText);
 </pre>

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -70,7 +70,7 @@ browser-compat: api.CSSValue.cssValueType
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;.style;
+<pre class="brush: js;">var styleDeclaration = document.styleSheets[0].cssRules[0].style;
 var cssValue = styleDeclaration.getPropertyCSSValue("color");
 console.log(cssValue.cssValueType);
 </pre>

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -70,7 +70,7 @@ browser-compat: api.CSSValue.cssValueType
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js; highlight[3]">var styleDeclaration = document.styleSheets[0].cssRules[0].style;
+<pre class="brush: js;.style;
 var cssValue = styleDeclaration.getPropertyCSSValue("color");
 console.log(cssValue.cssValueType);
 </pre>

--- a/files/en-us/web/api/document/elementsfrompoint/index.html
+++ b/files/en-us/web/api/document/elementsfrompoint/index.html
@@ -49,7 +49,7 @@ browser-compat: api.Document.elementsFromPoint
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js;highlight[1]">let output = document.getElementById("output");
+<pre class="brush: js;">let output = document.getElementById("output");
 if (document.elementsFromPoint) {
   let elements = document.elementsFromPoint(30, 20);
   for (var i = 0; i &lt; elements.length; i++) {

--- a/files/en-us/web/api/element/setattributenode/index.html
+++ b/files/en-us/web/api/element/setattributenode/index.html
@@ -36,7 +36,7 @@ browser-compat: api.Element.setAttributeNode
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[5]">let d1 = document.getElementById('one');
+<pre class="brush: js;">let d1 = document.getElementById('one');
 let d2 = document.getElementById('two');
 let a = d1.getAttributeNode('align');
 

--- a/files/en-us/web/api/extendableevent/waituntil/index.html
+++ b/files/en-us/web/api/extendableevent/waituntil/index.html
@@ -57,7 +57,7 @@ browser-compat: api.ExtendableEvent.waitUntil
 <p>Using <code>waitUntil()</code> within a service worker's <code>install</code> event:
 </p>
 
-<pre class="brush: js;highlight:[10]">addEventListener('install', event =&gt; {
+<pre class="brush: js;">addEventListener('install', event =&gt; {
   const preCache = async () =&gt; {
     const cache = await caches.open('static-v1');
     return cache.addAll([

--- a/files/en-us/web/api/formdata/entries/index.html
+++ b/files/en-us/web/api/formdata/entries/index.html
@@ -32,7 +32,7 @@ browser-compat: api.FormData.entries
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test FormData object
+<pre class="brush: js;">// Create a test FormData object
 var formData = new FormData();
 formData.append('key1', 'value1');
 formData.append('key2', 'value2');

--- a/files/en-us/web/api/formdata/keys/index.html
+++ b/files/en-us/web/api/formdata/keys/index.html
@@ -31,7 +31,7 @@ browser-compat: api.FormData.keys
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test FormData object
+<pre class="brush: js;">// Create a test FormData object
 var formData = new FormData();
 formData.append('key1', 'value1');
 formData.append('key2', 'value2');

--- a/files/en-us/web/api/formdata/values/index.html
+++ b/files/en-us/web/api/formdata/values/index.html
@@ -32,7 +32,7 @@ browser-compat: api.FormData.values
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test FormData object
+<pre class="brush: js;">// Create a test FormData object
 var formData = new FormData();
 formData.append('key1', 'value1');
 formData.append('key2', 'value2');

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -80,7 +80,7 @@ browser-compat: api.GlobalEventHandlers.ontransitioncancel
   color and size change, and causes the box to rotate, while the mouse cursor hovers over
   it.</p>
 
-<pre class="brush: css highlight:[13,14]">.box {
+<pre class="brush: css">.box {
   margin-left: 70px;
   margin-top: 30px;
   border-style: solid;

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -77,7 +77,7 @@ browser-compat: api.GlobalEventHandlers.ontransitionend
   color and size change, and causes the box to rotate, while the mouse cursor hovers over
   it.</p>
 
-<pre class="brush: css highlight:[13,14]">.box {
+<pre class="brush: css">.box {
   margin-left: 70px;
   margin-top: 30px;
   border-style: solid;

--- a/files/en-us/web/api/headers/entries/index.html
+++ b/files/en-us/web/api/headers/entries/index.html
@@ -32,7 +32,7 @@ browser-compat: api.Headers.entries
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test Headers object
+<pre class="brush: js;">// Create a test Headers object
 var myHeaders = new Headers();
 myHeaders.append('Content-Type', 'text/xml');
 myHeaders.append('Vary', 'Accept-Language');

--- a/files/en-us/web/api/headers/keys/index.html
+++ b/files/en-us/web/api/headers/keys/index.html
@@ -31,7 +31,7 @@ browser-compat: api.Headers.keys
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test Headers object
+<pre class="brush: js;">// Create a test Headers object
 var myHeaders = new Headers();
 myHeaders.append('Content-Type', 'text/xml');
 myHeaders.append('Vary', 'Accept-Language');

--- a/files/en-us/web/api/headers/values/index.html
+++ b/files/en-us/web/api/headers/values/index.html
@@ -31,7 +31,7 @@ browser-compat: api.Headers.values
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[7]">// Create a test Headers object
+<pre class="brush: js;">// Create a test Headers object
 var myHeaders = new Headers();
 myHeaders.append('Content-Type', 'text/xml');
 myHeaders.append('Vary', 'Accept-Language');

--- a/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.html
@@ -63,7 +63,7 @@ browser-compat: api.HTMLCanvasElement.mozGetAsFile
     URL using the {{domxref("FileReader.readAsDataURL", "readAsDataURL()")}} method. Then
     a new {{HTMLElement("img")}} element is created using the new data URL.</p>
 
-  <pre class="brush: js;highlight:[17]">function draw() {
+  <pre class="brush: js;">function draw() {
   var canvas = document.getElementById('canvas');
   var ctx = canvas.getContext('2d');
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.html
@@ -95,7 +95,7 @@ var lowQuality = canvas.toDataURL('image/jpeg', 0.1);
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js;highlight:[33]">window.addEventListener('load', removeColors);
+<pre class="brush: js;">window.addEventListener('load', removeColors);
 
 function showColorImg() {
   this.style.display = 'none';

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
@@ -60,7 +60,7 @@ browser-compat: api.HTMLIFrameElement.referrerPolicy
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[3]">var iframe = document.createElement("iframe");
+<pre class="brush: js;">var iframe = document.createElement("iframe");
 iframe.src = "/";
 iframe.referrerPolicy = "unsafe-url";
 var body = document.getElementsByTagName("body")[0];

--- a/files/en-us/web/api/htmliframeelement/src/index.html
+++ b/files/en-us/web/api/htmliframeelement/src/index.html
@@ -18,7 +18,7 @@ browser-compat: api.HTMLIFrameElement.src
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[3]">var iframe = document.createElement("iframe");
+<pre class="brush: js;">var iframe = document.createElement("iframe");
 iframe.src = "/";
 var body = document.getElementsByTagName("body")[0];
 body.appendChild(iframe); // Fetch the image using the complete URL as the referrer

--- a/files/en-us/web/api/htmliframeelement/srcdoc/index.html
+++ b/files/en-us/web/api/htmliframeelement/srcdoc/index.html
@@ -9,7 +9,7 @@ browser-compat: api.HTMLIFrameElement.srcdoc
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js highlight:[3] line-numbers">var iframe = document.createElement("iframe");
+<pre class="brush: js line-numbers">var iframe = document.createElement("iframe");
 iframe.srcdoc = `&lt;!DOCTYPE html&gt;&lt;p&gt;Hello World!&lt;/p&gt;`;
 document.body.appendChild(iframe);</pre>
 

--- a/files/en-us/web/api/htmlimageelement/decoding/index.html
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.html
@@ -44,7 +44,7 @@ browser-compat: api.HTMLImageElement.decoding
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[3]">var img = new Image();
+<pre class="brush: js;">var img = new Image();
 img.decoding = 'sync';
 img.src = 'img/logo.png';
 </pre>

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
@@ -61,7 +61,7 @@ browser-compat: api.HTMLImageElement.referrerPolicy
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[3]">var img = new Image();
+<pre class="brush: js;">var img = new Image();
 img.src = 'img/logo.png';
 img.referrerPolicy = 'origin';
 

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
@@ -71,7 +71,7 @@ browser-compat: api.HTMLScriptElement.referrerPolicy
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[3]">var scriptElem = document.createElement("script");
+<pre class="brush: js;">var scriptElem = document.createElement("script");
 scriptElem.src = "/";
 scriptElem.referrerPolicy = "unsafe-url";
 document.body.appendChild(scriptElem);

--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.html
@@ -40,7 +40,7 @@ browser-compat: api.HTMLSelectElement.selectedIndex
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight[6]">var selectElem = document.getElementById('select')
+<pre class="brush: js;">var selectElem = document.getElementById('select')
 var pElem = document.getElementById('p')
 
 // When a new &lt;option&gt; is selected

--- a/files/en-us/web/api/htmltableelement/createcaption/index.html
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.html
@@ -46,7 +46,7 @@ browser-compat: api.HTMLTableElement.createCaption
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js highlight:[2]">let table = document.querySelector('table');
+<pre class="brush: js">let table = document.querySelector('table');
 let caption = table.createCaption();
 caption.textContent = 'This caption was created by JavaScript!';</pre>
 

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.html
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.html
@@ -27,7 +27,7 @@ browser-compat: api.HTMLTableElement.deleteCaption
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html; highlight:[2]">&lt;table&gt;
+<pre class="brush: html;">&lt;table&gt;
   &lt;caption&gt;This caption will be deleted!&lt;/caption&gt;
   &lt;tr&gt;&lt;td&gt;Cell 1.1&lt;/td&gt;&lt;td&gt;Cell 1.2&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;td&gt;Cell 2.1&lt;/td&gt;&lt;td&gt;Cell 2.2&lt;/td&gt;&lt;/tr&gt;
@@ -35,7 +35,7 @@ browser-compat: api.HTMLTableElement.deleteCaption
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[2]">let table = document.querySelector('table');
+<pre class="brush: js;">let table = document.querySelector('table');
 table.deleteCaption();</pre>
 
 <h3 id="Result">Result</h3>

--- a/files/en-us/web/api/htmltableelement/deleterow/index.html
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.html
@@ -46,7 +46,7 @@ browser-compat: api.HTMLTableElement.deleteRow
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html; highlight:[3]">&lt;table&gt;
+<pre class="brush: html;">&lt;table&gt;
   &lt;tr&gt;&lt;td&gt;Cell 1.1&lt;/td&gt;&lt;td&gt;Cell 1.2&lt;/td&gt;&lt;td&gt;Cell 1.3&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;td&gt;Cell 2.1&lt;/td&gt;&lt;td&gt;Cell 2.2&lt;/td&gt;&lt;td&gt;Cell 2.3&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;td&gt;Cell 3.1&lt;/td&gt;&lt;td&gt;Cell 3.2&lt;/td&gt;&lt;td&gt;Cell 3.3&lt;/td&gt;&lt;/tr&gt;
@@ -54,7 +54,7 @@ browser-compat: api.HTMLTableElement.deleteRow
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[4]">let table = document.querySelector('table');
+<pre class="brush: js;">let table = document.querySelector('table');
 
 // Delete second row
 table.deleteRow(1);</pre>

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.html
@@ -25,7 +25,7 @@ browser-compat: api.HTMLTableElement.deleteTFoot
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html; highlight:[5]">&lt;table&gt;
+<pre class="brush: html;">&lt;table&gt;
   &lt;thead&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Score&lt;/th&gt;&lt;/thead&gt;
   &lt;tr&gt;&lt;td&gt;Bob&lt;/td&gt;&lt;td&gt;541&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;td&gt;Jim&lt;/td&gt;&lt;td&gt;225&lt;/td&gt;&lt;/tr&gt;
@@ -34,7 +34,7 @@ browser-compat: api.HTMLTableElement.deleteTFoot
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[2]">let table = document.querySelector('table');
+<pre class="brush: js;">let table = document.querySelector('table');
 table.deleteTFoot();</pre>
 
 <h3 id="Result">Result</h3>

--- a/files/en-us/web/api/htmltableelement/deletethead/index.html
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.html
@@ -25,7 +25,7 @@ browser-compat: api.HTMLTableElement.deleteTHead
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html; highlight:[2]">&lt;table&gt;
+<pre class="brush: html;">&lt;table&gt;
   &lt;thead&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Occupation&lt;/th&gt;&lt;/thead&gt;
   &lt;tr&gt;&lt;td&gt;Bob&lt;/td&gt;&lt;td&gt;Plumber&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;td&gt;Jim&lt;/td&gt;&lt;td&gt;Roofer&lt;/td&gt;&lt;/tr&gt;
@@ -33,7 +33,7 @@ browser-compat: api.HTMLTableElement.deleteTHead
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[2]">let table = document.querySelector('table');
+<pre class="brush: js;">let table = document.querySelector('table');
 table.deleteTHead();</pre>
 
 <h3 id="Result">Result</h3>

--- a/files/en-us/web/api/idbdatabase/close/index.html
+++ b/files/en-us/web/api/idbdatabase/close/index.html
@@ -32,7 +32,7 @@ browser-compat: api.IDBDatabase.close
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[17]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4); // opening a database.
 
 // Create event handlers for both success and failure of

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.html
@@ -124,7 +124,7 @@ browser-compat: api.IDBDatabase.createObjectStore
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[18]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var request = window.indexedDB.open("toDoList", 4);
 
 // This handler is called when a new version of the database

--- a/files/en-us/web/api/idbdatabase/index.html
+++ b/files/en-us/web/api/idbdatabase/index.html
@@ -73,7 +73,7 @@ browser-compat: api.IDBDatabase
 
 <p>In the following code snippet, we open a database asynchronously ({{domxref("IDBFactory")}}), handle success and error cases, and create a new object store in the case that an upgrade is needed ({{ domxref("IDBdatabase") }}). For a complete working example, see our <a href="https://github.com/mdn/to-do-notifications/">To-do Notifications</a> app (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 
-<pre class="brush: js;highlight:[15,28,30,31,32,37]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);
 
 // these two event handlers act on the IDBDatabase object,

--- a/files/en-us/web/api/idbdatabase/name/index.html
+++ b/files/en-us/web/api/idbdatabase/name/index.html
@@ -39,7 +39,7 @@ browser-compat: api.IDBDatabase.name
   <a href="https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages">To-do Notifications</a>
    app (<a href="https://chrisdavidmills.github.io/to-do-notifications/">view example live</a>).</p>
 
-<pre class="brush: js;highlight:[16]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);
 
 // these two event handlers act on the database being

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.html
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.html
@@ -37,7 +37,7 @@ browser-compat: api.IDBDatabase.objectStoreNames
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[17]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);
 
 // these two event handlers act on the database being opened successfully, or not

--- a/files/en-us/web/api/idbdatabase/onabort/index.html
+++ b/files/en-us/web/api/idbdatabase/onabort/index.html
@@ -31,7 +31,7 @@ browser-compat: api.IDBDatabase.onabort
   creates a new object store; it also includes <code>onerror</code> and
   <code>onabort</code> functions to handle non-success cases.</p>
 
-<pre class="brush: js;highlight:[8,9,10]">DBOpenRequest.onupgradeneeded = function(event) {
+<pre class="brush: js;">DBOpenRequest.onupgradeneeded = function(event) {
   var db = event.target.result;
 
   db.onerror = function() {

--- a/files/en-us/web/api/idbdatabase/onerror/index.html
+++ b/files/en-us/web/api/idbdatabase/onerror/index.html
@@ -35,7 +35,7 @@ browser-compat: api.IDBDatabase.onerror
 <p>This example shows an {{domxref("IDBOpenDBRequest.onupgradeneeded")}} block that
   creates a new object store; it also includes <code>onerror</code> and <code>onabort</code> functions to handle non-success cases.</p>
 
-<pre class="brush: js;highlight:[4,5,6]">DBOpenRequest.onupgradeneeded = function(event) {
+<pre class="brush: js;">DBOpenRequest.onupgradeneeded = function(event) {
   var db = this.result;
 
   db.onerror = function(event) {

--- a/files/en-us/web/api/idbdatabase/onversionchange/index.html
+++ b/files/en-us/web/api/idbdatabase/onversionchange/index.html
@@ -38,7 +38,7 @@ browser-compat: api.IDBDatabase.onversionchange
   creates a new object store; it also includes <code>onerror</code> and <code>onabort</code> functions to handle non-success cases, and
   an onversionchange function to notify when a database structure change has occurred.</p>
 
-<pre class="brush: js;highlight:[28,29,30,31,32]">request.onupgradeneeded = function(event) {
+<pre class="brush: js;">request.onupgradeneeded = function(event) {
   var db = event.target.result;
 
   db.onerror = function(event) {

--- a/files/en-us/web/api/idbdatabase/version/index.html
+++ b/files/en-us/web/api/idbdatabase/version/index.html
@@ -35,7 +35,7 @@ browser-compat: api.IDBDatabase.version
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[17]">// Let us open our database
+<pre class="brush: js;">// Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);
 
 // these two event handlers act on the database

--- a/files/en-us/web/api/idbenvironment/index.html
+++ b/files/en-us/web/api/idbenvironment/index.html
@@ -37,7 +37,7 @@ browser-compat: api.IDBEnvironment
 
 <p>The following code creates a request for a database to be opened asynchronously, after which the database is opened when the request's <code>onsuccess</code> handler is fired:</p>
 
-<pre class="brush: js;highlight:[3]">var db;
+<pre class="brush: js;">var db;
 function openDB() {
  var DBOpenRequest = window.indexedDB.open("toDoList");
  DBOpenRequest.onsuccess = function(e) {

--- a/files/en-us/web/api/idbfactory/cmp/index.html
+++ b/files/en-us/web/api/idbfactory/cmp/index.html
@@ -90,7 +90,7 @@ browser-compat: api.IDBFactory.cmp
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[3]">var a = 1;
+<pre class="brush: js;">var a = 1;
 var b = 2;
 var result = window.indexedDB.cmp(a, b);
 console.log( "Comparison results: " + result );</pre>

--- a/files/en-us/web/api/idbfactory/index.html
+++ b/files/en-us/web/api/idbfactory/index.html
@@ -36,7 +36,7 @@ browser-compat: api.IDBFactory
 
 <p>In the following code snippet, we make a request to open a database, and include handlers for the success and error cases. For a full working example, see our <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> app (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 
-<pre class="brush:js;highlight:[10]">// In the following line, you should include the prefixes of implementations you want to test.
+<pre class="brush:js;">// In the following line, you should include the prefixes of implementations you want to test.
 window.indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
 // DON'T use "var indexedDB = ..." if you're not in a function.
 // Moreover, you may need references to some window.IDB* objects:

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -93,7 +93,7 @@ browser-compat: api.IDBIndex.get
     demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the
     example live</a>.)</p>
 
-<pre class="brush: js;highlight[7]">function displayDataByIndex() {
+<pre class="brush: js;">function displayDataByIndex() {
   tableEntry.innerHTML = '';
   var transaction = db.transaction(['contactsList'], 'readonly');
   var objectStore = transaction.objectStore('contactsList');

--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -47,7 +47,7 @@ browser-compat: api.IDBOpenDBRequest
 
 <p>In the following example you can see the onupgradeneeded handler being used to update the database structure if a database with a higher version number is loaded. For a full working example, see our <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> app (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 
-<pre class="brush: js; highlight:[16,28,29,31,32,33,34,35,36]">var db;
+<pre class="brush: js;">var db;
 
 // Let us open our database
 var DBOpenRequest = window.indexedDB.open("toDoList", 4);

--- a/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.html
+++ b/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.html
@@ -42,7 +42,7 @@ browser-compat: api.IDBOpenDBRequest.onupgradeneeded
     Notifications</a> app (<a class="external"
     href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 
-<pre class="brush: js highlight:[17,29,30,32,33,34,35,36,37]">var db;
+<pre class="brush: js">var db;
 
 // Request version 3 of the database.
 var request = window.indexedDB.open("library", 3);

--- a/files/en-us/web/api/idbrequest/onsuccess/index.html
+++ b/files/en-us/web/api/idbrequest/onsuccess/index.html
@@ -42,7 +42,7 @@ browser-compat: api.IDBRequest.onsuccess
     href="https://mdn.github.io/to-do-notifications/">view
     example live</a>.)</p>
 
-<pre class="brush: js;highlight:[11]">var title = "Walk dog";
+<pre class="brush: js;">var title = "Walk dog";
 
 // Open up a transaction as usual
 var objectStore = db.transaction(['toDoList'], "readwrite").objectStore('toDoList');

--- a/files/en-us/web/api/idbrequest/result/index.html
+++ b/files/en-us/web/api/idbrequest/result/index.html
@@ -42,7 +42,7 @@ browser-compat: api.IDBRequest.result
     Notifications</a> app (<a href="https://mdn.github.io/to-do-notifications/">view
     example live</a>>.)</p>
 
-<pre class="brush: js;highlight:[11]">var title = "Walk dog";
+<pre class="brush: js;">var title = "Walk dog";
 
 // Open up a transaction as usual
 var objectStore = db.transaction(['toDoList'], "readwrite").objectStore('toDoList');

--- a/files/en-us/web/api/idbrequest/source/index.html
+++ b/files/en-us/web/api/idbrequest/source/index.html
@@ -48,7 +48,7 @@ var <em>IDBObjectStore</em> = <em>request</em>.source;
     href="https://mdn.github.io/to-do-notifications/">view
     example live</a>.)</p>
 
-<pre class="brush: js;highlight:[11]">var title = "Walk dog";
+<pre class="brush: js;">var title = "Walk dog";
 
 // Open up a transaction as usual
 var objectStore = db.transaction(['toDoList'], "readwrite").objectStore('toDoList');

--- a/files/en-us/web/api/mediarecorder/stream/index.html
+++ b/files/en-us/web/api/mediarecorder/stream/index.html
@@ -28,7 +28,7 @@ browser-compat: api.MediaRecorder.stream
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[13,14]">if (navigator.getUserMedia) {
+<pre class="brush: js;">if (navigator.getUserMedia) {
    console.log('getUserMedia supported.');
    navigator.getUserMedia (
       // constraints - only audio needed for this app

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.html
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.html
@@ -45,7 +45,7 @@ tags:
 
 <p>However, we wanted to make the third area (which contains the recorded samples you can play back) take up whatever space is left, regardless of the device height. Flexbox could be the answer here, but it's a bit overkill for such a simple layout. Instead, the problem was solved by making the third container's height equal to 100% of the parent height, minus the heights and padding of the other two:</p>
 
-<pre class="brush: css highlight[4]">.sound-clips {
+<pre class="brush: css">.sound-clips {
   box-shadow: inset 0 3px 4px rgba(0,0,0,0.7);
   background-color: rgba(0,0,0,0.1);
   height: calc(100% - 240px - 0.7rem);

--- a/files/en-us/web/api/messagechannel/port1/index.html
+++ b/files/en-us/web/api/messagechannel/port1/index.html
@@ -39,7 +39,7 @@ browser-compat: api.MessageChannel.port1
   putting it into a paragraph. The <code>handleMessage</code> method is associated to the
   <code>port1</code> to listen when the message arrives.</p>
 
-<pre class="brush: js highlight[13]">var channel = new MessageChannel();
+<pre class="brush: js">var channel = new MessageChannel();
 var para = document.querySelector('p');
 
 var ifr = document.querySelector('iframe');

--- a/files/en-us/web/api/mutationobserver/takerecords/index.html
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.html
@@ -55,7 +55,7 @@ browser-compat: api.MutationObserver.takeRecords
   {{domxref("MutationRecord")}}s by calling <code>takeRecords()</code> just before
   disconnecting the observer.</p>
 
-<pre class="brush: js; highlight:[12-18]">const targetNode = document.querySelector("#someElement");
+<pre class="brush: js;">const targetNode = document.querySelector("#someElement");
 const observerOptions = {
   childList: true,
   attributes: true

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
@@ -98,7 +98,7 @@ browser-compat: api.Navigator.requestMediaKeySystemAccess
 
 <p>For example:</p>
 
-<pre class="example-bad brush: js highlight[5,8]">let clearKeyOptions = [
+<pre class="example-bad brush: js">let clearKeyOptions = [
   {
     initDataTypes: ['keyids', 'webm'],
     audioCapabilities: [
@@ -119,7 +119,7 @@ navigator.requestMediaKeySystemAccess('org.w3.clearkey', clearKeyOptions)
   warning to console, because <code>"codecs"</code> is not included in the
   <code>contentType</code> strings. This could be corrected as follows:</p>
 
-<pre class="example-good brush: js highlight[5-6,9-10]">let clearKeyOptions = [
+<pre class="example-good brush: js">let clearKeyOptions = [
   {
     initDataTypes: ['keyids', 'webm'],
     audioCapabilities: [

--- a/files/en-us/web/api/nodelist/entries/index.html
+++ b/files/en-us/web/api/nodelist/entries/index.html
@@ -26,7 +26,7 @@ browser-compat: api.NodeList.entries
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[12]">var node = document.createElement("div");
+<pre class="brush: js;">var node = document.createElement("div");
 var kid1 = document.createElement("p");
 var kid2 = document.createTextNode("hey");
 var kid3 = document.createElement("span");

--- a/files/en-us/web/api/nodelist/foreach/index.html
+++ b/files/en-us/web/api/nodelist/foreach/index.html
@@ -54,7 +54,7 @@ browser-compat: api.NodeList.forEach
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[6]">let node = document.createElement("div");
+<pre class="brush: js;">let node = document.createElement("div");
 let kid1 = document.createElement("p");
 let kid2 = document.createTextNode("hey");
 let kid3 = document.createElement("span");

--- a/files/en-us/web/api/nodelist/keys/index.html
+++ b/files/en-us/web/api/nodelist/keys/index.html
@@ -27,7 +27,7 @@ browser-compat: api.NodeList.keys
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[13]">var node = document.createElement("div");
+<pre class="brush: js;">var node = document.createElement("div");
 var kid1 = document.createElement("p");
 var kid2 = document.createTextNode("hey");
 var kid3 = document.createElement("span");

--- a/files/en-us/web/api/nodelist/values/index.html
+++ b/files/en-us/web/api/nodelist/values/index.html
@@ -27,7 +27,7 @@ browser-compat: api.NodeList.values
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight:[13]">var node = document.createElement("div");
+<pre class="brush: js;">var node = document.createElement("div");
 var kid1 = document.createElement("p");
 var kid2 = document.createTextNode("hey");
 var kid3 = document.createElement("span");

--- a/files/en-us/web/api/oscillatornode/detune/index.html
+++ b/files/en-us/web/api/oscillatornode/detune/index.html
@@ -33,7 +33,7 @@ oscillator.detune.setValueAtTime(100, audioCtx.currentTime); // value in cents</
 
 <p>The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For applied examples/information, check out our <a href="https://mdn.github.io/violent-theremin/">Violent Theremin demo</a> (<a href="https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js">see app.js</a> for relevant code).</p>
 
-<pre class="brush: js;highlight[9]">// create web audio api context
+<pre class="brush: js;">// create web audio api context
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 // create Oscillator node

--- a/files/en-us/web/api/oscillatornode/frequency/index.html
+++ b/files/en-us/web/api/oscillatornode/frequency/index.html
@@ -33,7 +33,7 @@ oscillator.frequency.setValueAtTime(440, audioCtx.currentTime); // value in hert
 
 <p>The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For an applied example, check out our <a href="https://mdn.github.io/violent-theremin/">Violent Theremin demo</a> (<a href="https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js">see app.js</a> for relevant code).</p>
 
-<pre class="brush: js;highlight[8]">// create web audio api context
+<pre class="brush: js;">// create web audio api context
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 // create Oscillator node

--- a/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
+++ b/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
@@ -39,7 +39,7 @@ browser-compat: api.OscillatorNode.setPeriodicWave
 <p>The following example illustrates simple usage of <code>createPeriodicWave()</code>,
   recreating a sine wave from a periodic wave.</p>
 
-<pre class="brush: js;highlight[13]">var real = new Float32Array(2);
+<pre class="brush: js;">var real = new Float32Array(2);
 var imag = new Float32Array(2);
 var ac = new AudioContext();
 var osc = ac.createOscillator();

--- a/files/en-us/web/api/oscillatornode/type/index.html
+++ b/files/en-us/web/api/oscillatornode/type/index.html
@@ -64,7 +64,7 @@ browser-compat: api.OscillatorNode.type
     href="https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js">see
     app.js</a> for relevant code).</p>
 
-<pre class="brush: js;highlight[7]">// create web audio api context
+<pre class="brush: js;">// create web audio api context
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 // create Oscillator node

--- a/files/en-us/web/api/path2d/addpath/index.html
+++ b/files/en-us/web/api/path2d/addpath/index.html
@@ -50,7 +50,7 @@ browser-compat: api.Path2D.addPath
   Finally, we draw the first path (which now contains both rectangles) using
   {{domxref("CanvasRenderingContext2D.fill()", "fill()")}}.</p>
 
-<pre class="brush: js; highlight:[19]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 // Create first path and add a rectangle

--- a/files/en-us/web/api/path2d/path2d/index.html
+++ b/files/en-us/web/api/path2d/path2d/index.html
@@ -46,7 +46,7 @@ new Path2D(<em>d</em>);
 
 <pre class="brush: html hidden">&lt;canvas id="canvas"&gt;&lt;/canvas&gt;</pre>
 
-<pre class="brush: js highlight:[4,7]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let path1 = new Path2D();
@@ -71,7 +71,7 @@ ctx.stroke(path2);
 
 <pre class="brush: html hidden">&lt;canvas id="canvas"&gt;&lt;/canvas&gt;</pre>
 
-<pre class="brush: js highlight:[4]">const canvas = document.getElementById('canvas');
+<pre class="brush: js">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let p = new Path2D('M10 10 h 80 v 80 h -80 Z');

--- a/files/en-us/web/api/response/json/index.html
+++ b/files/en-us/web/api/response/json/index.html
@@ -44,7 +44,7 @@ browser-compat: api.Response.json
   values out of the resulting objects as you'd expect and insert them into list items to
   display our product data.</p>
 
-<pre class="brush: js highlight[5]">const myList = document.querySelector('ul');
+<pre class="brush: js">const myList = document.querySelector('ul');
 const myRequest = new Request('products.json');
 
 fetch(myRequest)

--- a/files/en-us/web/api/rtcicecandidatestats/networktype/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/networktype/index.html
@@ -53,7 +53,7 @@ browser-compat: api.RTCIceCandidateStats.networkType
   statistics reports for candidates that use or would use a cellular data network to a log
   view.</p>
 
-<pre class="brush: js; highlight[4]">window.setInterval(function() {
+<pre class="brush: js;">window.setInterval(function() {
   myPeerConnection.getStats(null).then(stats =&gt; {
     let statsOutput = "";
 

--- a/files/en-us/web/api/selection/deletefromdocument/index.html
+++ b/files/en-us/web/api/selection/deletefromdocument/index.html
@@ -40,7 +40,7 @@ browser-compat: api.Selection.deleteFromDocument
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight:[6]">let button = document.querySelector('button');
+<pre class="brush: js;">let button = document.querySelector('button');
 button.addEventListener('click', deleteSelection);
 
 function deleteSelection() {

--- a/files/en-us/web/api/svgcircleelement/cx/index.html
+++ b/files/en-us/web/api/svgcircleelement/cx/index.html
@@ -37,7 +37,7 @@ browser-compat: api.SVGCircleElement.cx
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight[2]">const circle = document.getElementById('circle');
+<pre class="brush: js;">const circle = document.getElementById('circle');
 console.log(circle.cx);
 </pre>
 

--- a/files/en-us/web/api/svgcircleelement/cy/index.html
+++ b/files/en-us/web/api/svgcircleelement/cy/index.html
@@ -35,7 +35,7 @@ browser-compat: api.SVGCircleElement.cy
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight[2]">const circle = document.getElementById('circle');
+<pre class="brush: js;">const circle = document.getElementById('circle');
 console.log(circle.cy);
 </pre>
 

--- a/files/en-us/web/api/svgcircleelement/r/index.html
+++ b/files/en-us/web/api/svgcircleelement/r/index.html
@@ -35,7 +35,7 @@ browser-compat: api.SVGCircleElement.r
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight[2]">const circle = document.getElementById('circle');
+<pre class="brush: js;">const circle = document.getElementById('circle');
 console.log(circle.r);
 </pre>
 

--- a/files/en-us/web/api/svggraphicselement/copy_event/index.html
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.html
@@ -67,7 +67,7 @@ browser-compat: api.SVGGraphicsElement.copy_event
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js; highlight[1]">document.getElementsByTagName("text")[0].addEventListener("copy", evt =&gt; {
+<pre class="brush: js;.addEventListener("copy", evt =&gt; {
   evt.clipboardData.setData('text/plain', document.getSelection().toString().toUpperCase());
   evt.preventDefault();
 });</pre>

--- a/files/en-us/web/api/svggraphicselement/copy_event/index.html
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.html
@@ -67,7 +67,7 @@ browser-compat: api.SVGGraphicsElement.copy_event
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js;.addEventListener("copy", evt =&gt; {
+<pre class="brush: js;">document.getElementsByTagName("text")[0].addEventListener("copy", evt =&gt; {
   evt.clipboardData.setData('text/plain', document.getSelection().toString().toUpperCase());
   evt.preventDefault();
 });</pre>

--- a/files/en-us/web/api/svgimageelement/decoding/index.html
+++ b/files/en-us/web/api/svgimageelement/decoding/index.html
@@ -38,7 +38,7 @@ SVGImageElement.decoding = refStr;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[3]">var img = new Image();
+<pre class="brush: js;">var img = new Image();
 img.decoding = 'sync';
 img.src = 'img/logo.svg';
 </pre>

--- a/files/en-us/web/api/textmetrics/width/index.html
+++ b/files/en-us/web/api/textmetrics/width/index.html
@@ -22,7 +22,7 @@ browser-compat: api.TextMetrics.width
 
 <p>... you can get a {{domxref("TextMetrics")}} object using the following code:</p>
 
-<pre class="brush: js;highlight:[5]">const canvas = document.getElementById('canvas');
+<pre class="brush: js;">const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let text = ctx.measureText('foo'); // TextMetrics object

--- a/files/en-us/web/api/urlsearchparams/entries/index.html
+++ b/files/en-us/web/api/urlsearchparams/entries/index.html
@@ -33,7 +33,7 @@ browser-compat: api.URLSearchParams.entries
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[5]">// Create a test URLSearchParams object
+<pre class="brush: js;">// Create a test URLSearchParams object
 var searchParams = new URLSearchParams("key1=value1&amp;key2=value2");
 
 // Display the key/value pairs

--- a/files/en-us/web/api/urlsearchparams/foreach/index.html
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.html
@@ -46,7 +46,7 @@ browser-compat: api.URLSearchParams.forEach
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[5]">// Create a test URLSearchParams object
+<pre class="brush: js;">// Create a test URLSearchParams object
 var searchParams = new URLSearchParams("key1=value1&amp;key2=value2");
 
 // Log the values

--- a/files/en-us/web/api/urlsearchparams/keys/index.html
+++ b/files/en-us/web/api/urlsearchparams/keys/index.html
@@ -35,7 +35,7 @@ browser-compat: api.URLSearchParams.keys
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[5]">// Create a test URLSearchParams object
+<pre class="brush: js;">// Create a test URLSearchParams object
 var searchParams = new URLSearchParams("key1=value1&amp;key2=value2");
 
 // Display the keys

--- a/files/en-us/web/api/urlsearchparams/sort/index.html
+++ b/files/en-us/web/api/urlsearchparams/sort/index.html
@@ -33,7 +33,7 @@ browser-compat: api.URLSearchParams.sort
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[5]">// Create a test URLSearchParams object
+<pre class="brush: js;">// Create a test URLSearchParams object
 var searchParams = new URLSearchParams("c=4&amp;a=2&amp;b=3&amp;a=1");
 
 // Sort the key/value pairs

--- a/files/en-us/web/api/urlsearchparams/values/index.html
+++ b/files/en-us/web/api/urlsearchparams/values/index.html
@@ -33,7 +33,7 @@ browser-compat: api.URLSearchParams.values
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js;highlight:[5]">// Create a test URLSearchParams object
+<pre class="brush: js;">// Create a test URLSearchParams object
 var searchParams = new URLSearchParams("key1=value1&amp;key2=value2");
 
 // Display the values

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.html
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>The {{domxref("Performance.mark","performance.mark()")}} method is used to create a performance mark. The method takes one argument, the <em>name</em> of the mark, as shown in the following example.</p>
 
-<pre class="brush: js highlight:[8]">function create_marks(ev) {
+<pre class="brush: js">function create_marks(ev) {
   if (performance.mark === undefined) {
     log("Create Marks: performance.mark Not supported", 0);
     return;
@@ -45,7 +45,7 @@ tags:
 
 <p>The {{domxref("Performance")}} interface has three methods to retrieve marks. The following examples shows how to use each of these methods ({{domxref("Performance.getEntries","performance.getEntries()")}}, {{domxref("Performance.getEntriesByType","performance.getEntriesByType(entryType)")}}, and {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name, entryType)")}} ) to retrieve one or more marks.</p>
 
-<pre class="brush: js highlight:[9,19,26]">function display_marks(ev) {
+<pre class="brush: js">function display_marks(ev) {
   if (performance.getEntries === undefined) {
     log("Display Marks: performance.getEntries Not supported", 0);
     return;
@@ -87,7 +87,7 @@ tags:
 
 <p>The {{domxref("Performance.clearMarks","performance.clearMarks()")}} method is used to remove one or more marks from the browser's performance timeline. If a specific mark <em>name</em> is given to this method, only the mark(s) with that name will be removed. However, if no argument is given, then all {{domxref("PerformanceEntry","performance entries")}} of type "<code>mark</code>" will be removed from the performance timeline. The following example demonstrates both uses of this method.</p>
 
-<pre class="brush: js highlight:[10,14]">function clear_marks(obj) {
+<pre class="brush: js">function clear_marks(obj) {
   if (performance.clearMarks === undefined) {
     log("Clear Marks: performance.clearMarks Not supported", 0);
     return;
@@ -113,7 +113,7 @@ tags:
 
 <p>A <code>measure</code> is created by calling <code>performance.measure(measureName, startMarkName, endMarkName)</code> where <code>measureName</code> is the measure's name and <code>startMarkName</code> and <code>endMarkName</code> are the start and end names, respectively, of the marks the measure will be placed between (in the performance timeline).</p>
 
-<pre class="brush: js highlight:[18]">function create_measures(ev) {
+<pre class="brush: js">function create_measures(ev) {
   if (performance.measure === undefined) {
     log("Create Measures: performance.measure Not supported", 1);
     return;
@@ -148,7 +148,7 @@ tags:
 
 <p>The {{domxref("Performance")}} interface has three methods to retrieve measures. The following examples shows how to use each of these methods ({{domxref("Performance.getEntries","performance.getEntries()")}}, {{domxref("Performance.getEntriesByType","performance.getEntriesByType(entryType)")}}, and {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name, entryType)")}}) to retrieve one or more measures.</p>
 
-<pre class="brush: js highlight:[9,19,26]">function display_measures(ev) {
+<pre class="brush: js">function display_measures(ev) {
   if (performance.getEntries === undefined) {
     log("Display Measures: performance.getEntries Not supported", 1);
     return;
@@ -190,7 +190,7 @@ tags:
 
 <p>The {{domxref("Performance.clearMeasures","performance.clearMeasures()")}} method is used to remove <em>measures</em> from the browser's performance timeline. If the method is called with a specific measure name, all measures with that name will be removed from the timeline. If the method is called with no arguments, all {{domxref("PerformanceEntry","performance entries")}} with a type of "<code>measure</code>" will be removed from the timeline. The following examples shows both uses of this method.</p>
 
-<pre class="brush: js highlight:[10,14]">function clear_measures(obj) {
+<pre class="brush: js">function clear_measures(obj) {
   if (performance.clearMeasures === undefined) {
     log("Clear Mearsures: performance.clearMeasures Not supported", 1);
     return;

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
@@ -84,7 +84,7 @@ browser-compat: api.WebGLRenderingContext.enableVertexAttribArray
   the attribute that will be used by the WebGL layer to pass individual vertexes from the
   vertex buffer into the vertex shader function.</p>
 
-<pre class="brush: js highlight[6]">gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+<pre class="brush: js">gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
 
 aVertexPosition =
     gl.getAttribLocation(shaderProgram, "aVertexPosition");

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
@@ -122,7 +122,7 @@ browser-compat: api.WebGLRenderingContext.getUniformLocation
         basic 2D WebGL animation example</a>, obtains the locations of three uniforms from
     the shading program, then sets the value of each of the three uniforms.</p>
 
-<pre class="brush: js highlight[3-8]">gl.useProgram(shaderProgram);
+<pre class="brush: js">gl.useProgram(shaderProgram);
 
 uScalingFactor =
     gl.getUniformLocation(shaderProgram, "uScalingFactor");

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
@@ -274,7 +274,7 @@ gl.bufferData(gl.ARRAY_BUFFER, buffer, gl.STATIC_DRAW);
 <p>Then, we specify the memory layout of the array buffer, either by setting the index
   ourselves:</p>
 
-<pre class="brush: js, highlight:[3, 6, 9]">//Describe the layout of the buffer:
+<pre class="brush: js,">//Describe the layout of the buffer:
 //1. position, not normalized
 gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 20, 0);
 gl.enableVertexAttribArray(0);
@@ -297,7 +297,7 @@ gl.linkProgram(shaderProgram);
 <p>Or we can use the index provided by the graphics card instead of setting the index
   ourselves; this avoids the re-linking of the shader program.</p>
 
-<pre class="brush: js, highlight:[2, 6, 10]">const locPosition = gl.getAttribLocation(shaderProgram, 'position');
+<pre class="brush: js,">const locPosition = gl.getAttribLocation(shaderProgram, 'position');
 gl.vertexAttribPointer(locPosition, 3, gl.FLOAT, false, 20, 0);
 gl.enableVertexAttribArray(locPosition);
 

--- a/files/en-us/web/api/windoworworkerglobalscope/indexeddb/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/indexeddb/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WindowOrWorkerGlobalScope.indexedDB
   which the database is opened when the request's <code>onsuccess</code> handler is fired:
 </p>
 
-<pre class="brush: js;highlight:[3]">var db;
+<pre class="brush: js;">var db;
 function openDB() {
  var DBOpenRequest = window.indexedDB.open('toDoList');
  DBOpenRequest.onsuccess = function(e) {

--- a/files/en-us/web/api/worklet/addmodule/index.html
+++ b/files/en-us/web/api/worklet/addmodule/index.html
@@ -66,7 +66,7 @@ browser-compat: api.Worklet.addModule
 
 <h3 id="AudioWorklet_example">AudioWorklet example</h3>
 
-<pre class="brush: js highlight:[3,4,5]">const audioCtx = new AudioContext();
+<pre class="brush: js">const audioCtx = new AudioContext();
 const audioWorklet = audioCtx.audioWorklet;
 await audioWorklet.addModule('modules/bypassFilter.js', {
   credentials: 'omit',


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8364 .

The `highlight[...]` and `highlight:[...]` classes are not supported in Markdown and the converter will not convert code blocks that contain them.

This PR removes them.

One risk with this is that the text refers explicitly to highlighted lines, which then wouldn't make any sense. I've done my best to check that this isn't happening. Also it's worth noting that `highlight` has *never* worked in Yari.