### PR TITLE
fixing broken examples in CSS Paint API guide

### DIFF
--- a/files/en-us/web/api/css_painting_api/guide/index.html
+++ b/files/en-us/web/api/css_painting_api/guide/index.html
@@ -269,9 +269,9 @@ li:nth-of-type(3n+1) {
 
 <h4>Result</h4>
 
-<p>While you can't play with the worklet's script, you can alter the custom property values to change the colors and width of the background image.</p>
+<p>While you can't play with the worklet's script, you can alter the custom property values in DevTools to change the colors and width of the background image.</p>
 
-<p>{{EmbedLiveSample("Using_the_paint_worklet_3", 300, 300)}}</p>
+{{EmbedGHLiveSample("css-examples/houdini/css_painting_api/example-boxbg.html", '100%', 400)}}
 
 <h2 id="Adding_complexity">Adding complexity</h2>
 
@@ -348,6 +348,10 @@ h6 { --highColor: hsla(355, 90%, 60%, 0.3); }</pre>
 <p>You could try making the background images above without the CSS paint API. It is doable, but you would have to declare a different, fairly complex linear gradient for each different color you wanted to create. With the CSS Paint API, one worklet can be re-used, with different colors passed in this case.</p>
 
 <h2 id="Passing_parameters">Passing parameters</h2>
+
+<div class="notecard note">
+  <p><strong>Note: </strong> The following example requires the Experimental Web Platform features flag to be enabled in Chrome or Edge by visiting <code>abbout://flags</code>.</p>
+</div>
 
 <p>With the CSS Paint API, we not only have access to custom properties and regular properties, but we can pass custom arguments to the <code>paint()</code> function as well.</p>
 

--- a/files/en-us/web/api/css_painting_api/guide/index.html
+++ b/files/en-us/web/api/css_painting_api/guide/index.html
@@ -350,7 +350,7 @@ h6 { --highColor: hsla(355, 90%, 60%, 0.3); }</pre>
 <h2 id="Passing_parameters">Passing parameters</h2>
 
 <div class="notecard note">
-  <p><strong>Note: </strong> The following example requires the Experimental Web Platform features flag to be enabled in Chrome or Edge by visiting <code>abbout://flags</code>.</p>
+  <p><strong>Note:</strong> The following example requires the Experimental Web Platform features flag to be enabled in Chrome or Edge by visiting <code>about://flags</code>.</p>
 </div>
 
 <p>With the CSS Paint API, we not only have access to custom properties and regular properties, but we can pass custom arguments to the <code>paint()</code> function as well.</p>

--- a/files/en-us/web/api/css_painting_api/index.html
+++ b/files/en-us/web/api/css_painting_api/index.html
@@ -49,77 +49,42 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>To draw directly into an element's background using JavaScript in our CSS, we define a paint worklet using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function, tell the document to include the worklet using the paintWorklet addModule() method, then include the image we created using the CSS <code><a href="/en-US/docs/Web/CSS/paint()">paint()</a></code> function.</p>
+<p>The following example creates a list of items with a background image that rotates between three different colors and three widths. In a supporting browser you will see something like the image below.</p>
 
-<h3>Paint worklet</h3>
+<p><img alt="The width and color of the background image changes based on the custom properties" src="Guide/boxbg.png"></p>
 
-<p>We create our PaintWorklet called 'hollowHighlights' using the <code><a href="/en-US/docs/Web/API/PaintWorklet/registerPaint">registerPaint()</a></code> function:</p>
+<p>To achieve this we'll define two custom CSS properties, <code>--boxColor</code> and <code>--widthSubtractor</code>.</p>
 
-<pre class="brush: js">registerPaint('hollowHighlights', class {
+<h3>The paint worklet</h3>
 
-  static get inputProperties() { return ['--boxColor']; }
+<p>In our worklet, we can reference these custom properties.</p>
 
-  static get inputArguments() { return ['*','&lt;length&gt;']; }
-
+<pre class="brush: js">registerPaint('boxbg', class {
   static get contextOptions() { return {alpha: true}; }
 
-  paint(ctx, size, props, args) {
-		const x = 0;
-		const y = size.height * 0.3;
-		const blockWidth = size.width * 0.33;
-		const blockHeight = size.height * 0.85;
+  /*
+     use this function to retrieve any custom properties (or regular properties, such as 'height')
+     defined for the element, return them in the specified array
+  */
+  static get inputProperties() { return ['--boxColor', '--widthSubtractor']; }
 
-		const theColor = props.get( '--boxColor' );
-		const strokeType = args[0].toString();
-		const strokeWidth = parseInt(args[1]);
+  paint(ctx, size, props) {
+    /*
+       ctx -&gt; drawing context
+       size -&gt; paintSize: width and height
+       props -&gt; properties: get() method
+    */
 
-		console.log(theColor);
-
-		if ( strokeWidth ) {
-			ctx.lineWidth = strokeWidth;
-		} else {
-			ctx.lineWidth = 1.0;
-		}
-
-		if ( strokeType === 'stroke' ) {
-			ctx.fillStyle = 'transparent';
-			ctx.strokeStyle = theColor;
-		} else if ( strokeType === 'filled' ) {
-			ctx.fillStyle = theColor;
-			ctx.strokeStyle = theColor;
-		} else {
-			ctx.fillStyle = 'none';
-			ctx.strokeStyle = 'none';
-		}
-
-		ctx.beginPath();
-		ctx.moveTo( x, y );
-		ctx.lineTo( blockWidth, y );
-		ctx.lineTo( blockWidth + blockHeight, blockHeight );
-		ctx.lineTo( x, blockHeight );
-		ctx.lineTo( x, y );
-		ctx.closePath();
-		ctx.fill();
-		ctx.stroke();
-
-		for (let i = 0; i &lt; 4; i++) {
-			let start = i * 2;
-			ctx.beginPath();
-			ctx.moveTo( blockWidth + (start * 10) + 10, y);
-			ctx.lineTo( blockWidth + (start * 10) + 20, y);
-			ctx.lineTo( blockWidth + (start * 10) + 20 + blockHeight, blockHeight);
-			ctx.lineTo( blockWidth + (start * 10) + 10 + blockHeight, blockHeight);
-			ctx.lineTo( blockWidth + (start * 10) + 10, y);
-			ctx.closePath();
-			ctx.fill();
-			ctx.stroke();
-		}
+    ctx.fillStyle = props.get('--boxColor');
+    ctx.fillRect(0, size.height/3, size.width*0.4 - props.get('--widthSubtractor'), size.height*0.6);
   }
 });</pre>
 
+<p>We used the <code>inputProperties()</code> method in the <code>registerPaint()</code> class to get the values of two custom properties set on an element that has <code>boxbg</code> applied to it and then used those within our <code>paint()</code> function. The <code>inputProperties()</code> method can return all properties affecting the element, not just custom properties.</p>
+
 <h3>Using the paint worklet</h3>
 
-<p>We then include the paintWorklet:</p>
+<h4>HTML</h4>
 
 <pre class="brush: html">&lt;ul&gt;
     &lt;li&gt;item 1&lt;/li&gt;
@@ -139,36 +104,40 @@ tags:
     &lt;li&gt;item 15&lt;/li&gt;
     &lt;li&gt;item 16&lt;/li&gt;
     &lt;li&gt;item 17&lt;/li&gt;
-    &lt;li&gt;item 18&lt;/li&gt;
-    &lt;li&gt;item 19&lt;/li&gt;
-    &lt;li&gt;item 20&lt;/li&gt;
-&lt;/ul&gt;</pre>
-
-<pre class="brush: js">  CSS.paintWorklet.addModule('https://mdn.github.io/houdini-examples/cssPaint/intro/worklets/hilite.js');
+    &lt;li&gt;item&lt;/li&gt;
+&lt;/ul&gt;
 </pre>
 
-<p>Then we can use the {{cssxref('&lt;image&gt;')}} with the CSS {{cssxref('paint()')}} function:</p>
+<h4>CSS</h4>
+
+<p>In our CSS, we define the <code>--boxColor</code> and <code>--widthSubtractor</code> custom properties.</p>
 
 <pre class="brush: css">li {
+   background-image: paint(boxbg);
    --boxColor: hsla(55, 90%, 60%, 1.0);
-   background-image: paint(hollowHighlights, stroke, 2px);
 }
 
 li:nth-of-type(3n) {
    --boxColor: hsla(155, 90%, 60%, 1.0);
-   background-image: paint(hollowHighlights, filled,  3px);
+   --widthSubtractor: 20;
 }
 
 li:nth-of-type(3n+1) {
    --boxColor: hsla(255, 90%, 60%, 1.0);
-   background-image: paint(hollowHighlights, stroke, 1px);
+   --widthSubtractor: 40;
 }</pre>
 
-<p>We've included a custom property in the selector block defining a boxColor. Custom properties are accessible to the PaintWorklet.</p>
+<h4>JavaScript</h4>
 
-<h3>Result</h3>
+<p>In our <code>&lt;script&gt;</code> we register the worklet:</p>
 
-<p>{{EmbedLiveSample("Using_the_paint_worklet", 300, 300)}}</p>
+<pre class="brush: js">CSS.paintWorklet.addModule('boxbg.js');</pre>
+
+<h4>Result</h4>
+
+<p>While you can't play with the worklet's script, you can alter the custom property values in DevTools to change the colors and width of the background image.</p>
+
+{{EmbedGHLiveSample("css-examples/houdini/css_painting_api/example-boxbg.html", '100%', 400)}}
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes #8327 

As mentioned in the issue, I did a bit of poking around and found two broken examples. The first I couldn't get working by cobbling together the elements from the live example on the page, but works standalone, so I added it to the css-examples repo and embedded the finished example from there. 

The second (which was the one the report was made about) requires experimental web platform features to work due to the custom arguments feature. So I've added a note, and also used the example that works without the flag on the overview page for the spec.