### PR TITLE
Remove various classes, part 1

### DIFF
--- a/files/en-us/web/api/analysernode/fftsize/index.html
+++ b/files/en-us/web/api/analysernode/fftsize/index.html
@@ -26,7 +26,7 @@ browser-compat: api.AnalyserNode.fftSize
 
 <p>Must be a power of 2 between <math><semantics><msup><mn>2</mn><mn>5</mn></msup><annotation encoding="TeX">2^5</annotation></semantics></math> and <math><semantics><msup><mn>2</mn><mn>15</mn></msup><annotation encoding="TeX">2^15</annotation></semantics></math>, so one of: <code>32</code>, <code>64</code>, <code>128</code>, <code>256</code>, <code>512</code>, <code>1024</code>, <code>2048</code>, <code>4096</code>, <code>8192</code>, <code>16384</code>, and <code>32768</code>. Defaults to <code>2048</code>.</p>
 
-<p class="note"><strong>Note</strong>: If its value is not a power of 2, or it is outside the specified range, a {{domxref("DOMException")}} with the name <code>IndexSizeError</code> is thrown.</p>
+<p><strong>Note</strong>: If its value is not a power of 2, or it is outside the specified range, a {{domxref("DOMException")}} with the name <code>IndexSizeError</code> is thrown.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.html
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.html
@@ -26,7 +26,7 @@ browser-compat: api.AnalyserNode.maxDecibels
 
 <p>When getting data from <code>getByteFrequencyData()</code>, any frequencies with an amplitude of <code>maxDecibels</code> or higher will be returned as <code>255</code>.</p>
 
-<p class="note"><strong>Note</strong>: If a value less than or equal to <code>AnalyserNode.minDecibels</code> is set, an <code>IndexSizeError</code> exception is thrown.</p>
+<p><strong>Note</strong>: If a value less than or equal to <code>AnalyserNode.minDecibels</code> is set, an <code>IndexSizeError</code> exception is thrown.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/audionode/index.html
+++ b/files/en-us/web/api/audionode/index.html
@@ -24,7 +24,7 @@ browser-compat: api.AudioNode
 
 <p>{{InheritanceDiagram}}</p>
 
-<p class="note"><strong>Note</strong>: An <code>AudioNode</code> can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.</p>
+<p><strong>Note</strong>: An <code>AudioNode</code> can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/process/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.html
@@ -143,7 +143,7 @@ browser-compat: api.AudioWorkletProcessor.process
     property.</li>
 </ol>
 
-<p class="note"><strong>Note</strong>: An absence of the <code>return</code> statement
+<p><strong>Note</strong>: An absence of the <code>return</code> statement
   means that the method returns <code>undefined</code>, and as this is a falsy value, it
   is like returning <code>false</code>. Omitting an explicit <code>return</code> statement
   may cause hard-to-detect problems for your nodes.</p>

--- a/files/en-us/web/api/authenticatorresponse/index.html
+++ b/files/en-us/web/api/authenticatorresponse/index.html
@@ -19,12 +19,10 @@ browser-compat: api.AuthenticatorResponse
 
 <p>Below is a list of interfaces based on the AuthenticatorResponse interface.</p>
 
-<div class="index">
 <ul>
  <li>{{domxref("AuthenticatorAssertionResponse")}}</li>
  <li>{{domxref("AuthenticatorAttestationResponse")}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/canvas_api/index.html
+++ b/files/en-us/web/api/canvas_api/index.html
@@ -43,7 +43,6 @@ ctx.fillRect(10, 10, 150, 100);
 
 <h2 id="Reference">Reference</h2>
 
-<div class="index">
 <ul>
  <li>{{domxref("HTMLCanvasElement")}}</li>
  <li>{{domxref("CanvasRenderingContext2D")}}</li>
@@ -57,7 +56,6 @@ ctx.fillRect(10, 10, 150, 100);
  <li>{{domxref("Path2D")}} {{experimental_inline}}</li>
  <li>{{domxref("ImageBitmapRenderingContext")}} {{experimental_inline}}</li>
 </ul>
-</div>
 
 <div class="notecard note">
 <p><strong>Note:</strong> The interfaces related to the <code>WebGLRenderingContext</code> are referenced under <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>.</p>

--- a/files/en-us/web/api/console/index.html
+++ b/files/en-us/web/api/console/index.html
@@ -229,7 +229,7 @@ console.timeEnd("answer time");
 
 <p>Notice that the timer's name is displayed both when the timer is started and when it's stopped.</p>
 
-<p class="note"><strong>Note:</strong> It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header. If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.</p>
+<p><strong>Note:</strong> It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header. If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.</p>
 
 <h3 id="Stack_traces">Stack traces</h3>
 

--- a/files/en-us/web/api/css_object_model/index.html
+++ b/files/en-us/web/api/css_object_model/index.html
@@ -14,7 +14,6 @@ tags:
 
 <h2 id="Reference">Reference</h2>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("AnimationEvent")}}</li>
  <li>{{DOMxRef("CaretPosition")}}</li>
@@ -53,7 +52,6 @@ tags:
  <li>{{DOMxRef("StyleSheetList")}}</li>
  <li>{{DOMxRef("TransitionEvent")}}</li>
 </ul>
-</div>
 
 <p>Several other interfaces are also extended by the CSSOM-related specifications: {{DOMxRef("Document")}}, {{DOMxRef("Window")}}, {{DOMxRef("Element")}}, {{DOMxRef("HTMLElement")}}, {{DOMxRef("HTMLImageElement")}}, {{DOMxRef("Range")}}, {{DOMxRef("MouseEvent")}}, and {{DOMxRef("SVGElement")}}.</p>
 
@@ -61,7 +59,6 @@ tags:
 
 <p>{{SeeCompatTable}}</p>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("CSSImageValue")}} {{Experimental_Inline}}</li>
  <li>{{DOMxRef("CSSKeywordValue")}} {{Experimental_Inline}}</li>
@@ -92,19 +89,16 @@ tags:
  <li>{{DOMxRef("StylePropertyMap")}} {{Experimental_Inline}}</li>
  <li>{{DOMxRef("StylePropertyMapReadOnly")}} {{Experimental_Inline}}</li>
 </ul>
-</div>
 
 <h3 id="Obsolete_CSSOM_interfaces">Obsolete CSSOM interfaces {{deprecated_inline}}</h3>
 
 <p>{{deprecated_header}}</p>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("CSSPrimitiveValue")}} {{deprecated_inline}}</li>
  <li>{{DOMxRef("CSSValue")}} {{deprecated_inline}}</li>
  <li>{{DOMxRef("CSSValueList")}} {{deprecated_inline}}</li>
 </ul>
-</div>
 
 <h2 id="Tutorials">Tutorials</h2>
 

--- a/files/en-us/web/api/cssmathvalue/index.html
+++ b/files/en-us/web/api/cssmathvalue/index.html
@@ -19,7 +19,6 @@ browser-compat: api.CSSMathValue
 
 <p>Below is a list of interfaces based on the CSSMathValue interface.</p>
 
-<div class="index">
 <ul>
  <li>{{domxref('CSSMathInvert')}}</li>
  <li>{{domxref('CSSMathMax')}}</li>
@@ -28,7 +27,6 @@ browser-compat: api.CSSMathValue
  <li>{{domxref('CSSMathProduct')}}</li>
  <li>{{domxref('CSSMathSum')}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/index.html
+++ b/files/en-us/web/api/cssnumericvalue/index.html
@@ -19,7 +19,6 @@ browser-compat: api.CSSNumericValue
 
 <p>Below is a list of interfaces based on the CSSNumericValue interface.</p>
 
-<div class="index">
 <ul>
 	<li>{{domxref('CSSMathClamp')}}</li>
 	<li>{{domxref('CSSMathInvert')}}</li>
@@ -32,7 +31,6 @@ browser-compat: api.CSSNumericValue
 	<li>{{domxref('CSSNumericArray')}}</li>
 	<li>{{domxref('CSSUnitValue')}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/cssrule/index.html
+++ b/files/en-us/web/api/cssrule/index.html
@@ -12,7 +12,6 @@ browser-compat: api.CSSRule
 
 <p>The <strong><code>CSSRule</code></strong> interface represents a single CSS rule. There are several types of rules which inherit properties from <code>CSSRule</code>.</p>
 
-<div class="index">
   <ul>
     <li>{{DOMXRef("CSSStyleRule")}}</li>
     <li>{{DOMXRef("CSSImportRule")}}</li>
@@ -28,7 +27,6 @@ browser-compat: api.CSSRule
     <li>{{DOMXRef("CSSFontFeatureValuesRule")}}</li>
     <li>{{DOMXRef("CSSViewportRule")}}</li>
   </ul>
-</div>
 
 <h2 id="Properties_common_to_all_CSSRule_instances">Properties common to all CSSRule instances</h2>
 

--- a/files/en-us/web/api/cssstylevalue/index.html
+++ b/files/en-us/web/api/cssstylevalue/index.html
@@ -19,7 +19,6 @@ browser-compat: api.CSSStyleValue
 
 <p>Below is a list of interfaces based on the <code>CSSStyleValue</code> interface.</p>
 
-<div class="index">
 <ul>
 	<li>{{domxref('CSSImageValue')}}</li>
 	<li>{{domxref('CSSKeywordValue')}}</li>
@@ -28,7 +27,6 @@ browser-compat: api.CSSStyleValue
 	<li>{{domxref('CSSTransformValue')}}</li>
 	<li>{{domxref('CSSUnparsedValue')}}</li>
 </ul>
-</div>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/en-us/web/api/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/index.html
@@ -20,7 +20,6 @@ browser-compat: api.CSSTransformValue
 
 <p>Below is a list of interfaces based on the <code>CSSTransformValue</code> interface.</p>
 
-<div class="index">
 <ul>
 	<li>{{domxref('CSSTranslate')}}</li>
 	<li>{{domxref('CSSRotate')}}</li>
@@ -31,7 +30,6 @@ browser-compat: api.CSSTransformValue
 	<li>{{domxref('CSSPerspective')}}</li>
 	<li>{{domxref('CSSMatrixComponent')}}</li>
 </ul>
-</div>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.html
+++ b/files/en-us/web/api/datatransfer/cleardata/index.html
@@ -17,7 +17,7 @@ browser-compat: api.DataTransfer.clearData
   operation's {{domxref("DataTransfer","drag data")}} for the given type. If data for the
   given type does not exist, this method does nothing.</p>
 
-<p class="note">If this method is called with no arguments or the format is an empty
+<p>If this method is called with no arguments or the format is an empty
   {{domxref("DOMString","string")}}, the data of all types will be removed.</p>
 
 <p>This method does <em>not</em> remove files from the drag operation, so it's possible

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.html
@@ -23,7 +23,7 @@ browser-compat: api.DataTransfer.mozClearDataAt
   last format for the item is removed, the entire item is removed, reducing
   {{domxref("DataTransfer.mozItemCount","mozItemCount")}} by one.</p>
 
-<p class="note">Removing the last format for a particular index removes that item
+<p>Removing the last format for a particular index removes that item
   entirely, shifting the remaining items down and changing their indices.</p>
 
 <div class="note"><p><strong>Note:</strong> This method is Gecko-specific.</p></div>

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.html
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.html
@@ -31,7 +31,7 @@ browser-compat: api.Document.getElementsByTagNameNS
     "element.localName")}}).</li>
 </ul>
 
-<p class="note"><strong>Note:</strong> While the W3C specification says
+<p><strong>Note:</strong> While the W3C specification says
   <code>elements</code> is a <code>NodeList</code>, this method returns a
   {{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer. Opera returns a
   <code>NodeList</code>, but with a <code>namedItem</code> method implemented, which makes
@@ -40,7 +40,7 @@ browser-compat: api.Document.getElementsByTagNameNS
     href="https://bugzilla.mozilla.org/show_bug.cgi?id=14869">bug 14869</a> for details.
 </p>
 
-<p class="note"><strong>Note:</strong> Currently parameters in this method are
+<p><strong>Note:</strong> Currently parameters in this method are
   case-sensitive, but they were case-insensitive in Firefox 3.5 and before. See the <a
     href="/en-US/docs/Mozilla/Firefox/Releases/3.6#dom">developer release note for Firefox
     3.6</a> and a note in Browser compatibility section in

--- a/files/en-us/web/api/document/open/index.html
+++ b/files/en-us/web/api/document/open/index.html
@@ -53,10 +53,6 @@ document.close();
 <p>An automatic <code>document.open()</code> call happens when
   {{domxref("document.write()")}} is called after the page has loaded.</p>
 
-<p>For years Firefox and Internet Explorer additionally erased all JavaScript variables,
-  etc., in addition to removing all nodes. This is no longer the case.<span
-    class="comment">document non-spec'ed parameters to document.open</span></p>
-
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 
 <p>Starting with Gecko 1.9, this method is subject to the same same-origin policy as other

--- a/files/en-us/web/api/document_object_model/index.html
+++ b/files/en-us/web/api/document_object_model/index.html
@@ -24,7 +24,6 @@ tags:
 
 <h2 id="DOM_interfaces">DOM interfaces</h2>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("Attr")}}</li>
  <li>{{DOMxRef("CDATASection")}}</li>
@@ -65,13 +64,11 @@ tags:
  <li>{{DOMxRef("Worker")}}</li>
  <li>{{DOMxRef("XMLDocument")}} {{Experimental_Inline}}</li>
 </ul>
-</div>
 
 <h3 id="Obsolete_DOM_interfaces">Obsolete DOM interfaces</h3>
 
 <p>The Document Object Model has been highly simplified. To achieve this, the following interfaces present in the different DOM level 3 or earlier specifications have been removed. It is uncertain whether some may be reintroduced in the future or not, but for the time being they should be considered obsolete and should be avoided:</p>
 
-<div class="index">
 <ul>
  <li><code>DOMConfiguration</code></li>
  <li><code>DOMErrorHandler</code></li>
@@ -90,7 +87,6 @@ tags:
  <li><code>TypeInfo</code></li>
  <li><code>UserDataHandler</code></li>
 </ul>
-</div>
 
 <h2 id="HTML_DOM">HTML DOM</h2>
 
@@ -102,7 +98,6 @@ tags:
 
 <h3 id="SVG_element_interfaces">SVG element interfaces</h3>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("SVGAElement")}}</li>
  <li>{{DOMxRef("SVGAltGlyphElement")}} {{Deprecated_Inline}}</li>
@@ -200,7 +195,6 @@ tags:
  <li>{{DOMxRef("SVGViewElement")}}</li>
  <li>{{DOMxRef("SVGVKernElement")}} {{Deprecated_Inline}}</li>
 </ul>
-</div>
 
 <h3 id="SVG_data_type_interfaces">SVG data type interfaces</h3>
 
@@ -208,7 +202,6 @@ tags:
 
 <h4 id="Static_type">Static type</h4>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("SVGAngle")}}</li>
  <li>{{DOMxRef("SVGColor")}} {{Deprecated_Inline}}</li>
@@ -251,11 +244,9 @@ tags:
  <li>{{DOMxRef("SVGTransform")}}</li>
  <li>{{DOMxRef("SVGTransformList")}}</li>
 </ul>
-</div>
 
 <h4 id="Animated_type">Animated type</h4>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("SVGAnimatedAngle")}}</li>
  <li>{{DOMxRef("SVGAnimatedBoolean")}}</li>
@@ -272,20 +263,16 @@ tags:
  <li>{{DOMxRef("SVGAnimatedString")}}</li>
  <li>{{DOMxRef("SVGAnimatedTransformList")}}</li>
 </ul>
-</div>
 
 <h3 id="SMIL-related_interfaces">SMIL-related interfaces</h3>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("ElementTimeControl")}}</li>
  <li>{{DOMxRef("TimeEvent")}}</li>
 </ul>
-</div>
 
 <h3 id="Other_SVG_interfaces">Other SVG interfaces</h3>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("GetSVGDocument")}}</li>
  <li>{{DOMxRef("ShadowAnimation")}}</li>
@@ -302,7 +289,6 @@ tags:
  <li>{{DOMxRef("SVGZoomAndPan")}}</li>
  <li>{{DOMxRef("SVGZoomEvent")}} {{Deprecated_Inline}}</li>
 </ul>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dragevent/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/dragevent/index.html
@@ -13,12 +13,12 @@ browser-compat: api.DragEvent.DragEvent
 
 <p>This constructor is used to create a synthetic {{domxref("DragEvent")}} object.</p>
 
-<p class="note">Although this interface has a constructor, it is not possible to create a
+<p>Although this interface has a constructor, it is not possible to create a
   useful {{domxref("DataTransfer")}} object from script, since {{domxref("DataTransfer")}}
   objects have a processing and security model that is coordinated by the browser during
   drag-and-drops.</p>
 
-<p class="note">This interface inherits properties from {{domxref("MouseEvent")}} and
+<p>This interface inherits properties from {{domxref("MouseEvent")}} and
   {{domxref("Event")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -42,7 +42,7 @@ browser-compat: api.DragEvent.DragEvent
   </dd>
 </dl>
 
-<p class="note">The <code>DragEventInit</code> dictionary inherits from the
+<p>The <code>DragEventInit</code> dictionary inherits from the
   {{domxref("MouseEvent.MouseEvent","MouseEventInit dictionary")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/index.html
@@ -12,7 +12,7 @@ browser-compat: api.DragEvent
 
 <p>The <strong><code>DragEvent</code></strong> interface is a {{domxref("Event","DOM event")}} that represents a drag and drop interaction. The user initiates a drag by placing a pointer device (such as a mouse) on the touch surface and then dragging the pointer to a new location (such as another DOM element). Applications are free to interpret a drag and drop interaction in an application-specific way.</p>
 
-<p class="note">This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref("Event")}}.</p>
+<p>This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref("Event")}}.</p>
 
 <h2 id="Properties">Properties</h2>
 
@@ -23,7 +23,7 @@ browser-compat: api.DragEvent
 
 <h2 id="Constructors">Constructors</h2>
 
-<p class="note">Although this interface has a constructor, it is not possible to create a useful DataTransfer object from script, since {{domxref("DataTransfer")}} objects have a processing and security model that is coordinated by the browser during drag-and-drops.</p>
+<p>Although this interface has a constructor, it is not possible to create a useful DataTransfer object from script, since {{domxref("DataTransfer")}} objects have a processing and security model that is coordinated by the browser during drag-and-drops.</p>
 
 <dl>
  <dt>{{domxref("DragEvent.DragEvent", "DragEvent()")}}</dt>

--- a/files/en-us/web/api/element/getattributenodens/index.html
+++ b/files/en-us/web/api/element/getattributenodens/index.html
@@ -23,8 +23,6 @@ browser-compat: api.Element.getAttributeNodeNS
  <li><code>nodeName</code> is a string specifying the name of the attribute.</li>
 </ul>
 
-<p><span class="comment">== Example == TBD The example needs to be fixed pre&gt; // html: &lt;div id="top" /&gt; t = document.getElementById("top"); specialNode = t.getAttributeNodeNS( "<a href="https://www.mozilla.org/ns/specialspace">http://www.mozilla.org/ns/specialspace</a>", "id"); // iNode.value = "full-top" &lt;/pre</span></p>
-
 <h2 id="Notes">Notes</h2>
 
 <p><code>getAttributeNodeNS</code> is more specific than <a href="getAttributeNode">getAttributeNode</a> in that it allows you to specify attributes that are part of a particular namespace. The corresponding setter method is <a href="/en-US/docs/Web/API/Element/setAttributeNodeNS">setAttributeNodeNS</a>.</p>

--- a/files/en-us/web/api/encoding_api/index.html
+++ b/files/en-us/web/api/encoding_api/index.html
@@ -17,14 +17,12 @@ tags:
 
 <h2 id="Interfaces">Interfaces</h2>
 
-<div class="index">
 <ul>
  <li>{{DOMxRef("TextDecoder")}}</li>
  <li>{{DOMxRef("TextEncoder")}}</li>
  <li>{{DOMxRef("TextDecoderStream")}}</li>
  <li>{{DOMxRef("TextEncoderStream")}}</li>
 </ul>
-</div>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/api/event/index.html
+++ b/files/en-us/web/api/event/index.html
@@ -34,7 +34,6 @@ browser-compat: api.Event
 
 <p>Note that all event interfaces have names which end in "Event".</p>
 
-<div class="index">
 <ul>
  <li>{{domxref("AnimationEvent")}}</li>
  <li>{{domxref("AudioProcessingEvent")}}</li>
@@ -88,7 +87,6 @@ browser-compat: api.Event
  <li>{{domxref("WebGLContextEvent")}}</li>
  <li>{{domxref("WheelEvent")}}</li>
 </ul>
-</div>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/html_dom_api/index.html
+++ b/files/en-us/web/api/html_dom_api/index.html
@@ -93,7 +93,6 @@ tags:
 
 <p>These interfaces represent specific HTML elements (or sets of related elements which have the same properties and methods associated with them).</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLAnchorElement")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLAreaElement")}}</span></span></li>
@@ -163,19 +162,15 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLUnknownElement")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLVideoElement")}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Deprecated_HTML_Element_Interfaces">Deprecated HTML Element Interfaces</h4>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLMarqueeElement")}} {{deprecated_inline}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Obsolete_HTML_Element_Interfaces">Obsolete HTML Element Interfaces</h4>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLBaseFontElement")}} {{deprecated_inline}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLFontElement")}} {{deprecated_inline}}</span></span></li>
@@ -184,43 +179,35 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLIsIndexElement")}} {{deprecated_inline}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLMenuItemElement")}} {{deprecated_inline}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Web_app_and_browser_integration_interfaces">Web app and browser integration interfaces</h3>
 
 <p>These interfaces offer access to the browser window and document that contain the HTML, as well as to the browser's state, available plugins (if any), and various configuration options.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("BarProp")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("Navigator")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("Window")}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Deprecated_web_app_and_browser_integration_interfaces">Deprecated web app and browser integration interfaces</h4>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("External")}} {{deprecated_inline}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Obsolete_web_app_and_browser_integration_interfaces">Obsolete web app and browser integration interfaces</h4>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("ApplicationCache")}} {{deprecated_inline}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("Plugin")}} {{deprecated_inline}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("PluginArray")}} {{deprecated_inline}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Form_support_interfaces">Form support interfaces</h3>
 
 <p>These interfaces provide structure and functionality required by the elements used to create and manage forms, including the {{HTMLElement("form")}} and {{HTMLElement("input")}} elements.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("FormDataEvent")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HTMLFormControlsCollection")}}</span></span></li>
@@ -228,13 +215,11 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("RadioNodeList")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("ValidityState")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Canvas_and_image_interfaces">Canvas and image interfaces</h3>
 
 <p>These interfaces represent objects used by the Canvas API as well as the {{HTMLElement("img")}} element and {{HTMLElement("picture")}} elements.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("CanvasGradient")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("CanvasPattern")}}</span></span></li>
@@ -247,13 +232,11 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("Path2D")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("TextMetrics")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Media_interfaces">Media interfaces</h3>
 
 <p>The media interfaces provide HTML access to the contents of the media elements: {{HTMLElement("audio")}} and {{HTMLElement("video")}}.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("AudioTrack")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("AudioTrackList")}}</span></span></li>
@@ -267,26 +250,22 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("VideoTrack")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("VideoTrackList")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Drag_and_drop_interfaces">Drag and drop interfaces</h3>
 
 <p>These interfaces are used by the {{DOMxRef("HTML_Drag_and_Drop_API", "", "", "1")}} to represent individual draggable (or dragged) items, groups of dragged or draggable items, and to handle the drag and drop process.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DataTransfer")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DataTransferItem")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DataTransferItemList")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DragEvent")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Page_history_interfaces">Page history interfaces</h3>
 
 <p>The History API interfaces let you access information about the browser's history, as well as to shift the browser's current tab forward and backward through that history.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("BeforeUnloadEvent")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("HashChangeEvent")}}</span></span></li>
@@ -295,23 +274,19 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("PageTransitionEvent")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("PopStateEvent")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Web_Components_interfaces">Web Components interfaces</h3>
 
 <p>These interfaces are used by the <a href="/en-US/docs/Web/Web_Components">Web Components API</a> to create and manage the available <a href="/en-US/docs/Web/Web_Components/Using_custom_elements">custom elements</a>.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("CustomElementRegistry")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Miscellaneous_and_supporting_interfaces">Miscellaneous and supporting interfaces</h3>
 
 <p>These supporting object types are used in a variety of ways in the HTML DOM API. In addition, {{domxref("PromiseRejectionEvent")}} represents the event delivered when a {{Glossary("JavaScript")}} {{jsxref("Promise")}} is rejected.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DOMStringList")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DOMStringMap")}}</span></span></li>
@@ -321,7 +296,6 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("MimeTypeArray")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("PromiseRejectionEvent")}}</span></span></li>
 </ul>
-</div>
 
 <h3 id="Interfaces_belonging_to_other_APIs">Interfaces belonging to other APIs</h3>
 
@@ -331,18 +305,15 @@ tags:
 
 <p>The {{DOMxRef("Web_Storage_API", "", "", "1")}} provides the ability for web sites to store data either temporarily or permanently on the user's device for later re-use.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("Storage")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("StorageEvent")}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Web_Workers_interfaces">Web Workers interfaces</h4>
 
 <p>These interfaces are used by the {{DOMxRef("Web_Workers_API", "", "", "1")}} both to establish the ability for workers to interact with an app and its content, but also to support messaging between windows or apps.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("BroadcastChannel")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("DedicatedWorkerGlobalScope")}}</span></span></li>
@@ -356,28 +327,23 @@ tags:
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("WorkerLocation")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("WorkerNavigator ")}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="WebSocket_interfaces">WebSocket interfaces</h4>
 
 <p>These interfaces, defined by the HTML specification, are used by the {{DOMxRef("WebSockets_API", "", "", "1")}}.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("CloseEvent")}}</span></span></li>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("WebSocket")}}</span></span></li>
 </ul>
-</div>
 
 <h4 id="Server-sent_events_interfaces">Server-sent events interfaces</h4>
 
 <p>The {{domxref("EventSource")}} interface represents the source which sent or is sending {{DOMxRef("Server-sent_events", "server-sent events", "", "1")}}.</p>
 
-<div class="index">
 <ul>
  <li><span class="indexListRow"><span class="indexListTerm">{{DOMxRef("EventSource")}}</span></span></li>
 </ul>
-</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>The following describes the steps that occur during a drag and drop operation.</p>
 
-<p class="note">The drag operations described in this document use the {{domxref("DataTransfer")}} interface. This document does <em>not</em> use the {{domxref("DataTransferItem")}} interface nor the {{domxref("DataTransferItemList")}} interface.</p>
+<p>The drag operations described in this document use the {{domxref("DataTransfer")}} interface. This document does <em>not</em> use the {{domxref("DataTransferItem")}} interface nor the {{domxref("DataTransferItemList")}} interface.</p>
 
 <h2 id="draggableattribute">The <code>draggable</code> Attribute</h2>
 

--- a/files/en-us/web/api/html_drag_and_drop_api/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.html
@@ -75,7 +75,7 @@ tags:
  </tbody>
 </table>
 
-<p class="note"><strong>Note:</strong> Neither <code>dragstart</code> nor <code>dragend</code> events are fired when dragging a file into the browser from the OS.</p>
+<p><strong>Note:</strong> Neither <code>dragstart</code> nor <code>dragend</code> events are fired when dragging a file into the browser from the OS.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 
@@ -93,7 +93,7 @@ tags:
 
 <p>A key difference between the {{domxref("DataTransfer")}} and {{domxref("DataTransferItem")}} interfaces is that the former uses the synchronous {{domxref("DataTransfer.getData","getData()")}} method to access a drag item's data, but the latter instead uses the asynchronous {{domxref("DataTransferItem.getAsString","getAsString()")}} method.</p>
 
-<p class="note"><strong>Note:</strong> {{domxref("DragEvent")}} and {{domxref("DataTransfer")}} are broadly supported on desktop browsers. However, the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces have limited browser support. See {{anch("Interoperability")}} for more information about drag-and-drop interoperability.</p>
+<p><strong>Note:</strong> {{domxref("DragEvent")}} and {{domxref("DataTransfer")}} are broadly supported on desktop browsers. However, the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces have limited browser support. See {{anch("Interoperability")}} for more information about drag-and-drop interoperability.</p>
 
 <h3 id="Gecko-specific_interfaces">Gecko-specific interfaces</h3>
 

--- a/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>Mozilla supports the ability to drag multiple items using some additional non-standard methods. These are methods that mirror the {{domxref("DataTransfer.types","types")}} property as well as the {{domxref("DataTransfer.getData","getData()")}}, {{domxref("DataTransfer.setData","setData()")}} and {{domxref("DataTransfer.clearData","clearData()")}} methods, however, they take an additional argument that specifies the index of the item to retrieve, modify or remove.</p>
 
-<p class="note">The drag processing described in this document use the {{domxref("DataTransfer")}} interface. This processing does <em>not</em> use the {{domxref("DataTransferItem")}} interface nor the {{domxref("DataTransferItemList")}} interface.</p>
+<p>The drag processing described in this document use the {{domxref("DataTransfer")}} interface. This processing does <em>not</em> use the {{domxref("DataTransferItem")}} interface nor the {{domxref("DataTransferItemList")}} interface.</p>
 
 <h2 id="Setting_and_getting_with_indices">Setting and getting with indices</h2>
 
@@ -34,7 +34,7 @@ dt.mozSetDataAt("text/plain", "Second data to drag", 1);
 <pre>event.dataTransfer.mozClearDataAt("text/plain", 1);
 </pre>
 
-<p class="note">Caution: removing the last format for a particular index will remove that item entirely, shifting the remaining items down, so the later items will have different indices. For example:</p>
+<p>Caution: removing the last format for a particular index will remove that item entirely, shifting the remaining items down, so the later items will have different indices. For example:</p>
 
 <pre>var dt = event.dataTransfer;
 dt.mozSetDataAt("text/uri-list", "URL1", 0);

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>It is recommended to always add data of the <code>text/plain</code> type as a fallback for applications or drop targets that do not support other types, unless there is no logical text alternative. Always add this <code>text/plain</code> type last, as it is the least specific and shouldn’t be preferred.</p>
 
-<p class="note">Note: In older code, you may find <code>text/unicode</code> or the <code>Text</code> types. These are equivalent to <code>text/plain</code>, and will store and retrieve plain text data.</p>
+<p>Note: In older code, you may find <code>text/unicode</code> or the <code>Text</code> types. These are equivalent to <code>text/plain</code>, and will store and retrieve plain text data.</p>
 
 <h2 id="link">Dragging Links</h2>
 
@@ -37,7 +37,7 @@ dt.setData("text/plain", "https://www.mozilla.org");
 
 <p>As usual, set the <code>text/plain</code> type last, as a fallback for the <code>text/uri-list</code> type.</p>
 
-<p class="note">Note: the URL type is <code>ur<em><strong>i</strong></em>-list</code> with an <em>I</em>, not an <em>L</em>.</p>
+<p>Note: the URL type is <code>ur<em><strong>i</strong></em>-list</code> with an <em>I</em>, not an <em>L</em>.</p>
 
 <p>To drag multiple links, separate each link inside the <code>text/uri-list</code> data with a CRLF linebreak. Lines that begin with a number sign (<code>#</code>) are comments, and should not be considered URLs. You can use comments to indicate the purpose of a URL, the title associated with a URL, or other data.</p>
 

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -77,7 +77,7 @@ browser-compat: api.HTMLInputElement
   <tr>
    <td><code>value</code></td>
    <td><em><code>string</code>:</em> <strong>Returns / Sets</strong> the current value of the control.
-    <p class="note"><strong>Note:</strong> If the user enters a value different from the value expected, this may return an empty string.</p>
+    <p><strong>Note:</strong> If the user enters a value different from the value expected, this may return an empty string.</p>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/api/iirfilternode/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/iirfilternode/index.html
@@ -39,7 +39,7 @@ browser-compat: api.IIRFilterNode.IIRFilterNode
 	</dd>
 </dl>
 
-<p class="note">Unlike other nodes in the Web Audio API, the options passed into the IIR
+<p>Unlike other nodes in the Web Audio API, the options passed into the IIR
 	filter upon creation are not optional. The filter needs these values to work and with
 	the vast range of filters available, there is no default.</p>
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.html
+++ b/files/en-us/web/api/keyboardevent/charcode/index.html
@@ -71,10 +71,7 @@ input.addEventListener('keypress', function(e) {
     <code>keyCode</code> or <code>charCode</code>, query the {{
     domxref("KeyboardEvent.which", "which") }} property.</li>
   <li>Characters entered through an IME do not register through <code>keyCode</code> or
-    <code>charCode</code>. <span class="comment">Actually with the Chinese IME I'm using,
-      entering the IME results in a keypress event with keyCode = 229 and no other key
-      events fire until the IME exits (which may happen after multiple characters are
-      inputted). I'm not sure if other IME's work this way.</span></li>
+    <code>charCode</code>.</li>
   <li>For a list of the <code>charCode</code> values associated with particular keys, run
     <a
       href="/en-US/docs/Web/API/Document_Object_Model/Examples#example_7:_displaying_event_object_properties">Example

--- a/files/en-us/web/api/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/index.html
@@ -246,7 +246,7 @@ browser-compat: api.KeyboardEvent
  <dd>The event behavior depends on the specific platform. It will either behave like Windows or Mac depending on what the native event model does.</dd>
 </dl>
 
-<p class="note"><p><strong>Note:</strong> Manually firing an event does <em>not</em> generate the default action associated with that event. For example, manually firing a key event does not cause that letter to appear in a focused text input. In the case of UI events, this is important for security reasons, as it prevents scripts from simulating user actions that interact with the browser itself.</p>
+<p><p><strong>Note:</strong> Manually firing an event does <em>not</em> generate the default action associated with that event. For example, manually firing a key event does not cause that letter to appear in a focused text input. In the case of UI events, this is important for security reasons, as it prevents scripts from simulating user actions that interact with the browser itself.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/media_streams_api/index.html
+++ b/files/en-us/web/api/media_streams_api/index.html
@@ -30,7 +30,6 @@ tags:
 
 <p>In these reference articles, you'll find the fundamental information you'll need to know about each of the interfaces that make up the Media Capture and Streams API.</p>
 
-<div class="index">
 <ul>
  <li>{{domxref("BlobEvent")}}</li>
  <li>{{domxref("CanvasCaptureMediaStreamTrack")}}</li>
@@ -52,13 +51,11 @@ tags:
  <li>{{domxref("OverconstrainedError")}}</li>
  <li>{{domxref("URL")}}</li>
 </ul>
-</div>
 
 <p>Early versions of the Media Capture and Streams API specification included separate <code>AudioStreamTrack</code> and <code>VideoStreamTrack</code> interfaces—each based upon {{domxref("MediaStreamTrack")}}—which represented streams of those types. These no longer exist, and you should update any existing code to instead use <code>MediaStreamTrack</code> directly.</p>
 
 <h2 id="Events">Events</h2>
 
-<div class="index">
 <ul>
  <li>{{event("addtrack")}}</li>
  <li>{{event("ended")}}</li>
@@ -68,7 +65,6 @@ tags:
  <li>{{event("started")}}</li>
  <li>{{event("unmuted")}}</li>
 </ul>
-</div>
 
 <h2 id="Guides_and_tutorials">Guides and tutorials</h2>
 

--- a/files/en-us/web/api/microsoft_extensions/index.html
+++ b/files/en-us/web/api/microsoft_extensions/index.html
@@ -18,7 +18,6 @@ tags:
 
 <h2 id="Touch_APIs">Touch APIs</h2>
 
-<div class="index">
 <ul>
 	<li>{{DOMxRef("Element.msZoomTo()")}}</li>
 	<li>{{Event("msContentZoom")}}</li>
@@ -27,11 +26,9 @@ tags:
 	<li>{{DOMxRef("Touch.MsManipulationViewsEnabled")}}</li>
 	<li>{{Event("MSPointerHover")}} {{Deprecated_Inline}}</li>
 </ul>
-</div>
 
 <h2 id="Media_APIs">Media APIs</h2>
 
-<div class="index">
 <ul>
 	<li>{{DOMxRef("HTMLVideoElement.msFrameStep()")}}</li>
 	<li>{{DOMxRef("HTMLVideoElement.msHorizontalMirror")}}</li>
@@ -61,21 +58,17 @@ tags:
 	<li>{{DOMxRef("HTMLVideoElement.onMSVideoOptimalLayoutChanged")}}</li>
 	<li>{{DOMxRef("msFirstPaint")}}</li>
 </ul>
-</div>
 
 <h2 id="Pinned_Sites_APIs">Pinned Sites APIs</h2>
 
-<div class="index">
 <ul>
 	<li>{{DOMxRef("MSSiteModeEvent")}}</li>
 	<li>{{DOMxRef("mssitemodejumplistitemremoved")}}</li>
 	<li>{{DOMxRef("msthumbnailclick")}}</li>
 </ul>
-</div>
 
 <h2 id="Other_APIs">Other APIs</h2>
 
-<div class="index">
 <ul>
 	<li><code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/x-ms-aria-flowfrom">x-ms-aria-flowfrom</a></code></li>
 	<li><code><a href="/en-US/docs/Web/HTML/Global_attributes/x-ms-acceleratorkey">x-ms-acceleratorkey</a></code></li>
@@ -93,7 +86,6 @@ tags:
 	<li>{{DOMxRef("msPutPropertyEnabled")}}</li>
 	<li>{{DOMxRef("msWriteProfilerMark")}}</li>
 </ul>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/online_and_offline_events/index.html
+++ b/files/en-us/web/api/navigator/online_and_offline_events/index.html
@@ -100,7 +100,7 @@ tags:
 }
 </pre>
 
-<p>And the corresponding HTML<span class="comment">XXX When mochitests for this are created, point to those instead and update this example -nickolay</span></p>
+<p>And the corresponding HTML:</p>
 
 <pre class="brush: html">&lt;div id="status"&gt;&lt;/div&gt;
 &lt;div id="log"&gt;&lt;/div&gt;

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
@@ -65,7 +65,7 @@ var <em>offlineAudioCtx</em> = new OfflineAudioContext(<em>options</em>);</pre>
 <p>A new {{domxref("OfflineAudioContext")}} object whose associated
   <code>AudioBuffer</code> is configured as requested.</p>
 
-<p class="note">Like a regular <code>AudioContext</code>, an
+<p>Like a regular <code>AudioContext</code>, an
   <code>OfflineAudioContext</code> can be the target of events, therefore it implements
   the {{domxref("EventTarget")}} interface.</p>
 
@@ -80,7 +80,7 @@ const source = offlineCtx.createBufferSource();
 // etc...
 </pre>
 
-<p class="note">For a full working example, see our <a class="external external-icon"
+<p>For a full working example, see our <a class="external external-icon"
     href="https://mdn.github.io/webaudio-examples/offline-audio-context-promise/">offline-audio-context-promise</a>
   Github repo (see the <a class="external external-icon"
     href="https://github.com/mdn/webaudio-examples/blob/master/offline-audio-context-promise/index.html">source

--- a/files/en-us/web/api/orientationsensor/index.html
+++ b/files/en-us/web/api/orientationsensor/index.html
@@ -23,12 +23,10 @@ browser-compat: api.OrientationSensor
 
 <p>Below is a list of interfaces based on the OrientationSensor interface.</p>
 
-<div class="index">
 <ul>
  <li>{{domxref('AbsoluteOrientationSensor')}}</li>
  <li>{{domxref('RelativeOrientationSensor')}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/performance_timeline/index.html
+++ b/files/en-us/web/api/performance_timeline/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>Besides the {{domxref("PerformanceObserver","PerformanceObserver's")}} interface's {{domxref("PerformanceObserver.observe","observe()")}} method (which is used to register the {{domxref("PerformanceEntry.entryType","entry types")}} to <em>observe</em>), the {{domxref("PerformanceObserver")}} interface also has a {{domxref("PerformanceObserver.disconnect","disconnect()")}} method that stops an observer from receiving further events.</p>
 
-<p class="note">Performance observers were added to the <code>Level 2</code> version of the standard and were not widely implemented.</p>
+<p>Performance observers were added to the <code>Level 2</code> version of the standard and were not widely implemented.</p>
 
 <h2>Specifications</h2>
 

--- a/files/en-us/web/api/performanceentry/duration/index.html
+++ b/files/en-us/web/api/performanceentry/duration/index.html
@@ -50,7 +50,7 @@ browser-compat: api.PerformanceEntry.duration
   apply for a particular performance metric, the browser may choose to return a duration
   of 0.</p>
 
-<p class="note">Note: if the performance entry has an
+<p>Note: if the performance entry has an
   {{domxref("PerformanceEntry.entryType","entryType")}} of "<code>resource</code>" (i.e.
   the entry is a {{domxref("PerformanceResourceTiming")}} object), this property returns
   the difference between the {{domxref("PerformanceResourceTiming.responseEnd")}} and

--- a/files/en-us/web/api/performanceentry/starttime/index.html
+++ b/files/en-us/web/api/performanceentry/starttime/index.html
@@ -46,7 +46,7 @@ browser-compat: api.PerformanceEntry.startTime
 <p>A {{domxref("DOMHighResTimeStamp")}} representing the first timestamp when the
   {{domxref("PerformanceEntry","performance entry")}} was created.</p>
 
-<p class="note">Note: if the performance entry has an
+<p>Note: if the performance entry has an
   {{domxref("PerformanceEntry.entryType","entryType")}} of "<code>resource</code>" (i.e.
   the entry is a {{domxref("PerformanceResourceTiming")}} object), this property returns
   the {{domxref("PerformanceResourceTiming.fetchStart")}}

--- a/files/en-us/web/api/performanceeventtiming/index.html
+++ b/files/en-us/web/api/performanceeventtiming/index.html
@@ -13,7 +13,6 @@ browser-compat: api.PerformanceEventTiming
 ---
 <p>The <code>PerformanceEventTiming</code> interface of the Event Timing API provides timing information for the event types listed below.</p>
 
-<div class="index">
 <ul>
  <li>{{event("auxclick")}}</li>
  <li>{{event("beforeinput")}}</li>
@@ -52,7 +51,6 @@ browser-compat: api.PerformanceEventTiming
  <li>{{event("touchend")}}</li>
  <li>{{event("touchcancel")}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceObserverEntryList.getEntries
   available in the observer's callback function (as the first parameter in the callback).
 </p>
 
-<p class="note">This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
+<p>This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
   interfaces.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceObserverEntryList.getEntriesByName
   {{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in
   the observer's callback function (as the first parameter in the callback).</p>
 
-<p class="note">This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
+<p>This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
   interfaces.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
@@ -13,7 +13,7 @@ browser-compat: api.PerformanceObserverEntryList.getEntriesByType
 
 <p>The <strong><code>getEntriesByType()</code></strong> method of the {{domxref("PerformanceObserverEntryList")}} returns a list of explicitly <em>observed</em> {{domxref("PerformanceEntry","performance entry", '', 'true')}} objects for a given {{domxref("PerformanceEntry.entryType","performance entry type", '', 'true')}}. The list's members are determined by the set of {{domxref("PerformanceEntry.entryType","entry types", '', 'true')}} specified in the call to the {{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in the observer's callback function (as the first parameter in the callback).</p>
 
-<p class="note">This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}} interfaces.</p>
+<p>This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}} interfaces.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performanceobserverentrylist/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/index.html
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceObserverEntryList
 
 <p>The <strong><code>PerformanceObserverEntryList</code></strong> interface is a list of {{domxref("PerformanceEntry","peformance events", '', 'true')}} that were explicitly <em>observed</em> via the {{domxref("PerformanceObserver.observe","observe()")}} method.</p>
 
-<p class="note">Note: this interface is exposed to {{domxref("Window")}} and {{domxref("Worker")}}.</p>
+<p>Note: this interface is exposed to {{domxref("Window")}} and {{domxref("Worker")}}.</p>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.html
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.html
@@ -134,7 +134,7 @@ function init() {
 
 <p>The application uses {{HTMLElement("div")}} elements for the touch areas and provides buttons to enable logging and to clear the log.</p>
 
-<p class="note">To prevent the browser's default touch behavior from overriding this application's pointer handling, the {{cssxref("touch-action")}} property is applied to the {{HTMLElement("body")}} element.</p>
+<p>To prevent the browser's default touch behavior from overriding this application's pointer handling, the {{cssxref("touch-action")}} property is applied to the {{HTMLElement("body")}} element.</p>
 
 <pre class="brush: html">&lt;body onload="init();" style="touch-action:none"&gt;
  &lt;div id="target1"&gt; Tap, Hold or Swipe me 1&lt;/div&gt;

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.html
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.html
@@ -148,7 +148,7 @@ var prevDiff = -1;
 
 <p>The application uses a {{HTMLElement("div")}} element for the touch area and provides buttons to enable logging and to clear the log.</p>
 
-<p class="note">To prevent the browser's default touch behavior from overriding this application's pointer handling, the {{cssxref("touch-action")}} property is applied to the {{HTMLElement("body")}} element.</p>
+<p>To prevent the browser's default touch behavior from overriding this application's pointer handling, the {{cssxref("touch-action")}} property is applied to the {{HTMLElement("body")}} element.</p>
 
 <pre class="brush: html">&lt;body onload="init();" style="touch-action:none"&gt;
  &lt;div id="target"&gt;Touch and Hold with 2 pointers, then pinch in or out.&lt;br/&gt;

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -50,201 +50,214 @@ tags:
 
 <h3 id="Monitor_availability_of_presentation_displays">Monitor availability of presentation displays</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"presentBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Present<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-comment">// The Present button is visible if at least one presentation display is available</span>
-  <span class="hljs-keyword">var</span> presentBtn = <span class="hljs-built_in">document</span>.getElementById(<span class="hljs-string">"presentBtn"</span>);
-  <span class="hljs-comment">// It is also possible to use relative presentation URL e.g. "presentation.html"</span>
-  <span class="hljs-keyword">var</span> presUrls = [<span class="hljs-string">"http://example.com/presentation.html"</span>,
-                  <span class="hljs-string">"http://example.net/alternate.html"</span>];
-  <span class="hljs-comment">// show or hide present button depending on display availability</span>
-  <span class="hljs-keyword">var</span> handleAvailabilityChange = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">available</span>) </span>{
-    presentBtn.style.display = available ? <span class="hljs-string">"inline"</span> : <span class="hljs-string">"none"</span>;
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;button id="presentBtn" style="display: none;"&gt;Present&lt;/button&gt;
+&lt;script&gt;
+  // The Present button is visible if at least one presentation display is available
+  var presentBtn = document.getElementById("presentBtn");
+  // It is also possible to use relative presentation URL e.g. "presentation.html"
+  var presUrls = ["http://example.com/presentation.html",
+                  "http://example.net/alternate.html"];
+  // show or hide present button depending on display availability
+  var handleAvailabilityChange = function(available) {
+    presentBtn.style.display = available ? "inline" : "none";
   };
-  <span class="hljs-comment">// Promise is resolved as soon as the presentation display availability is</span>
-  <span class="hljs-comment">// known.</span>
-  <span class="hljs-keyword">var</span> request = <span class="hljs-keyword">new</span> PresentationRequest(presUrls);
-  request.getAvailability().then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">availability</span>) </span>{
-    <span class="hljs-comment">// availability.value may be kept up-to-date by the controlling UA as long</span>
-    <span class="hljs-comment">// as the availability object is alive. It is advised for the web developers</span>
-    <span class="hljs-comment">// to discard the object as soon as it's not needed.</span>
+  // Promise is resolved as soon as the presentation display availability is
+  // known.
+  var request = new PresentationRequest(presUrls);
+  request.getAvailability().then(function(availability) {
+    // availability.value may be kept up-to-date by the controlling UA as long
+    // as the availability object is alive. It is advised for the web developers
+    // to discard the object as soon as it's not needed.
     handleAvailabilityChange(availability.value);
-    availability.onchange = <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{ handleAvailabilityChange(<span class="hljs-keyword">this</span>.value); };
-  }).catch(<span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{
-    <span class="hljs-comment">// Availability monitoring is not supported by the platform, so discovery of</span>
-    <span class="hljs-comment">// presentation displays will happen only after request.start() is called.</span>
-    <span class="hljs-comment">// Pretend the devices are available for simplicity; or, one could implement</span>
-    <span class="hljs-comment">// a third state for the button.</span>
-    handleAvailabilityChange(<span class="hljs-literal">true</span>);
+    availability.onchange = function() { handleAvailabilityChange(this.value); };
+  }).catch(function() {
+    // Availability monitoring is not supported by the platform, so discovery of
+    // presentation displays will happen only after request.start() is called.
+    // Pretend the devices are available for simplicity; or, one could implement
+    // a third state for the button.
+    handleAvailabilityChange(true);
   });
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h3 id="Starting_a_new_presentation">Starting a new presentation</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  presentBtn.onclick = <span class="hljs-function"><span class="hljs-keyword">function</span> () </span>{
-    <span class="hljs-comment">// Start new presentation.</span>
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;script&gt;
+  presentBtn.onclick = function () {
+    // Start new presentation.
     request.start()
-      <span class="hljs-comment">// The connection to the presentation will be passed to setConnection on</span>
-      <span class="hljs-comment">// success.</span>
+      // The connection to the presentation will be passed to setConnection on
+      // success.
       .then(setConnection);
-      <span class="hljs-comment">// Otherwise, the user canceled the selection dialog or no screens were</span>
-      <span class="hljs-comment">// found.</span>
+      // Otherwise, the user canceled the selection dialog or no screens were
+      // found.
   };
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h3 id="Reconnect_to_a_presentation">Reconnect to a presentation</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"reconnectBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Reconnect<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-keyword">var</span> reconnect = <span class="hljs-function"><span class="hljs-keyword">function</span> () </span>{
-    <span class="hljs-comment">// read presId from localStorage if exists</span>
-    <span class="hljs-keyword">var</span> presId = localStorage[<span class="hljs-string">"presId"</span>];
-    <span class="hljs-comment">// presId is mandatory when reconnecting to a presentation.</span>
-    <span class="hljs-keyword">if</span> (!!presId) {
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;button id="reconnectBtn" style="display: none;"&gt;Reconnect&lt;/button&gt;
+&lt;script&gt;
+  var reconnect = function () {
+    // read presId from localStorage if exists
+    var presId = localStorage["presId"];
+    // presId is mandatory when reconnecting to a presentation.
+    if (!!presId) {
       request.reconnect(presId)
-        <span class="hljs-comment">// The new connection to the presentation will be passed to</span>
-        <span class="hljs-comment">// setConnection on success.</span>
+        // The new connection to the presentation will be passed to
+        // setConnection on success.
         .then(setConnection);
-        <span class="hljs-comment">// No connection found for presUrl and presId, or an error occurred.</span>
+        // No connection found for presUrl and presId, or an error occurred.
     }
   };
-  <span class="hljs-comment">// On navigation of the controller, reconnect automatically.</span>
-  <span class="hljs-built_in">document</span>.addEventListener(<span class="hljs-string">"DOMContentLoaded"</span>, reconnect);
-  <span class="hljs-comment">// Or allow manual reconnection.</span>
+  // On navigation of the controller, reconnect automatically.
+  document.addEventListener("DOMContentLoaded", reconnect);
+  // Or allow manual reconnection.
   reconnectBtn.onclick = reconnect;
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h3 id="Presentation_initiation_by_the_controlling_UA">Presentation initiation by the controlling UA</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-comment">&lt;!-- Setting presentation.defaultRequest allows the page to specify the
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;!-- Setting presentation.defaultRequest allows the page to specify the
      PresentationRequest to use when the controlling UA initiates a
-     presentation. --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  navigator.presentation.defaultRequest = <span class="hljs-keyword">new</span> PresentationRequest(presUrls);
-  navigator.presentation.defaultRequest.onconnectionavailable = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">evt</span>) </span>{
+     presentation. --&gt;
+&lt;script&gt;
+  navigator.presentation.defaultRequest = new PresentationRequest(presUrls);
+  navigator.presentation.defaultRequest.onconnectionavailable = function(evt) {
     setConnection(evt.connection);
   };
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h3 id="Monitor_connections_state_and_exchange_data">Monitor connection's state and exchange data</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"disconnectBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Disconnect<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"stopBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Stop<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"reconnectBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Reconnect<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-keyword">let</span> connection;
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;button id="disconnectBtn" style="display: none;"&gt;Disconnect&lt;/button&gt;
+&lt;button id="stopBtn" style="display: none;"&gt;Stop&lt;/button&gt;
+&lt;button id="reconnectBtn" style="display: none;"&gt;Reconnect&lt;/button&gt;
+&lt;script&gt;
+  let connection;
 
-  <span class="hljs-comment">// The Disconnect and Stop buttons are visible if there is a connected presentation</span>
-  <span class="hljs-keyword">const</span> stopBtn = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">"#stopBtn"</span>);
-  <span class="hljs-keyword">const</span> reconnectBtn = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">"#reconnectBtn"</span>);
-  <span class="hljs-keyword">const</span> disconnectBtn = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">"#disconnectBtn"</span>);
+  // The Disconnect and Stop buttons are visible if there is a connected presentation
+  const stopBtn = document.querySelector("#stopBtn");
+  const reconnectBtn = document.querySelector("#reconnectBtn");
+  const disconnectBtn = document.querySelector("#disconnectBtn");
 
-  stopBtn.onclick = <span class="hljs-function"><span class="hljs-params">_</span> =&gt;</span> {
-    connection &amp;&amp; connection.terminate();
+  stopBtn.onclick = _ =&gt; {
+    connection && connection.terminate();
   };
 
-  disconnectBtn.onclick = <span class="hljs-function"><span class="hljs-params">_</span> =&gt;</span> {
-    connection &amp;&amp; connection.close();
+  disconnectBtn.onclick = _ =&gt; {
+    connection && connection.close();
   };
 
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">setConnection</span>(<span class="hljs-params">newConnection</span>) </span>{
-    <span class="hljs-comment">// Disconnect from existing presentation, if not attempting to reconnect</span>
-    <span class="hljs-keyword">if</span> (connection &amp;&amp; connection != newConnection &amp;&amp; connection.state != <span class="hljs-string">'closed'</span>) {
-      connection.onclosed = <span class="hljs-literal">undefined</span>;
+  function setConnection(newConnection) {
+    // Disconnect from existing presentation, if not attempting to reconnect
+    if (connection && connection != newConnection && connection.state != 'closed') {
+      connection.onclosed = undefined;
       connection.close();
     }
 
-    <span class="hljs-comment">// Set the new connection and save the presentation ID</span>
+    // Set the new connection and save the presentation ID
     connection = newConnection;
-    localStorage[<span class="hljs-string">"presId"</span>] = connection.id;
+    localStorage["presId"] = connection.id;
 
-    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">showConnectedUI</span>() </span>{
-      <span class="hljs-comment">// Allow the user to disconnect from or terminate the presentation</span>
-      stopBtn.style.display = <span class="hljs-string">"inline"</span>;
-      disconnectBtn.style.display = <span class="hljs-string">"inline"</span>;
-      reconnectBtn.style.display = <span class="hljs-string">"none"</span>;
+    function showConnectedUI() {
+      // Allow the user to disconnect from or terminate the presentation
+      stopBtn.style.display = "inline";
+      disconnectBtn.style.display = "inline";
+      reconnectBtn.style.display = "none";
     }
 
-    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">showDisconnectedUI</span>() </span>{
-      disconnectBtn.style.display = <span class="hljs-string">"none"</span>;
-      stopBtn.style.display = <span class="hljs-string">"none"</span>;
-      reconnectBtn.style.display = localStorage[<span class="hljs-string">"presId"</span>] ? <span class="hljs-string">"inline"</span> : <span class="hljs-string">"none"</span>;
+    function showDisconnectedUI() {
+      disconnectBtn.style.display = "none";
+      stopBtn.style.display = "none";
+      reconnectBtn.style.display = localStorage["presId"] ? "inline" : "none";
     }
 
-    <span class="hljs-comment">// Monitor the connection state</span>
-    connection.onconnect = <span class="hljs-function"><span class="hljs-params">_</span> =&gt;</span> {
+    // Monitor the connection state
+    connection.onconnect = _ =&gt; {
       showConnectedUI();
 
-      <span class="hljs-comment">// Register message handler</span>
-      connection.onmessage = <span class="hljs-function"><span class="hljs-params">message</span> =&gt;</span> {
-        <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Received message: <span class="hljs-subst">${message.data}</span>`</span>);
+      // Register message handler
+      connection.onmessage = message =&gt; {
+        console.log(`Received message: ${message.data}`);
       };
 
-      <span class="hljs-comment">// Send initial message to presentation page</span>
-      connection.send(<span class="hljs-string">"Say hello"</span>);
+      // Send initial message to presentation page
+      connection.send("Say hello");
     };
 
-    connection.onclose = <span class="hljs-function"><span class="hljs-params">_</span> =&gt;</span> {
-      connection = <span class="hljs-literal">null</span>;
+    connection.onclose = _ =&gt; {
+      connection = null;
       showDisconnectedUI();
     };
 
-    connection.onterminate = <span class="hljs-function"><span class="hljs-params">_</span> =&gt;</span> {
-      <span class="hljs-comment">// Remove presId from localStorage if exists</span>
-      <span class="hljs-keyword">delete</span> localStorage[<span class="hljs-string">"presId"</span>];
-      connection = <span class="hljs-literal">null</span>;
+    connection.onterminate = _ =&gt; {
+      // Remove presId from localStorage if exists
+      delete localStorage["presId"];
+      connection = null;
       showDisconnectedUI();
     };
   };
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;</pre>
 
 <h3 id="Monitor_available_connections_and_say_hello">Monitor available connection(s) and say hello</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- presentation.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-keyword">var</span> addConnection = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">connection</span>) </span>{
-    <span class="hljs-keyword">this</span>.onmessage = <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">message</span>) </span>{
-      <span class="hljs-keyword">if</span> (message.data == <span class="hljs-string">"say hello"</span>)
-        <span class="hljs-keyword">this</span>.send(<span class="hljs-string">"hello"</span>);
+<pre class="brush: html">
+&lt;!-- presentation.html --&gt;
+&lt;script&gt;
+  var addConnection = function(connection) {
+    this.onmessage = function (message) {
+      if (message.data == "say hello")
+        this.send("hello");
     };
   };
 
-  navigator.presentation.receiver.connectionList.then(<span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">list</span>) </span>{
-    list.connections.map(<span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">connection</span>) </span>{
+  navigator.presentation.receiver.connectionList.then(function (list) {
+    list.connections.map(function (connection) {
       addConnection(connection);
     });
-    list.onconnectionavailable = <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">evt</span>) </span>{
+    list.onconnectionavailable = function (evt) {
       addConnection(evt.connection);
     };
   });
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h3 id="Passing_locale_information_with_a_message">Passing locale information with a message</h3>
 
-<pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  connection.send(<span class="hljs-string">"{string: '你好，世界!', lang: 'zh-CN'}"</span>);
-  connection.send(<span class="hljs-string">"{string: 'こんにちは、世界!', lang: 'ja'}"</span>);
-  connection.send(<span class="hljs-string">"{string: '안녕하세요, 세계!', lang: 'ko'}"</span>);
-  connection.send(<span class="hljs-string">"{string: 'Hello, world!', lang: 'en-US'}"</span>);
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+<pre class="brush: html">
+&lt;!-- controller.html --&gt;
+&lt;script&gt;
+  connection.send("{string: '你好，世界!', lang: 'zh-CN'}");
+  connection.send("{string: 'こんにちは、世界!', lang: 'ja'}");
+  connection.send("{string: '안녕하세요, 세계!', lang: 'ko'}");
+  connection.send("{string: 'Hello, world!', lang: 'en-US'}");
+&lt;/script&gt;
 
-<span class="hljs-comment">&lt;!-- presentation.html --&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  connection.onmessage = <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">message</span>) </span>{
-    <span class="hljs-keyword">var</span> messageObj = <span class="hljs-built_in">JSON</span>.parse(message.data);
-    <span class="hljs-keyword">var</span> spanElt = <span class="hljs-built_in">document</span>.createElement(<span class="hljs-string">"SPAN"</span>);
+&lt;!-- presentation.html --&gt;
+&lt;script&gt;
+  connection.onmessage = function (message) {
+    var messageObj = JSON.parse(message.data);
+    var spanElt = document.createElement("SPAN");
     spanElt.lang = messageObj.lang;
     spanElt.textContent = messageObj.string;
-    <span class="hljs-built_in">document</span>.appendChild(spanElt);
+    document.appendChild(spanElt);
   };
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
+&lt;/script&gt;
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -50,7 +50,6 @@ tags:
 
 <h3 id="Monitor_availability_of_presentation_displays">Monitor availability of presentation displays</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"presentBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Present<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
@@ -80,11 +79,9 @@ tags:
     handleAvailabilityChange(<span class="hljs-literal">true</span>);
   });
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Starting_a_new_presentation">Starting a new presentation</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   presentBtn.onclick = <span class="hljs-function"><span class="hljs-keyword">function</span> () </span>{
@@ -97,11 +94,9 @@ tags:
       <span class="hljs-comment">// found.</span>
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Reconnect_to_a_presentation">Reconnect to a presentation</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"reconnectBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Reconnect<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
@@ -122,11 +117,9 @@ tags:
   <span class="hljs-comment">// Or allow manual reconnection.</span>
   reconnectBtn.onclick = reconnect;
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Presentation_initiation_by_the_controlling_UA">Presentation initiation by the controlling UA</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-comment">&lt;!-- Setting presentation.defaultRequest allows the page to specify the
      PresentationRequest to use when the controlling UA initiates a
@@ -137,11 +130,9 @@ tags:
     setConnection(evt.connection);
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Monitor_connections_state_and_exchange_data">Monitor connection's state and exchange data</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"disconnectBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Disconnect<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"stopBtn"</span> <span class="hljs-attr">style</span>=<span class="hljs-string">"display: none;"</span>&gt;</span>Stop<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
@@ -212,11 +203,9 @@ tags:
     };
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Monitor_available_connections_and_say_hello">Monitor available connection(s) and say hello</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- presentation.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-keyword">var</span> addConnection = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">connection</span>) </span>{
@@ -235,11 +224,9 @@ tags:
     };
   });
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h3 id="Passing_locale_information_with_a_message">Passing locale information with a message</h3>
 
-<div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   connection.send(<span class="hljs-string">"{string: '你好，世界!', lang: 'zh-CN'}"</span>);
@@ -258,11 +245,11 @@ tags:
     <span class="hljs-built_in">document</span>.appendChild(spanElt);
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 
 <table>
+ <tbody>
   <tr>
    <th>Specification</th>
   </tr>
@@ -276,10 +263,8 @@ tags:
 
 <h3 id="Presentation"><code>Presentation</code></h3>
 
-<div>
 
 <p>{{Compat("api.Presentation")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/resource_timing_api/index.html
+++ b/files/en-us/web/api/resource_timing_api/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>{{AvailableInWorkers}}</p>
 
-<p class="note">The <code>PerformanceResourceTiming</code> interface extends the {{domxref("PerformanceEntry")}} for {{domxref("PerformanceEntry","performance entries", "", 1)}} which have an {{domxref("PerformanceEntry.entryType","entryType")}} of "<code>resource</code>".</p>
+<p>The <code>PerformanceResourceTiming</code> interface extends the {{domxref("PerformanceEntry")}} for {{domxref("PerformanceEntry","performance entries", "", 1)}} which have an {{domxref("PerformanceEntry.entryType","entryType")}} of "<code>resource</code>".</p>
 
 <h2 id="High-resolution_timestamps">High-resolution timestamps</h2>
 

--- a/files/en-us/web/api/screen_orientation_api/index.html
+++ b/files/en-us/web/api/screen_orientation_api/index.html
@@ -15,11 +15,9 @@ tags:
 
 <h2 id="Interfaces">Interfaces</h2>
 
-<div class="index">
 <ul>
 	<li>{{DOMxRef("ScreenOrientation")}}</li>
 </ul>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/sensor/index.html
+++ b/files/en-us/web/api/sensor/index.html
@@ -21,7 +21,6 @@ browser-compat: api.Sensor
 
 <p>Below is a list of interfaces based on the <code>Sensor</code> interface.</p>
 
-<div class="index">
 <ul>
 	<li>{{domxref('Accelerometer')}}</li>
 	<li>{{domxref('AmbientLightSensor')}}</li>
@@ -31,7 +30,6 @@ browser-compat: api.Sensor
 	<li>{{domxref('Magnetometer')}}</li>
 	<li>{{domxref('OrientationSensor')}}</li>
 </ul>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/svgnumber/index.html
+++ b/files/en-us/web/api/svgnumber/index.html
@@ -20,7 +20,7 @@ browser-compat: api.SVGNumber
 <dl>
  <dt>{{domxref("SVGNumber.value")}}</dt>
  <dd>A float representing the number.
- <p class="note">Note: If the <code>SVGNumber</code> is read-only, a {{domxref("DOMException")}} with the code NO_MODIFICATION_ALLOWED_ERR is raised on an attempt to change the value.</p>
+ <p>Note: If the <code>SVGNumber</code> is read-only, a {{domxref("DOMException")}} with the code NO_MODIFICATION_ALLOWED_ERR is raised on an attempt to change the value.</p>
  </dd>
 </dl>
 

--- a/files/en-us/web/api/svgstyleelement/index.html
+++ b/files/en-us/web/api/svgstyleelement/index.html
@@ -24,15 +24,15 @@ browser-compat: api.SVGStyleElement
 <dl>
  <dt>{{domxref("SVGStyleElement.type")}}</dt>
  <dd>A {{domxref("DOMString")}} corresponding to the {{SVGAttr("type")}} attribute of the given element.
- <p class="note">SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
+ <p>SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
  </dd>
  <dt>{{domxref("SVGStyleElement.media")}}</dt>
  <dd>A {{domxref("DOMString")}} corresponding to the {{SVGAttr("media")}} attribute of the given element.
- <p class="note">SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
+ <p>SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
  </dd>
  <dt>{{domxref("SVGStyleElement.title")}}</dt>
  <dd>A {{domxref("DOMString")}} corresponding to the {{SVGAttr("title")}} attribute of the given element.
- <p class="note">SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
+ <p>SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code <code>NO_MODIFICATION_ALLOWED_ERR</code> on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.</p>
  </dd>
 </dl>
 

--- a/files/en-us/web/api/svgtextcontentelement/index.html
+++ b/files/en-us/web/api/svgtextcontentelement/index.html
@@ -66,11 +66,11 @@ browser-compat: api.SVGTextContentElement
  <dd>Returns a float representing the computed length of the formatted text advance distance for a substring of text within the element. Note that this method only accounts for the widths of the glyphs in the substring and any extra spacing inserted by the CSS 'letter-spacing' and 'word-spacing' properties. Visual spacing adjustments made by the 'x' attribute is ignored.</dd>
  <dt>{{domxref("SVGTextContentElement.getStartPositionOfChar()")}}</dt>
  <dd>Returns a {{domxref("DOMPoint")}} representing the position of a typographic character after text layout has been performed.
- <p class="note"><strong>Note:</strong> In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.</p>
+ <p><strong>Note:</strong> In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.</p>
  </dd>
  <dt>{{domxref("SVGTextContentElement.getEndPositionOfChar()")}}</dt>
  <dd>Returns a {{domxref("DOMPoint")}} representing the trailing position of a typographic character after text layout has been performed.
- <p class="note"><strong>Note:</strong> In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.</p>
+ <p><strong>Note:</strong> In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.</p>
  </dd>
  <dt>{{domxref("SVGTextContentElement.getExtentOfChar()")}}</dt>
  <dd>Returns a {{domxref("DOMRect")}} representing the computed tight bounding box of the glyph cell that corresponds to a given typographic character.</dd>

--- a/files/en-us/web/api/texttrack/mode/index.html
+++ b/files/en-us/web/api/texttrack/mode/index.html
@@ -19,7 +19,7 @@ browser-compat: api.TextTrack.mode
     <code>showing</code>. You can read this value to determine the current mode,
   and you can change this value to switch modes.</p>
 
-<p class="note">Safari additionally requires the <code><strong>default</strong></code>
+<p>Safari additionally requires the <code><strong>default</strong></code>
   boolean attribute to be set to true when implementing your own video player controls in
   order for the subtitles cues to be shown.</p>
 

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -28,7 +28,6 @@ tags:
 
 <h3 id="Standard_interfaces">Standard interfaces</h3>
 
-<div class="index">
 <ul>
  <li>{{domxref("WebGLRenderingContext")}}</li>
  <li>{{domxref("WebGL2RenderingContext")}}</li>
@@ -48,11 +47,9 @@ tags:
  <li>{{domxref("WebGLUniformLocation")}}</li>
  <li>{{domxref("WebGLVertexArrayObject")}}</li>
 </ul>
-</div>
 
 <h3 id="Extensions">Extensions</h3>
 
-<div class="index">
 <ul>
  <li>{{domxref("ANGLE_instanced_arrays")}}</li>
  <li>{{domxref("EXT_blend_minmax")}}</li>
@@ -91,7 +88,6 @@ tags:
  <li>{{domxref("WEBGL_lose_context")}}</li>
  <li>{{domxref("WEBGL_multi_draw")}}</li>
 </ul>
-</div>
 
 <h3 id="Events">Events</h3>
 

--- a/files/en-us/web/api/webrtc_statistics_api/index.html
+++ b/files/en-us/web/api/webrtc_statistics_api/index.html
@@ -72,7 +72,7 @@ function getConnectionStats() {
    <th scope="row"><code>candidate-pair</code></th>
    <td>Statistics describing the change from one {{domxref("RTCIceTransport")}} to another, such as during an <a href="/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ice_restart">ICE restart</a>.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCIceCandidatePairStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -85,7 +85,7 @@ function getConnectionStats() {
    <th scope="row"><code>certificate</code></th>
    <td>Statistics about a certificate being used by an {{domxref("RTCIceTransport")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCCertificateStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -104,7 +104,7 @@ function getConnectionStats() {
    <th scope="row"><code>csrc</code></th>
    <td>Statistics for a single contributing source (CSRC) that contributed to one of the connection's inbound RTP streams.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCRtpContributingSourceStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -117,7 +117,7 @@ function getConnectionStats() {
    <th scope="row"><code>data-channel</code></th>
    <td>Statistics related to one {{domxref("RTCDataChannel")}} on the connection.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCDataChannelStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -130,7 +130,7 @@ function getConnectionStats() {
    <th scope="row"><code>ice-server</code></th>
    <td>Statistics about the connection to an {{Glossary("ICE")}} server ({{Glossary("STUN")}} or {{Glossary("TURN")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCIceServerStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -143,7 +143,7 @@ function getConnectionStats() {
    <th scope="row"><code>inbound-rtp</code></th>
    <td>Statistics describing the state of one of the connection's inbound data streams.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCInboundRtpStreamStats")}}
       <ul>
        <li>{{domxref("RTCReceivedRtpStreamStats")}}
@@ -164,7 +164,7 @@ function getConnectionStats() {
    <th scope="row"><code>local-candidate</code></th>
    <td>Statistics about a local ICE candidate associated with the connection's {{domxref("RTCIceTransport")}}s.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCIceCandidateStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -177,7 +177,7 @@ function getConnectionStats() {
    <th scope="row"><code>media-source</code></th>
    <td>Statistics about the media produced by the {{domxref("MediaStreamTrack")}} attached to an RTP sender. The dictionary this key maps to depends on the track's {{domxref("MediaStreamTrack.kind", "kind")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCAudioSourceStats")}} <em>or</em> {{domxref("RTCVideoSourceStats")}}
       <ul>
        <li>{{domxref("RTCMediaSourceStats")}}
@@ -194,7 +194,7 @@ function getConnectionStats() {
    <th scope="row"><code>outbound-rtp</code></th>
    <td>Statistics describing the state of one of the outbound data streams on this connection.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCOutboundRtpStreamStats")}}
       <ul>
        <li>{{domxref("RTCSentRtpStreamStats")}}
@@ -215,7 +215,7 @@ function getConnectionStats() {
    <th scope="row"><code>peer-connection</code></th>
    <td>Statistics describing the state of the {{domxref("RTCPeerConnection")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCPeerConnectionStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -228,7 +228,7 @@ function getConnectionStats() {
    <th scope="row"><code>receiver</code></th>
    <td>Statistics related to a specific {{domxref("RTCRtpReceiver")}} and the media associated with that receiver. The specific type of object representing the statistics depends on the media <code>kind</code>.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCAudioReceiverStats")}} <em>or</em> {{domxref("RTCVideoReceiverStats")}}
       <ul>
        <li>{{domxref("RTCAudioHandlerStats")}} <em>or</em> {{domxref("RTCVideoHandlerStats")}}
@@ -249,7 +249,7 @@ function getConnectionStats() {
    <th scope="row"><code>remote-candidate</code></th>
    <td>Statistics about a remote ICE candidate associated with the connection's {{domxref("RTCIceTransport")}}s.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCIceCandidateStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -262,7 +262,7 @@ function getConnectionStats() {
    <th scope="row"><code>remote-inbound-rtp</code></th>
    <td>Statistics describing the state of the inbound data stream from the perspective of the remote peer.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCRemoteInboundRtpStreamStats")}}
       <ul>
        <li>{{domxref("RTCReceivedRtpStreamStats")}}
@@ -283,7 +283,7 @@ function getConnectionStats() {
    <th scope="row"><code>remote-outbound-rtp</code></th>
    <td>Statistics describing the state of the outbound data stream from the perpsective of the remote peer.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCRemoteOutboundRtpStreamStats")}}
       <ul>
        <li>{{domxref("RTCSentRtpStreamStats")}}
@@ -304,7 +304,7 @@ function getConnectionStats() {
    <th scope="row"><code>sctp-transport</code></th>
    <td>Statistics about an {{domxref("RTCSctpTransport")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCSctpTransportStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -317,7 +317,7 @@ function getConnectionStats() {
    <th scope="row"><code>sender</code></th>
    <td>Statistics related to a specific {{domxref("RTCRtpSender")}} and the media associated with that sender. The type of object representing this statistic depends on the <code>kind</code> of the media.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCAudioSenderStats")}} <em>or</em> {{domxref("RTCVideoSenderStats")}}
       <ul>
        <li>{{domxref("RTCAudioHandlerStats")}} <em>or</em> {{domxref("RTCVideoHandlerStats")}}
@@ -338,7 +338,7 @@ function getConnectionStats() {
    <th scope="row"><code>stream</code> {{deprecated_inline}}</th>
    <td>Statistics about a particular media {{domxref("MediaStream")}}. This has been obsoleted since the transition to WebRTC being track-based rather than stream-based.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCMediaStreamStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -357,7 +357,7 @@ function getConnectionStats() {
     </div>
    </td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCSenderVideoTrackAttachmentStats")}} <em>or </em>{{domxref("RTCSenderAudioTrackAttachmentStats")}} <em>or</em> {{domxref("RTCReceiverVideoTrackAttachmentStats")}} <em>or</em> {{domxref("RTCReceiverAudioTrackAttachmentStats")}}
       <ul>
        <li>{{domxref("RTCMediaHandlerStats")}}
@@ -374,7 +374,7 @@ function getConnectionStats() {
    <th scope="row"><code>transceiver</code></th>
    <td>Statistics related to a specific {{domxref("RTCRtpTransceiver")}}.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCRtpTransceiverStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>
@@ -387,7 +387,7 @@ function getConnectionStats() {
    <th scope="row"><code>transport</code></th>
    <td>Statistics about a transport used by the connection.</td>
    <td>
-    <ul class="directory-tree">
+    <ul>
      <li>{{domxref("RTCTransportStats")}}
       <ul>
        <li>{{domxref("RTCStats")}}</li>

--- a/files/en-us/web/api/window/alert/index.html
+++ b/files/en-us/web/api/window/alert/index.html
@@ -42,8 +42,7 @@ alert("Hello world!");</pre>
 <p>The alert dialog should be used for messages which do not require any response on the
   part of the user, other than the acknowledgement of the message.</p>
 
-<p><span class="comment">The following text is shared between this article,
-    DOM:window.prompt and DOM:window.confirm</span> Dialog boxes are modal windows - they
+<p>Dialog boxes are modal windows - they
   prevent the user from accessing the rest of the program's interface until the dialog box
   is closed. For this reason, you should not overuse any function that creates a dialog
   box (or modal window).</p>

--- a/files/en-us/web/api/window/confirm/index.html
+++ b/files/en-us/web/api/window/confirm/index.html
@@ -49,8 +49,7 @@ browser-compat: api.Window.confirm
 
 <h2 id="Notes">Notes</h2>
 
-<p><span class="comment">The following text is shared between this article,
-    DOM:window.prompt and DOM:window.alert</span> Dialog boxes are modal windows — they
+<p>Dialog boxes are modal windows — they
   prevent the user from accessing the rest of the program's interface until the dialog box
   is closed. For this reason, you should not overuse any function that creates a dialog
   box (or modal window). Regardless, there are good reasons to <a

--- a/files/en-us/web/api/window/orientation/index.html
+++ b/files/en-us/web/api/window/orientation/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Window.orientation
 
 <p>Its only possible values are <code>-90</code>, <code>0</code>, <code>90</code>, and <code>180</code>. Positive values are counterclockwise; negative values are clockwise.</p>
 
-<p class="note">This property is deprecated. Use the {{domxref("Screen.orientation")}} property instead, available on the {{domxref("window.screen")}} property.</p>
+<p>This property is deprecated. Use the {{domxref("Screen.orientation")}} property instead, available on the {{domxref("window.screen")}} property.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/window/orientationchange_event/index.html
+++ b/files/en-us/web/api/window/orientationchange_event/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Window.orientationchange_event
 
 <p>The <code>orientationchange</code> event is fired when the orientation of the device has changed.</p>
 
-<p class="note">This event is deprecated. Listen for the {{domxref("ScreenOrientation/change_event", "change")}} event instead.</p>
+<p>This event is deprecated. Listen for the {{domxref("ScreenOrientation/change_event", "change")}} event instead.</p>
 
 
 <table class="properties">

--- a/files/en-us/web/api/window/prompt/index.html
+++ b/files/en-us/web/api/window/prompt/index.html
@@ -68,8 +68,7 @@ sign = window.prompt('Are you feeling lucky', 'sure'); // open the window with T
 <p>A prompt dialog contains a single-line textbox, a Cancel button, and an OK button, and
   returns the (possibly empty) text the user entered into that textbox.</p>
 
-<p><span class="comment">The following text is shared between this article,
-    DOM:window.confirm and DOM:window.alert</span> Dialog boxes are modal windows; they
+<p>Dialog boxes are modal windows; they
   prevent the user from accessing the rest of the program's interface until the dialog box
   is closed. For this reason, you should not overuse any function that creates a dialog
   box (or modal window).</p>

--- a/files/en-us/web/api/worklet/index.html
+++ b/files/en-us/web/api/worklet/index.html
@@ -59,7 +59,7 @@ browser-compat: api.Worklet
  </tbody>
 </table>
 
-<p class="note">For 3D rendering with <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>, you don't use Worklets. Instead, you write Vertex Shaders and Fragment Shaders using GLSL code, and those shaders will then run on the graphics card.</p>
+<p>For 3D rendering with <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>, you don't use Worklets. Instead, you write Vertex Shaders and Fragment Shaders using GLSL code, and those shaders will then run on the graphics card.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/xsltprocessor/generating_html/index.html
+++ b/files/en-us/web/api/xsltprocessor/generating_html/index.html
@@ -9,7 +9,7 @@ slug: Web/API/XSLTProcessor/Generating_HTML
 
 <p>The <code>&lt;body&gt;</code> element of the article now contains HTML elements (a <code>&lt;b&gt;</code> and <code>&lt;u&gt;</code> tag, see figure 2). The XML document contains both HTML elements and XML elements, but only one namespace is needed, namely for the XML elements. Since there is no HTML namespace, and using the XHTML namespace would force the XSL to create an XML document that would not behave like a HTML document, the <code>xsl:output</code> in the XSL Stylesheet will make sure the resulting document will be handled as HTML. For the XML elements, our own namespace is needed, <code><a href="http://devedge.netscape.com/2002/de">http://devedge.netscape.com/2002/de</a></code>, and it is given the prefix myNS <code>(xmlns:myNS="http://devedge.netscape.com/2002/de")</code>.</p>
 
-<p><small><strong>Figure 2 XML file :(example2.xml)<span class="comment">view example | view source</span></strong></small> <span class="comment">XML Document (example2.xml):</span></p>
+<p><strong>Figure 2 XML file :(example2.xml)</strong></p>
 
 <pre>&lt;?xml version="1.0"?&gt;
 &lt;?xml-stylesheet type="text/xsl" href="example2.xsl"?&gt;
@@ -27,7 +27,7 @@ slug: Web/API/XSLTProcessor/Generating_HTML
 
 <p>The XSL Stylesheet used will need to have two namespaces - one for the XSLT elements and one for our own XML elements used in the XML document. The output of the XSL Stylesheet is set to <code>HTML</code> by using the <code>xsl:output</code> element. By setting the output to be HTML and not having a namespace on the resulting elements (colored in blue), those elements will be treated as HTML elements.</p>
 
-<p><small><strong>Figure 3 : XSL Stylesheet with 2 namespaces</strong> (example2.xsl)</small> <span class="comment">XSL Stylesheet (example2.xsl):</span></p>
+<p><strong>Figure 3 : XSL Stylesheet with 2 namespaces</strong> (example2.xsl)</p>
 
 <pre>  &lt;?xml version="1.0"?&gt;
   &lt;xsl:stylesheet version="1.0"
@@ -41,7 +41,7 @@ slug: Web/API/XSLTProcessor/Generating_HTML
 
 <p>A template matching the root node of the XML document is created and used to create the basic structure of the HTML page.</p>
 
-<p><small><strong>Figure 4 : Creating the basic HTML document</strong></small> <span class="comment">XSL Stylesheet (example2.xsl):</span></p>
+<p><strong>Figure 4 : Creating the basic HTML document</strong></p>
 
 <pre>  ...
   &lt;xsl:template match="/"&gt;
@@ -82,7 +82,7 @@ slug: Web/API/XSLTProcessor/Generating_HTML
 
 <p>Three more <code>xsl:template</code>'s are needed to complete the example. The first <code>xsl:template</code> is used for the author nodes, while the second one processes the body node. The third template has a general matching rule which will match any node and any attribute. It is needed in order to preserve the html elements in the XML document, since it matches all of them and copies them out into the HTML document the transformation creates.</p>
 
-<p><strong><small>Figure 5 : Final 3 Templates</small></strong> <span class="comment">XSL Stylesheet(example2.xsl):</span></p>
+<p><strong>Figure 5 : Final 3 Templates</strong></p>
 
 <pre>  ...
   &lt;xsl:template match="myNS:Author"&gt;
@@ -111,7 +111,7 @@ slug: Web/API/XSLTProcessor/Generating_HTML
 
 <p>The final XSLT stylesheet looks as follows:</p>
 
-<p><small><strong>Figure 6 : final XSLT Stylesheet<span class="comment">view example | view source</span></strong></small> <span class="comment">XSL Stylesheet:</span></p>
+<p><strong>Figure 6 : final XSLT Stylesheet</strong></p>
 
 <pre>  &lt;?xml version="1.0"?&gt;
   &lt;xsl:stylesheet version="1.0"


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8364 .

This cleans out various useless classes.

* https://github.com/mdn/content/commit/be7397a8269448014ada0d8d378acc59675e1619 : removes `<div class="index">`
* https://github.com/mdn/content/commit/8c729814aa9373247fc55953c42fede701b63e56 : removes the "note" class on `<p>` elements
* https://github.com/mdn/content/commit/bd975b59368071180de223cd6eaa431a3f5652fb : removes the "directory-tree" class on `<ul>` elements (this used to do something long ago)
* https://github.com/mdn/content/commit/40292c062e03adacaafce70f7066f40682b7d435 : removes `div class="example">`
* https://github.com/mdn/content/commit/2b1f4e43666bdb276bc38bcf8a53bb8dbd9e16e5 : replaces all the code blocks in https://developer.mozilla.org/en-US/docs/Web/API/Presentation_API with non-mangled versions
* https://github.com/mdn/content/commit/f9fc369c6a242cd445d726327bba560989482795 : removes `<span class="comment">` elements - it appears people think these are hidden?

