### PR TITLE
Fix code typo in “Basic Concepts of grid layout”

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -482,8 +482,8 @@ You can omit the end value if the area only spans one track.
 }
 
 .box2 {
-  grid-column: 1 / 3;
-  grid-row: 5;
+  grid-column: 1;
+  grid-row: 3 / 5;
 }
 ```
 


### PR DESCRIPTION
Shorthand lines 485 and 486 were incorrect

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
??



> What was wrong/why is this fix needed? (quick summary only)
Obvious typo. Original code is wrong and produces very different result


> Anything else that could help us review it
