### PR TITLE
Sidebars included in extension.getViews when windowId specified

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.extension.getViews
   <dt><code>type</code>{{optional_inline}}</dt>
   <dd><code>string</code>. An {{WebExtAPIRef('extension.ViewType')}} indicating the type of view to get. If omitted, this function returns all views.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>
-  <dd><code>integer</code>. The window to restrict the search to. If omitted, this function returns all views.</dd>
+  <dd><code>integer</code>. The window to restrict the search to. If omitted, this function returns all views. In Firefox version 92 and earlier, sidebar details are not returned.</dd>
  </dl>
  </dd>
 </dl>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -53,6 +53,10 @@ tags:
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
+<ul>
+  <li>Sidebars are now included in {{WebExtAPIRef("extension.getViews")}} when <code>windowId</code> is specified ({{bug(1612390)}}).</li>
+</ul>
+
 <h4 id="removals_webext">Removals</h4>
 
 <h2 id="Older_versions">Older versions</h2>


### PR DESCRIPTION
Provides documentation for [Bug 1612390](https://bugzilla.mozilla.org/show_bug.cgi?id=1612390) including:
* release note
* note about availability of sidebars on `extension.getViews(windowId)`