### PR TITLE
Line element better code for user ease.

### DIFF
--- a/files/en-us/web/svg/tutorial/basic_shapes/index.html
+++ b/files/en-us/web/svg/tutorial/basic_shapes/index.html
@@ -95,7 +95,7 @@ tags:
 
 <p>The {{SVGElement("line")}} element takes the positions of two points as parameters and draws a straight line between them.</p>
 
-<pre class="brush:xml;gutter:false;">&lt;line x1="10" x2="50" y1="110" y2="150"/&gt;</pre>
+<pre class="brush:xml;gutter:false;">&lt;line x1="10" x2="50" y1="110" y2="150" stroke="black" stroke-width="5"/&gt;</pre>
 
 <dl>
  <dt><code>x1</code></dt>


### PR DESCRIPTION
When a user copies the code of Line element and runs in local device, it shows nothing. It is because there is no stroke attribute associated. So, here I have proposed change for line element code.




> What was wrong/why is this fix needed? (quick summary only)
>
>If user directly copies the content of line element then it will not show any output in their local device. So, I have attached stroke attribute in line element. 


