### PR TITLE
Update navigator.canShare, navigator.share, Web Share API

### DIFF
--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -9,44 +9,72 @@ tags:
 - Share
 browser-compat: api.Navigator.canShare
 ---
-<div>{{APIRef("HTML DOM")}}{{Non-standard_Header}}{{SeeCompatTable}}{{securecontext_header}}</div>
+<div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
 
-<p>The <strong><code>Navigator.canShare()</code></strong> method of the Web Share API returns <code>true</code> if a call to {{domxref("navigator.share()")}} would succeed.</p>
+<p>The <strong><code>Navigator.canShare()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> returns <code>true</code> if the equivalent call to {{domxref("navigator.share()")}} would succeed.</p>
+
+<p>The method can be used to feature-test if a data types is supported on a particular platform, including both the existing fields and new share data type extensions.</p>
 
 <p>The Web Share API is gated by the <a href="/en-US/docs/Web/API/Permissions_API"><code>web-share</code> permission</a> (and corresponding <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy).
   The <strong><code>canShare()</code></strong> method will return <code>false</code> if the permission is supported on the platform but has not been granted.</p>
 
+<div class="notecard warning">
+  <p><strong>Warning:</strong> The method is flawed in that it may return <code>true</code> for invalid share data that specifies more than one property:</p>
+  <ul>
+    <li>Unsupported fields will be ignored: if there are other supported and valid fields in the share data parameter the method will return <code>true</code> even though part of the data is not shareable.</li>
+    <li>The specification does not require that new supported fields in the data are valid. It is possible that extension fields might be dropped even if valid, and the data still be considered "sharable".</li>
+  </ul> 
+  <p>The method is recommended for feature detection. If used with a single field it will return <code>true</code> only if that field is supported and valid.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">navigator.canShare()
+<pre class="brush: js">navigator.canShare() //always returns false
 navigator.canShare(data)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
   <dt><code>data</code> {{optional_inline}}</dt>
-  <dd>An object containing data to share that matches what you would pass to {{domxref("navigator.share()")}}.</dd>
+  <dd><p>An object defining the share data to test (an object with the same properties is passed to {{domxref("navigator.share()")}}).</p>
+
+  <dd><p>All properties are optional but at least one valid data property must be specified or the method will return <code>false</code>.</p>
+
+  <p>The "base" set of options are listed below:</p>
+    <ul>
+      <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>
+      <li><code>text</code>: A {{domxref("USVString")}} representing text to be shared.</li>
+      <li><code>title</code>: A {{domxref("USVString")}} representing the title to be shared.</li>
+      <li><code>files</code>: An array of files to be shared.</li>
+    </ul>
+   <p>Additional options may be supported in future.
+     Properties that are not supported on a particular platform will be ignored (the method will return <code>false</code> if there are no other valid properties in the data).</p>
+  </dd>
 </dl>
+
 
 <h3 id="Return_value">Return value</h3>
 
-<p>The value <code>true</code> if the specified <code>data</code> can be shared with {{domxref("Navigator.share()")}}, otherwise <code>false</code>.</p>
+<p><code>true</code> if the specified <code>data</code> can be shared with {{domxref("Navigator.share()")}}, otherwise <code>false</code>.</p>
+
 
 <h2 id="Examples">Examples</h2>
 
+<h3 id="sending_the_mdn_url">Sending the MDN URL</h3>
+
 <p>The example checks whether <code>navigator.canShare()</code> is defined, and if so uses it to check whether <code>navigator.share()</code> can share the specified data.</p>
 
-<div class="notecard note">
-  <p><strong>Note:</strong>The separate check for whether <code>navigator.canShare()</code> is defined is needed because "<code>if (navigator.canShare)</code>" evaluates to <code>false</code> in this case, even if the <code>navigator.share()</code> method might be supported and otherwise work.</p>
-</div>
-
-<h3 id="HTML">HTML</h3>
+<h4 id="HTML">HTML</h4>
 
 <p>The HTML just creates a paragraph in which to display the result of the test.</p>
 
 <pre class="brush: html">&lt;p class="result"&gt;&lt;/p&gt;</pre>
 
-<h3 id="JavaScript">JavaScript</h3>
+<h4 id="JavaScript">JavaScript</h4>
+
+<div class="notecard note">
+  <p><strong>Note:</strong>The first test on <code>!navigator.canShare</code> is needed because the method maybe be <code>undefined</code> even if <code>navigator.share()</code> is supported.</p>
+</div>
 
 <pre class="brush: js">let shareData = {
   title: 'MDN',
@@ -56,21 +84,50 @@ navigator.canShare(data)</pre>
 
 const resultPara = document.querySelector('.result');
 
-if (typeof navigator.canShare === 'undefined') {
+if (!navigator.canShare) {
   resultPara.textContent = 'navigator.canShare() not supported.';
 }
-else if (navigator.canShare && navigator.canShare(shareData)) {
+else if (navigator.canShare(shareData)) {
   resultPara.textContent = 'navigator.canShare() supported. We can use navigator.share() to send the data.';
 } else {
-  resultPara.textContent = 'navigator.canShare() supported. Specified data cannot be shared.';
+  resultPara.textContent = 'Specified data cannot be shared.';
 }
 </pre>
 
-<h3 id="Result">Result</h3>
+<h4 id="Result">Result</h4>
 
 <p>The box below should state whether <code>navigator.canShare()</code> is supported on this browser, and if so, whether or not we can use <code>navigator.share()</code> to share the specified data:</p>
 
-<p>{{EmbedLiveSample('Examples')}}</p>
+<p>{{EmbedLiveSample('sending_the_mdn_url')}}</p>
+
+
+<h3>Feature checking example</h3>
+
+<p>The javascript code fragment below demonstrates the logic for checking whether new share data is actually supported.</p>
+
+<pre class="brush: js">// Feature that may not be supported
+let testShare = { someNewKey: 'Some kind of magic data' }
+
+// Complex data that uses new key
+const shareData = {
+  title: 'MDN',
+  text: 'Learn web development on MDN!',
+  url: 'https://developer.mozilla.org',
+  someNewKey: 'Some kind of magic data'
+}
+
+//Test just the key before sharing
+if (navigator.canShare(testShare)) {
+  // Use navigator.share() to share 'shareData'
+} else {
+  // Handle case that new data type can't be shared.
+}
+</pre>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -40,7 +40,7 @@ navigator.canShare(data)</pre>
   <p>Properties that are unknown to the user agent are ignored; share data is only assessed on properties understood by the user agent.
     All properties are optional but at least one known data property must be specified or the method will return <code>false</code>.</p>
 
-  <p>The "base" set of options are listed below:</p>
+  <p>Possible values are:</p>
     <ul>
       <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>
       <li><code>text</code>: A {{domxref("USVString")}} representing text to be shared.</li>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -9,7 +9,7 @@ tags:
 - Share
 browser-compat: api.Navigator.canShare
 ---
-<div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
+<div>{{APIRef("Web Share API")}}{{securecontext_header}}</div>
 
 <p>The <strong><code>Navigator.canShare()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> returns <code>true</code> if the equivalent call to {{domxref("navigator.share()")}} would succeed.</p>
 
@@ -134,5 +134,4 @@ if (navigator.canShare(testShare)) {
 
 <ul>
   <li>{{domxref("navigator.share()")}}</li>
-  <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
 </ul>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Navigator.canShare
 
 <ul>
   <li>The <code>data</code> parameter has been omitted or only contains properties with unknown values. Note that any properties that are not recognized by the user agent are ignored.</li>
-  <li>URL data is badly formatted.</li>
+  <li>A URL is badly formatted.</li>
   <li>Files are specified but the implementation does not support file sharing.</li>
   <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>
 </ul>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -100,7 +100,7 @@ else if (navigator.canShare(shareData)) {
 <p>This method feature tests whether a particular data property is valid and shareable.
   If used with a single <code>data</code> property it will return <code>true</code> only if that property is valid and can be shared on the platform.</p>
 
-<p>The javascript code fragment below demonstrates the logic for checking that a data property is supported.</p>
+<p>The code below demonstrates verifying that a data property is supported.</p>
 
 <pre class="brush: js">// Feature that may not be supported
 let testShare = { someNewProperty: 'Data to share' }

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -113,7 +113,7 @@ const shareData = {
   someNewProperty: 'Data to share'
 }
 
-// Test key is valid and supported before sharing
+// Test that the key is valid and supported before sharing
 if (navigator.canShare(testShare)) {
   // Use navigator.share() to share 'shareData'
 } else {

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -13,9 +13,15 @@ browser-compat: api.Navigator.canShare
 
 <p>The <strong><code>Navigator.canShare()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> returns <code>true</code> if the equivalent call to {{domxref("navigator.share()")}} would succeed.</p>
 
-<p>The method will generally return <code>false</code> if the implementation does not support sharing of an indicated data type, for example files, or if sharing that data type would be considered a "hostile share" by the user-agent.
-  Note however that the method will simply ignore data properties that are not recognised/understood by the user agent.</p>
+<p>The method will return <code>false</code> if the data cannot be <em>validated</em>. Reasons the data might be invalid include:</p>
 
+<ul>
+  <li>The <code>data</code> parameter has been omitted or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>
+  <li>URL data is badly formatted</li>
+  <li>Files are specified but the implementation does not support file sharing.</li>
+  <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>
+</ul>
+  
 <p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
     The <strong><code>canShare()</code></strong> method will return <code>false</code> if the permission is supported but has not been granted.</p>
 

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -97,7 +97,7 @@ else if (navigator.canShare(shareData)) {
 
 <h3>Feature checking example</h3>
 
-<p>The method can be used to feature-test if a particular data property is valid and shareable.
+<p>This method feature tests whether a particular data property is valid and shareable.
   If used with a single <code>data</code> property it will return <code>true</code> only if that property is valid and can be shared on the platform.</p>
 
 <p>The javascript code fragment below demonstrates the logic for checking that a data property is supported.</p>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -16,7 +16,7 @@ browser-compat: api.Navigator.canShare
 <p>The method returns <code>false</code> if the data cannot be <em>validated</em>. Reasons the data might be invalid include:</p>
 
 <ul>
-  <li>The <code>data</code> parameter has been omitted or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>
+  <li>The <code>data</code> parameter has been omitted or only contains properties with unknown values. Note that any properties that are not recognized by the user agent are ignored.</li>
   <li>URL data is badly formatted.</li>
   <li>Files are specified but the implementation does not support file sharing.</li>
   <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -29,14 +29,14 @@ browser-compat: api.Navigator.canShare
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">navigator.canShare() //always returns false
+<pre class="brush: js">navigator.canShare()
 navigator.canShare(data)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
   <dt><code>data</code> {{optional_inline}}</dt>
-  <dd><p>An object defining the share data to test (an object with the same properties is passed to {{domxref("navigator.share()")}}).</p>
+  <dd><p>An object defining the share data to test. Typically, an object with the same properties is passed to {{domxref("navigator.share()")}} if this call returns <code>true</code>.</p>
 
   <dd><p>All properties are optional but at least one valid data property must be specified or the method will return <code>false</code>.</p>
 
@@ -55,7 +55,7 @@ navigator.canShare(data)</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<p><code>true</code> if the specified <code>data</code> can be shared with {{domxref("Navigator.share()")}}, otherwise <code>false</code>.</p>
+<p>Returns <code>true</code> if the specified <code>data</code> can be shared with {{domxref("Navigator.share()")}}, otherwise <code>false</code>.</p>
 
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.canShare
 
 <p>The <strong><code>Navigator.canShare()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> returns <code>true</code> if the equivalent call to {{domxref("navigator.share()")}} would succeed.</p>
 
-<p>The method will return <code>false</code> if the data cannot be <em>validated</em>. Reasons the data might be invalid include:</p>
+<p>The method returns <code>false</code> if the data cannot be <em>validated</em>. Reasons the data might be invalid include:</p>
 
 <ul>
   <li>The <code>data</code> parameter has been omitted or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Navigator.canShare
 
 <ul>
   <li>The <code>data</code> parameter has been omitted or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>
-  <li>URL data is badly formatted</li>
+  <li>URL data is badly formatted.</li>
   <li>Files are specified but the implementation does not support file sharing.</li>
   <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>
 </ul>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -13,19 +13,11 @@ browser-compat: api.Navigator.canShare
 
 <p>The <strong><code>Navigator.canShare()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> returns <code>true</code> if the equivalent call to {{domxref("navigator.share()")}} would succeed.</p>
 
-<p>The method can be used to feature-test if a data types is supported on a particular platform, including both the existing fields and new share data type extensions.</p>
+<p>The method will generally return <code>false</code> if the implementation does not support sharing of an indicated data type, for example files, or if sharing that data type would be considered a "hostile share" by the user-agent.
+  Note however that the method will simply ignore data properties that are not recognised/understood by the user agent.</p>
 
-<p>The Web Share API is gated by the <a href="/en-US/docs/Web/API/Permissions_API"><code>web-share</code> permission</a> (and corresponding <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy).
-  The <strong><code>canShare()</code></strong> method will return <code>false</code> if the permission is supported on the platform but has not been granted.</p>
-
-<div class="notecard warning">
-  <p><strong>Warning:</strong> The method is flawed in that it may return <code>true</code> for invalid share data that specifies more than one property:</p>
-  <ul>
-    <li>Unsupported fields will be ignored: if there are other supported and valid fields in the share data parameter the method will return <code>true</code> even though part of the data is not shareable.</li>
-    <li>The specification does not require that new supported fields in the data are valid. It is possible that extension fields might be dropped even if valid, and the data still be considered "sharable".</li>
-  </ul> 
-  <p>The method is recommended for feature detection. If used with a single field it will return <code>true</code> only if that field is supported and valid.</p>
-</div>
+<p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
+    The <strong><code>canShare()</code></strong> method will return <code>false</code> if the permission is supported but has not been granted.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -36,19 +28,19 @@ navigator.canShare(data)</pre>
 
 <dl>
   <dt><code>data</code> {{optional_inline}}</dt>
-  <dd><p>An object defining the share data to test. Typically, an object with the same properties is passed to {{domxref("navigator.share()")}} if this call returns <code>true</code>.</p>
+  <dd><p>An object defining the share data to test.
+    Typically, an object with the same properties is passed to {{domxref("navigator.share()")}} if this call returns <code>true</code>.</p>
 
-  <dd><p>All properties are optional but at least one valid data property must be specified or the method will return <code>false</code>.</p>
+  <p>Properties that are unknown to the user agent are ignored; share data is only assessed on properties understood by the user agent.
+    All properties are optional but at least one known data property must be specified or the method will return <code>false</code>.</p>
 
   <p>The "base" set of options are listed below:</p>
     <ul>
       <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>
       <li><code>text</code>: A {{domxref("USVString")}} representing text to be shared.</li>
       <li><code>title</code>: A {{domxref("USVString")}} representing the title to be shared.</li>
-      <li><code>files</code>: An array of files to be shared.</li>
+      <li><code>files</code>: An array of {{domxref("File")}} objects representing files to be shared.</li>
     </ul>
-   <p>Additional options may be supported in future.
-     Properties that are not supported on a particular platform will be ignored (the method will return <code>false</code> if there are no other valid properties in the data).</p>
   </dd>
 </dl>
 
@@ -62,7 +54,7 @@ navigator.canShare(data)</pre>
 
 <h3 id="sending_the_mdn_url">Sending the MDN URL</h3>
 
-<p>The example checks whether <code>navigator.canShare()</code> is defined, and if so uses it to check whether <code>navigator.share()</code> can share the specified data.</p>
+<p>The example uses <code>navigator.canShare()</code> to check whether <code>navigator.share()</code> can share the specified data.</p>
 
 <h4 id="HTML">HTML</h4>
 
@@ -71,10 +63,6 @@ navigator.canShare(data)</pre>
 <pre class="brush: html">&lt;p class="result"&gt;&lt;/p&gt;</pre>
 
 <h4 id="JavaScript">JavaScript</h4>
-
-<div class="notecard note">
-  <p><strong>Note:</strong>The first test on <code>!navigator.canShare</code> is needed because the method maybe be <code>undefined</code> even if <code>navigator.share()</code> is supported.</p>
-</div>
 
 <pre class="brush: js">let shareData = {
   title: 'MDN',
@@ -103,24 +91,27 @@ else if (navigator.canShare(shareData)) {
 
 <h3>Feature checking example</h3>
 
-<p>The javascript code fragment below demonstrates the logic for checking whether new share data is actually supported.</p>
+<p>The method can be used to feature-test if a particular data property is valid and shareable.
+  If used with a single <code>data</code> property it will return <code>true</code> only if that property is valid and can be shared on the platform.</p>
+
+<p>The javascript code fragment below demonstrates the logic for checking that a data property is supported.</p>
 
 <pre class="brush: js">// Feature that may not be supported
-let testShare = { someNewKey: 'Some kind of magic data' }
+let testShare = { someNewProperty: 'Data to share' }
 
 // Complex data that uses new key
 const shareData = {
   title: 'MDN',
   text: 'Learn web development on MDN!',
   url: 'https://developer.mozilla.org',
-  someNewKey: 'Some kind of magic data'
+  someNewProperty: 'Data to share'
 }
 
-//Test just the key before sharing
+// Test key is valid and supported before sharing
 if (navigator.canShare(testShare)) {
   // Use navigator.share() to share 'shareData'
 } else {
-  // Handle case that new data type can't be shared.
+  // Handle case that new data property can't be shared.
 }
 </pre>
 
@@ -139,4 +130,3 @@ if (navigator.canShare(testShare)) {
   <li>{{domxref("navigator.share()")}}</li>
   <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
 </ul>
-<p></p>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -74,7 +74,7 @@ browser-compat: api.Navigator.share
 
 <h2 id="Examples">Examples</h2>
 
-<p>The example below shows how a button click can be used to invoke the Web Share API to share MDN's URL.
+<p>The example below shows a button click invoking the Web Share API to share MDN's URL.
   This is taken from our <a href="https://mdn.github.io/dom-examples/web-share/">Web share test</a> (<a href="https://github.com/mdn/dom-examples/blob/master/web-share/index.html">see the source code</a>).</p>
 
 <h3 id="HTML">HTML</h3>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -11,73 +11,117 @@ browser-compat: api.Navigator.share
 ---
 <div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
 
-<p>The <strong><code>navigator.share()</code></strong> method of the Web Share API invokes
-  the native sharing mechanism of the device.</p>
+<p>The <strong><code>navigator.share()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> invokes the native sharing mechanism of the device in order to share data such as text, URLs or files. The available <em>share targets</em> depend on the device, but might include the clipboard, contacts and email applications, websites, bluetooth, etc.</p>
+
+<p>The method requires that the current document has the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy and {{Glossary("transient activation")}} (it must be triggered off a UI event like a button click and cannot be launched at arbitrary points by a script). Further the method must specify valid data that is supported for sharing by the native implementation.</p>
+
+<p>The method resolves a {{jsxref("Promise")}} with <code>undefined</code> as soon as the data is successfully passed to the <em>share target</em>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">const <em>sharePromise</em> = navigator.share(<var>data</var>);
+<pre class="brush: js">navigator.share(data)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
   <dt><code><var>data</var></code></dt>
-  <dd>An object containing data to share. At least one of the following fields must be
-    specified. Available options are:</dd>
+  <dd>
+    <p>An object containing data to share.</p>
+
+    <p>Properties that are unknown to the user agent are ignored; share data is only assessed on properties understood by the user agent.
+      All properties are optional but at least one known data property must be specified.</p>
+  
+    <p>The "base" set of options are listed below:</p>
+
+    <ul>
+      <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>
+      <li><code>text</code>: A {{domxref("USVString")}} representing text to be shared.</li>
+      <li><code>title</code>: A {{domxref("USVString")}} representing a title to be shared.</li>
+      <li><code>files</code>: An array of {{domxref("File")}} objects representing files to be shared.</li>
+    </ul>
+  </dd>
 </dl>
 
-<ul>
-  <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>
-  <li><code>text</code>: A {{domxref("USVString")}} representing text to be shared.</li>
-  <li><code>title</code>: A {{domxref("USVString")}} representing the title to be shared.
-  </li>
-  <li><code>files</code>: A "FrozenArray" representing the array of files to be shared.
-  </li>
-</ul>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Promise")}} that will be fulfilled once a user has completed a share
-  action (usually the user has chosen an application to share to). It will reject
-  immediately if the <var>data</var> parameter is not correctly specified, and will also
-  reject if the user cancels sharing.</p>
+<p>A {{jsxref("Promise")}}. This will be resolved with <code>undefined</code> once the data has been sent to the share target, or rejected with one of the <a href="#exceptions">Exceptions</a> given below.</p>
+
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<p>The {{jsxref("Promise")}} may be rejected with one of the following <code>DOMException</code> values:</p>
+
+<dl>
+  <dt><code>NotAllowedError</code></dt>
+  <dd>The <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission has not been granted, or the window does not have {{Glossary("transient activation")}}, or a file share is being blocked due to security considerations.</dd>
+  <dt><code>TypeError</code></dt>
+  <dd>The specified share data cannot be validated. Possible reasons include:
+    <ul>
+      <li>The <code>data</code> parameter has been omitted completely or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>
+      <li>URL data is badly formatted.</li>
+      <li>Files are specified but the implementation does not support file sharing.</li>
+      <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>
+    </ul>
+  </dd>
+  <dt><code>AbortError</code></dt>
+  <dd>The user canceled the share operation or there are no share targets available.</dd>
+  <dt><code>DataError</code></dt>
+  <dd>There was a problem starting the share target or transmitting the data.</dd>
+</dl>
+
 
 <h2 id="Examples">Examples</h2>
 
-<p>In our <a href="https://mdn.github.io/dom-examples/web-share/">Web share test</a> (<a
-    href="https://github.com/mdn/dom-examples/blob/master/web-share/index.html">see the
-    source code</a>) there is a button which, when clicked, invokes the Web Share API to
-  share MDN's URL. The JavaScript looks like this:</p>
+<p>The example below shows how a button click can be used to invoke the Web Share API to share MDN's URL.
+  This is taken from our <a href="https://mdn.github.io/dom-examples/web-share/">Web share test</a> (<a href="https://github.com/mdn/dom-examples/blob/master/web-share/index.html">see the source code</a>).</p>
+
+<h3 id="HTML">HTML</h3>
+
+<p>The HTML just creates a button to trigger the share, and a paragraph in which to display the result of the test.</p>
+
+<pre class="brush: html">&lt;p&gt;&lt;button&gt;Share MDN!&lt;/button&gt;&lt;/p&gt;
+&lt;p class="result"&gt;&lt;/p&gt;</pre>
+
+<h3 id="JavaScript">JavaScript</h3>
 
 <pre class="brush: js">const shareData = {
-  title: 'MDN',
-  text: 'Learn web development on MDN!',
-  url: 'https://developer.mozilla.org',
-}
-
-const btn = document.querySelector('button');
-const resultPara = document.querySelector('.result');
-
-// Must be triggered some kind of "user activation"
-btn.addEventListener('click', async () =&gt; {
-  try {
-    await navigator.share(shareData)
-    resultPara.textContent = 'MDN shared successfully'
-  } catch(err) {
-    resultPara.textContent = 'Error: ' + err
+    title: 'MDN',
+    text: 'Learn web development on MDN!',
+    url: 'https://developer.mozilla.org'
   }
-});</pre>
+  
+  const btn = document.querySelector('button');
+  const resultPara = document.querySelector('.result');
+  
+  // Share must be triggered by "user activation"
+  btn.addEventListener('click', async () => {
+    try {
+      await navigator.share(shareData)
+      resultPara.textContent = 'MDN shared successfully'
+    } catch(err) {
+      resultPara.textContent = 'Error: ' + err
+    }
+  });
+</pre>
+
+<h3 id="Result">Result</h3>
+
+<p>Click the button to launch the share dialog on your platform.
+  Text will appear below the button to indicate whether the share was successful or provide an error code.</p>
+
+<p>{{EmbedLiveSample('Examples')}}</p>
+
 
 <h4 id="Sharing_Files"><strong>Sharing Files</strong></h4>
 
-<p>To share files, first test for and call <code>navigator.canShare()</code>. Then include
-  an array of files in the call to <code>navigator.share():</code></p>
+<p>To share files, first test for and call {{domxref("navigator.canShare()")}}. Then include an array of files in the call to <code>navigator.share()</code>:</p>
 
-<p>Notice: That the sample handles feature detection by testing for
-  <code>navigator.canShare()</code> rather than for <code>navigator.share()</code>. The
-  data object passed to <code>canShare()</code> only supports the <code>files</code>
-  property. Image, video, audio, and text files can be shared.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> This code sample handles feature detection by testing for <code>navigator.canShare()</code> rather than for <code>navigator.share()</code>.
+    The data object passed to <code>canShare()</code> only includes the <code>files</code> property. Image, video, audio, and text files can be shared.</p>
+</div>
 
 <pre class="brush: js">if (navigator.canShare &amp;&amp; navigator.canShare({ files: filesArray })) {
   navigator.share({
@@ -103,4 +147,6 @@ btn.addEventListener('click', async () =&gt; {
 
 <ul>
   <li>{{domxref("navigator.canShare()")}}</li>
+  <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
+  <li><a href="https://web.dev/web-share-target/">Receiving shared data with the Web Share Target API</a> (https://web.dev/)</li>
 </ul>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -119,7 +119,7 @@ browser-compat: api.Navigator.share
 <p>To share files, first test for and call {{domxref("navigator.canShare()")}}. Then include an array of files in the call to <code>navigator.share()</code>:</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> This code sample handles feature detection by testing for <code>navigator.canShare()</code> rather than for <code>navigator.share()</code>.
+  <p><strong>Note:</strong> This sample feature detects by testing for <code>navigator.canShare()</code> rather than for <code>navigator.share()</code>.
     The data object passed to <code>canShare()</code> only includes the <code>files</code> property. Image, video, audio, and text files can be shared.</p>
 </div>
 

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -32,7 +32,7 @@ browser-compat: api.Navigator.share
     <p>Properties that are unknown to the user agent are ignored; share data is only assessed on properties understood by the user agent.
       All properties are optional but at least one known data property must be specified.</p>
   
-    <p>The "base" set of options are listed below:</p>
+    <p>Possible values are:</p>
 
     <ul>
       <li><code>url</code>: A {{domxref("USVString")}} representing a URL to be shared.</li>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.share
 
 <p>The <strong><code>navigator.share()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> invokes the native sharing mechanism of the device to share data such as text, URLs, or files. The available <em>share targets</em> depend on the device, but might include the clipboard, contacts and email applications, websites, bluetooth, etc.</p>
 
-<p>The method requires that the current document has the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy and {{Glossary("transient activation")}} (it must be triggered off a UI event like a button click and cannot be launched at arbitrary points by a script). Further the method must specify valid data that is supported for sharing by the native implementation.</p>
+<p>This method requires that the current document have the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy and {{Glossary("transient activation")}}. (It must be triggered off a UI event like a button click and cannot be launched at arbitrary points by a script.) Further, the method must specify valid data that is supported for sharing by the native implementation.</p>
 
 <p>The method resolves a {{jsxref("Promise")}} with <code>undefined</code> as soon as the data is successfully passed to the <em>share target</em>.</p>
 

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -60,7 +60,7 @@ browser-compat: api.Navigator.share
   <dd>The specified share data cannot be validated. Possible reasons include:
     <ul>
       <li>The <code>data</code> parameter was omitted completely or only contains properties with unknown values. Note that any properties that are not recognized by the user agent are ignored.</li>
-      <li>URL data is badly formatted.</li>
+      <li>A URL is badly formatted.</li>
       <li>Files are specified but the implementation does not support file sharing.</li>
       <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>
     </ul>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -9,7 +9,7 @@ tags:
 - Web
 browser-compat: api.Navigator.share
 ---
-<div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
+<div>{{APIRef("Web Share API")}}{{securecontext_header}}</div>
 
 <p>The <strong><code>navigator.share()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> invokes the native sharing mechanism of the device to share data such as text, URLs, or files. The available <em>share targets</em> depend on the device, but might include the clipboard, contacts and email applications, websites, bluetooth, etc.</p>
 
@@ -148,5 +148,4 @@ browser-compat: api.Navigator.share
 <ul>
   <li>{{domxref("navigator.canShare()")}}</li>
   <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
-  <li><a href="https://web.dev/web-share-target/">Receiving shared data with the Web Share Target API</a> (https://web.dev/)</li>
 </ul>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -59,7 +59,7 @@ browser-compat: api.Navigator.share
   <dt><code>TypeError</code></dt>
   <dd>The specified share data cannot be validated. Possible reasons include:
     <ul>
-      <li>The <code>data</code> parameter has been omitted completely or only only contains "unknown" properties. Note that any properties that are not recognized by the user agent are ignored.</li>
+      <li>The <code>data</code> parameter was omitted completely or only contains properties with unknown values. Note that any properties that are not recognized by the user agent are ignored.</li>
       <li>URL data is badly formatted.</li>
       <li>Files are specified but the implementation does not support file sharing.</li>
       <li>Sharing the specified data would be considered a "hostile share" by the user-agent.</li>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -46,7 +46,7 @@ browser-compat: api.Navigator.share
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Promise")}}. This will be resolved with <code>undefined</code> once the data has been sent to the share target, or rejected with one of the <a href="#exceptions">Exceptions</a> given below.</p>
+<p>A {{jsxref("Promise")}} that resolves with <code>undefined</code> once the data has been sent to the share target, or rejected with one of the <a href="#exceptions">Exceptions</a> given below.</p>
 
 
 <h3 id="Exceptions">Exceptions</h3>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -11,7 +11,7 @@ browser-compat: api.Navigator.share
 ---
 <div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
 
-<p>The <strong><code>navigator.share()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> invokes the native sharing mechanism of the device in order to share data such as text, URLs or files. The available <em>share targets</em> depend on the device, but might include the clipboard, contacts and email applications, websites, bluetooth, etc.</p>
+<p>The <strong><code>navigator.share()</code></strong> method of the <a href="/en-US/docs/Web/API/Web_Share_API">Web Share API</a> invokes the native sharing mechanism of the device to share data such as text, URLs, or files. The available <em>share targets</em> depend on the device, but might include the clipboard, contacts and email applications, websites, bluetooth, etc.</p>
 
 <p>The method requires that the current document has the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy and {{Glossary("transient activation")}} (it must be triggered off a UI event like a button click and cannot be launched at arbitrary points by a script). Further the method must specify valid data that is supported for sharing by the native implementation.</p>
 

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>The code fragment below shows how you can share a link using {{domxref("navigator.share()")}} triggered off a button click.</p>
+<p>The code below shows how you can share a link using {{domxref("navigator.share()")}}, triggered off a button click.</p>
 
 <pre class="brush: js;">const shareData = {
   title: 'MDN',

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -13,22 +13,40 @@ tags:
 
 <p>The <strong>Web Share API</strong> provides a mechanism for sharing text, links, files, and other content to an arbitrary <em>share target</em> selected by the user.</p>
 
-<p>The available share targets are provided using the native mechanisms of the underlying operating system. They might, for example, include the system clipboard or other services, Bluetooth or WiFi, email, contacts or messaging applications, and websites.</p>
-
-<p>The API consists of just two methods:</p>
-
-<ul>
-  <li>{{domxref("navigator.canShare()")}}: Returns a boolean indicating whether the specified data is sharable.</li>
-  <li>{{domxref("navigator.share()")}}: Returns a {{jsxref("Promise")}} that resolves if the passed data was successfully sent to a share target. This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</li>
-</ul>
-
-<p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
-  If the policy is supported but has not been granted, both methods will indicate that the data is not sharable.</p>
+{{securecontext_header}}
 
 <div class="notecard note">
   <p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (not exposed via {{domxref("WorkerNavigator")}}).</p>
 </div>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> This API should not be confused with the <a href="/en-US/docs/Web/API/Web_Share_Target_API">Web Share Target API</a>, which allows a website to specify itself as a share target.</p>
+</div>
+
+<h2 id="concepts_and_usage">Concepts and usage</h2>
+
+<p>The <strong>Web Share API</strong> allows a site to share text, links, files, and other content to user-selected share targets, utilizing the sharing mechanisms of the underlying operating system.
+These share targets typically include the system clipboard, email, contacts or messaging applications, and Bluetooth or WiFi channels.</p>
+
+<p>The API has just two methods.
+  The {{domxref("navigator.canShare()")}} method may be used to first validate whether some data is "sharable", prior to passing it to {{domxref("navigator.share()")}} for sending.</p>
+
+<p>The {{domxref("navigator.share()")}} method invokes the native sharing mechanism of the underlying operating system and passes the specified data.
+    It requires {{Glossary("transient activation")}}, and hence must be triggered off a UI event like a button click.
+    Further, the method must specify valid data that is supported for sharing by the native implementation.</p>
+
+<p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
+  If the policy is supported but has not been granted, both methods will indicate that the data is not sharable.</p>
+
+<h2 id="interfaces">Interfaces</h2>
+
+<dl>
+ <dt>{{domxref("navigator.canShare()")}}</dt>
+ <dd>Returns a boolean indicating whether the specified data is sharable.</dd>
+ <dt>{{domxref("navigator.share()")}}</dt>
+ <dd>Returns a {{jsxref("Promise")}} that resolves if the passed data was successfully sent to a share target.
+   This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</dd>
+</dl>
 
 <h2 id="Example">Example</h2>
 
@@ -64,9 +82,10 @@ btn.addEventListener('click', async () => {
 
 {{Compat("api.Navigator.share")}}
 
+{{Compat("api.Navigator.canShare")}}
+
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
   <li><a href="https://web.dev/web-share-target/">Receiving shared data with the Web Share Target API</a> (https://web.dev/)</li>
 </ul>

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -23,7 +23,7 @@ tags:
 </ul>
 
 <p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
-  If the policy is supported but has not been granted, both methods will immediately indicate that the data is not sharable.</p>
+  If the policy is supported but has not been granted, both methods will indicate that the data is not sharable.</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (not exposed via {{domxref("WorkerNavigator")}}).</p>

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -18,7 +18,7 @@ tags:
 <p>The API consists of just two methods:</p>
 
 <ul>
-  <li>{{domxref("navigator.canShare()")}}: Validate that the specified data is sharable (check if a call with the same data to {{domxref("navigator.share()")}} would succeed).</li>
+  <li>{{domxref("navigator.canShare()")}}: Returns a boolean indicating whether the specified data is sharable.</li>
   <li>{{domxref("navigator.share()")}}: Share the specified data. This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</li>
 </ul>
 

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -6,8 +6,9 @@ tags:
   - Apps
   - Web Share
   - Web Share API
-  - Guide
+  - Landing
   - Overview
+  - Reference
 ---
 <div>{{DefaultAPISidebar("Web Share API")}}</div>
 

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -1,0 +1,72 @@
+---
+title: Web Share API
+slug: Web/API/Web_Share_API
+tags:
+  - API
+  - Apps
+  - Web Share
+  - Web Share API
+  - Guide
+  - Overview
+---
+<div>{{DefaultAPISidebar("Web Share API")}}</div>
+
+<p>The <strong>Web Share API</strong> provides a mechanism for sharing text, links, files and other content to an arbitrary <em>share target</em> selected by the user.</p>
+
+<p>The available share targets are provided using the native mechanisms of the underlying operating system. They might, for example, include the system clipboard or other services, Bluetooth or WiFi, email, contacts or messaging applications, and websites.</p>
+
+<p>The API consists of just two methods:</p>
+
+<ul>
+  <li>{{domxref("navigator.canShare()")}}: Validate that the specified data is sharable (check if a call with the same data to {{domxref("navigator.share()")}} would succeed).</li>
+  <li>{{domxref("navigator.share()")}}: Share the specified data. This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</li>
+</ul>
+
+<p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.
+  If the policy is supported but has not been granted, both methods will immediately indicate that the data is not sharable.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (not exposed via {{domxref("WorkerNavigator")}}).</p>
+</div>
+
+
+<h2 id="Example">Example</h2>
+
+<p>The code fragment below shows how you can share a link using {{domxref("navigator.share()")}} triggered off a button click.</p>
+
+<pre class="brush: js;">const shareData = {
+  title: 'MDN',
+  text: 'Learn web development on MDN!',
+  url: 'https://developer.mozilla.org'
+}
+
+const btn = document.querySelector('button');
+const resultPara = document.querySelector('.result');
+
+// Share must be triggered by "user activation"
+btn.addEventListener('click', async () => {
+  try {
+    await navigator.share(shareData)
+    resultPara.textContent = 'MDN shared successfully'
+  } catch(err) {
+    resultPara.textContent = 'Error: ' + err
+  }
+});
+</pre>
+
+<p>The above example is taken from our <a href="https://mdn.github.io/dom-examples/web-share/">Web share test</a> (<a href="https://github.com/mdn/dom-examples/blob/master/web-share/index.html">see the source code</a>). You can also see this as a live example in {{domxref("navigator.share()")}}.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications("api.Navigator.share")}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+{{Compat("api.Navigator.share")}}
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://wpt.live/web-share/">https://wpt.live/web-share/</a> (web platform tests)</li>
+  <li><a href="https://web.dev/web-share-target/">Receiving shared data with the Web Share Target API</a> (https://web.dev/)</li>
+</ul>

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Web Share API")}}</div>
 
-<p>The <strong>Web Share API</strong> provides a mechanism for sharing text, links, files and other content to an arbitrary <em>share target</em> selected by the user.</p>
+<p>The <strong>Web Share API</strong> provides a mechanism for sharing text, links, files, and other content to an arbitrary <em>share target</em> selected by the user.</p>
 
 <p>The available share targets are provided using the native mechanisms of the underlying operating system. They might, for example, include the system clipboard or other services, Bluetooth or WiFi, email, contacts or messaging applications, and websites.</p>
 

--- a/files/en-us/web/api/web_share_api/index.html
+++ b/files/en-us/web/api/web_share_api/index.html
@@ -19,7 +19,7 @@ tags:
 
 <ul>
   <li>{{domxref("navigator.canShare()")}}: Returns a boolean indicating whether the specified data is sharable.</li>
-  <li>{{domxref("navigator.share()")}}: Share the specified data. This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</li>
+  <li>{{domxref("navigator.share()")}}: Returns a {{jsxref("Promise")}} that resolves if the passed data was successfully sent to a share target. This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).</li>
 </ul>
 
 <p>The Web Share API is gated by the <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share">web-share</a> permission policy.


### PR DESCRIPTION
Further updates to `navigator.canShare`.

The main reason is that following some digging, I have verified that the message is a bit flawed. Essentially it can return invalid `true` if it does not understand data. It is however useful for feature detection.
I added a simple example using pseudo code for that, and explained it. 

Also removed the non-standard header and experimental flag. IMO it is not to either - though I am testing that in BCD. BCD also has spec update. 

Also noted that the value for the data is a "base set". This can be extended. Lots of work to be done in Web Share API doc (still to be created). 
