### PR TITLE
Fix layout for `space` argument of `JSON.stringify`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -48,8 +48,9 @@ JSON.stringify(value, replacer, space)
     `10`). Values less than 1 indicate that no space should be used.
 
     If this is a `String`, the string (or the first 10 characters of the
-    string, if it's longer than that) is used as white space. If this parameter is not
-    provided (or is {{JSxRef("null")}}), no white space is used.
+    string, if it's longer than that) is used as white space. 
+    
+    If this parameter is not provided (or is {{JSxRef("null")}}), no white space is used.
 
 ### Return value
 


### PR DESCRIPTION
Move the case where the argument is not provided or is `null` on its own paragraph.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8361

> What was wrong/why is this fix needed? (quick summary only)

The _not provided or `null`_ case should have its own paragraph, to find it quickly without having to read the rest.

> Anything else that could help us review it
