### PR TITLE
Replace deprecated onKeyPress with onKeyDown

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -60,7 +60,7 @@ The developer is required to change the value of the `aria-checked` attribute d
 
 - `onclick`
   - : Handle mouse clicks on both the checkbox and the associated label that will change the state of the checkbox by changing the value of the `aria-checked` attribute and the appearance of the checkbox so it appears checked or unchecked to the sighted user
-- `onKeyPress`
+- `onKeyDown`
 
   - : Handle the case where the user presses the <kbd>Space</kbd> key to change the state of the checkbox by changing the value of the `aria-checked` attribute and the appearance of the checkbox so it appears checked or unchecked to the sighted user
 
@@ -71,9 +71,9 @@ The following example creates an otherwise non-semantic checkbox element using C
 #### HTML
 
 ```html
-<span role="checkbox" id="chkPref" aria-checked="false" onclick="changeCheckbox()" onKeyPress="changeCheckbox()"
+<span role="checkbox" id="chkPref" aria-checked="false" onclick="changeCheckbox()" onKeyDown="changeCheckbox(event.keyCode)"
    tabindex="0" aria-labelledby="chk1-label"></span>
-<label id="chk1-label" onclick="changeCheckbox()" onKeyPress="changeCheckbox()">Remember my preferences</label>
+<label id="chk1-label" onclick="changeCheckbox()" onKeyDown="changeCheckbox(event.keyCode)">Remember my preferences</label>
 ```
 
 #### CSS
@@ -81,6 +81,10 @@ The following example creates an otherwise non-semantic checkbox element using C
 ```css
 [role="checkbox"] {
     padding:5px;
+}
+
+[role="checkbox"]:focus {
+    border: 2px solid #0198E1;
 }
 
 [aria-checked="true"]::before {
@@ -95,7 +99,11 @@ The following example creates an otherwise non-semantic checkbox element using C
 #### JavaScript
 
 ```js
-function changeCheckbox(event) {
+function changeCheckbox(keyCode) {
+    const spacebarKeyCode = 32;
+    if (keyCode && keyCode !== spacebarKeyCode) {
+      return;
+    }
     let item = document.getElementById('chkPref');
     switch(item.getAttribute('aria-checked')) {
         case "true":
@@ -120,6 +128,11 @@ When the `checkbox` role is added to an element, the user agent should do the fo
 Assistive technology products should do the following:
 
 - Screen readers should announce the element as a checkbox, and optionally provide instructions on how to activate it.
+
+People implementing checkboxes should do the following:
+- Ensure that the checkbox can be reached and interacted with by both keyboard controls and clicks
+- Keep the `aria-checked` attribute up to date following user interactions
+- Provide styles that indicate when the checkbox has focus
 
 > **Note:** Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and may change.
 

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -80,19 +80,19 @@ The following example creates an otherwise non-semantic checkbox element using C
 
 ```css
 [role="checkbox"] {
-    padding:5px;
+  padding:5px;
 }
 
 [role="checkbox"]:focus {
-    border: 2px solid #0198E1;
+  border: 2px solid #0198E1;
 }
 
 [aria-checked="true"]::before {
-    content: "[x]";
+  content: "[x]";
 }
 
 [aria-checked="false"]::before {
-    content: "[ ]";
+  content: "[ ]";
 }
 ```
 
@@ -100,19 +100,17 @@ The following example creates an otherwise non-semantic checkbox element using C
 
 ```js
 function changeCheckbox(keyCode) {
-    const spacebarKeyCode = 32;
-    if (keyCode && keyCode !== spacebarKeyCode) {
-      return;
-    }
-    let item = document.getElementById('chkPref');
-    switch(item.getAttribute('aria-checked')) {
-        case "true":
-            item.setAttribute('aria-checked', "false");
-            break;
-        case "false":
-            item.setAttribute('aria-checked', "true");
-            break;
-    }
+  const spacebarKeyCode = 32;
+  const item = document.getElementById('chkPref');
+  const checked = item.getAttribute('aria-checked');
+
+  if (keyCode && keyCode !== spacebarKeyCode) {
+    return;
+  } else if (checked === 'true') {
+    item.setAttribute('aria-checked', 'false')
+  } else {
+    item.setAttribute('aria-checked', 'true')
+  }
 }
 ```
 

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -101,15 +101,15 @@ The following example creates an otherwise non-semantic checkbox element using C
 ```js
 function changeCheckbox(keyCode) {
   const spacebarKeyCode = 32;
-  const item = document.getElementById('chkPref');
-  const checked = item.getAttribute('aria-checked');
+  const item = document.getElementById("chkPref");
+  const checked = item.getAttribute("aria-checked");
 
   if (keyCode && keyCode !== spacebarKeyCode) {
     return;
-  } else if (checked === 'true') {
-    item.setAttribute('aria-checked', 'false')
+  } else if (checked === "true") {
+    item.setAttribute("aria-checked", "false");
   } else {
-    item.setAttribute('aria-checked', 'true')
+    item.setAttribute("aria-checked", "true");
   }
 }
 ```


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

onKeyPress is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event), but it was being used in a checkbox example on the [checkbox role page](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role).

The article guides devs to handle spacebar inputs, however the given example fired for all keys that keyDown would have captured (any alphabet key, enter, spacebar, etc).

Lastly the example was missing focus styles, which are [critical for accessibility](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html). 

> Anything else that could help us review it

The onKeyPress page suggests using [onKeyDown](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event) instead, so that's what I used here.

I relied on `event.keyCode` instead of `event.key` because the value of event.key for spacebar is an empty string. Whitespace can be ambiguous and a source of invisible characters pain for JS developers, so I used the unambiguous keycode value instead.

Here's a [codepen](https://codepen.io/jweber/pen/ZEyGPab) showing the new version. To test it, click the checkbox a few times, try tabbing to it via keyboard, and press spacebar a few times.

## Possible followups

I'd love to use a series of if...if else...else statements instead of if + a case switch, to improve readability. If that seems ok to you, I can make that change or open a second PR. I didn't want to change too much at once.

Here's an example refactor:
```js
function changeCheckbox(keyCode) {
  let spacebarKeyCode = 32;
  let item = document.getElementById('chkPref');
  let checked = item.getAttribute('aria-checked');

  if (keyCode && keyCode !== spacebarKeyCode) {
    return;
  } else if (checked === 'true') {
    item.setAttribute('aria-checked', 'false')
  } else {
    item.setAttribute('aria-checked', 'true')
  }
}
```