### PR TITLE
Replacing the deprecated element in :nth-last-of-type() CSS Reference

### DIFF
--- a/files/en-us/web/css/_colon_nth-last-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.md
@@ -45,7 +45,7 @@ See {{Cssxref(":nth-last-child")}} for a more detailed explanation of its syntax
   <span>This is another span.</span>
   <em>This is emphasized.</em>
   <span>Wow, this span gets limed!!!</span>
-  <strike>This is struck through.</strike>
+  <del>This is struck through.</del>
   <span>Here is one last span.</span>
 </div>
 ```


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

https://github.com/mdn/content/issues/8385

> What was wrong/why is this fix needed? (quick summary only)


The deprecated element used in an example can be removed at any time.
> Anything else that could help us review it
<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike">strike</a>