### PR TITLE
Fixes #1828 by adding provided link

### DIFF
--- a/files/en-us/web/api/window/resize_event/index.html
+++ b/files/en-us/web/api/window/resize_event/index.html
@@ -39,6 +39,8 @@ browser-compat: api.Window.resize_event
 
 <p>There is a proposal to allow all elements to be notified of resize changes. See <a href="https://wicg.github.io/ResizeObserver/">Resize Observer</a> to read the draft document, and <a href="https://github.com/WICG/ResizeObserver/issues">GitHub issues</a> to read the on-going discussions.</p>
 
+<p>If the resize event is triggered too many times for your application, see <a href="http://bencentra.com/code/2015/02/27/optimizing-window-resize.html">Optimizing window.onresize</a> to control the time after which the event fires.</p>
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Window_size_logger">Window size logger</h3>


### PR DESCRIPTION
Adds a link that contains code to throttle/debounce resize events.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #1828

> What was wrong/why is this fix needed? (quick summary only)
The window.resize() event fires too many times during a window resize. The suggested link provides code examples to control the time after which the event fires using `setTimeout`. Instead of duplicating the examples, which are more of an optimization technique, added a link.

> Anything else that could help us review it
