### PR TITLE
FF92 RelNote: Object.hasOwn() shipped

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -34,8 +34,10 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
-  <li>Access to audio output devices, like speakers and headphones, is now protected by the <a href="speaker-selection"></a> feature policy ({{bug(1577199)}}).</li>
+  <li>Access to audio output devices, like speakers and headphones, is now protected by the <a href="speaker-selection">speaker-selection</a> feature policy ({{bug(1577199)}}).</li>
+  <li>{{jsxref("Object.hasOwn()")}} can be used to test whether a property was defined on an object or inherited ({{bug(1721149)}}).</li>
 </ul>
+
 
 <h4 id="removals_js">Removals</h4>
 


### PR DESCRIPTION
Release note for `Object.hasOwn()` shipping. This is the only docs work required for #8273 as feature was documented for FF91 (nightly only)