### PR TITLE
FF92: Add WebShare API to list of experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1220,14 +1220,14 @@ tags:
  <thead>
   <tr>
    <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Version changed</th>
    <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <th scope="row">Nightly</th>
-   <td>71</td>
+   <td>92</td>
    <td>Yes</td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1227,8 +1227,8 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Nightly</th>
-   <td>92</td>
-   <td>Yes</td>
+   <td>71</td>
+   <td>No (default). Yes (Windows from version 92)</td>
   </tr>
   <tr>
    <th scope="row">Developer Edition</th>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1211,6 +1211,49 @@ tags:
  </tbody>
 </table>
 
+<h3 id="WebRTC_and_media">WebShare API</h3>
+
+<p>The <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> allows sharing of files, URLs and other data from a site.
+  Note that Firefox implements {{domxref("Navigator.share()")}} but not {{domxref("Navigator.canShare()")}} ({{bug(1666203)}}).</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>71</td>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>71</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>71</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>71</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>dom.webshare.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+
+
 <h3 id="WebRTC_and_media">WebRTC and media</h3>
 
 <p>The following experimental features include those found in the <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a>, the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>, the <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions API</a>, the <a href="/en-US/docs/Web/API/Encrypted_Media_Extensions_API">Encrypted Media Extensions API</a>, and the <a href="/en-US/docs/Web/API/Media_Streams_API">Media Capture and Streams API</a>.</p>


### PR DESCRIPTION
This adds web share API to list of experimental features, as part of #7749

Note that this should have been added in FF71. The change that happened in FF92 was that on Nightly *on Windows only* the preference was enabled by default 
